### PR TITLE
Add Github actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         run: go mod download
 
       - name: Build
-        run: go build -v .
+        run: make build
 
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Build/Lint/Test
 on:
   push:
     paths-ignore:
@@ -37,15 +37,12 @@ jobs:
           cache: true
           cache-dependency-path: tools/go.sum
       - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: '1.2.*'
-          terraform_wrapper: false
 
       - name: Lint
         run: make lint
 
   test:
-    name: Matrix Test
+    name: Matrix Acceptance Test
     needs: build
     runs-on: ubuntu-latest
     services:
@@ -64,8 +61,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform:
-          - '1.3.3'
         elasticsearch:
           - '7.11.2'
           - '7.12.1'
@@ -84,9 +79,6 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
 
       - name: Get dependencies
         run: go mod download
@@ -96,7 +88,6 @@ jobs:
         run: make testacc
         env:
           TF_ACC: "1"
-          TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
           ELASTICSEARCH_VERSION: ${{ matrix.elasticsearch }}
           ELASTICSEARCH_ENDPOINTS: "http://localhost:9200"
           ELASTICSEARCH_USERNAME: "elastic"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
           cache: true
           cache-dependency-path: tools/go.sum
       - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - name: Lint
         run: make lint
@@ -83,6 +85,8 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
 
       - name: Get dependencies
         run: go mod download

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
     name: Matrix Acceptance Test
     needs: build
     runs-on: ubuntu-latest
+    env:
+      ELASTIC_PASSWORD: password
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:${{ matrix.elasticsearch }}
@@ -59,7 +61,6 @@ jobs:
           xpack.security.enabled: true
           repositories.url.allowed_urls: https://example.com/*
           path.repo: /tmp
-          ELASTIC_PASSWORD: password
         ports:
           - 9200:9200
         options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
@@ -99,4 +100,4 @@ jobs:
           ELASTICSEARCH_VERSION: ${{ matrix.elasticsearch }}
           ELASTICSEARCH_ENDPOINTS: "http://localhost:9200"
           ELASTICSEARCH_USERNAME: "elastic"
-          ELASTICSEARCH_PASSWORD: "password"
+          ELASTICSEARCH_PASSWORD: ${{ env.ELASTIC_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           xpack.security.enabled: true
           repositories.url.allowed_urls: https://example.com/*
           path.repo: /tmp
+          ELASTIC_PASSWORD: ${{ env.ELASTIC_PASSWORD }}
         ports:
           - 9200:9200
         options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,103 @@
+name: Tests
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: Build
+        run: go build -v .
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'tools/go.mod'
+          cache: true
+          cache-dependency-path: tools/go.sum
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.2.*'
+          terraform_wrapper: false
+
+      - name: Lint
+        run: make lint
+
+  test:
+    name: Matrix Test
+    needs: build
+    runs-on: ubuntu-latest
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:${{ matrix.elasticsearch }}
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: true
+          repositories.url.allowed_urls: https://example.com/*
+          path.repo: /tmp
+          ELASTIC_PASSWORD: password
+        ports:
+          - 9200:9200
+        options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform:
+          - '1.3.3'
+        elasticsearch:
+          - '7.11.2'
+          - '7.12.1'
+          - '7.13.4'
+          - '7.14.2'
+          - '7.15.2'
+          - '7.16.3'
+          - '7.17.4'
+          - '8.0.1'
+          - '8.1.3'
+          - '8.2.2'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+
+      - name: Get dependencies
+        run: go mod download
+
+      - name: TF acceptance tests
+        timeout-minutes: 10
+        run: make testacc
+        env:
+          TF_ACC: "1"
+          TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
+          ELASTICSEARCH_VERSION: ${{ matrix.elasticsearch }}
+          ELASTICSEARCH_ENDPOINTS: "http://localhost:9200"
+          ELASTICSEARCH_USERNAME: "elastic"
+          ELASTICSEARCH_PASSWORD: "password"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: lint ## build the terraform provider
 
 
 .PHONY: testacc
-testacc: lint ## Run acceptance tests
+testacc: ## Run acceptance tests
 	TF_ACC=1 go test -v ./... -count $(ACCTEST_COUNT) -parallel $(ACCTEST_PARALLELISM) $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
 
 
@@ -75,7 +75,24 @@ golangci-lint:
 
 
 .PHONY: lint
-lint: setup misspell golangci-lint ## Run lints to check the spelling and common go patterns
+lint: setup misspell golangci-lint check-fmt check-docs ## Run lints to check the spelling and common go patterns
+
+.PHONY: fmt
+fmt: ## Format code
+	go fmt ./...
+	terraform fmt --recursive
+
+.PHONY:check-fmt
+check-fmt: fmt ## Check if code is formatted
+	@if [ "`git status --porcelain `" ]; then \
+	  echo "Unformatted files were detected. Please run 'make fmt' to format code, and commit the changes" && echo `git status --porcelain docs/` && exit 1; \
+	fi
+
+.PHONY: check-docs
+check-docs: docs-generate  ## Check uncommitted changes on docs
+	@if [ "`git status --porcelain docs/`" ]; then \
+	  echo "Uncommitted changes were detected in the docs folder. Please run 'make docs-generate' to autogenerate the docs, and commit the changes" && echo `git status --porcelain docs/` && exit 1; \
+	fi
 
 
 .PHONY: setup

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -25,7 +25,7 @@ resource "elasticstack_elasticsearch_index" "my_index" {
   }
 
   alias {
-    name   = "my_alias_2"
+    name = "my_alias_2"
     filter = jsonencode({
       term = { "user.id" = "developer" }
     })

--- a/examples/resources/elasticstack_elasticsearch_index/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_index/resource.tf
@@ -10,7 +10,7 @@ resource "elasticstack_elasticsearch_index" "my_index" {
   }
 
   alias {
-    name   = "my_alias_2"
+    name = "my_alias_2"
     filter = jsonencode({
       term = { "user.id" = "developer" }
     })


### PR DESCRIPTION
Resolves #168

Add Github action workflow which includes
- build
- lint (misspell golangci-lint fmt-check docs-check)
- acctest
  - matrix is used to replace jenkins, but if we keep jenkins, then just specifying the latest version might be enough.

example run is below
https://github.com/k-yomo/terraform-provider-elasticstack/actions/runs/3342618068