### PR TITLE
Refactor dataSourceSecurityUserRead

### DIFF
--- a/internal/elasticsearch/security/user_data_source.go
+++ b/internal/elasticsearch/security/user_data_source.go
@@ -2,10 +2,8 @@ package security
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
-	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,33 +73,7 @@ func dataSourceSecurityUserRead(ctx context.Context, d *schema.ResourceData, met
 	if diags.HasError() {
 		return diags
 	}
-
-	user, diags := elasticsearch.GetUser(ctx, client, usernameId)
-	if diags.HasError() {
-		return diags
-	}
-
-	metadata, err := json.Marshal(user.Metadata)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	// set the fields
-	if err := d.Set("email", user.Email); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("full_name", user.FullName); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("roles", user.Roles); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("metadata", string(metadata)); err != nil {
-		return diag.FromErr(err)
-	}
-	if err := d.Set("enabled", user.Enabled); err != nil {
-		return diag.FromErr(err)
-	}
 	d.SetId(id.String())
-	return diags
+
+	return resourceSecurityUserRead(ctx, d, meta)
 }


### PR DESCRIPTION
Refactor `dataSourceSecurityUserRead` to use `resourceSecurityUserRead` to simplify the code.