### PR TITLE
[ci] change the url in CI configuration

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -20,7 +20,7 @@
           description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,&lt;commitId&gt;, etc.)"
     properties:
       - github:
-          url: https://github.com/elastic/terraform-provider-elasticstack
+          url: git@github.com:elastic/terraform-provider-elasticstack.git
       - inject:
           properties-content: HOME=$JENKINS_HOME
     pipeline-scm:
@@ -31,7 +31,7 @@
             reference-repo: /var/lib/jenkins/.git-references/terraform-provider-elasticstack.git
             branches:
               - ${branch_specifier}
-            url: https://github.com/elastic/terraform-provider-elasticstack
+            url: git@github.com:elastic/terraform-provider-elasticstack.git
     vault: []
     wrappers:
       - ansicolor


### PR DESCRIPTION
If the URL contains HTTP(s) the checkout would be made, looks like,
using password auth, which is not supported by GitHub.
We must use SSH to get our source.