### PR TITLE
Create an ApiClient directly from the env variables for acceptance testing

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -35,8 +34,4 @@ func PreCheck(t *testing.T) {
 	if !((!usernamePasswordOk && apikeyOk) || (usernamePasswordOk && !apikeyOk)) {
 		t.Fatal("Either ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD must be set, or ELASTICSEARCH_API_KEY must be set for acceptance tests to run")
 	}
-}
-
-func ApiClient() *clients.ApiClient {
-	return Provider.Meta().(*clients.ApiClient)
 }

--- a/internal/elasticsearch/index/ilm_test.go
+++ b/internal/elasticsearch/index/ilm_test.go
@@ -78,7 +78,10 @@ func TestAccResourceILM(t *testing.T) {
 	})
 }
 func serverVersionLessThanTotalShardsPerNodeLimit() (bool, error) {
-	client := acctest.ApiClient()
+	client, err := clients.NewAcceptanceTestingClient()
+	if err != nil {
+		return false, err
+	}
 	serverVersion, diags := client.ServerVersion(context.Background())
 	if diags.HasError() {
 		return false, fmt.Errorf("failed to parse the elasticsearch version %v", diags)


### PR DESCRIPTION
This makes the client accessible to all test callbacks, and doesn't rely on the Terraform provider being fully configured, i.e the first step having been run