### PR TITLE
Add v8.6.0 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
           - '8.3.3'
           - '8.4.3'
           - '8.5.3'
+          - '8.6.0'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
This PR adds recently released [v8.6.0](https://github.com/elastic/elasticsearch/releases/tag/v8.6.0) to CI.