### PR TITLE
Fix request dump debug log

### DIFF
--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -359,6 +359,11 @@ func buildEsClient(d *schema.ResourceData, baseConfig BaseConfig, useEnvAsDefaul
 		}
 	}
 
+	if logging.IsDebugOrHigher() {
+		config.EnableDebugLogger = true
+		config.Logger = &debugLogger{Name: "elasticsearch"}
+	}
+
 	es, err := elasticsearch.NewClient(config)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
@@ -367,9 +372,6 @@ func buildEsClient(d *schema.ResourceData, baseConfig BaseConfig, useEnvAsDefaul
 			Detail:   err.Error(),
 		})
 		return nil, diags
-	}
-	if logging.IsDebugOrHigher() {
-		es.Transport = newDebugTransport("elasticsearch", es.Transport)
 	}
 
 	return es, diags

--- a/internal/clients/debug.go
+++ b/internal/clients/debug.go
@@ -38,7 +38,7 @@ func newDebugTransport(name string, transport esapi.Transport) *debugTransport {
 
 func (d *debugTransport) Perform(r *http.Request) (*http.Response, error) {
 	ctx := r.Context()
-	reqData, err := httputil.DumpRequestOut(r, true)
+	reqData, err := httputil.DumpRequest(r, true)
 	if err == nil {
 		tflog.Debug(ctx, fmt.Sprintf(logReqMsg, d.name, prettyPrintJsonLines(reqData)))
 	} else {


### PR DESCRIPTION
Resolves #258 

`httputil.DumpRequestOut` is actually executing dummy [RondTrip](https://github.com/golang/go/blob/733ba921875ea11088f1f447cbca418f651aae5c/src/net/http/httputil/dump.go#L146) and it causes following error since the schema and host is not set at the point.
`request dump error: &errors.errorString{s:"unsupported protocol scheme \"\""}`

This PR changes the method to use `httputil.DumpRequest` which can work with an incomplete url.
```
2023-01-25T01:36:36.976+0900 [DEBUG] provider.terraform-provider-elasticstack: elasticsearch API Request Details:
---[ REQUEST ]---------------------------------------
GET /products?flat_settings=true HTTP/1.1


-----------------------------------------------------: @module=elasticstack tf_mux_provider=*schema.GRPCProviderServer tf_provider_addr=registry.terraform.io/elastic/elasticstack tf_rpc=ApplyResourceChange @caller=/Users/k-yomo/go/src/github.com/k-yomo/terraform-provider-elasticstack/internal/clients/debug.go:46 tf_req_id=6f651534-de0f-0549-41c9-ce9789c53b9f tf_resource_type=elasticstack_elasticsearch_index timestamp=2023-01-25T01:36:36.976+0900
```