### PR TITLE
Fix issue with `allocate` action for ILM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Update only changed index settings ([#52](https://github.com/elastic/terraform-provider-elasticstack/issues/52))
+- Handle `allocate` action in ILM policy ([#59](https://github.com/elastic/terraform-provider-elasticstack/issues/59))
 
 ## [0.2.0] - 2022-01-27
 ### Added

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -31,6 +31,20 @@ resource "elasticstack_elasticsearch_index_lifecycle" "my_ilm" {
     readonly {}
   }
 
+  warm {
+    min_age = "0ms"
+    set_priority {
+      priority = 60
+    }
+    readonly {}
+    allocate {
+      exclude = jsonencode({
+        box_type = "hot"
+      })
+      number_of_replicas = 0
+    }
+  }
+
   delete {
     min_age = "2d"
     delete {}
@@ -52,7 +66,7 @@ resource "elasticstack_elasticsearch_index_lifecycle" "my_ilm" {
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
 - **frozen** (Block List, Max: 1) The index is no longer being updated and is queried rarely. The information still needs to be searchable, but it’s okay if those queries are extremely slow. (see [below for nested schema](#nestedblock--frozen))
 - **hot** (Block List, Max: 1) The index is actively being updated and queried. (see [below for nested schema](#nestedblock--hot))
-- **metadata** (String) Optional user metadata about the ilm policy.
+- **metadata** (String) Optional user metadata about the ilm policy. Must be valid JSON document.
 - **warm** (Block List, Max: 1) The index is no longer being updated but is still being queried. (see [below for nested schema](#nestedblock--warm))
 
 ### Read-Only
@@ -79,10 +93,10 @@ Optional:
 
 Optional:
 
-- **exclude** (String) Assigns an index to nodes that have none of the specified custom attributes.
-- **include** (String) Assigns an index to nodes that have at least one of the specified custom attributes.
+- **exclude** (String) Assigns an index to nodes that have none of the specified custom attributes. Must be valid JSON document.
+- **include** (String) Assigns an index to nodes that have at least one of the specified custom attributes. Must be valid JSON document.
 - **number_of_replicas** (Number) Number of replicas to assign to the index.
-- **require** (String) Assigns an index to nodes that have all of the specified custom attributes.
+- **require** (String) Assigns an index to nodes that have all of the specified custom attributes. Must be valid JSON document.
 
 
 <a id="nestedblock--cold--freeze"></a>
@@ -299,10 +313,10 @@ Optional:
 
 Optional:
 
-- **exclude** (String) Assigns an index to nodes that have none of the specified custom attributes.
-- **include** (String) Assigns an index to nodes that have at least one of the specified custom attributes.
+- **exclude** (String) Assigns an index to nodes that have none of the specified custom attributes. Must be valid JSON document.
+- **include** (String) Assigns an index to nodes that have at least one of the specified custom attributes. Must be valid JSON document.
 - **number_of_replicas** (Number) Number of replicas to assign to the index.
-- **require** (String) Assigns an index to nodes that have all of the specified custom attributes.
+- **require** (String) Assigns an index to nodes that have all of the specified custom attributes. Must be valid JSON document.
 
 
 <a id="nestedblock--warm--forcemerge"></a>

--- a/examples/resources/elasticstack_elasticsearch_index_lifecycle/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_index_lifecycle/resource.tf
@@ -16,6 +16,20 @@ resource "elasticstack_elasticsearch_index_lifecycle" "my_ilm" {
     readonly {}
   }
 
+  warm {
+    min_age = "0ms"
+    set_priority {
+      priority = 60
+    }
+    readonly {}
+    allocate {
+      exclude = jsonencode({
+        box_type = "hot"
+      })
+      number_of_replicas = 0
+    }
+  }
+
   delete {
     min_age = "2d"
     delete {}

--- a/internal/clients/index.go
+++ b/internal/clients/index.go
@@ -52,6 +52,7 @@ func (a *ApiClient) GetElasticsearchIlm(policyName string) (*models.PolicyDefini
 	if err := json.NewDecoder(res.Body).Decode(&ilm); err != nil {
 		return nil, diag.FromErr(err)
 	}
+	log.Printf("[TRACE] get ILM policy '%s' from ES API: %#+v", policyName, ilm)
 
 	if ilm, ok := ilm[policyName]; ok {
 		return &ilm, diags

--- a/internal/elasticsearch/index/ilm_test.go
+++ b/internal/elasticsearch/index/ilm_test.go
@@ -46,7 +46,12 @@ func TestAccResourceILM(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "hot.0.readonly.#", "0"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "hot.#", "1"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "delete.#", "0"),
-					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.#", "0"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.#", "1"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.min_age", "0ms"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.set_priority.0.priority", "60"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.readonly.#", "1"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.allocate.#", "1"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.allocate.0.number_of_replicas", "0"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "cold.#", "0"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "frozen.#", "0"),
 				),
@@ -105,6 +110,21 @@ resource "elasticstack_elasticsearch_index_lifecycle" "test" {
       max_age = "2d"
     }
   }
+
+  warm {
+    min_age = "0ms"
+    set_priority {
+      priority = 60
+    }
+    readonly {}
+    allocate {
+      exclude = jsonencode({
+        box_type = "hot"
+      })
+      number_of_replicas = 0
+    }
+  }
+
 }
  `, name)
 }


### PR DESCRIPTION
Allocate action can contain `include`, `exclude` and `require` fields, which are JSON objects and must be handled appropriately.

fix https://github.com/elastic/terraform-provider-elasticstack/issues/59

