### PR TITLE
Fix role imoprt example

### DIFF
--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -115,5 +115,5 @@ Optional:
 Import is supported using the following syntax:
 
 ```shell
-terraform import elasticstack_elasticsearch_security_role <cluster_uuid>/<role name>
+terraform import elasticstack_elasticsearch_security_role.my_role <cluster_uuid>/<role name>
 ```

--- a/examples/resources/elasticstack_elasticsearch_security_role/import.sh
+++ b/examples/resources/elasticstack_elasticsearch_security_role/import.sh
@@ -1,1 +1,1 @@
-terraform import elasticstack_elasticsearch_security_role <cluster_uuid>/<role name>
+terraform import elasticstack_elasticsearch_security_role.my_role <cluster_uuid>/<role name>


### PR DESCRIPTION
This PR fixes the missing resource id in the role resource import example.
https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/elasticsearch_security_role#import