### PR TITLE
Fix error handling

### DIFF
--- a/internal/clients/logstash.go
+++ b/internal/clients/logstash.go
@@ -66,7 +66,7 @@ func (a *ApiClient) DeleteLogstashPipeline(ctx context.Context, pipeline_id stri
 	var diags diag.Diagnostics
 	res, err := a.es.LogstashDeletePipeline(pipeline_id, a.es.LogstashDeletePipeline.WithContext(ctx))
 
-	if err != nil && res.IsError() {
+	if err != nil {
 		return diag.FromErr(err)
 	}
 	defer res.Body.Close()

--- a/internal/clients/security.go
+++ b/internal/clients/security.go
@@ -65,7 +65,7 @@ func (a *ApiClient) GetElasticsearchUser(ctx context.Context, username string) (
 func (a *ApiClient) DeleteElasticsearchUser(ctx context.Context, username string) diag.Diagnostics {
 	var diags diag.Diagnostics
 	res, err := a.es.Security.DeleteUser(username, a.es.Security.DeleteUser.WithContext(ctx))
-	if err != nil && res.IsError() {
+	if err != nil {
 		return diag.FromErr(err)
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
It's possible that the response is nil when error is not nil.
This PR fixes the error handling that might cause panic with null pointer exception.
`res.IsError()` is still handled in the following `utils.CheckError(res, "error message")`