### PR TITLE
Parallelize acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 ### Added
 - Allow use of `api_key` instead of `username`/`password` for authentication ([#130](https://github.com/elastic/terraform-provider-elasticstack/pull/130))
 ### Fixed
-- Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
+- Parallelize acceptance tests ([#140](https://github.com/elastic/terraform-provider-elasticstack/pull/140))
+- Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#139](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
 - Make API calls context aware to be able to handle timeouts ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/138))
 - Correctly identify a missing security user ([#101](https://github.com/elastic/terraform-provider-elasticstack/issues/101))
 - Support **7.x** Elasticsearch < **7.15** by removing the default `media_type` attribute in the Append processor ([#118](https://github.com/elastic/terraform-provider-elasticstack/pull/118))

--- a/internal/elasticsearch/cluster/settings_test.go
+++ b/internal/elasticsearch/cluster/settings_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccResourceClusterSettings(t *testing.T) {
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceClusterSettingsDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/cluster/slm_test.go
+++ b/internal/elasticsearch/cluster/slm_test.go
@@ -15,7 +15,7 @@ func TestAccResourceSLM(t *testing.T) {
 	// generate a random policy name
 	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkSlmDestroy(name),
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/cluster/snapshot_repository_data_source_test.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_data_source_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceSnapRepoFs(t *testing.T) {
 	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{
@@ -57,7 +57,7 @@ data "elasticstack_elasticsearch_snapshot_repository" "test_fs_repo" {
 func TestAccDataSourceSnapRepoUrl(t *testing.T) {
 	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/cluster/snapshot_repository_test.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_test.go
@@ -15,7 +15,7 @@ func TestAccResourceSnapRepoFs(t *testing.T) {
 	// generate a random policy name
 	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkRepoDestroy(name),
 		ProviderFactories: acctest.Providers,
@@ -36,7 +36,7 @@ func TestAccResourceSnapRepoFs(t *testing.T) {
 func TestAccResourceSnapRepoUrl(t *testing.T) {
 	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkRepoDestroy(name),
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/index/component_template_test.go
+++ b/internal/elasticsearch/index/component_template_test.go
@@ -15,7 +15,7 @@ func TestAccResourceComponentTemplate(t *testing.T) {
 	// generate a random username
 	templateName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceComponentTemplateDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/index/data_stream_test.go
+++ b/internal/elasticsearch/index/data_stream_test.go
@@ -15,7 +15,7 @@ func TestAccResourceDataStream(t *testing.T) {
 	// generate renadom name
 	dsName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlpha)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceDataStreamDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/index/ilm_test.go
+++ b/internal/elasticsearch/index/ilm_test.go
@@ -15,7 +15,7 @@ func TestAccResourceILM(t *testing.T) {
 	// generate a random policy name
 	policyName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceILMDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/index/index_test.go
+++ b/internal/elasticsearch/index/index_test.go
@@ -15,7 +15,7 @@ func TestAccResourceIndex(t *testing.T) {
 	// generate renadom index name
 	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceIndexDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/index/template_test.go
+++ b/internal/elasticsearch/index/template_test.go
@@ -15,7 +15,7 @@ func TestAccResourceIndexTemplate(t *testing.T) {
 	// generate random template name
 	templateName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceIndexTemplateDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/ingest/pipeline_test.go
+++ b/internal/elasticsearch/ingest/pipeline_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccResourceIngestPipeline(t *testing.T) {
 	pipelineName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceIngestPipelineDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/ingest/processor_append_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_append_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorAppend(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_bytes_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_bytes_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorBytes(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_circle_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_circle_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorCircle(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_community_id_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_community_id_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorCommunityId(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_convert_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_convert_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorConvert(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_csv_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_csv_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorCSV(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_date_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_date_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorDate(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_date_index_name_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_date_index_name_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorDateIndexName(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_dissect_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_dissect_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorDissect(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_dot_expander_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_dot_expander_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorDotExpander(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_drop_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_drop_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorDrop(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_fail_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_fail_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorFail(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_fingerprint_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_fingerprint_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorFingerprint(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_foreach_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_foreach_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorForeach(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_geoip_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_geoip_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorGeoip(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_grok_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_grok_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorGrok(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_gsub_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_gsub_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorGsub(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_html_strip_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_html_strip_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorHtmlStrip(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_join_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_join_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorJoin(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_json_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_json_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorJson(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_kv_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_kv_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorKV(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_lowercase_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_lowercase_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorLowercase(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_network_direction_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_network_direction_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorNetworkDirection(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_pipeline_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_pipeline_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorPipeline(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_registered_domain_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_registered_domain_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorRegisteredDomain(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_remove_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_remove_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorRemove(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_rename_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_rename_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorRename(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_script_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_script_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorScript(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_set_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_set_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorSet(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_set_security_user_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_set_security_user_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorSetSecurityUser(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_sort_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_sort_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorSort(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_split_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_split_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorSplit(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_trim_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_trim_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorTrim(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_uppercase_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_uppercase_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorUppercase(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_uri_parts_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_uri_parts_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorUriParts(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_urldecode_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_urldecode_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorUrldecode(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/ingest/processor_user_agent_data_source_test.go
+++ b/internal/elasticsearch/ingest/processor_user_agent_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceIngestProcessorUserAgent(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -15,7 +15,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 	// generate a random username
 	roleName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceSecurityRoleDestroy,
 		ProviderFactories: acctest.Providers,

--- a/internal/elasticsearch/security/user_data_source_test.go
+++ b/internal/elasticsearch/security/user_data_source_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceSecurityUser(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{

--- a/internal/elasticsearch/security/user_test.go
+++ b/internal/elasticsearch/security/user_test.go
@@ -15,7 +15,7 @@ func TestAccResourceSecurityUser(t *testing.T) {
 	// generate a random username
 	username := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		CheckDestroy:      checkResourceSecurityUserDestroy,
 		ProviderFactories: acctest.Providers,


### PR DESCRIPTION
This PR updates acceptance tests to use `ParallelTest` to be able to run in parallel and reduce time.