### PR TITLE
add insecure option to disable TLS validation

### DIFF
--- a/docs/data-sources/elasticsearch_security_user.md
+++ b/docs/data-sources/elasticsearch_security_user.md
@@ -52,5 +52,6 @@ output "user" {
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.

--- a/docs/data-sources/elasticsearch_snapshot_repository.md
+++ b/docs/data-sources/elasticsearch_snapshot_repository.md
@@ -80,6 +80,7 @@ output "repo_url" {
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,5 +81,6 @@ provider "elasticstack" {
 Optional:
 
 - **endpoints** (List of String, Sensitive) A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) Password to use for API authentication to Elasticsearch.
 - **username** (String) Username to use for API authentication to Elasticsearch.

--- a/docs/resources/elasticsearch_cluster_settings.md
+++ b/docs/resources/elasticsearch_cluster_settings.md
@@ -62,6 +62,7 @@ resource "elasticstack_elasticsearch_cluster_settings" "my_cluster_settings" {
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -170,6 +170,7 @@ Required:
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/resources/elasticsearch_index_template.md
+++ b/docs/resources/elasticsearch_index_template.md
@@ -75,6 +75,7 @@ Optional:
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -78,6 +78,7 @@ Required:
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/resources/elasticsearch_security_user.md
+++ b/docs/resources/elasticsearch_security_user.md
@@ -78,6 +78,7 @@ resource "elasticstack_elasticsearch_security_user" "dev" {
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/resources/elasticsearch_snapshot_lifecycle.md
+++ b/docs/resources/elasticsearch_snapshot_lifecycle.md
@@ -77,6 +77,7 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "slm_policy" {
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/docs/resources/elasticsearch_snapshot_repository.md
+++ b/docs/resources/elasticsearch_snapshot_repository.md
@@ -80,6 +80,7 @@ Optional:
 Optional:
 
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
+- **insecure** (Boolean) Disable TLS certificate validation
 - **password** (String, Sensitive) A password to use for API authentication to Elasticsearch.
 - **username** (String) A username to use for API authentication to Elasticsearch.
 

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -82,6 +83,12 @@ func NewApiClientFunc(version string, p *schema.Provider) func(context.Context, 
 					}
 					config.Addresses = endpoints
 				}
+
+				if insecure, ok := esConfig["insecure"]; ok && insecure.(bool) {
+					tr := http.DefaultTransport.(*http.Transport)
+					tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+					config.Transport = tr
+				}
 			}
 		}
 
@@ -120,6 +127,11 @@ func NewApiClient(d *schema.ResourceData, meta interface{}) (*ApiClient, error) 
 				addrs = append(addrs, e.(string))
 			}
 			config.Addresses = addrs
+		}
+		if insecure := conn["insecure"]; insecure.(bool) {
+			tr := http.DefaultTransport.(*http.Transport)
+			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			config.Transport = tr
 		}
 
 		es, err := elasticsearch.NewClient(config)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,6 +48,12 @@ func New(version string) func() *schema.Provider {
 									Type: schema.TypeString,
 								},
 							},
+							"insecure": {
+								Description: "Disable TLS certificate validation",
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Default:     false,
+							},
 						},
 					},
 				},

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -145,6 +145,12 @@ func AddConnectionSchema(providedSchema map[string]*schema.Schema) {
 						Type: schema.TypeString,
 					},
 				},
+				"insecure": {
+					Description: "Disable TLS certificate validation",
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     false,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This is my attempt to implement an insecure option to disable TLS validation.

I believe I've also addressed the issues brought up in my other PR for the ca_file option.  

I'm a little unsure on my use of http.DefaultTransport.  After looking at the elasticsearch-go and elastic-transport-go source, it's my understanding that if no transport is set in elasticsearch.Config, then http.DefaultTransport is used.  

Feedback is certainly welcome. 

related https://github.com/elastic/terraform-provider-elasticstack/issues/34