### PR TITLE
Apply zeroish values in SLM policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+### Fixed
+- Respect `ignore_unavailable` and `include_global_state` values when configuring SLM policies ([#224](https://github.com/elastic/terraform-provider-elasticstack/pull/224))
 - Refactor API client functions and return diagnostics ([#220](https://github.com/elastic/terraform-provider-elasticstack/pull/220))
 
 ## [0.5.0] - 2022-12-07

--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -193,13 +193,11 @@ func resourceSlmPut(ctx context.Context, d *schema.ResourceData, meta interface{
 		vv := v.(string)
 		slmConfig.ExpandWildcards = &vv
 	}
-	if v, ok := d.GetOk("ignore_unavailable"); ok {
-		vv := v.(bool)
-		slmConfig.IgnoreUnavailable = &vv
+	if v, ok := d.Get("ignore_unavailable").(bool); ok {
+		slmConfig.IgnoreUnavailable = &v
 	}
-	if v, ok := d.GetOk("include_global_state"); ok {
-		vv := v.(bool)
-		slmConfig.IncludeGlobalState = &vv
+	if v, ok := d.Get("include_global_state").(bool); ok {
+		slmConfig.IncludeGlobalState = &v
 	}
 	indices := make([]string, 0)
 	if v, ok := d.GetOk("indices"); ok {

--- a/internal/elasticsearch/cluster/slm_test.go
+++ b/internal/elasticsearch/cluster/slm_test.go
@@ -34,6 +34,13 @@ func TestAccResourceSLM(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_snapshot_lifecycle.test_slm", "indices.*", "data-*"),
 				),
 			},
+			{
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_snapshot_lifecycle.test_slm", "ignore_unavailable", "false"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_snapshot_lifecycle.test_slm", "include_global_state", "false"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/109

`GetOk` returns `ok=false` for zero valued attributes, so this option was never being set in the policy and the default (true) was applied. 