### PR TITLE
Add recent elasticsearch versions to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,16 +70,16 @@ jobs:
       fail-fast: false
       matrix:
         elasticsearch:
-          - '7.11.2'
-          - '7.12.1'
-          - '7.13.4'
           - '7.14.2'
           - '7.15.2'
           - '7.16.3'
           - '7.17.4'
           - '8.0.1'
           - '8.1.3'
-          - '8.2.2'
+          - '8.2.3'
+          - '8.3.3'
+          - '8.4.3'
+          - '8.5.3'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         elasticsearch:
+          - '7.13.4'
           - '7.14.2'
           - '7.15.2'
           - '7.16.3'


### PR DESCRIPTION
Added these versions to CI and remove old 3 versions. 
- `8.3.3`
- `8.4.3`
- `8.5.3`

https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html

📝 Need to update `Status checks` too