### PR TITLE
Add support for index creation query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Respect `ignore_unavailable` and `include_global_state` values when configuring SLM policies ([#224](https://github.com/elastic/terraform-provider-elasticstack/pull/224))
 - Refactor API client functions and return diagnostics ([#220](https://github.com/elastic/terraform-provider-elasticstack/pull/220))
 - Fix not to recreate index when field is removed from mapping ([#232](https://github.com/elastic/terraform-provider-elasticstack/pull/232))
+- Add query params fields to index resource  ([#244](https://github.com/elastic/terraform-provider-elasticstack/pull/244))
 
 ## [0.5.0] - 2022-12-07
 

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -79,6 +79,7 @@ resource "elasticstack_elasticsearch_index" "my_index" {
 - `final_pipeline` (String) Final ingest pipeline for the index. Indexing requests will fail if the final pipeline is set and the pipeline does not exist. The final pipeline always runs after the request pipeline (if specified) and the default pipeline (if it exists). The special pipeline name _none indicates no ingest pipeline will run.
 - `gc_deletes` (String) The length of time that a deleted document's version number remains available for further versioned operations.
 - `highlight_max_analyzed_offset` (Number) The maximum number of characters that will be analyzed for a highlight request.
+- `include_type_name` (Boolean) If true, a mapping type is expected in the body of mappings. Defaults to false.
 - `indexing_slowlog_level` (String) Set which logging level to use for the search slow log, can be: `warn`, `info`, `debug`, `trace`
 - `indexing_slowlog_source` (String) Set the number of characters of the `_source` to include in the slowlog lines, `false` or `0` will skip logging the source entirely and setting it to `true` will log the entire source regardless of size. The original `_source` is reformatted by default to make sure that it fits on a single log line.
 - `indexing_slowlog_threshold_index_debug` (String) Set the cutoff for shard level slow search logging of slow searches for indexing queries, in time units, e.g. `2s`
@@ -91,6 +92,7 @@ If specified, this mapping can include: field names, [field data types](https://
 **NOTE:** 
 - Changing datatypes in the existing _mappings_ will force index to be re-created.
 - Removing field will be ignored by default same as elasticsearch. You need to recreate the index to remove field completely.
+- `master_timeout` (String) Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Defaults to `30s`.
 - `max_docvalue_fields_search` (Number) The maximum number of `docvalue_fields` that are allowed in a query.
 - `max_inner_result_window` (Number) The maximum value of `from + size` for inner hits definition and top hits aggregations to this index.
 - `max_ngram_diff` (Number) The maximum allowed difference between min_gram and max_gram for NGramTokenizer and NGramTokenFilter.
@@ -124,7 +126,9 @@ If specified, this mapping can include: field names, [field data types](https://
 - `shard_check_on_startup` (String) Whether or not shards should be checked for corruption before opening. When corruption is detected, it will prevent the shard from being opened. Accepts `false`, `true`, `checksum`.
 - `sort_field` (Set of String) The field to sort shards in this index by.
 - `sort_order` (List of String) The direction to sort shards in. Accepts `asc`, `desc`.
+- `timeout` (String) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Defaults to `30s`.
 - `unassigned_node_left_delayed_timeout` (String) Time to delay the allocation of replica shards which become unassigned because a node has left, in time units, e.g. `10s`
+- `wait_for_active_shards` (String) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (number_of_replicas+1). Default: `1`, the primary shard.
 
 ### Read-Only
 

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -79,7 +79,7 @@ resource "elasticstack_elasticsearch_index" "my_index" {
 - `final_pipeline` (String) Final ingest pipeline for the index. Indexing requests will fail if the final pipeline is set and the pipeline does not exist. The final pipeline always runs after the request pipeline (if specified) and the default pipeline (if it exists). The special pipeline name _none indicates no ingest pipeline will run.
 - `gc_deletes` (String) The length of time that a deleted document's version number remains available for further versioned operations.
 - `highlight_max_analyzed_offset` (Number) The maximum number of characters that will be analyzed for a highlight request.
-- `include_type_name` (Boolean) If true, a mapping type is expected in the body of mappings. Defaults to false.
+- `include_type_name` (Boolean) If true, a mapping type is expected in the body of mappings. Defaults to false. Supported for Elasticsearch 7.x.
 - `indexing_slowlog_level` (String) Set which logging level to use for the search slow log, can be: `warn`, `info`, `debug`, `trace`
 - `indexing_slowlog_source` (String) Set the number of characters of the `_source` to include in the slowlog lines, `false` or `0` will skip logging the source entirely and setting it to `true` will log the entire source regardless of size. The original `_source` is reformatted by default to make sure that it fits on a single log line.
 - `indexing_slowlog_threshold_index_debug` (String) Set the cutoff for shard level slow search logging of slow searches for indexing queries, in time units, e.g. `2s`

--- a/internal/clients/elasticsearch/index.go
+++ b/internal/clients/elasticsearch/index.go
@@ -12,7 +12,6 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
@@ -210,8 +209,6 @@ func DeleteIndexTemplate(ctx context.Context, apiClient *clients.ApiClient, temp
 	return diags
 }
 
-var includeTypeNameUnsupportedVersion = version.Must(version.NewVersion("8.0.0"))
-
 func PutIndex(ctx context.Context, apiClient *clients.ApiClient, index *models.Index, params *models.PutIndexParams) diag.Diagnostics {
 	var diags diag.Diagnostics
 	indexBytes, err := json.Marshal(index)
@@ -226,11 +223,7 @@ func PutIndex(ctx context.Context, apiClient *clients.ApiClient, index *models.I
 		apiClient.GetESClient().Indices.Create.WithMasterTimeout(params.MasterTimeout),
 		apiClient.GetESClient().Indices.Create.WithTimeout(params.Timeout),
 	}
-	serverVersion, diags := apiClient.ServerVersion(ctx)
-	if diags.HasError() {
-		return diags
-	}
-	if serverVersion.LessThan(includeTypeNameUnsupportedVersion) {
+	if params.IncludeTypeName {
 		opts = append(opts, apiClient.GetESClient().Indices.Create.WithIncludeTypeName(params.IncludeTypeName))
 	}
 	res, err := apiClient.GetESClient().Indices.Create(

--- a/internal/clients/elasticsearch/index.go
+++ b/internal/clients/elasticsearch/index.go
@@ -8,9 +8,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
@@ -208,15 +210,33 @@ func DeleteIndexTemplate(ctx context.Context, apiClient *clients.ApiClient, temp
 	return diags
 }
 
-func PutIndex(ctx context.Context, apiClient *clients.ApiClient, index *models.Index) diag.Diagnostics {
+var includeTypeNameUnsupportedVersion = version.Must(version.NewVersion("8.0.0"))
+
+func PutIndex(ctx context.Context, apiClient *clients.ApiClient, index *models.Index, params *models.PutIndexParams) diag.Diagnostics {
 	var diags diag.Diagnostics
 	indexBytes, err := json.Marshal(index)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	req := apiClient.GetESClient().Indices.Create.WithBody(bytes.NewReader(indexBytes))
-	res, err := apiClient.GetESClient().Indices.Create(index.Name, req, apiClient.GetESClient().Indices.Create.WithContext(ctx))
+	opts := []func(*esapi.IndicesCreateRequest){
+		apiClient.GetESClient().Indices.Create.WithBody(bytes.NewReader(indexBytes)),
+		apiClient.GetESClient().Indices.Create.WithContext(ctx),
+		apiClient.GetESClient().Indices.Create.WithWaitForActiveShards(params.WaitForActiveShards),
+		apiClient.GetESClient().Indices.Create.WithMasterTimeout(params.MasterTimeout),
+		apiClient.GetESClient().Indices.Create.WithTimeout(params.Timeout),
+	}
+	serverVersion, diags := apiClient.ServerVersion(ctx)
+	if diags.HasError() {
+		return diags
+	}
+	if serverVersion.LessThan(includeTypeNameUnsupportedVersion) {
+		opts = append(opts, apiClient.GetESClient().Indices.Create.WithIncludeTypeName(params.IncludeTypeName))
+	}
+	res, err := apiClient.GetESClient().Indices.Create(
+		index.Name,
+		opts...,
+	)
 	if err != nil {
 		diag.FromErr(err)
 	}

--- a/internal/elasticsearch/index/index_test.go
+++ b/internal/elasticsearch/index/index_test.go
@@ -196,6 +196,10 @@ resource "elasticstack_elasticsearch_index" "test" {
       value = "20s"
     }
   }
+
+	wait_for_active_shards = "all"
+	master_timeout = "1m"
+	timeout = "1m"
 }
 	`, name)
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -210,7 +210,7 @@ type PutIndexParams struct {
 	WaitForActiveShards string
 	MasterTimeout       time.Duration
 	Timeout             time.Duration
-	IncludeTypeName     bool
+	IncludeTypeName     bool // IncludeTypeName is supported only in v7.x
 }
 
 type IndexAlias struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 type User struct {
 	Username     string                 `json:"-"`
 	FullName     string                 `json:"full_name,omitempty"`
@@ -183,6 +185,13 @@ type Index struct {
 	Aliases  map[string]IndexAlias  `json:"aliases,omitempty"`
 	Mappings map[string]interface{} `json:"mappings,omitempty"`
 	Settings map[string]interface{} `json:"settings,omitempty"`
+}
+
+type PutIndexParams struct {
+	WaitForActiveShards string
+	MasterTimeout       time.Duration
+	Timeout             time.Duration
+	IncludeTypeName     bool
 }
 
 type IndexAlias struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -2,7 +2,6 @@ package models
 
 import "time"
 
-
 type ClusterInfo struct {
 	Name        string `json:"name"`
 	ClusterName string `json:"cluster_name"`

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+	"time"
+)
+
+// StringIsDuration is a SchemaValidateFunc which tests to make sure the supplied string is valid duration.
+func StringIsDuration(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %s to be string", k)}
+	}
+
+	if _, err := time.ParseDuration(v); err != nil {
+		return nil, []error{fmt.Errorf("%q contains an invalid duration: %s", k, err)}
+	}
+
+	return nil, nil
+}

--- a/internal/utils/validation_test.go
+++ b/internal/utils/validation_test.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestStringIsDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		i            interface{}
+		k            string
+		wantWarnings []string
+		wantErrors   []error
+	}{
+		{
+			name: "valid duration string",
+			i:    "30s",
+			k:    "timeout",
+		},
+		{
+			name:       "invalid duration string",
+			i:          "30ss",
+			k:          "timeout",
+			wantErrors: []error{errors.New(`"timeout" contains an invalid duration: time: unknown unit "ss" in duration "30ss"`)},
+		},
+		{
+			name:       "invalid type",
+			i:          30,
+			k:          "timeout",
+			wantErrors: []error{errors.New("expected type of timeout to be string")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotWarnings, gotErrors := StringIsDuration(tt.i, tt.k)
+			if !reflect.DeepEqual(gotWarnings, tt.wantWarnings) {
+				t.Errorf("StringIsDuration() gotWarnings = %v, want %v", gotWarnings, tt.wantWarnings)
+			}
+			if !reflect.DeepEqual(gotErrors, tt.wantErrors) {
+				t.Errorf("StringIsDuration() gotErrors = %v, want %v", gotErrors, tt.wantErrors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolve #242 

This PR adds support for the following query params that we can set for index creation.
- `include_type_name`
- `wait_for_active_shards`
- `master_timeout`
- `timeout`
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-create-index.html#indices-create-api-query-params

📝 `master_timeout` and `timeout` are used in the other apis, so it might be better to make it reusable.
https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html#ilm-put-lifecycle-query-params