### PR TITLE
[ISSUE-125] Add allow_restricted_indices setting to security role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+*.vscode
 
 website/vendor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixed
 - Correctly identify a missing security user ([#101](https://github.com/elastic/terraform-provider-elasticstack/issues/101))
 - Support **7.x** Elasticsearch < **7.15** by removing the default `media_type` attribute in the Append processor ([#118](https://github.com/elastic/terraform-provider-elasticstack/pull/118))
+- Add `allow_restricted_indices` setting to security role ([#125](https://github.com/elastic/terraform-provider-elasticstack/issues/125))
 
 ## [0.3.3] - 2023-03-22
 ### Fixed

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -99,6 +99,7 @@ Optional:
 
 - **field_security** (Block List, Max: 1) The document fields that the owners of the role have read access to. (see [below for nested schema](#nestedblock--indices--field_security))
 - **query** (String) A search query that defines the documents the owners of the role have read access to.
+- **allow_restricted_indices** (Boolean) Include matching restricted indices in names parameter (usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information).
 
 <a id="nestedblock--indices--field_security"></a>
 ### Nested Schema for `indices.field_security`

--- a/internal/elasticsearch/security/role.go
+++ b/internal/elasticsearch/security/role.go
@@ -127,7 +127,7 @@ func ResourceRole() *schema.Resource {
 						Optional:         true,
 					},
 					"allow_restricted_indices": {
-						Description: "Include matching restricted indices in names parameter.",
+						Description: "Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.",
 						Type:        schema.TypeBool,
 						Optional:    true,
 					},

--- a/internal/elasticsearch/security/role.go
+++ b/internal/elasticsearch/security/role.go
@@ -126,6 +126,11 @@ func ResourceRole() *schema.Resource {
 						DiffSuppressFunc: utils.DiffJsonSuppress,
 						Optional:         true,
 					},
+					"allow_restricted_indices": {
+						Description: "Include matching restricted indices in names parameter.",
+						Type:        schema.TypeBool,
+						Optional:    true,
+					},
 				},
 			},
 		},
@@ -269,6 +274,10 @@ func resourceSecurityRolePut(ctx context.Context, d *schema.ResourceData, meta i
 				}
 				newIndex.FieldSecurity = &fieldSecurity
 			}
+
+			allowRestrictedIndices := index["allow_restricted_indices"].(bool)
+			newIndex.AllowRestrictedIndices = &allowRestrictedIndices
+
 			indices[i] = newIndex
 		}
 		role.Indices = indices
@@ -392,6 +401,7 @@ func flattenIndicesData(indices *[]models.IndexPerms) []interface{} {
 			oi["names"] = index.Names
 			oi["privileges"] = index.Privileges
 			oi["query"] = index.Query
+			oi["allow_restricted_indices"] = index.AllowRestrictedIndices
 
 			if index.FieldSecurity != nil {
 				fsec := make(map[string]interface{})

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -58,8 +58,8 @@ resource "elasticstack_elasticsearch_security_role" "test" {
   cluster = ["all"]
 
   indices {
-    names      = ["index1", "index2"]
-    privileges = ["all"]
+    names                    = ["index1", "index2"]
+    privileges               = ["all"]
   }
 
   applications {

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -62,7 +62,7 @@ resource "elasticstack_elasticsearch_security_role" "test" {
   indices {
     names                    = ["index1", "index2"]
     privileges               = ["all"]
-		allow_restricted_indices = true
+    allow_restricted_indices = true
   }
 
   applications {

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -24,6 +24,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 				Config: testAccResourceSecurityRoleCreate(roleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "indices.0.allow_restricted_indices", "true"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "indices.*.names.*", "index1"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "indices.*.names.*", "index2"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "cluster.*", "all"),
@@ -41,6 +42,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 					resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_security_role.test", "run_as"),
 					resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_security_role.test", "global"),
 					resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_security_role.test", "applications"),
+					resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_security_role.test", "indices.0.allow_restricted_indices"),
 				),
 			},
 		},
@@ -60,6 +62,7 @@ resource "elasticstack_elasticsearch_security_role" "test" {
   indices {
     names                    = ["index1", "index2"]
     privileges               = ["all"]
+		allow_restricted_indices = true
   }
 
   applications {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -22,10 +22,11 @@ type Role struct {
 }
 
 type IndexPerms struct {
-	FieldSecurity *FieldSecurity `json:"field_security,omitempty"`
-	Names         []string       `json:"names"`
-	Privileges    []string       `json:"privileges"`
-	Query         *string        `json:"query,omitempty"`
+	FieldSecurity          *FieldSecurity `json:"field_security,omitempty"`
+	Names                  []string       `json:"names"`
+	Privileges             []string       `json:"privileges"`
+	Query                  *string        `json:"query,omitempty"`
+	AllowRestrictedIndices *bool          `json:"allow_restricted_indices,omitempty"`
 }
 
 type FieldSecurity struct {

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,0 @@
-provider "elasticstack" {
-  elasticsearch {
-    username  = "elastic"
-    password  = "changeme"
-    endpoints = ["http://localhost:9200"]
-  }
-}
-

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,8 @@
+provider "elasticstack" {
+  elasticsearch {
+    username  = "elastic"
+    password  = "changeme"
+    endpoints = ["http://localhost:9200"]
+  }
+}
+


### PR DESCRIPTION
- Add allow_restricted_indices setting (identified as missing: https://github.com/elastic/terraform-provider-elasticstack/issues/125)