### PR TITLE
CI: minor changes in the sh step, use environment variable for parameters, and default git checkout credentials

### DIFF
--- a/.ci/pipelines/acceptance.groovy
+++ b/.ci/pipelines/acceptance.groovy
@@ -6,7 +6,6 @@ pipeline {
     HOME = "${env.JENKINS_HOME}"
     REPOSITORY = "terraform-provider-elasticstack"
     GIT_REFERENCE_REPO = "/var/lib/jenkins/.git-references/terraform-provider-elasticstack.git"
-    GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     branch_specifier = "${params?.branch_specifier}"
   }
   parameters {
@@ -19,8 +18,7 @@ pipeline {
         estcGithubCheckout(github_org: 'elastic',
                             repository: env.REPOSITORY,
                             revision: env.ghprbActualCommit ?: env.CHANGE_BRANCH ?: env.BRANCH_NAME ?: env.branch_specifier,
-                            reference_repo: env.GIT_REFERENCE_REPO,
-                            credentials: env.GIT_CREDENTIALS)
+                            reference_repo: env.GIT_REFERENCE_REPO)
       }
     }
     stage('Acceptance Tests') {


### PR DESCRIPTION
### What

Cosmetic changes in the `sh` step to use the label argument to highlight whats the step about in the OpenTelemetry distributed traces.
Set environment variable with the parameter value to avoid issues with the very first build.
Use default git checkout credentials defined in `estcGithubCheckout`