### PR TITLE
Make sure to define ID as rad-only/computed attribute

### DIFF
--- a/docs/resources/elasticsearch_cluster_settings.md
+++ b/docs/resources/elasticsearch_cluster_settings.md
@@ -52,9 +52,12 @@ resource "elasticstack_elasticsearch_cluster_settings" "my_cluster_settings" {
 ### Optional
 
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
-- **id** (String) The ID of this resource.
 - **persistent** (Block List, Max: 1) Settings will apply across restarts. (see [below for nested schema](#nestedblock--persistent))
 - **transient** (Block List, Max: 1) Settings do not survive a full cluster restart. (see [below for nested schema](#nestedblock--transient))
+
+### Read-Only
+
+- **id** (String) Internal identifier of the resource
 
 <a id="nestedblock--elasticsearch_connection"></a>
 ### Nested Schema for `elasticsearch_connection`

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -66,7 +66,6 @@ resource "elasticstack_elasticsearch_index" "my_index" {
 
 - **alias** (Block Set) Aliases for the index. (see [below for nested schema](#nestedblock--alias))
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
-- **id** (String) The ID of this resource.
 - **mappings** (String) Mapping for fields in the index.
 If specified, this mapping can include: field names, field data types (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html), mapping parameters (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html).
 **NOTE:** changing datatypes in the existing _mappings_ will force index to be re-created.
@@ -75,6 +74,7 @@ If specified, this mapping can include: field names, field data types (https://w
 
 ### Read-Only
 
+- **id** (String) Internal identifier of the resource
 - **settings_raw** (String) All raw settings fetched from the cluster.
 
 <a id="nestedblock--alias"></a>

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -52,12 +52,12 @@ resource "elasticstack_elasticsearch_index_lifecycle" "my_ilm" {
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
 - **frozen** (Block List, Max: 1) The index is no longer being updated and is queried rarely. The information still needs to be searchable, but it’s okay if those queries are extremely slow. (see [below for nested schema](#nestedblock--frozen))
 - **hot** (Block List, Max: 1) The index is actively being updated and queried. (see [below for nested schema](#nestedblock--hot))
-- **id** (String) The ID of this resource.
 - **metadata** (String) Optional user metadata about the ilm policy.
 - **warm** (Block List, Max: 1) The index is no longer being updated but is still being queried. (see [below for nested schema](#nestedblock--warm))
 
 ### Read-Only
 
+- **id** (String) Internal identifier of the resource
 - **modified_date** (String) The DateTime of the last modification.
 
 <a id="nestedblock--cold"></a>

--- a/docs/resources/elasticsearch_index_template.md
+++ b/docs/resources/elasticsearch_index_template.md
@@ -58,11 +58,14 @@ resource "elasticstack_elasticsearch_index_template" "my_data_stream" {
 - **composed_of** (List of String) An ordered list of component template names.
 - **data_stream** (Block List, Max: 1) If this object is included, the template is used to create data streams and their backing indices. Supports an empty object. (see [below for nested schema](#nestedblock--data_stream))
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
-- **id** (String) The ID of this resource.
 - **metadata** (String) Optional user metadata about the index template.
 - **priority** (Number) Priority to determine index template precedence when a new data stream or index is created.
 - **template** (Block List, Max: 1) Template to be applied. It may optionally include an aliases, mappings, or settings configuration. (see [below for nested schema](#nestedblock--template))
 - **version** (Number) Version number used to manage index templates externally.
+
+### Read-Only
+
+- **id** (String) Internal identifier of the resource
 
 <a id="nestedblock--data_stream"></a>
 ### Nested Schema for `data_stream`

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -57,10 +57,13 @@ output "role" {
 - **cluster** (Set of String) A list of cluster privileges. These privileges define the cluster level actions that users with this role are able to execute.
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
 - **global** (String) An object defining global privileges.
-- **id** (String) The ID of this resource.
 - **indices** (Block Set) A list of indices permissions entries. (see [below for nested schema](#nestedblock--indices))
 - **metadata** (String) Optional meta-data.
 - **run_as** (Set of String) A list of users that the owners of this role can impersonate.
+
+### Read-Only
+
+- **id** (String) Internal identifier of the resource
 
 <a id="nestedblock--applications"></a>
 ### Nested Schema for `applications`

--- a/docs/resources/elasticsearch_security_user.md
+++ b/docs/resources/elasticsearch_security_user.md
@@ -66,11 +66,14 @@ resource "elasticstack_elasticsearch_security_user" "dev" {
 - **email** (String) The email of the user.
 - **enabled** (Boolean) Specifies whether the user is enabled. The default value is true.
 - **full_name** (String) The full name of the user.
-- **id** (String) The ID of this resource.
 - **metadata** (String) Arbitrary metadata that you want to associate with the user.
 - **password** (String, Sensitive) The user’s password. Passwords must be at least 6 characters long.
 - **password_hash** (String, Sensitive) A hash of the user’s password. This must be produced using the same hashing algorithm as has been configured for password storage (see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#hashing-settings).
 - **roles** (Set of String) A set of roles the user has. The roles determine the user’s access permissions. Default is [].
+
+### Read-Only
+
+- **id** (String) Internal identifier of the resource
 
 <a id="nestedblock--elasticsearch_connection"></a>
 ### Nested Schema for `elasticsearch_connection`

--- a/docs/resources/elasticsearch_snapshot_lifecycle.md
+++ b/docs/resources/elasticsearch_snapshot_lifecycle.md
@@ -61,7 +61,6 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "slm_policy" {
 - **expand_wildcards** (String) Determines how wildcard patterns in the `indices` parameter match data streams and indices. Supports comma-separated values, such as `closed,hidden`.
 - **expire_after** (String) Time period after which a snapshot is considered expired and eligible for deletion.
 - **feature_states** (Set of String) Feature states to include in the snapshot.
-- **id** (String) The ID of this resource.
 - **ignore_unavailable** (Boolean) If `false`, the snapshot fails if any data stream or index in indices is missing or closed. If `true`, the snapshot ignores missing or closed data streams and indices.
 - **include_global_state** (Boolean) If `true`, include the cluster state in the snapshot.
 - **indices** (Set of String) Comma-separated list of data streams and indices to include in the snapshot.
@@ -70,6 +69,10 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "slm_policy" {
 - **min_count** (Number) Minimum number of snapshots to retain, even if the snapshots have expired.
 - **partial** (Boolean) If `false`, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available.
 - **snapshot_name** (String) Name automatically assigned to each snapshot created by the policy.
+
+### Read-Only
+
+- **id** (String) Internal identifier of the resource
 
 <a id="nestedblock--elasticsearch_connection"></a>
 ### Nested Schema for `elasticsearch_connection`

--- a/docs/resources/elasticsearch_snapshot_repository.md
+++ b/docs/resources/elasticsearch_snapshot_repository.md
@@ -50,10 +50,13 @@ resource "elasticstack_elasticsearch_snapshot_repository" "my_fs_repo" {
 - **fs** (Block List, Max: 1) Shared filesystem repository. Repositories of this type use a shared filesystem to store snapshots. This filesystem must be accessible to all master and data nodes in the cluster. (see [below for nested schema](#nestedblock--fs))
 - **gcs** (Block List, Max: 1) Support for using the Google Cloud Storage service as a repository for Snapshot/Restore. See: https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-gcs.html (see [below for nested schema](#nestedblock--gcs))
 - **hdfs** (Block List, Max: 1) Support for using HDFS File System as a repository for Snapshot/Restore. See: https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-hdfs.html (see [below for nested schema](#nestedblock--hdfs))
-- **id** (String) The ID of this resource.
 - **s3** (Block List, Max: 1) Support for using AWS S3 as a repository for Snapshot/Restore. See: https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html (see [below for nested schema](#nestedblock--s3))
 - **url** (Block List, Max: 1) URL repository. Repositories of this type are read-only for the cluster. This means the cluster can retrieve or restore snapshots from the repository but cannot write or create snapshots in it. (see [below for nested schema](#nestedblock--url))
 - **verify** (Boolean) If true, the request verifies the repository is functional on all master and data nodes in the cluster.
+
+### Read-Only
+
+- **id** (String) Internal identifier of the resource
 
 <a id="nestedblock--azure"></a>
 ### Nested Schema for `azure`

--- a/internal/elasticsearch/cluster/settings.go
+++ b/internal/elasticsearch/cluster/settings.go
@@ -45,6 +45,11 @@ func ResourceSettings() *schema.Resource {
 	}
 
 	settingsSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"persistent": {
 			Description: "Settings will apply across restarts.",
 			Type:        schema.TypeList,

--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -17,6 +17,11 @@ import (
 
 func ResourceSlm() *schema.Resource {
 	slmSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"name": {
 			Description: "ID for the snapshot lifecycle policy you want to create or update.",
 			Type:        schema.TypeString,

--- a/internal/elasticsearch/cluster/snapshot_repository.go
+++ b/internal/elasticsearch/cluster/snapshot_repository.go
@@ -204,6 +204,11 @@ func ResourceSnapshotRepository() *schema.Resource {
 	//--
 
 	snapRepoSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"name": {
 			Description: "Name of the snapshot repository to register or update.",
 			Type:        schema.TypeString,

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -18,6 +18,11 @@ var supportedIlmPhases = [...]string{"hot", "warm", "cold", "frozen", "delete"}
 
 func ResourceIlm() *schema.Resource {
 	ilmSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"name": {
 			Description: "Identifier for the policy.",
 			Type:        schema.TypeString,

--- a/internal/elasticsearch/index/index.go
+++ b/internal/elasticsearch/index/index.go
@@ -19,6 +19,11 @@ import (
 
 func ResourceIndex() *schema.Resource {
 	indexSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"name": {
 			Description: "Name of the index you wish to create.",
 			Type:        schema.TypeString,

--- a/internal/elasticsearch/index/template.go
+++ b/internal/elasticsearch/index/template.go
@@ -15,6 +15,11 @@ import (
 
 func ResourceTemplate() *schema.Resource {
 	templateSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"name": {
 			Description: "Name of the index template to create.",
 			Type:        schema.TypeString,

--- a/internal/elasticsearch/security/role.go
+++ b/internal/elasticsearch/security/role.go
@@ -15,6 +15,11 @@ import (
 
 func ResourceRole() *schema.Resource {
 	roleSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"name": {
 			Description: "The name of the role.",
 			Type:        schema.TypeString,

--- a/internal/elasticsearch/security/user.go
+++ b/internal/elasticsearch/security/user.go
@@ -16,6 +16,11 @@ import (
 
 func ResourceUser() *schema.Resource {
 	userSchema := map[string]*schema.Schema{
+		"id": {
+			Description: "Internal identifier of the resource",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"username": {
 			Description: "An identifier for the user (see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html#security-api-put-user-path-params).",
 			Type:        schema.TypeString,


### PR DESCRIPTION
We must explicitly define ID in the schema, to make sure it's rendered as read-only in the docs, since it should not be possible to change or set the id in the TF resource definition. 