### PR TITLE
Add min_* conditions to rollover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - Add 'mapping_coerce' field to index resource ([#229](https://github.com/elastic/terraform-provider-elasticstack/pull/229))
+- Add 'min_*' conditions to ILM rollover ([#250](https://github.com/elastic/terraform-provider-elasticstack/pull/250))
 
 ### Fixed
 - Respect `ignore_unavailable` and `include_global_state` values when configuring SLM policies ([#224](https://github.com/elastic/terraform-provider-elasticstack/pull/224))

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -262,10 +262,10 @@ Optional:
 - `max_docs` (Number) Triggers rollover after the specified maximum number of documents is reached.
 - `max_primary_shard_size` (String) Triggers rollover when the largest primary shard in the index reaches a certain size.
 - `max_size` (String) Triggers rollover when the index reaches a certain size.
-- `min_age` (String) Prevents rollover until after the minimum elapsed time from index creation is reached.
-- `min_docs` (Number) Prevents rollover until after the specified minimum number of documents is reached.
-- `min_primary_shard_docs` (Number) Prevents rollover until the largest primary shard in the index reaches a certain number of documents.
-- `min_primary_shard_size` (String) Prevents rollover until the largest primary shard in the index reaches a certain size.
+- `min_age` (String) Prevents rollover until after the minimum elapsed time from index creation is reached. Supported from Elasticsearch version **8.4**
+- `min_docs` (Number) Prevents rollover until after the specified minimum number of documents is reached. Supported from Elasticsearch version **8.4**
+- `min_primary_shard_docs` (Number) Prevents rollover until the largest primary shard in the index reaches a certain number of documents. Supported from Elasticsearch version **8.4**
+- `min_primary_shard_size` (String) Prevents rollover until the largest primary shard in the index reaches a certain size. Supported from Elasticsearch version **8.4**
 - `min_size` (String) Prevents rollover until the index reaches a certain size.
 
 

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -262,6 +262,11 @@ Optional:
 - `max_docs` (Number) Triggers rollover after the specified maximum number of documents is reached.
 - `max_primary_shard_size` (String) Triggers rollover when the largest primary shard in the index reaches a certain size.
 - `max_size` (String) Triggers rollover when the index reaches a certain size.
+- `min_age` (String) Prevents rollover until after the minimum elapsed time from index creation is reached.
+- `min_docs` (Number) Prevents rollover until after the specified minimum number of documents is reached.
+- `min_primary_shard_docs` (Number) Prevents rollover until the largest primary shard in the index reaches a certain number of documents.
+- `min_primary_shard_size` (String) Prevents rollover until the largest primary shard in the index reaches a certain size.
+- `min_size` (String) Prevents rollover until the index reaches a certain size.
 
 
 <a id="nestedblock--hot--searchable_snapshot"></a>

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -273,6 +273,31 @@ var supportedActions = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
+				"min_age": {
+					Description: "Prevents rollover until after the minimum elapsed time from index creation is reached.",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
+				"min_docs": {
+					Description: "Prevents rollover until after the specified minimum number of documents is reached.",
+					Type:        schema.TypeInt,
+					Optional:    true,
+				},
+				"min_size": {
+					Description: "Prevents rollover until the index reaches a certain size.",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
+				"min_primary_shard_size": {
+					Description: "Prevents rollover until the largest primary shard in the index reaches a certain size.",
+					Type:        schema.TypeString,
+					Optional:    true,
+				},
+				"min_primary_shard_docs": {
+					Description: "Prevents rollover until the largest primary shard in the index reaches a certain number of documents.",
+					Type:        schema.TypeInt,
+					Optional:    true,
+				},
 			},
 		},
 	},
@@ -478,7 +503,7 @@ func expandPhase(p map[string]interface{}, serverVersion *version.Version) (*mod
 					}
 				}
 			case "rollover":
-				actions[actionName], diags = expandAction(a, serverVersion, "max_age", "max_docs", "max_size", "max_primary_shard_size")
+				actions[actionName], diags = expandAction(a, serverVersion, "max_age", "max_docs", "max_size", "max_primary_shard_size", "min_age", "min_docs", "min_size", "min_primary_shard_size", "min_primary_shard_docs")
 			case "searchable_snapshot":
 				actions[actionName], diags = expandAction(a, serverVersion, "snapshot_repository", "force_merge_index")
 			case "set_priority":
@@ -514,9 +539,14 @@ var ilmActionSettingOptions = map[string]struct {
 	def            interface{}
 	minVersion     *version.Version
 }{
-	"number_of_replicas":    {skipEmptyCheck: true},
-	"total_shards_per_node": {skipEmptyCheck: true, def: -1, minVersion: version.Must(version.NewVersion("7.16.0"))},
-	"priority":              {skipEmptyCheck: true},
+	"number_of_replicas":     {skipEmptyCheck: true},
+	"total_shards_per_node":  {skipEmptyCheck: true, def: -1, minVersion: version.Must(version.NewVersion("7.16.0"))},
+	"priority":               {skipEmptyCheck: true},
+	"min_age":                {def: "", minVersion: version.Must(version.NewVersion("8.4.0"))},
+	"min_docs":               {def: 0, minVersion: version.Must(version.NewVersion("8.4.0"))},
+	"min_size":               {def: "", minVersion: version.Must(version.NewVersion("8.4.0"))},
+	"min_primary_shard_size": {def: "", minVersion: version.Must(version.NewVersion("8.4.0"))},
+	"min_primary_shard_docs": {def: 0, minVersion: version.Must(version.NewVersion("8.4.0"))},
 }
 
 func expandAction(a []interface{}, serverVersion *version.Version, settings ...string) (map[string]interface{}, diag.Diagnostics) {

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -534,6 +534,7 @@ func expandPhase(p map[string]interface{}, serverVersion *version.Version) (*mod
 	return &phase, diags
 }
 
+var RolloverMinConditionsMinSupportedVersion = version.Must(version.NewVersion("8.4.0"))
 var ilmActionSettingOptions = map[string]struct {
 	skipEmptyCheck bool
 	def            interface{}
@@ -542,11 +543,11 @@ var ilmActionSettingOptions = map[string]struct {
 	"number_of_replicas":     {skipEmptyCheck: true},
 	"total_shards_per_node":  {skipEmptyCheck: true, def: -1, minVersion: version.Must(version.NewVersion("7.16.0"))},
 	"priority":               {skipEmptyCheck: true},
-	"min_age":                {def: "", minVersion: version.Must(version.NewVersion("8.4.0"))},
-	"min_docs":               {def: 0, minVersion: version.Must(version.NewVersion("8.4.0"))},
-	"min_size":               {def: "", minVersion: version.Must(version.NewVersion("8.4.0"))},
-	"min_primary_shard_size": {def: "", minVersion: version.Must(version.NewVersion("8.4.0"))},
-	"min_primary_shard_docs": {def: 0, minVersion: version.Must(version.NewVersion("8.4.0"))},
+	"min_age":                {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
+	"min_docs":               {def: 0, minVersion: RolloverMinConditionsMinSupportedVersion},
+	"min_size":               {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
+	"min_primary_shard_size": {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
+	"min_primary_shard_docs": {def: 0, minVersion: RolloverMinConditionsMinSupportedVersion},
 }
 
 func expandAction(a []interface{}, serverVersion *version.Version, settings ...string) (map[string]interface{}, diag.Diagnostics) {

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -274,12 +274,12 @@ var supportedActions = map[string]*schema.Schema{
 					Optional:    true,
 				},
 				"min_age": {
-					Description: "Prevents rollover until after the minimum elapsed time from index creation is reached.",
+					Description: "Prevents rollover until after the minimum elapsed time from index creation is reached. Supported from Elasticsearch version **8.4**",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
 				"min_docs": {
-					Description: "Prevents rollover until after the specified minimum number of documents is reached.",
+					Description: "Prevents rollover until after the specified minimum number of documents is reached. Supported from Elasticsearch version **8.4**",
 					Type:        schema.TypeInt,
 					Optional:    true,
 				},
@@ -289,12 +289,12 @@ var supportedActions = map[string]*schema.Schema{
 					Optional:    true,
 				},
 				"min_primary_shard_size": {
-					Description: "Prevents rollover until the largest primary shard in the index reaches a certain size.",
+					Description: "Prevents rollover until the largest primary shard in the index reaches a certain size. Supported from Elasticsearch version **8.4**",
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
 				"min_primary_shard_docs": {
-					Description: "Prevents rollover until the largest primary shard in the index reaches a certain number of documents.",
+					Description: "Prevents rollover until the largest primary shard in the index reaches a certain number of documents. Supported from Elasticsearch version **8.4**",
 					Type:        schema.TypeInt,
 					Optional:    true,
 				},

--- a/internal/elasticsearch/index/ilm_test.go
+++ b/internal/elasticsearch/index/ilm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/index"
 	"github.com/elastic/terraform-provider-elasticstack/internal/versionutils"
 	"github.com/hashicorp/go-version"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -72,6 +73,35 @@ func TestAccResourceILM(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.allocate.#", "1"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.allocate.0.number_of_replicas", "1"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "warm.0.allocate.0.total_shards_per_node", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceILMRolloverConditions(t *testing.T) {
+	// generate a random policy name
+	policyName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		CheckDestroy:             checkResourceILMDestroy,
+		ProtoV5ProviderFactories: acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(index.RolloverMinConditionsMinSupportedVersion),
+				Config:   testAccResourceILMCreateWithRolloverConditions(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "name", policyName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_age", "7d"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_docs", "10000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_size", "100gb"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_primary_shard_size", "50gb"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_age", "3d"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_docs", "1000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_size", "50gb"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_size", "25gb"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_docs", "500"),
 				),
 			},
 		},
@@ -183,6 +213,38 @@ resource "elasticstack_elasticsearch_index_lifecycle" "test" {
     }
   }
 
+}
+ `, name)
+}
+
+func testAccResourceILMCreateWithRolloverConditions(name string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index_lifecycle" "test_rollover" {
+  name = "%s"
+
+  hot {
+    rollover {
+      max_age = "7d"
+      max_docs = 10000
+      max_size = "100gb"
+      max_primary_shard_size = "50gb"
+      min_age = "3d"
+      min_docs = 1000
+      min_size = "50gb"
+      min_primary_shard_size = "25gb"
+      min_primary_shard_docs = 500
+    }
+
+    readonly {}
+  }
+
+  delete {
+    delete {}
+  }
 }
  `, name)
 }

--- a/internal/versionutils/testutils.go
+++ b/internal/versionutils/testutils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-func CheckIfVersionIsUnsupported(v *version.Version) func() (bool, error) {
+func CheckIfVersionIsUnsupported(minSupportedVersion *version.Version) func() (bool, error) {
 	return func() (b bool, err error) {
 		client, err := clients.NewAcceptanceTestingClient()
 		if err != nil {
@@ -19,6 +19,6 @@ func CheckIfVersionIsUnsupported(v *version.Version) func() (bool, error) {
 			return false, fmt.Errorf("failed to parse the elasticsearch version %v", diags)
 		}
 
-		return serverVersion.LessThan(v), nil
+		return serverVersion.LessThan(minSupportedVersion), nil
 	}
 }


### PR DESCRIPTION
Resolves #247 

This PR adds `min_*` fields to rollover which is released in [8.4.0](https://www.elastic.co/guide/en/elasticsearch///reference/master/release-notes-8.4.0.html).
https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-rollover.html