### PR TITLE
Remove lint from build and test

### DIFF
--- a/.ci/Makefile.ci
+++ b/.ci/Makefile.ci
@@ -12,6 +12,10 @@ ELASTICSEARCH_MEM ?= 1024m
 
 SOURCE_LOCATION ?= $(shell pwd)
 
+.PHONY: build-ci
+build-ci: ## build the terraform provider
+	go build -o ${BINARY}
+
 # Retry command - first argumment is how many attempts are required, second argument is the command to run
 # Backoff starts with 1 second and double with next itteration
 retry = until [ $$(if [ -z "$$attempt" ]; then echo -n "0"; else echo -n "$$attempt"; fi) -ge $(1) ]; do \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         run: go mod download
 
       - name: Build
-        run: make build
+        run: make build-ci
 
   lint:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ $(GOBIN): ## create bin/ in the current directory
 
 
 .PHONY: build
-build: lint ## build the terraform provider
+build: ## build the terraform provider
 	go build -o ${BINARY}
 
 
@@ -30,7 +30,7 @@ testacc: ## Run acceptance tests
 
 
 .PHONY: test
-test: lint ## Run unit tests
+test: ## Run unit tests
 	go test -v $(TEST) $(TESTARGS) -timeout=5m -parallel=4
 
 

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,7 @@ $(GOBIN): ## create bin/ in the current directory
 
 
 .PHONY: build
-build: ## build the terraform provider
-	go build -o ${BINARY}
+build: lint build-ci ## build the terraform provider
 
 
 .PHONY: testacc


### PR DESCRIPTION
I just found that build takes time because of running lint too.
This PR remove lint from build and make CI faster.
https://github.com/elastic/terraform-provider-elasticstack/actions/runs/3343380392/jobs/5536539164