### PR TITLE
Added title in the cloud guide

### DIFF
--- a/docs/guides/elasticstack-and-cloud.md
+++ b/docs/guides/elasticstack-and-cloud.md
@@ -5,7 +5,7 @@ description: |-
     An example of how to spin up a deployment and configure it in a single plan.
 ---
 
-# 
+# Using the Elastic Stack provider with Elastic Cloud
 
 A common scenario for using the Elastic Stack provider, is to manage & configure Elastic Cloud deployments.
 In order to do that, we'll use both the Elastic Cloud provider, as well as the Elastic Stack provider.

--- a/templates/guides/elasticstack-and-cloud.md.tmpl
+++ b/templates/guides/elasticstack-and-cloud.md.tmpl
@@ -5,7 +5,7 @@ description: |-
     An example of how to spin up a deployment and configure it in a single plan.
 ---
 
-# 
+# Using the Elastic Stack provider with Elastic Cloud
 
 A common scenario for using the Elastic Stack provider, is to manage & configure Elastic Cloud deployments.
 In order to do that, we'll use both the Elastic Cloud provider, as well as the Elastic Stack provider.


### PR DESCRIPTION
Currently this title is missing which leaves empty `#` in the beginning of the file, see https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/guides/elasticstack-and-cloud