### PR TITLE
Refactor deprecated debug method with simplified one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Add individual setting fields ([#137](https://github.com/elastic/terraform-provider-elasticstack/pull/137))
 - Allow use of `api_key` instead of `username`/`password` for authentication ([#130](https://github.com/elastic/terraform-provider-elasticstack/pull/130))
 ### Fixed
-- Ignore user's metadata with underscore prefix ([#143](https://github.com/elastic/terraform-provider-elasticstack/pull/143))
+- Refactor main function not to use deprecated debug method ([#149](https://github.com/elastic/terraform-provider-elasticstack/pull/149))
 - Expose provider package ([#142](https://github.com/elastic/terraform-provider-elasticstack/pull/142))
 - Upgrade Go version to 1.19 and sdk version to v2.22.0 ([#139](https://github.com/elastic/terraform-provider-elasticstack/pull/139))
 - Make API calls context aware to be able to handle timeouts ([#138](https://github.com/elastic/terraform-provider-elasticstack/pull/138))

--- a/main.go
+++ b/main.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"context"
 	"flag"
-	"log"
 
 	"github.com/elastic/terraform-provider-elasticstack/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -26,14 +24,10 @@ func main() {
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	opts := &plugin.ServeOpts{ProviderFunc: provider.New(version)}
-
-	if debugMode {
-		err := plugin.Debug(context.Background(), "registry.terraform.io/elastic/elasticstack", opts)
-		if err != nil {
-			log.Fatal(err.Error())
-		}
-		return
+	opts := &plugin.ServeOpts{
+		ProviderFunc: provider.New(version),
+		ProviderAddr: "registry.terraform.io/elastic/elasticstack",
+		Debug:        debugMode,
 	}
 
 	plugin.Serve(opts)


### PR DESCRIPTION
This PR refactors the main function not to use deprecated `plugin.Debug`.
The change is pretty much the same as the below PR.
https://github.com/hashicorp/terraform-provider-scaffolding/pull/104/files