### PR TITLE
Configure the stack provider with Cloud credentials rather than elasticsearch_connection

### DIFF
--- a/examples/cloud/deployment.tf
+++ b/examples/cloud/deployment.tf
@@ -16,6 +16,16 @@ data "ec_stack" "latest" {
   region        = "gcp-us-central1"
 }
 
+provider "elasticstack" {
+  # Use our Elastic Cloud deployment outputs for connection details.
+  # This also allows the provider to create the proper relationships between the two resources.
+  elasticsearch {
+    endpoints = ["${ec_deployment.cluster.elasticsearch[0].https_endpoint}"]
+    username  = ec_deployment.cluster.elasticsearch_username
+    password  = ec_deployment.cluster.elasticsearch_password
+  }
+}
+
 # Defining a user for ingesting
 resource "elasticstack_elasticsearch_security_user" "user" {
   username = "ingest_user"
@@ -30,14 +40,6 @@ resource "elasticstack_elasticsearch_security_user" "user" {
     "open"   = false
     "number" = 49
   })
-
-  # Use our Elastic Cloud deployemnt outputs for connection details.
-  # This also allows the provider to create the proper relationships between the two resources.
-  elasticsearch_connection {
-    endpoints = ["${ec_deployment.cluster.elasticsearch[0].https_endpoint}"]
-    username  = ec_deployment.cluster.elasticsearch_username
-    password  = ec_deployment.cluster.elasticsearch_password
-  }
 }
 
 # Configuring my cluster with an index template as well.
@@ -62,11 +64,5 @@ resource "elasticstack_elasticsearch_index_template" "my_template" {
         "username" : { "type" : "keyword" }
       }
     })
-  }
-
-  elasticsearch_connection {
-    endpoints = ["${ec_deployment.cluster.elasticsearch[0].https_endpoint}"]
-    username  = ec_deployment.cluster.elasticsearch_username
-    password  = ec_deployment.cluster.elasticsearch_password
   }
 }

--- a/examples/cloud/provider.tf
+++ b/examples/cloud/provider.tf
@@ -16,8 +16,3 @@ provider "ec" {
   # You can fill in your API key here, or use an environment variable instead
   apikey = "<api key>"
 }
-
-provider "elasticstack" {
-  # In this example, connectivity to Elasticsearch is defined per resource
-  elasticsearch {}
-}

--- a/templates/guides/elasticstack-and-cloud.md.tmpl
+++ b/templates/guides/elasticstack-and-cloud.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 A common scenario for using the Elastic Stack provider, is to manage & configure Elastic Cloud deployments.
 In order to do that, we'll use both the Elastic Cloud provider, as well as the Elastic Stack provider.
-Start off by configuring the two providers in a `provider.tf` file for example:
+Start off by configuring just the Elastic Cloud provider in a `provider.tf` file for example:
 
 {{ tffile "examples/cloud/provider.tf" }}
 


### PR DESCRIPTION
This property should probably be a last resort. It's not available during an import and there's just better ways to handle this. 

Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/114