### PR TITLE
Support import of the index settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Update only changed index settings ([#52](https://github.com/elastic/terraform-provider-elasticstack/issues/52))
+- Enable import of index settings ([#53](https://github.com/elastic/terraform-provider-elasticstack/issues/53))
 
 ## [0.2.0] - 2022-01-27
 ### Added

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -127,8 +127,15 @@ Required:
 
 ## Import
 
+**NOTE:** While importing index resource, keep in mind, that some of the default index settings will be imported into the TF state too.
+You can later adjust the index configuration to account for those imported settings.
+
+Some of the default settings, which could be imported are: `index.number_of_replicas`, `index.number_of_shards` and `index.routing.allocation.include._tier_preference`.
+
 Import is supported using the following syntax:
 
 ```shell
+# NOTE: while importing index resource, keep in mind, that some of the default index settings will be imported into the TF state too
+# You can later adjust the index configuration to account for those imported settings
 terraform import elasticstack_elasticsearch_index.my_index <cluster_uuid>/<index_name>
 ```

--- a/examples/resources/elasticstack_elasticsearch_index/import.sh
+++ b/examples/resources/elasticstack_elasticsearch_index/import.sh
@@ -1,2 +1,4 @@
+# NOTE: while importing index resource, keep in mind, that some of the default index settings will be imported into the TF state too
+# You can later adjust the index configuration to account for those imported settings
 terraform import elasticstack_elasticsearch_index.my_index <cluster_uuid>/<index_name>
 

--- a/internal/elasticsearch/index/index.go
+++ b/internal/elasticsearch/index/index.go
@@ -411,10 +411,20 @@ func resourceIndexRead(ctx context.Context, d *schema.ResourceData, meta interfa
 			return diag.FromErr(err)
 		}
 		// we also need to populate the managed settings, important for import
+		existingSettings := make(map[string]interface{})
+		if setts, ok := d.GetOk("settings"); ok {
+			existingSettings = flattenIndexSettings(setts.([]interface{}))
+		}
 		settings := make(map[string]interface{})
 		result := make([]interface{}, 0)
 		for k, v := range index.Settings {
-			if _, ok := ignoredDefaults[k]; ok {
+			// if there are defined settings, use them for to populate the config map
+			if len(existingSettings) > 0 {
+				if _, ok := existingSettings[k]; !ok {
+					continue
+				}
+				// or import everything ignoring defaults
+			} else if _, ok := ignoredDefaults[k]; ok {
 				continue
 			}
 			setting := make(map[string]interface{})

--- a/templates/resources/elasticsearch_index.md.tmpl
+++ b/templates/resources/elasticsearch_index.md.tmpl
@@ -18,6 +18,11 @@ Creates or updates an index. This resource can define settings, mappings and ali
 
 ## Import
 
+**NOTE:** While importing index resource, keep in mind, that some of the default index settings will be imported into the TF state too.
+You can later adjust the index configuration to account for those imported settings.
+
+Some of the default settings, which could be imported are: `index.number_of_replicas`, `index.number_of_shards` and `index.routing.allocation.include._tier_preference`.
+
 Import is supported using the following syntax:
 
 {{ codefile "shell" "examples/resources/elasticstack_elasticsearch_index/import.sh" }}


### PR DESCRIPTION
Make sure we are able to import all the index settings. Also, after index is created we support only the settings, which are defined in the TF files. 

fix https://github.com/elastic/terraform-provider-elasticstack/issues/53