### PR TITLE
Suppress index template diff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ build: lint ## build the terraform provider
 
 .PHONY: testacc
 testacc: lint ## Run acceptance tests
-	TF_ACC=1 go test ./... -v -count $(ACCTEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+	TF_ACC=1 go test -v ./... -count $(ACCTEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
 
 .PHONY: test
 test: lint ## Run unit tests
-	go test $(TEST) $(TESTARGS) -timeout=5m -parallel=4
+	go test -v $(TEST) $(TESTARGS) -timeout=5m -parallel=4
 
 
 .PHONY: docs-generate

--- a/internal/elasticsearch/index/template.go
+++ b/internal/elasticsearch/index/template.go
@@ -136,7 +136,7 @@ func ResourceTemplate() *schema.Resource {
 						Description:      "Configuration options for the index. See, https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings",
 						Type:             schema.TypeString,
 						Optional:         true,
-						DiffSuppressFunc: utils.DiffJsonSuppress,
+						DiffSuppressFunc: utils.DiffIndexTemplateSettingSuppress,
 						ValidateFunc:     validation.StringIsJSON,
 					},
 				},
@@ -396,10 +396,6 @@ func flattenTemplateData(template *models.Template) ([]interface{}, diag.Diagnos
 		tmpl["mappings"] = string(m)
 	}
 	if template.Settings != nil {
-		if index, ok := template.Settings["index"]; ok {
-			delete(template.Settings, "index")
-			template.Settings = index.(map[string]interface{})
-		}
 		s, err := json.Marshal(template.Settings)
 		if err != nil {
 			return nil, diag.FromErr(err)

--- a/internal/utils/diffs.go
+++ b/internal/utils/diffs.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DiffJsonSuppress(k, old, new string, d *schema.ResourceData) bool {
+	result, _ := JSONBytesEqual([]byte(old), []byte(new))
+	return result
+}
+
+func DiffIndexTemplateSettingSuppress(k, old, new string, d *schema.ResourceData) bool {
+	var o, n map[string]interface{}
+	if err := json.Unmarshal([]byte(old), &o); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(new), &n); err != nil {
+		return false
+	}
+	return MapsEqual(normalizeIndexSettings(FlattenMap(o)), normalizeIndexSettings(FlattenMap(n)))
+}
+
+func normalizeIndexSettings(m map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		if strings.HasPrefix(k, "index.") {
+			out[k] = fmt.Sprintf("%v", v)
+			continue
+		}
+		out[fmt.Sprintf("index.%s", k)] = fmt.Sprintf("%v", v)
+	}
+	return out
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,86 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+)
+
+func TestFlattenMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in  map[string]interface{}
+		out map[string]interface{}
+	}{
+		{
+			map[string]interface{}{"key1": map[string]interface{}{"key2": 1}},
+			map[string]interface{}{"key1.key2": 1},
+		},
+		{
+			map[string]interface{}{"key1": map[string]interface{}{"key2": map[string]interface{}{"key3": 1}}},
+			map[string]interface{}{"key1.key2.key3": 1},
+		},
+		{
+			map[string]interface{}{"key1": 1},
+			map[string]interface{}{"key1": 1},
+		},
+		{
+			map[string]interface{}{"key1": "test"},
+			map[string]interface{}{"key1": "test"},
+		},
+		{
+			map[string]interface{}{"key1": map[string]interface{}{"key2": 1, "key3": "test", "key4": []int{1, 2, 3}}},
+			map[string]interface{}{"key1.key2": 1, "key1.key3": "test", "key1.key4": []int{1, 2, 3}},
+		},
+	}
+
+	for _, tc := range tests {
+		res := utils.FlattenMap(tc.in)
+		if !utils.MapsEqual(res, tc.out) {
+			t.Errorf("Could not properly flatten the map: %+v <> %+v", res, tc.out)
+		}
+	}
+}
+
+func TestDiffIndexTemplateSuppress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		old   string
+		new   string
+		equal bool
+	}{
+		{
+			`{"key1.key2": 2, "index.key2.key1": "3"}`,
+			`{"index": {"key1.key2": "2", "key2.key1": "3"}}`,
+			true,
+		},
+		{
+			`{"key1": "2", "key2": "3"}`,
+			`{"index": {"key1": "2", "key2": "3"}}`,
+			true,
+		},
+		{
+			`{"index":{"key1": "2", "key2": "3"}}`,
+			`{"index": {"key1": "2", "key2": "3"}}`,
+			true,
+		},
+		{
+			`{"key1": "2", "key2": "3"}`,
+			`{"index.key1": "2", "index.key2": "3"}`,
+			true,
+		},
+		{
+			`{"key1": 1, "key2": 2}`,
+			`{"key1": "2", "index.key2": "3"}`,
+			false,
+		},
+	}
+
+	for _, tc := range tests {
+		if sup := utils.DiffIndexTemplateSettingSuppress("", tc.old, tc.new, nil); sup != tc.equal {
+			t.Errorf("Failed for test case: %+v", tc)
+		}
+	}
+}


### PR DESCRIPTION
Make sure to normalize and check the user's supplied settings.

Index templates support configuring the index settings (https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings)
and ES API flexible enough so the following formats if are sent by user will be valid:

```json
{ "index.number_of_routing_shards": "2" }
```

```json
{ "number_of_routing_shards": "2" }
```

```json
{ "index": { "number_of_routing_shards": 2 } }
```

This PR adds special suppression function, which makes sure to normalize
the configured settings and the settings which are returned from ES API
and only then compare them and decides if there is a diff drift.

Also add few tests for utils package and small refactoring of the project
structure.