### PR TITLE
Improve index resource usability by adding individual setting fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## [Unreleased]
 ### Added
+- Add individual setting fields ([#137](https://github.com/elastic/terraform-provider-elasticstack/pull/137))
 - Allow use of `api_key` instead of `username`/`password` for authentication ([#130](https://github.com/elastic/terraform-provider-elasticstack/pull/130))
 ### Fixed
-- Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
+- Ignore user's metadata with underscore prefix ([#143](https://github.com/elastic/terraform-provider-elasticstack/pull/143))
+- Expose provider package ([#142](https://github.com/elastic/terraform-provider-elasticstack/pull/142))
+- Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#139](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
 - Make API calls context aware to be able to handle timeouts ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/138))
 - Correctly identify a missing security user ([#101](https://github.com/elastic/terraform-provider-elasticstack/issues/101))
 - Support **7.x** Elasticsearch < **7.15** by removing the default `media_type` attribute in the Append processor ([#118](https://github.com/elastic/terraform-provider-elasticstack/pull/118))

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Alternatively an `api_key` can be specified instead of `username` and `password`
 ```terraform
 provider "elasticstack" {
   elasticsearch {
-    api_key  = "base64encodedapikeyhere=="
+    api_key   = "base64encodedapikeyhere=="
     endpoints = ["http://localhost:9200"]
   }
 }

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -69,12 +69,66 @@ resource "elasticstack_elasticsearch_index" "my_index" {
 ### Optional
 
 - **alias** (Block Set) Aliases for the index. (see [below for nested schema](#nestedblock--alias))
+- **analysis_analyzer** (String) A JSON string describing the analyzers applied to the index.
+- **analysis_filter** (String) A JSON string describing the filters applied to the index.
+- **analysis_normalizer** (String) A JSON string describing the normalizers applied to the index.
+- **analysis_tokenizer** (String) A JSON string describing the tokenizers applied to the index.
+- **analyze_max_token_count** (Number) The maximum number of tokens that can be produced using _analyze API.
+- **auto_expand_replicas** (String) Set the number of replicas to the node count in the cluster. Set to a dash delimited lower and upper bound (e.g. 0-5) or use all for the upper bound (e.g. 0-all)
+- **blocks_metadata** (Boolean) Set to `true` to disable index metadata reads and writes.
+- **blocks_read** (Boolean) Set to `true` to disable read operations against the index.
+- **blocks_read_only** (Boolean) Set to `true` to make the index and index metadata read only, `false` to allow writes and metadata changes.
+- **blocks_read_only_allow_delete** (Boolean) Identical to `index.blocks.read_only` but allows deleting the index to free up resources.
+- **blocks_write** (Boolean) Set to `true` to disable data write operations against the index. This setting does not affect metadata.
+- **codec** (String) The `default` value compresses stored data with LZ4 compression, but this can be set to `best_compression` which uses DEFLATE for a higher compression ratio. This can be set only on creation.
+- **default_pipeline** (String) The default ingest node pipeline for this index. Index requests will fail if the default pipeline is set and the pipeline does not exist.
 - **elasticsearch_connection** (Block List, Max: 1) Used to establish connection to Elasticsearch server. Overrides environment variables if present. (see [below for nested schema](#nestedblock--elasticsearch_connection))
+- **final_pipeline** (String) Final ingest pipeline for the index. Indexing requests will fail if the final pipeline is set and the pipeline does not exist. The final pipeline always runs after the request pipeline (if specified) and the default pipeline (if it exists). The special pipeline name _none indicates no ingest pipeline will run.
+- **gc_deletes** (String) The length of time that a deleted document's version number remains available for further versioned operations.
+- **highlight_max_analyzed_offset** (Number) The maximum number of characters that will be analyzed for a highlight request.
+- **indexing_slowlog_level** (String) Set which logging level to use for the search slow log, can be: `warn`, `info`, `debug`, `trace`
+- **indexing_slowlog_source** (String) Set the number of characters of the `_source` to include in the slowlog lines, `false` or `0` will skip logging the source entirely and setting it to `true` will log the entire source regardless of size. The original `_source` is reformatted by default to make sure that it fits on a single log line.
+- **indexing_slowlog_threshold_index_debug** (String) Set the cutoff for shard level slow search logging of slow searches for indexing queries, in time units, e.g. `2s`
+- **indexing_slowlog_threshold_index_info** (String) Set the cutoff for shard level slow search logging of slow searches for indexing queries, in time units, e.g. `5s`
+- **indexing_slowlog_threshold_index_trace** (String) Set the cutoff for shard level slow search logging of slow searches for indexing queries, in time units, e.g. `500ms`
+- **indexing_slowlog_threshold_index_warn** (String) Set the cutoff for shard level slow search logging of slow searches for indexing queries, in time units, e.g. `10s`
+- **load_fixed_bitset_filters_eagerly** (Boolean) Indicates whether cached filters are pre-loaded for nested queries. This can be set only on creation.
 - **mappings** (String) Mapping for fields in the index.
 If specified, this mapping can include: field names, [field data types](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html), [mapping parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html).
 **NOTE:** changing datatypes in the existing _mappings_ will force index to be re-created.
-- **settings** (Block List, Max: 1) Configuration options for the index. See, https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings.
+- **max_docvalue_fields_search** (Number) The maximum number of `docvalue_fields` that are allowed in a query.
+- **max_inner_result_window** (Number) The maximum value of `from + size` for inner hits definition and top hits aggregations to this index.
+- **max_ngram_diff** (Number) The maximum allowed difference between min_gram and max_gram for NGramTokenizer and NGramTokenFilter.
+- **max_refresh_listeners** (Number) Maximum number of refresh listeners available on each shard of the index.
+- **max_regex_length** (Number) The maximum length of regex that can be used in Regexp Query.
+- **max_rescore_window** (Number) The maximum value of `window_size` for `rescore` requests in searches of this index.
+- **max_result_window** (Number) The maximum value of `from + size` for searches to this index.
+- **max_script_fields** (Number) The maximum number of `script_fields` that are allowed in a query.
+- **max_shingle_diff** (Number) The maximum allowed difference between max_shingle_size and min_shingle_size for ShingleTokenFilter.
+- **max_terms_count** (Number) The maximum number of terms that can be used in Terms Query.
+- **number_of_replicas** (Number) Number of shard replicas.
+- **number_of_routing_shards** (Number) Value used with number_of_shards to route documents to a primary shard. This can be set only on creation.
+- **number_of_shards** (Number) Number of shards for the index. This can be set only on creation.
+- **query_default_field** (Set of String) Wildcard (*) patterns matching one or more fields. Defaults to '*', which matches all fields eligible for term-level queries, excluding metadata fields.
+- **refresh_interval** (String) How often to perform a refresh operation, which makes recent changes to the index visible to search. Can be set to `-1` to disable refresh.
+- **routing_allocation_enable** (String) Controls shard allocation for this index. It can be set to: `all` , `primaries` , `new_primaries` , `none`.
+- **routing_partition_size** (Number) The number of shards a custom routing value can go to. This can be set only on creation.
+- **routing_rebalance_enable** (String) Enables shard rebalancing for this index. It can be set to: `all`, `primaries` , `replicas` , `none`.
+- **search_idle_after** (String) How long a shard can not receive a search or get request until it’s considered search idle.
+- **search_slowlog_level** (String) Set which logging level to use for the search slow log, can be: `warn`, `info`, `debug`, `trace`
+- **search_slowlog_threshold_fetch_debug** (String) Set the cutoff for shard level slow search logging of slow searches in the fetch phase, in time units, e.g. `2s`
+- **search_slowlog_threshold_fetch_info** (String) Set the cutoff for shard level slow search logging of slow searches in the fetch phase, in time units, e.g. `5s`
+- **search_slowlog_threshold_fetch_trace** (String) Set the cutoff for shard level slow search logging of slow searches in the fetch phase, in time units, e.g. `500ms`
+- **search_slowlog_threshold_fetch_warn** (String) Set the cutoff for shard level slow search logging of slow searches in the fetch phase, in time units, e.g. `10s`
+- **search_slowlog_threshold_query_debug** (String) Set the cutoff for shard level slow search logging of slow searches in the query phase, in time units, e.g. `2s`
+- **search_slowlog_threshold_query_info** (String) Set the cutoff for shard level slow search logging of slow searches in the query phase, in time units, e.g. `5s`
+- **search_slowlog_threshold_query_trace** (String) Set the cutoff for shard level slow search logging of slow searches in the query phase, in time units, e.g. `500ms`
+- **search_slowlog_threshold_query_warn** (String) Set the cutoff for shard level slow search logging of slow searches in the query phase, in time units, e.g. `10s`
+- **settings** (Block List, Max: 1, Deprecated) DEPRECATED: Please use dedicated setting field. Configuration options for the index. See, https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-modules-settings.
 **NOTE:** Static index settings (see: https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#_static_index_settings) can be only set on the index creation and later cannot be removed or updated - _apply_ will return error (see [below for nested schema](#nestedblock--settings))
+- **shard_check_on_startup** (String) Whether or not shards should be checked for corruption before opening. When corruption is detected, it will prevent the shard from being opened. Accepts `false`, `true`, `checksum`.
+- **sort_field** (Set of String) The field to sort shards in this index by.
+- **sort_order** (List of String) The direction to sort shards in. Accepts `asc`, `desc`.
 
 ### Read-Only
 

--- a/internal/elasticsearch/index/index_test.go
+++ b/internal/elasticsearch/index/index_test.go
@@ -2,6 +2,7 @@ package index_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -12,10 +13,9 @@ import (
 )
 
 func TestAccResourceIndex(t *testing.T) {
-	// generate renadom index name
 	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceIndexDestroy,
 		ProviderFactories: acctest.Providers,
@@ -39,6 +39,99 @@ func TestAccResourceIndex(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test", "alias.#", "1"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test", "settings.#", "0"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourceIndexSettings(t *testing.T) {
+	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		CheckDestroy:      checkResourceIndexDestroy,
+		ProviderFactories: acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceIndexSettingsCreate(indexName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "name", indexName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "number_of_shards", "2"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "number_of_routing_shards", "2"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "codec", "best_compression"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "routing_partition_size", "1"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "shard_check_on_startup", "false"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "sort_field.0", "sort_key"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "sort_order.0", "asc"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "auto_expand_replicas", "0-5"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "search_idle_after", "30s"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "refresh_interval", "10s"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_result_window", "5000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_inner_result_window", "2000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_rescore_window", "1000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_docvalue_fields_search", "1500"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_script_fields", "500"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_ngram_diff", "100"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_shingle_diff", "200"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_refresh_listeners", "10"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "analyze_max_token_count", "500000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "highlight_max_analyzed_offset", "1000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_terms_count", "10000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "max_regex_length", "1000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "query_default_field.0", "field1"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "routing_allocation_enable", "primaries"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "routing_rebalance_enable", "primaries"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "gc_deletes", "30s"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "analysis_analyzer", `{"text_en":{"filter":["lowercase","minimal_english_stemmer"],"tokenizer":"standard","type":"custom"}}`),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "analysis_filter", `{"minimal_english_stemmer":{"language":"minimal_english","type":"stemmer"}}`),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "settings.0.setting.0.name", "number_of_replicas"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings", "settings.0.setting.0.value", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceIndexSettingsMigration(t *testing.T) {
+	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		CheckDestroy:      checkResourceIndexDestroy,
+		ProviderFactories: acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceIndexSettingsMigrationCreate(indexName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "name", indexName),
+					resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "number_of_replicas"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "settings.0.setting.0.name", "number_of_replicas"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "settings.0.setting.0.value", "2"),
+				),
+			},
+			{
+				Config: testAccResourceIndexSettingsMigrationUpdate(indexName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "name", indexName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "number_of_replicas", "1"),
+					resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_index.test_settings_migration", "settings.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceIndexSettingsConflict(t *testing.T) {
+	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		CheckDestroy:      checkResourceIndexDestroy,
+		ProviderFactories: acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceIndexSettingsConflict(indexName),
+				ExpectError: regexp.MustCompile("setting 'number_of_shards' is already defined by the other field, please remove it from `settings` not to produce unexpected settings"),
 			},
 		},
 	})
@@ -101,6 +194,132 @@ resource "elasticstack_elasticsearch_index" "test" {
       field1 = { type = "text" }
     }
   })
+}
+	`, name)
+}
+
+func testAccResourceIndexSettingsCreate(name string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index" "test_settings" {
+  name = "%s"
+
+  mappings = jsonencode({
+    properties = {
+      field1    = { type = "text" }
+      sort_key = { type = "keyword" }
+    }
+  })
+
+  number_of_shards = 2
+  number_of_routing_shards = 2
+  codec = "best_compression"
+  routing_partition_size = 1
+  shard_check_on_startup = "false"
+  sort_field = ["sort_key"]
+  sort_order = ["asc"]
+  auto_expand_replicas =  "0-5"
+  search_idle_after = "30s"
+  refresh_interval = "10s"
+  max_result_window = 5000
+  max_inner_result_window = 2000
+  max_rescore_window = 1000
+  max_docvalue_fields_search = 1500
+  max_script_fields = 500
+  max_ngram_diff = 100
+  max_shingle_diff = 200
+  max_refresh_listeners = 10
+  analyze_max_token_count = 500000
+  highlight_max_analyzed_offset = 1000
+  max_terms_count = 10000
+  max_regex_length = 1000
+  query_default_field = ["field1"]
+  routing_allocation_enable = "primaries"
+  routing_rebalance_enable = "primaries"
+  gc_deletes = "30s"
+  analysis_analyzer = jsonencode({
+    text_en = { 
+      type = "custom" 
+      tokenizer = "standard"
+      filter = ["lowercase", "minimal_english_stemmer"]
+    }
+  })
+  analysis_filter = jsonencode({
+    minimal_english_stemmer = {
+      type     = "stemmer"
+      language = "minimal_english"
+    }
+  })
+
+  settings {
+    setting {
+      name  = "number_of_replicas"
+      value = "2"
+    }
+  }
+}
+	`, name)
+}
+
+func testAccResourceIndexSettingsMigrationCreate(name string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index" "test_settings_migration" {
+  name = "%s"
+
+  settings {
+    setting {
+      name  = "number_of_replicas"
+      value = "2"
+    }
+  }
+}
+	`, name)
+}
+
+func testAccResourceIndexSettingsMigrationUpdate(name string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index" "test_settings_migration" {
+  name = "%s"
+
+  number_of_replicas = 1
+}
+	`, name)
+}
+
+func testAccResourceIndexSettingsConflict(name string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index" "test_settings_conflict" {
+  name = "%s"
+
+  mappings = jsonencode({
+    properties = {
+      field1    = { type = "text" }
+    }
+  })
+
+  number_of_shards = 2
+
+  settings {
+    setting {
+      name  = "number_of_shards"
+      value = "3"
+    }
+  }
 }
 	`, name)
 }

--- a/internal/elasticsearch/index/index_test.go
+++ b/internal/elasticsearch/index/index_test.go
@@ -131,7 +131,7 @@ func TestAccResourceIndexSettingsConflict(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceIndexSettingsConflict(indexName),
-				ExpectError: regexp.MustCompile("setting 'number_of_shards' is already defined by the other field, please remove it from `settings` not to produce unexpected settings"),
+				ExpectError: regexp.MustCompile("setting 'number_of_shards' is already defined by the other field, please remove it from `settings` to avoid unexpected settings"),
 			},
 		},
 	})


### PR DESCRIPTION
Resolves #124 

As mentioned in #124, current `settings` field's usability is low due to the limitation of type(string object with no nest) and causing issues like #108 and #119 .

This PR introduces individual fields to improve usability by allowing json for some fields like `analyzer` and robustness by having strict key and value type for each setting key.

### NOTE
- This PR is backward compatible, so the `settings` field is deprecated but still usable until we remove it (in  next major version update?).
- The schema is pretty much same as `phillbaker/terraform-provider-elasticsearch`'s [index resource](https://github.com/phillbaker/terraform-provider-elasticsearch/blob/master/es/resource_elasticsearch_index.go).  So it also makes it easier to migrate from `phillbaker/terraform-provider-elasticsearch`.
