### PR TITLE
Convert CI job to the `matrix` one for acceptance testing

### DIFF
--- a/.ci/pipelines/acceptance.groovy
+++ b/.ci/pipelines/acceptance.groovy
@@ -1,30 +1,43 @@
 @Library('estc') _
 
 pipeline {
-  agent { label('linux && immutable && docker') }
-  environment {
-    HOME = "${env.JENKINS_HOME}"
-    REPOSITORY = "terraform-provider-elasticstack"
-    GIT_REFERENCE_REPO = "/var/lib/jenkins/.git-references/terraform-provider-elasticstack.git"
-    branch_specifier = "${params?.branch_specifier}"
-  }
   parameters {
     string(name: 'branch_specifier', defaultValue: 'refs/heads/main', description: "the Git branch specifier to build (&lt;branchName&gt;, &lt;tagName&gt;,&lt;commitId&gt;, etc.)")
   }
+  agent none
   stages {
-    stage('Checkout') {
-      options { skipDefaultCheckout() }
-      steps {
-        estcGithubCheckout(github_org: 'elastic',
-                            repository: env.REPOSITORY,
-                            revision: env.ghprbActualCommit ?: env.CHANGE_BRANCH ?: env.BRANCH_NAME ?: env.branch_specifier,
-                            reference_repo: env.GIT_REFERENCE_REPO)
-      }
-    }
     stage('Acceptance Tests') {
-      steps {
-        dir('.') {
-          sh(label: 'Run ATs in docker', script: 'make docker-testacc')
+      matrix {
+        axes {
+          axis {
+            name 'ES_VERSION'
+            values '8.0.0', '7.15.1'
+          }
+        }
+        agent { label('linux && immutable && docker') }
+        environment {
+          HOME = "${env.JENKINS_HOME}"
+          REPOSITORY = "terraform-provider-elasticstack"
+          GIT_REFERENCE_REPO = "/var/lib/jenkins/.git-references/terraform-provider-elasticstack.git"
+          branch_specifier = "${params?.branch_specifier}"
+        }
+        stages {
+          stage('Checkout') {
+            options { skipDefaultCheckout() }
+            steps {
+              estcGithubCheckout(github_org: 'elastic',
+                                  repository: env.REPOSITORY,
+                                  revision: env.ghprbActualCommit ?: env.CHANGE_BRANCH ?: env.BRANCH_NAME ?: env.branch_specifier,
+                                  reference_repo: env.GIT_REFERENCE_REPO)
+            }
+          }
+          stage('Tests') {
+            steps {
+              dir('.') {
+                sh(label: 'Run ATs in docker', script: "ELASTICSEARCH_VERSION=${ES_VERSION} make docker-testacc")
+              }
+            }
+          }
         }
       }
     }

--- a/internal/elasticsearch/index/template.go
+++ b/internal/elasticsearch/index/template.go
@@ -208,7 +208,7 @@ func resourceIndexTemplatePut(ctx context.Context, d *schema.ResourceData, meta 
 		if old != nil && len(old.([]interface{})) == 1 {
 			if old.([]interface{})[0] != nil {
 				setting := old.([]interface{})[0].(map[string]interface{})
-				if _, ok := setting["allow_custom_routing"]; ok {
+				if acr, ok := setting["allow_custom_routing"]; ok && acr.(bool) {
 					hasAllowCustomRouting = true
 				}
 			}

--- a/internal/elasticsearch/index/template_test.go
+++ b/internal/elasticsearch/index/template_test.go
@@ -28,7 +28,7 @@ func TestAccResourceIndexTemplate(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test", "priority", "42"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test", "template.0.alias.#", "1"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test2", "name", fmt.Sprintf("%s-stream", templateName)),
-					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test2", "data_stream.0.allow_custom_routing", "true"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test2", "data_stream.0.hidden", "true"),
 				),
 			},
 			{
@@ -38,7 +38,7 @@ func TestAccResourceIndexTemplate(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_index_template.test", "index_patterns.*", fmt.Sprintf("%s-logs-*", templateName)),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test", "template.0.alias.#", "2"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test2", "name", fmt.Sprintf("%s-stream", templateName)),
-					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test2", "data_stream.0.allow_custom_routing", "false"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_template.test2", "data_stream.0.hidden", "false"),
 				),
 			},
 		},
@@ -73,7 +73,7 @@ resource "elasticstack_elasticsearch_index_template" "test2" {
 
   index_patterns = ["index-pattern-streams*"]
   data_stream {
-    allow_custom_routing = true
+    hidden = true
   }
 }
 	`, name, name, name)
@@ -109,7 +109,7 @@ resource "elasticstack_elasticsearch_index_template" "test2" {
 
   index_patterns = ["index-pattern-streams*"]
   data_stream {
-    allow_custom_routing = false
+    hidden = false
   }
 }
 	`, name, name, name)


### PR DESCRIPTION
I'm trying to follow docs from https://www.jenkins.io/doc/book/pipeline/syntax/#declarative-matrix to create a matrix job to test this provider with different versions of the ES 

This is the initial PR and just adds 2 ES version `'8.0.0'` and `'7.15.1'`. I just want to make sure the job does what it's supposed to do and later I also plan to run different tests depending on the version major version `8.x` or `7.x` 

Looking great: 
<img width="422" alt="image" src="https://user-images.githubusercontent.com/1931331/155316443-7c7af290-242f-4f83-98b8-2362c2c0d108.png">
