### PR TITLE
add "ca_file" option to the elasticstack provider

### DIFF
--- a/docs/data-sources/elasticsearch_security_user.md
+++ b/docs/data-sources/elasticsearch_security_user.md
@@ -51,6 +51,7 @@ output "user" {
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/data-sources/elasticsearch_snapshot_repository.md
+++ b/docs/data-sources/elasticsearch_snapshot_repository.md
@@ -79,6 +79,7 @@ output "repo_url" {
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,6 +80,7 @@ provider "elasticstack" {
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) Password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_cluster_settings.md
+++ b/docs/resources/elasticsearch_cluster_settings.md
@@ -61,6 +61,7 @@ resource "elasticstack_elasticsearch_cluster_settings" "my_cluster_settings" {
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -169,6 +169,7 @@ Required:
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_index_template.md
+++ b/docs/resources/elasticsearch_index_template.md
@@ -74,6 +74,7 @@ Optional:
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -77,6 +77,7 @@ Required:
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_security_user.md
+++ b/docs/resources/elasticsearch_security_user.md
@@ -77,6 +77,7 @@ resource "elasticstack_elasticsearch_security_user" "dev" {
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_snapshot_lifecycle.md
+++ b/docs/resources/elasticsearch_snapshot_lifecycle.md
@@ -76,6 +76,7 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "slm_policy" {
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_snapshot_repository.md
+++ b/docs/resources/elasticsearch_snapshot_repository.md
@@ -79,6 +79,7 @@ Optional:
 
 Optional:
 
+- **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -90,6 +90,7 @@ func NewApiClientFunc(version string, p *schema.Provider) func(context.Context, 
 					tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 					config.Transport = tr
 				}
+
 				if caFile, ok := esConfig["ca_file"]; ok && caFile.(string) != "" {
 					caCert, err := ioutil.ReadFile(caFile.(string))
 					if err != nil {

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -98,6 +98,7 @@ func NewApiClientFunc(version string, p *schema.Provider) func(context.Context, 
 							Summary:  "Unable to read CA File",
 							Detail:   err.Error(),
 						})
+						return nil, diags
 					}
 					config.CACert = caCert
 				}

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -146,6 +146,13 @@ func NewApiClient(d *schema.ResourceData, meta interface{}) (*ApiClient, error) 
 			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 			config.Transport = tr
 		}
+		if caFile, ok := conn["ca_file"]; ok && caFile.(string) != "" {
+			caCert, err := ioutil.ReadFile(caFile.(string))
+			if err != nil {
+				return nil, fmt.Errorf("Unable to read ca_file: %w", err)
+			}
+			config.CACert = caCert
+		}
 
 		es, err := elasticsearch.NewClient(config)
 		if err != nil {

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -88,6 +89,17 @@ func NewApiClientFunc(version string, p *schema.Provider) func(context.Context, 
 					tr := http.DefaultTransport.(*http.Transport)
 					tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 					config.Transport = tr
+				}
+				if caFile, ok := esConfig["ca_file"]; ok && caFile.(string) != "" {
+					caCert, err := ioutil.ReadFile(caFile.(string))
+					if err != nil {
+						diags = append(diags, diag.Diagnostic{
+							Severity: diag.Error,
+							Summary:  "Unable to read CA File",
+							Detail:   err.Error(),
+						})
+					}
+					config.CACert = caCert
 				}
 			}
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,6 +54,11 @@ func New(version string) func() *schema.Provider {
 								Optional:    true,
 								Default:     false,
 							},
+							"ca_file": {
+								Description: "Path to a custom Certificate Authority certificate",
+								Type:        schema.TypeString,
+								Optional:    true,
+							},
 						},
 					},
 				},

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -151,6 +151,11 @@ func AddConnectionSchema(providedSchema map[string]*schema.Schema) {
 					Optional:    true,
 					Default:     false,
 				},
+				"ca_file": {
+					Description: "Path to a custom Certificate Authority certificate",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
allows connecting to an elasticsearch cluster using a custom certificate authority.

I know just enough go to get myself in trouble, but figured I would try to solve my own problem anyways. resolves #34 

It adds the "ca_file" parameter to the elasticstack provider.  If ca_file is set, the certificate is read and its contents are added to the CACert field in the elasticsearch.Config struct. 



