### PR TITLE
Ignore user's metadata with underscore prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## [Unreleased]
 ### Added
 - Allow use of `api_key` instead of `username`/`password` for authentication ([#130](https://github.com/elastic/terraform-provider-elasticstack/pull/130))
+- Add debug log of eac req/res ([#141](https://github.com/elastic/terraform-provider-elasticstack/pull/141))
 ### Fixed
-- Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
+- Ignore user's metadata with underscore prefix ([#143](https://github.com/elastic/terraform-provider-elasticstack/pull/143))
+- Expose provider package ([#142](https://github.com/elastic/terraform-provider-elasticstack/pull/142))
+- Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#139](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
 - Make API calls context aware to be able to handle timeouts ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/138))
 - Correctly identify a missing security user ([#101](https://github.com/elastic/terraform-provider-elasticstack/issues/101))
 - Support **7.x** Elasticsearch < **7.15** by removing the default `media_type` attribute in the Append processor ([#118](https://github.com/elastic/terraform-provider-elasticstack/pull/118))

--- a/docs/resources/elasticsearch_security_user.md
+++ b/docs/resources/elasticsearch_security_user.md
@@ -67,7 +67,7 @@ resource "elasticstack_elasticsearch_security_user" "dev" {
 - **email** (String) The email of the user.
 - **enabled** (Boolean) Specifies whether the user is enabled. The default value is true.
 - **full_name** (String) The full name of the user.
-- **metadata** (String) Arbitrary metadata that you want to associate with the user.
+- **metadata** (String) Arbitrary metadata JSON string that you want to associate with the user. The metadata key can't start with `_`.
 - **password** (String, Sensitive) The user’s password. Passwords must be at least 6 characters long.
 - **password_hash** (String, Sensitive) A hash of the user’s password. This must be produced using the same hashing algorithm as has been configured for password storage (see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#hashing-settings).
 

--- a/internal/elasticsearch/security/user.go
+++ b/internal/elasticsearch/security/user.go
@@ -71,7 +71,7 @@ func ResourceUser() *schema.Resource {
 			},
 		},
 		"metadata": {
-			Description:      "Arbitrary metadata that you want to associate with the user.",
+			Description:      "Arbitrary metadata JSON string that you want to associate with the user. The metadata key can't start with `_`.",
 			Type:             schema.TypeString,
 			Optional:         true,
 			Computed:         true,

--- a/internal/elasticsearch/security/user.go
+++ b/internal/elasticsearch/security/user.go
@@ -3,12 +3,14 @@ package security
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -144,6 +146,12 @@ func resourceSecurityUserPut(ctx context.Context, d *schema.ResourceData, meta i
 		metadata := make(map[string]interface{})
 		if err := json.NewDecoder(strings.NewReader(v.(string))).Decode(&metadata); err != nil {
 			return diag.FromErr(err)
+		}
+		for k := range metadata {
+			if strings.HasPrefix(k, "_") {
+				tflog.Warn(ctx, fmt.Sprintf("user metadata '%s' is ignored due to having not allowed '_' prefix", k))
+				delete(metadata, k)
+			}
 		}
 		user.Metadata = metadata
 	}

--- a/internal/elasticsearch/security/user_test.go
+++ b/internal/elasticsearch/security/user_test.go
@@ -26,7 +26,9 @@ func TestAccResourceSecurityUser(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_user.test", "username", username),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_user.test", "roles.*", "kibana_user"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_user.test", "email", ""),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_user.test", "metadata", `{"test":"abc"}`),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccResourceSecurityUpdate(username),
@@ -47,6 +49,10 @@ resource "elasticstack_elasticsearch_security_user" "test" {
   roles     = ["kibana_user"]
   full_name = "Test User"
   password  = "qwerty123"
+  metadata = jsonencode({
+    test     = "abc"
+    _ignored = true
+  })
 }
 	`, username)
 }


### PR DESCRIPTION
Fixes #104 by ignoring metadata starting with `_` with a warning log.