### PR TITLE
Add api key option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Added
+- Allow use of `api_key` instead of `username`/`password` for authentication ([#130](https://github.com/elastic/terraform-provider-elasticstack/pull/130))
 ### Fixed
 - Correctly identify a missing security user ([#101](https://github.com/elastic/terraform-provider-elasticstack/issues/101))
 - Support **7.x** Elasticsearch < **7.15** by removing the default `media_type` attribute in the Append processor ([#118](https://github.com/elastic/terraform-provider-elasticstack/pull/118))

--- a/README.md
+++ b/README.md
@@ -53,11 +53,23 @@ provider "elasticstack" {
 }
 ```
 
+Alternatively an `api_key` can be specified instead of `username` and `password`:
+
+```terraform
+provider "elasticstack" {
+  elasticsearch {
+    api_key  = "base64encodedapikeyhere=="
+    endpoints = ["http://localhost:9200"]
+  }
+}
+```
 
 #### Environment Variables
 
 You can provide your credentials for the default connection via the `ELASTICSEARCH_USERNAME`, `ELASTICSEARCH_PASSWORD` and comma-separated list `ELASTICSEARCH_ENDPOINTS`,
 environment variables, representing your user, password and Elasticsearch API endpoints respectively.
+
+Alternatively the `ELASTICSEARCH_API_KEY` variable can be specified instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`.
 
 ```terraform
 provider "elasticstack" {

--- a/docs/data-sources/elasticsearch_security_user.md
+++ b/docs/data-sources/elasticsearch_security_user.md
@@ -51,6 +51,7 @@ output "user" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/data-sources/elasticsearch_snapshot_repository.md
+++ b/docs/data-sources/elasticsearch_snapshot_repository.md
@@ -79,6 +79,7 @@ output "repo_url" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,11 +38,23 @@ provider "elasticstack" {
 }
 ```
 
+Alternatively an `api_key` can be specified instead of `username` and `password`:
+
+```terraform
+provider "elasticstack" {
+  elasticsearch {
+    api_key  = "base64encodedapikeyhere=="
+    endpoints = ["http://localhost:9200"]
+  }
+}
+```
 
 ### Environment Variables
 
 You can provide your credentials for the default connection via the `ELASTICSEARCH_USERNAME`, `ELASTICSEARCH_PASSWORD` and comma-separated list `ELASTICSEARCH_ENDPOINTS`,
 environment variables, representing your user, password and Elasticsearch API endpoints respectively.
+
+Alternatively the `ELASTICSEARCH_API_KEY` variable can be specified instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`.
 
 ```terraform
 provider "elasticstack" {
@@ -80,6 +92,7 @@ provider "elasticstack" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_cluster_settings.md
+++ b/docs/resources/elasticsearch_cluster_settings.md
@@ -64,6 +64,7 @@ resource "elasticstack_elasticsearch_cluster_settings" "my_cluster_settings" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_component_template.md
+++ b/docs/resources/elasticsearch_component_template.md
@@ -89,6 +89,7 @@ Optional:
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_data_stream.md
+++ b/docs/resources/elasticsearch_data_stream.md
@@ -95,6 +95,7 @@ resource "elasticstack_elasticsearch_data_stream" "my_data_stream" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -103,6 +103,7 @@ Optional:
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -183,6 +183,7 @@ Required:
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_index_template.md
+++ b/docs/resources/elasticsearch_index_template.md
@@ -81,6 +81,7 @@ Optional:
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_ingest_pipeline.md
+++ b/docs/resources/elasticsearch_ingest_pipeline.md
@@ -94,6 +94,7 @@ resource "elasticstack_elasticsearch_ingest_pipeline" "ingest" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -80,6 +80,7 @@ Required:
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation
@@ -97,9 +98,9 @@ Required:
 
 Optional:
 
+- **allow_restricted_indices** (Boolean) Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.
 - **field_security** (Block List, Max: 1) The document fields that the owners of the role have read access to. (see [below for nested schema](#nestedblock--indices--field_security))
 - **query** (String) A search query that defines the documents the owners of the role have read access to.
-- **allow_restricted_indices** (Boolean) Include matching restricted indices in names parameter (usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information).
 
 <a id="nestedblock--indices--field_security"></a>
 ### Nested Schema for `indices.field_security`

--- a/docs/resources/elasticsearch_security_user.md
+++ b/docs/resources/elasticsearch_security_user.md
@@ -80,6 +80,7 @@ resource "elasticstack_elasticsearch_security_user" "dev" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_snapshot_lifecycle.md
+++ b/docs/resources/elasticsearch_snapshot_lifecycle.md
@@ -79,6 +79,7 @@ resource "elasticstack_elasticsearch_snapshot_lifecycle" "slm_policy" {
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/docs/resources/elasticsearch_snapshot_repository.md
+++ b/docs/resources/elasticsearch_snapshot_repository.md
@@ -82,6 +82,7 @@ Optional:
 
 Optional:
 
+- **api_key** (String, Sensitive) API Key to use for authentication to Elasticsearch
 - **ca_file** (String) Path to a custom Certificate Authority certificate
 - **endpoints** (List of String, Sensitive) A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.
 - **insecure** (Boolean) Disable TLS certificate validation

--- a/examples/provider/provider-apikey.tf
+++ b/examples/provider/provider-apikey.tf
@@ -1,0 +1,6 @@
+provider "elasticstack" {
+  elasticsearch {
+    api_key   = "base64encodedapikeyhere=="
+    endpoints = ["http://localhost:9200"]
+  }
+}

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -24,8 +24,14 @@ func PreCheck(t *testing.T) {
 	_, endpointsOk := os.LookupEnv("ELASTICSEARCH_ENDPOINTS")
 	_, userOk := os.LookupEnv("ELASTICSEARCH_USERNAME")
 	_, passOk := os.LookupEnv("ELASTICSEARCH_PASSWORD")
+	_, apikeyOk := os.LookupEnv("ELASTICSEARCH_API_KEY")
 
-	if !endpointsOk || !userOk || !passOk {
-		t.Fatal("ELASTICSEARCH_ENDPOINTS, ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD must be set for acceptance tests to run")
+	if !endpointsOk {
+		t.Fatal("ELASTICSEARCH_ENDPOINTS must be set for acceptance tests to run")
+	}
+
+	usernamePasswordOk := userOk && passOk
+	if !((!usernamePasswordOk && apikeyOk) || (usernamePasswordOk && !apikeyOk)) {
+		t.Fatal("Either ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD must be set, or ELASTICSEARCH_API_KEY must be set for acceptance tests to run")
 	}
 }

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -65,6 +65,9 @@ func NewApiClientFunc(version string, p *schema.Provider) func(context.Context, 
 				if password, ok := esConfig["password"]; ok {
 					config.Password = password.(string)
 				}
+				if apikey, ok := esConfig["api_key"]; ok {
+					config.APIKey = apikey.(string)
+				}
 
 				// default endpoints taken from Env if set
 				if es := os.Getenv("ELASTICSEARCH_ENDPOINTS"); es != "" {
@@ -132,6 +135,9 @@ func NewApiClient(d *schema.ResourceData, meta interface{}) (*ApiClient, error) 
 		}
 		if p := conn["password"]; p != nil {
 			config.Password = p.(string)
+		}
+		if k := conn["api_key"]; k != nil {
+			config.APIKey = k.(string)
 		}
 		if endpoints := conn["endpoints"]; endpoints != nil {
 			var addrs []string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -40,6 +40,13 @@ func New(version string) func() *schema.Provider {
 								Sensitive:   true,
 								DefaultFunc: schema.EnvDefaultFunc("ELASTICSEARCH_PASSWORD", nil),
 							},
+							"api_key": {
+								Description: "API Key to use for authentication to Elasticsearch",
+								Type:        schema.TypeString,
+								Optional:    true,
+								Sensitive:   true,
+								DefaultFunc: schema.EnvDefaultFunc("ELASTICSEARCH_API_KEY", nil),
+							},
 							"endpoints": {
 								Description: "A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.",
 								Type:        schema.TypeList,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -137,6 +137,13 @@ func AddConnectionSchema(providedSchema map[string]*schema.Schema) {
 					Sensitive:    true,
 					RequiredWith: []string{"elasticsearch_connection.0.username"},
 				},
+				"api_key": {
+					Description:   "API Key to use for authentication to Elasticsearch",
+					Type:          schema.TypeString,
+					Optional:      true,
+					Sensitive:     true,
+					ConflictsWith: []string{"elasticsearch_connection.0.username", "elasticsearch_connection.0.password"},
+				},
 				"endpoints": {
 					Description: "A list of endpoints the Terraform provider will point to. They must include the http(s) schema and port number.",
 					Type:        schema.TypeList,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -30,11 +30,16 @@ Default static credentials can be provided by adding the `username`, `password` 
 
 {{tffile "examples/provider/provider.tf"}}
 
+Alternatively an `api_key` can be specified instead of `username` and `password`:
+
+{{tffile "examples/provider/provider-apikey.tf"}}
 
 ### Environment Variables
 
 You can provide your credentials for the default connection via the `ELASTICSEARCH_USERNAME`, `ELASTICSEARCH_PASSWORD` and comma-separated list `ELASTICSEARCH_ENDPOINTS`,
 environment variables, representing your user, password and Elasticsearch API endpoints respectively.
+
+Alternatively the `ELASTICSEARCH_API_KEY` variable can be specified instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`.
 
 {{tffile "examples/provider/provider-env.tf"}}
 


### PR DESCRIPTION
The https://pkg.go.dev/github.com/elastic/go-elasticsearch/v8 client supports both username/password auth, as well as API Key. However the Terraform provider currently only supports username/password. I've made a quick change to allow the API Key to be specified instead. It is mainly just a schema change, and then the API client config needs to use the value from the provider schema.

I've tested this with one of my local projects, and it successfully created the user and role resources using only the API Key. Also the acceptance tests pass:

```
TF_ACC=1 go test -v ./... -count 1 -parallel 10  -timeout 120m
?       github.com/elastic/terraform-provider-elasticstack      [no test files]
?       github.com/elastic/terraform-provider-elasticstack/internal/acctest     [no test files]
?       github.com/elastic/terraform-provider-elasticstack/internal/clients     [no test files]
=== RUN   TestAccResourceClusterSettings
--- PASS: TestAccResourceClusterSettings (14.60s)
=== RUN   TestAccResourceSLM
--- PASS: TestAccResourceSLM (14.59s)
=== RUN   TestAccDataSourceSnapRepoFs
--- PASS: TestAccDataSourceSnapRepoFs (9.49s)
=== RUN   TestAccDataSourceSnapRepoUrl
--- PASS: TestAccDataSourceSnapRepoUrl (9.49s)
=== RUN   TestAccResourceSnapRepoFs
--- PASS: TestAccResourceSnapRepoFs (6.98s)
=== RUN   TestAccResourceSnapRepoUrl
--- PASS: TestAccResourceSnapRepoUrl (10.43s)
PASS
ok      github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/cluster       65.782s
=== RUN   TestAccResourceComponentTemplate
--- PASS: TestAccResourceComponentTemplate (12.73s)
=== RUN   TestAccResourceDataStream
--- PASS: TestAccResourceDataStream (9.19s)
=== RUN   TestAccResourceILM
--- PASS: TestAccResourceILM (11.57s)
=== RUN   TestAccResourceIndex
--- PASS: TestAccResourceIndex (11.79s)
=== RUN   TestAccResourceIndexTemplate
--- PASS: TestAccResourceIndexTemplate (10.19s)
PASS
ok      github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/index 55.673s
=== RUN   TestAccResourceIngestPipeline
--- PASS: TestAccResourceIngestPipeline (14.66s)
=== RUN   TestAccDataSourceIngestProcessorAppend
--- PASS: TestAccDataSourceIngestProcessorAppend (10.00s)
=== RUN   TestAccDataSourceIngestProcessorBytes
--- PASS: TestAccDataSourceIngestProcessorBytes (8.86s)
=== RUN   TestAccDataSourceIngestProcessorCircle
--- PASS: TestAccDataSourceIngestProcessorCircle (9.30s)
=== RUN   TestAccDataSourceIngestProcessorCommunityId
--- PASS: TestAccDataSourceIngestProcessorCommunityId (5.90s)
=== RUN   TestAccDataSourceIngestProcessorConvert
--- PASS: TestAccDataSourceIngestProcessorConvert (8.71s)
=== RUN   TestAccDataSourceIngestProcessorCSV
--- PASS: TestAccDataSourceIngestProcessorCSV (9.53s)
=== RUN   TestAccDataSourceIngestProcessorDate
--- PASS: TestAccDataSourceIngestProcessorDate (8.04s)
=== RUN   TestAccDataSourceIngestProcessorDateIndexName
--- PASS: TestAccDataSourceIngestProcessorDateIndexName (11.23s)
=== RUN   TestAccDataSourceIngestProcessorDissect
--- PASS: TestAccDataSourceIngestProcessorDissect (5.55s)
=== RUN   TestAccDataSourceIngestProcessorDotExpander
--- PASS: TestAccDataSourceIngestProcessorDotExpander (5.16s)
=== RUN   TestAccDataSourceIngestProcessorDrop
--- PASS: TestAccDataSourceIngestProcessorDrop (5.13s)
=== RUN   TestAccDataSourceIngestProcessorFail
--- PASS: TestAccDataSourceIngestProcessorFail (5.12s)
=== RUN   TestAccDataSourceIngestProcessorFingerprint
--- PASS: TestAccDataSourceIngestProcessorFingerprint (4.84s)
=== RUN   TestAccDataSourceIngestProcessorForeach
--- PASS: TestAccDataSourceIngestProcessorForeach (3.85s)
=== RUN   TestAccDataSourceIngestProcessorGeoip
--- PASS: TestAccDataSourceIngestProcessorGeoip (4.74s)
=== RUN   TestAccDataSourceIngestProcessorGrok
--- PASS: TestAccDataSourceIngestProcessorGrok (3.88s)
=== RUN   TestAccDataSourceIngestProcessorGsub
--- PASS: TestAccDataSourceIngestProcessorGsub (4.20s)
=== RUN   TestAccDataSourceIngestProcessorHtmlStrip
--- PASS: TestAccDataSourceIngestProcessorHtmlStrip (4.38s)
=== RUN   TestAccDataSourceIngestProcessorJoin
--- PASS: TestAccDataSourceIngestProcessorJoin (3.94s)
=== RUN   TestAccDataSourceIngestProcessorJson
--- PASS: TestAccDataSourceIngestProcessorJson (3.94s)
=== RUN   TestAccDataSourceIngestProcessorKV
--- PASS: TestAccDataSourceIngestProcessorKV (3.95s)
=== RUN   TestAccDataSourceIngestProcessorLowercase
--- PASS: TestAccDataSourceIngestProcessorLowercase (3.60s)
=== RUN   TestAccDataSourceIngestProcessorNetworkDirection
--- PASS: TestAccDataSourceIngestProcessorNetworkDirection (3.92s)
=== RUN   TestAccDataSourceIngestProcessorPipeline
--- PASS: TestAccDataSourceIngestProcessorPipeline (4.27s)
=== RUN   TestAccDataSourceIngestProcessorRegisteredDomain
--- PASS: TestAccDataSourceIngestProcessorRegisteredDomain (3.50s)
=== RUN   TestAccDataSourceIngestProcessorRemove
--- PASS: TestAccDataSourceIngestProcessorRemove (3.73s)
=== RUN   TestAccDataSourceIngestProcessorRename
--- PASS: TestAccDataSourceIngestProcessorRename (3.74s)
=== RUN   TestAccDataSourceIngestProcessorScript
--- PASS: TestAccDataSourceIngestProcessorScript (3.56s)
=== RUN   TestAccDataSourceIngestProcessorSet
--- PASS: TestAccDataSourceIngestProcessorSet (3.39s)
=== RUN   TestAccDataSourceIngestProcessorSetSecurityUser
--- PASS: TestAccDataSourceIngestProcessorSetSecurityUser (3.73s)
=== RUN   TestAccDataSourceIngestProcessorSort
--- PASS: TestAccDataSourceIngestProcessorSort (3.65s)
=== RUN   TestAccDataSourceIngestProcessorSplit
--- PASS: TestAccDataSourceIngestProcessorSplit (4.85s)
=== RUN   TestAccDataSourceIngestProcessorTrim
--- PASS: TestAccDataSourceIngestProcessorTrim (3.41s)
=== RUN   TestAccDataSourceIngestProcessorUppercase
--- PASS: TestAccDataSourceIngestProcessorUppercase (4.14s)
=== RUN   TestAccDataSourceIngestProcessorUriParts
--- PASS: TestAccDataSourceIngestProcessorUriParts (4.40s)
=== RUN   TestAccDataSourceIngestProcessorUrldecode
--- PASS: TestAccDataSourceIngestProcessorUrldecode (4.42s)
=== RUN   TestAccDataSourceIngestProcessorUserAgent
--- PASS: TestAccDataSourceIngestProcessorUserAgent (4.75s)
PASS
ok      github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/ingest        208.315s
=== RUN   TestAccResourceSecurityRole
--- PASS: TestAccResourceSecurityRole (15.28s)
=== RUN   TestAccDataSourceSecurityUser
--- PASS: TestAccDataSourceSecurityUser (13.49s)
=== RUN   TestAccResourceSecurityUser
--- PASS: TestAccResourceSecurityUser (10.84s)
PASS
ok      github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/security      39.764s
?       github.com/elastic/terraform-provider-elasticstack/internal/models      [no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
PASS
ok      github.com/elastic/terraform-provider-elasticstack/internal/provider    0.021s
=== RUN   TestFlattenMap
=== PAUSE TestFlattenMap
=== RUN   TestDiffIndexTemplateSuppress
=== PAUSE TestDiffIndexTemplateSuppress
=== CONT  TestFlattenMap
--- PASS: TestFlattenMap (0.00s)
=== CONT  TestDiffIndexTemplateSuppress
--- PASS: TestDiffIndexTemplateSuppress (0.00s)
PASS
ok      github.com/elastic/terraform-provider-elasticstack/internal/utils       0.031s
```

Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/71