### PR TITLE
Remove unnecessary unsetting id on delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - New resource `elasticstack_elasticsearch_logstash_pipeline` to manage Logstash pipelines ([Centralized Pipeline Management](https://www.elastic.co/guide/en/logstash/current/logstash-centralized-pipeline-management.html)) ([#151](https://github.com/elastic/terraform-provider-elasticstack/pull/151))
 
+### Fixed
+- Remove unnecessary unsetting id on delete ([#174](https://github.com/elastic/terraform-provider-elasticstack/pull/174))
+
 ## [0.4.0] - 2022-10-07
 ### Added
 

--- a/internal/elasticsearch/cluster/settings.go
+++ b/internal/elasticsearch/cluster/settings.go
@@ -287,6 +287,5 @@ func resourceClusterSettingsDelete(ctx context.Context, d *schema.ResourceData, 
 		return diags
 	}
 
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -339,6 +339,5 @@ func resourceSlmDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	if diags := client.DeleteElasticsearchSlm(ctx, id.ResourceId); diags.HasError() {
 		return diags
 	}
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/cluster/snapshot_repository.go
+++ b/internal/elasticsearch/cluster/snapshot_repository.go
@@ -454,6 +454,5 @@ func resourceSnapRepoDelete(ctx context.Context, d *schema.ResourceData, meta in
 	if diags := client.DeleteElasticsearchSnapshotRepository(ctx, compId.ResourceId); diags.HasError() {
 		return diags
 	}
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/index/component_template.go
+++ b/internal/elasticsearch/index/component_template.go
@@ -293,6 +293,5 @@ func resourceComponentTemplateDelete(ctx context.Context, d *schema.ResourceData
 	if diags := client.DeleteElasticsearchComponentTemplate(ctx, compId.ResourceId); diags.HasError() {
 		return diags
 	}
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/index/data_stream.go
+++ b/internal/elasticsearch/index/data_stream.go
@@ -222,6 +222,5 @@ func resourceDataStreamDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return diags
 	}
 
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -651,6 +651,5 @@ func resourceIlmDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 		return diags
 	}
 
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/index/index.go
+++ b/internal/elasticsearch/index/index.go
@@ -927,6 +927,5 @@ func resourceIndexDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	if diags := client.DeleteElasticsearchIndex(ctx, compId.ResourceId); diags.HasError() {
 		return diags
 	}
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/index/template.go
+++ b/internal/elasticsearch/index/template.go
@@ -420,6 +420,5 @@ func resourceIndexTemplateDelete(ctx context.Context, d *schema.ResourceData, me
 	if diags := client.DeleteElasticsearchIndexTemplate(ctx, compId.ResourceId); diags.HasError() {
 		return diags
 	}
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/ingest/pipeline.go
+++ b/internal/elasticsearch/ingest/pipeline.go
@@ -218,6 +218,5 @@ func resourceIngestPipelineTemplateDelete(ctx context.Context, d *schema.Resourc
 		return diags
 	}
 
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/security/role.go
+++ b/internal/elasticsearch/security/role.go
@@ -431,6 +431,5 @@ func resourceSecurityRoleDelete(ctx context.Context, d *schema.ResourceData, met
 		return diags
 	}
 
-	d.SetId("")
 	return diags
 }

--- a/internal/elasticsearch/security/user.go
+++ b/internal/elasticsearch/security/user.go
@@ -221,6 +221,5 @@ func resourceSecurityUserDelete(ctx context.Context, d *schema.ResourceData, met
 		return diags
 	}
 
-	d.SetId("")
 	return diags
 }


### PR DESCRIPTION
Unsetting id after deleting resource is taken care by SDK.  This PR removes unnecessary id unsetting on delete.
https://github.com/hashicorp/terraform-plugin-sdk/blob/156a6387060960ab65370f6488b95500e577ae49/helper/schema/resource.go#L813-L814