### PR TITLE
Cache cluster info to speed up application

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,5 +1,25 @@
 package models
 
+import "time"
+
+type ClusterInfo struct {
+	Name        string `json:"name"`
+	ClusterName string `json:"cluster_name"`
+	ClusterUUID string `json:"cluster_uuid"`
+	Version     struct {
+		Number                           string    `json:"number"`
+		BuildType                        string    `json:"build_type"`
+		BuildHash                        string    `json:"build_hash"`
+		BuildFlavor                      string    `json:"build_flavor"`
+		BuildDate                        time.Time `json:"build_date"`
+		BuildSnapshot                    bool      `json:"build_snapshot"`
+		LuceneVersion                    string    `json:"lucene_version"`
+		MinimumWireCompatibilityVersion  string    `json:"minimum_wire_compatibility_version"`
+		MinimumIndexCompatibilityVersion string    `json:"minimum_index_compatibility_version"`
+	} `json:"version"`
+	Tagline string `json:"tagline"`
+}
+
 type User struct {
 	Username     string                 `json:"-"`
 	FullName     string                 `json:"full_name,omitempty"`


### PR DESCRIPTION
Cluster info is retrieved for every resource to use cluster uuid now.  
This PR caches cluster info to be able to speed up it.