### PR TITLE
Refactor elasticsearch cluster client methods

### DIFF
--- a/internal/elasticsearch/cluster/script.go
+++ b/internal/elasticsearch/cluster/script.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -77,7 +78,7 @@ func resourceScriptRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diags
 	}
 
-	script, diags := client.GetElasticsearchScript(ctx, compId.ResourceId)
+	script, diags := elasticsearch.GetScript(ctx, client, compId.ResourceId)
 	if script == nil && diags == nil {
 		tflog.Warn(ctx, fmt.Sprintf(`Script "%s" not found, removing from state`, compId.ResourceId))
 		d.SetId("")
@@ -128,7 +129,7 @@ func resourceScriptPut(ctx context.Context, d *schema.ResourceData, meta interfa
 	if scriptContext, ok := d.GetOk("context"); ok {
 		script.Context = scriptContext.(string)
 	}
-	if diags := client.PutElasticsearchScript(ctx, &script); diags.HasError() {
+	if diags := elasticsearch.PutScript(ctx, client, &script); diags.HasError() {
 		return diags
 	}
 
@@ -146,5 +147,5 @@ func resourceScriptDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	if diags.HasError() {
 		return diags
 	}
-	return client.DeleteElasticsearchScript(ctx, compId.ResourceId)
+	return elasticsearch.DeleteScript(ctx, client, compId.ResourceId)
 }

--- a/internal/elasticsearch/cluster/settings.go
+++ b/internal/elasticsearch/cluster/settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -108,7 +109,7 @@ func resourceClusterSettingsPut(ctx context.Context, d *schema.ResourceData, met
 			}
 		}
 	}
-	if diags := client.PutElasticsearchSettings(ctx, settings); diags.HasError() {
+	if diags := elasticsearch.PutSettings(ctx, client, settings); diags.HasError() {
 		return diags
 	}
 	d.SetId(id.String())
@@ -209,7 +210,7 @@ func resourceClusterSettingsRead(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	clusterSettings, diags := client.GetElasticsearchSettings(ctx)
+	clusterSettings, diags := elasticsearch.GetSettings(ctx, client)
 	if diags.HasError() {
 		return diags
 	}
@@ -283,7 +284,7 @@ func resourceClusterSettingsDelete(ctx context.Context, d *schema.ResourceData, 
 		"persistent": pSettings,
 		"transient":  tSettings,
 	}
-	if diags := client.PutElasticsearchSettings(ctx, settings); diags.HasError() {
+	if diags := elasticsearch.PutSettings(ctx, client, settings); diags.HasError() {
 		return diags
 	}
 

--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/go-cty/cty"
@@ -231,7 +232,7 @@ func resourceSlmPut(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	slm.Config = &slmConfig
 
-	if diags := client.PutElasticsearchSlm(ctx, &slm); diags.HasError() {
+	if diags := elasticsearch.PutSlm(ctx, client, &slm); diags.HasError() {
 		return diags
 	}
 	d.SetId(id.String())
@@ -249,7 +250,7 @@ func resourceSlmRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diags
 	}
 
-	slm, diags := client.GetElasticsearchSlm(ctx, id.ResourceId)
+	slm, diags := elasticsearch.GetSlm(ctx, client, id.ResourceId)
 	if slm == nil && diags == nil {
 		tflog.Warn(ctx, fmt.Sprintf(`SLM policy "%s" not found, removing from state`, id.ResourceId))
 		d.SetId("")
@@ -338,7 +339,7 @@ func resourceSlmDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	if diags.HasError() {
 		return diags
 	}
-	if diags := client.DeleteElasticsearchSlm(ctx, id.ResourceId); diags.HasError() {
+	if diags := elasticsearch.DeleteSlm(ctx, client, id.ResourceId); diags.HasError() {
 		return diags
 	}
 	return diags

--- a/internal/elasticsearch/cluster/snapshot_repository.go
+++ b/internal/elasticsearch/cluster/snapshot_repository.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -345,7 +346,7 @@ func resourceSnapRepoPut(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	snapRepo.Settings = snapRepoSettings
 
-	if diags := client.PutElasticsearchSnapshotRepository(ctx, &snapRepo); diags.HasError() {
+	if diags := elasticsearch.PutSnapshotRepository(ctx, client, &snapRepo); diags.HasError() {
 		return diags
 	}
 	d.SetId(id.String())
@@ -373,7 +374,7 @@ func resourceSnapRepoRead(ctx context.Context, d *schema.ResourceData, meta inte
 		return diags
 	}
 
-	currentRepo, diags := client.GetElasticsearchSnapshotRepository(ctx, compId.ResourceId)
+	currentRepo, diags := elasticsearch.GetSnapshotRepository(ctx, client, compId.ResourceId)
 	if currentRepo == nil && diags == nil {
 		tflog.Warn(ctx, fmt.Sprintf(`Snapshot repository "%s" not found, removing from state`, compId.ResourceId))
 		d.SetId("")
@@ -457,7 +458,7 @@ func resourceSnapRepoDelete(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 
-	if diags := client.DeleteElasticsearchSnapshotRepository(ctx, compId.ResourceId); diags.HasError() {
+	if diags := elasticsearch.DeleteSnapshotRepository(ctx, client, compId.ResourceId); diags.HasError() {
 		return diags
 	}
 	return diags

--- a/internal/elasticsearch/cluster/snapshot_repository_data_source.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_data_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -262,7 +263,7 @@ func dataSourceSnapRepoRead(ctx context.Context, d *schema.ResourceData, meta in
 	if diags.HasError() {
 		return diags
 	}
-	currentRepo, diags := client.GetElasticsearchSnapshotRepository(ctx, repoName)
+	currentRepo, diags := elasticsearch.GetSnapshotRepository(ctx, client, repoName)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/100

As it stands the ApiClient struct is becoming cluttered and massive. Adding Kibana will only make this worse. First step in breaking up the API access methods. 