### PR TITLE
Debug log each req/res of API call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.22.0
 )
 
@@ -30,7 +31,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.3 // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.14.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect

--- a/internal/clients/cluster.go
+++ b/internal/clients/cluster.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
@@ -19,7 +18,6 @@ func (a *ApiClient) PutElasticsearchSnapshotRepository(ctx context.Context, repo
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending snapshot repository definition to ES API: %s", snapRepoBytes)
 	res, err := a.es.Snapshot.CreateRepository(repository.Name, bytes.NewReader(snapRepoBytes), a.es.Snapshot.CreateRepository.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
@@ -55,7 +53,6 @@ func (a *ApiClient) GetElasticsearchSnapshotRepository(ctx context.Context, name
 	if err := json.NewDecoder(res.Body).Decode(&snapRepoResponse); err != nil {
 		return nil, diag.FromErr(err)
 	}
-	log.Printf("[TRACE] response ES API snapshot repository: %+v", snapRepoResponse)
 
 	if currentRepo, ok := snapRepoResponse[name]; ok {
 		return &currentRepo, diags
@@ -89,7 +86,6 @@ func (a *ApiClient) PutElasticsearchSlm(ctx context.Context, slm *models.Snapsho
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending SLM to ES API: %s", slmBytes)
 	req := a.es.SlmPutLifecycle.WithBody(bytes.NewReader(slmBytes))
 	res, err := a.es.SlmPutLifecycle(slm.Id, req, a.es.SlmPutLifecycle.WithContext(ctx))
 	if err != nil {
@@ -155,7 +151,6 @@ func (a *ApiClient) PutElasticsearchSettings(ctx context.Context, settings map[s
 	if err != nil {
 		diag.FromErr(err)
 	}
-	log.Printf("[TRACE] settings to set: %s", settingsBytes)
 	res, err := a.es.Cluster.PutSettings(bytes.NewReader(settingsBytes), a.es.Cluster.PutSettings.WithContext(ctx))
 	if err != nil {
 		diag.FromErr(err)

--- a/internal/clients/debug.go
+++ b/internal/clients/debug.go
@@ -1,0 +1,86 @@
+package clients
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
+
+var _ esapi.Transport = &debugTransport{}
+
+type debugTransport struct {
+	name      string
+	transport esapi.Transport
+}
+
+func newDebugTransport(name string, transport esapi.Transport) *debugTransport {
+	return &debugTransport{
+		name:      name,
+		transport: transport,
+	}
+}
+
+func (d *debugTransport) Perform(r *http.Request) (*http.Response, error) {
+	ctx := r.Context()
+	reqData, err := httputil.DumpRequestOut(r, true)
+	if err == nil {
+		tflog.Debug(ctx, fmt.Sprintf(logReqMsg, d.name, prettyPrintJsonLines(reqData)))
+	} else {
+		tflog.Debug(ctx, fmt.Sprintf("%s API request dump error: %#v", d.name, err))
+	}
+
+	resp, err := d.transport.Perform(r)
+	if err != nil {
+		return resp, err
+	}
+
+	respData, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		tflog.Debug(ctx, fmt.Sprintf(logRespMsg, d.name, prettyPrintJsonLines(respData)))
+	} else {
+		tflog.Debug(ctx, fmt.Sprintf("%s API response dump error: %#v", d.name, err))
+	}
+
+	return resp, nil
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line,
+// transforming any lines that are complete json into pretty-printed json.
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			if err := json.Indent(&out, b, "", " "); err != nil {
+				continue
+			}
+			parts[i] = out.String()
+		}
+		// Mask Authorization header value
+		if strings.Contains(strings.ToLower(p), "authorization:") {
+			kv := strings.Split(p, ": ")
+			if len(kv) != 2 {
+				continue
+			}
+			kv[1] = strings.Repeat("*", len(kv[1]))
+			parts[i] = strings.Join(kv, ": ")
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/clients/index.go
+++ b/internal/clients/index.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -20,7 +19,6 @@ func (a *ApiClient) PutElasticsearchIlm(ctx context.Context, policy *models.Poli
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending new ILM policy to ES API: %s", policyBytes)
 	req := a.es.ILM.PutLifecycle.WithBody(bytes.NewReader(policyBytes))
 	res, err := a.es.ILM.PutLifecycle(policy.Name, req, a.es.ILM.PutLifecycle.WithContext(ctx))
 	if err != nil {
@@ -53,7 +51,6 @@ func (a *ApiClient) GetElasticsearchIlm(ctx context.Context, policyName string) 
 	if err := json.NewDecoder(res.Body).Decode(&ilm); err != nil {
 		return nil, diag.FromErr(err)
 	}
-	log.Printf("[TRACE] get ILM policy '%s' from ES API: %#+v", policyName, ilm)
 
 	if ilm, ok := ilm[policyName]; ok {
 		return &ilm, diags
@@ -86,7 +83,6 @@ func (a *ApiClient) PutElasticsearchComponentTemplate(ctx context.Context, templ
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending request to ES: %s to create component template '%s' ", templateBytes, template.Name)
 
 	res, err := a.es.Cluster.PutComponentTemplate(template.Name, bytes.NewReader(templateBytes), a.es.Cluster.PutComponentTemplate.WithContext(ctx))
 	if err != nil {
@@ -152,7 +148,6 @@ func (a *ApiClient) PutElasticsearchIndexTemplate(ctx context.Context, template 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending request to ES: %s to create template '%s' ", templateBytes, template.Name)
 
 	res, err := a.es.Indices.PutIndexTemplate(template.Name, bytes.NewReader(templateBytes), a.es.Indices.PutIndexTemplate.WithContext(ctx))
 	if err != nil {
@@ -196,7 +191,6 @@ func (a *ApiClient) GetElasticsearchIndexTemplate(ctx context.Context, templateN
 		return nil, diags
 	}
 	tpl := indexTemplates.IndexTemplates[0]
-	log.Printf("[TRACE] read index template from API: %+v", tpl)
 	return &tpl, diags
 }
 
@@ -219,7 +213,6 @@ func (a *ApiClient) PutElasticsearchIndex(ctx context.Context, index *models.Ind
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] index definition: %s", indexBytes)
 
 	req := a.es.Indices.Create.WithBody(bytes.NewReader(indexBytes))
 	res, err := a.es.Indices.Create(index.Name, req, a.es.Indices.Create.WithContext(ctx))
@@ -276,7 +269,6 @@ func (a *ApiClient) GetElasticsearchIndex(ctx context.Context, name string) (*mo
 
 func (a *ApiClient) DeleteElasticsearchIndexAlias(ctx context.Context, index string, aliases []string) diag.Diagnostics {
 	var diags diag.Diagnostics
-	log.Printf("[TRACE] Deleting aliases for index %s: %v", index, aliases)
 	res, err := a.es.Indices.DeleteAlias([]string{index}, aliases, a.es.Indices.DeleteAlias.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
@@ -294,7 +286,6 @@ func (a *ApiClient) UpdateElasticsearchIndexAlias(ctx context.Context, index str
 	if err != nil {
 		diag.FromErr(err)
 	}
-	log.Printf("[TRACE] updaing index %s alias: %s", index, aliasBytes)
 	req := a.es.Indices.PutAlias.WithBody(bytes.NewReader(aliasBytes))
 	res, err := a.es.Indices.PutAlias([]string{index}, alias.Name, req, a.es.Indices.PutAlias.WithContext(ctx))
 	if err != nil {
@@ -313,7 +304,6 @@ func (a *ApiClient) UpdateElasticsearchIndexSettings(ctx context.Context, index 
 	if err != nil {
 		diag.FromErr(err)
 	}
-	log.Printf("[TRACE] updaing index %s settings: %s", index, settingsBytes)
 	req := a.es.Indices.PutSettings.WithIndex(index)
 	res, err := a.es.Indices.PutSettings(bytes.NewReader(settingsBytes), req, a.es.Indices.PutSettings.WithContext(ctx))
 	if err != nil {
@@ -328,7 +318,6 @@ func (a *ApiClient) UpdateElasticsearchIndexSettings(ctx context.Context, index 
 
 func (a *ApiClient) UpdateElasticsearchIndexMappings(ctx context.Context, index, mappings string) diag.Diagnostics {
 	var diags diag.Diagnostics
-	log.Printf("[TRACE] updaing index %s mappings: %s", index, mappings)
 	req := a.es.Indices.PutMapping.WithIndex(index)
 	res, err := a.es.Indices.PutMapping(strings.NewReader(mappings), req, a.es.Indices.PutMapping.WithContext(ctx))
 	if err != nil {
@@ -375,7 +364,6 @@ func (a *ApiClient) GetElasticsearchDataStream(ctx context.Context, dataStreamNa
 	if err := json.NewDecoder(res.Body).Decode(&dStreams); err != nil {
 		return nil, diag.FromErr(err)
 	}
-	log.Printf("[TRACE] get data stream '%v' from ES api: %+v", dataStreamName, dStreams)
 	// if the DataStream found in must be the first index in the data_stream object
 	ds := dStreams["data_streams"][0]
 	return &ds, diags
@@ -402,7 +390,6 @@ func (a *ApiClient) PutElasticsearchIngestPipeline(ctx context.Context, pipeline
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] creating ingest pipeline %s: %s", pipeline.Name, pipelineBytes)
 
 	res, err := a.es.Ingest.PutPipeline(pipeline.Name, bytes.NewReader(pipelineBytes), a.es.Ingest.PutPipeline.WithContext(ctx))
 	if err != nil {
@@ -437,7 +424,6 @@ func (a *ApiClient) GetElasticsearchIngestPipeline(ctx context.Context, name *st
 	}
 	pipeline := pipelines[*name]
 	pipeline.Name = *name
-	log.Printf("[TRACE] get ingest pipeline %s from ES API: %#+v", *name, pipeline)
 
 	return &pipeline, diags
 }

--- a/internal/clients/security.go
+++ b/internal/clients/security.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
@@ -19,7 +18,6 @@ func (a *ApiClient) PutElasticsearchUser(ctx context.Context, user *models.User)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending request to ES: %s", userBytes)
 	res, err := a.es.Security.PutUser(user.Username, bytes.NewReader(userBytes), a.es.Security.PutUser.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)
@@ -51,7 +49,6 @@ func (a *ApiClient) GetElasticsearchUser(ctx context.Context, username string) (
 	if err := json.NewDecoder(res.Body).Decode(&users); err != nil {
 		return nil, diag.FromErr(err)
 	}
-	log.Printf("[TRACE] Fetch users from ES API: %#+v", users)
 
 	if user, ok := users[username]; ok {
 		return &user, diags
@@ -85,7 +82,6 @@ func (a *ApiClient) PutElasticsearchRole(ctx context.Context, role *models.Role)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Printf("[TRACE] sending request to ES: %s", roleBytes)
 	res, err := a.es.Security.PutRole(role.Name, bytes.NewReader(roleBytes), a.es.Security.PutRole.WithContext(ctx))
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/elasticsearch/index/data_stream.go
+++ b/internal/elasticsearch/index/data_stream.go
@@ -3,7 +3,6 @@ package index
 import (
 	"context"
 	"encoding/json"
-	"log"
 	"regexp"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
@@ -156,7 +155,6 @@ func resourceDataStreamRead(ctx context.Context, d *schema.ResourceData, meta in
 	if diags.HasError() {
 		return diags
 	}
-	log.Printf("[TRACE] read the data stream data: %+v", ds)
 
 	if err := d.Set("name", ds.Name); err != nil {
 		return diag.FromErr(err)

--- a/internal/elasticsearch/index/index.go
+++ b/internal/elasticsearch/index/index.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"reflect"
 	"regexp"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -208,7 +208,7 @@ If specified, this mapping can include: field names, [field data types](https://
 			if err := json.NewDecoder(strings.NewReader(new.(string))).Decode(&n); err != nil {
 				return true
 			}
-			log.Printf("[TRACE] mappings custom diff old = %+v new = %+v", o, n)
+			tflog.Trace(ctx, "mappings custom diff old = %+v new = %+v", o, n)
 
 			var isForceable func(map[string]interface{}, map[string]interface{}) bool
 			isForceable = func(old, new map[string]interface{}) bool {
@@ -363,7 +363,7 @@ func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		oldSettings, newSettings := d.GetChange("settings")
 		os := flattenIndexSettings(oldSettings.([]interface{}))
 		ns := flattenIndexSettings(newSettings.([]interface{}))
-		log.Printf("[TRACE] Change in the settings detected old settings = %+v, new  settings = %+v", os, ns)
+		tflog.Trace(ctx, fmt.Sprintf("Change in the settings detected old settings = %+v, new  settings = %+v", os, ns))
 		// make sure to add setting to the new map which were removed
 		for k, ov := range os {
 			if _, ok := ns[k]; !ok {
@@ -375,7 +375,6 @@ func resourceIndexUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 				delete(ns, k)
 			}
 		}
-		log.Printf("[TRACE] settings to update: %+v", ns)
 		if diags := client.UpdateElasticsearchIndexSettings(ctx, indexName, ns); diags.HasError() {
 			return diags
 		}
@@ -430,7 +429,6 @@ func resourceIndexRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	if diags.HasError() {
 		return diags
 	}
-	log.Printf("[TRACE] read the index data: %+v", index)
 
 	if index.Aliases != nil {
 		aliases, diags := FlattenIndexAliases(index.Aliases)


### PR DESCRIPTION
This PR introduces automatic debug log dump of each req/res instead of manually adding trace logs.
Also `log.Printf` is [legacy](https://www.terraform.io/plugin/log/writing) now, so it's replaced with `tflog`.

It would make it easier to debug an issue.
(e.g. below is the issue in a provider which uses the same debug transport.
https://github.com/k-yomo/terraform-provider-algolia/issues/79