### PR TITLE
Fix mapping Kibana alerting rule actions to api alerting.ActionInner

### DIFF
--- a/internal/clients/kibana/alerting.go
+++ b/internal/clients/kibana/alerting.go
@@ -57,6 +57,20 @@ func ruleResponseToModel(spaceID string, res *alerting.RuleResponseProperties) *
 	}
 }
 
+// Maps the rule actions to the struct required by the request model (ActionsInner)
+func ruleActionsToActionsInner(ruleActions []models.AlertingRuleAction) []alerting.ActionsInner {
+	actions := []alerting.ActionsInner{}
+	for index := range ruleActions {
+		action := ruleActions[index]
+		actions = append(actions, alerting.ActionsInner{
+			Group:  &action.Group,
+			Id:     &action.ID,
+			Params: action.Params,
+		})
+	}
+	return actions
+}
+
 func CreateAlertingRule(ctx context.Context, apiClient *clients.ApiClient, rule models.AlertingRule) (*models.AlertingRule, diag.Diagnostics) {
 	client, err := apiClient.GetAlertingClient()
 	if err != nil {
@@ -65,18 +79,9 @@ func CreateAlertingRule(ctx context.Context, apiClient *clients.ApiClient, rule 
 
 	ctxWithAuth := apiClient.SetAlertingAuthContext(ctx)
 
-	actions := []alerting.ActionsInner{}
-	for _, action := range rule.Actions {
-		actions = append(actions, alerting.ActionsInner{
-			Group:  &action.Group,
-			Id:     &action.ID,
-			Params: action.Params,
-		})
-	}
-
 	reqModel := alerting.CreateRuleRequest{
 		Consumer:   rule.Consumer,
-		Actions:    actions,
+		Actions:    ruleActionsToActionsInner(rule.Actions),
 		Enabled:    rule.Enabled,
 		Name:       rule.Name,
 		NotifyWhen: (*alerting.NotifyWhen)(&rule.NotifyWhen),
@@ -106,17 +111,8 @@ func UpdateAlertingRule(ctx context.Context, apiClient *clients.ApiClient, rule 
 
 	ctxWithAuth := apiClient.SetAlertingAuthContext(ctx)
 
-	actions := []alerting.ActionsInner{}
-	for _, action := range rule.Actions {
-		actions = append(actions, alerting.ActionsInner{
-			Group:  &action.Group,
-			Id:     &action.ID,
-			Params: action.Params,
-		})
-	}
-
 	reqModel := alerting.UpdateRuleRequest{
-		Actions:    actions,
+		Actions:    ruleActionsToActionsInner((rule.Actions)),
 		Name:       rule.Name,
 		NotifyWhen: (*alerting.NotifyWhen)(&rule.NotifyWhen),
 		Params:     rule.Params,


### PR DESCRIPTION
When creating a Kibana alerting rule with multiple actions (using the unreleased version of the provider), there is a bug at the point of copying the resource's action into the api struct `alerting.ActionsInner`.

For instance:

```terraform
resource "elasticstack_kibana_alerting_rule" "my_kibana_alerting_rule" {
  name         = "tf - my kibana alerting rule"
  consumer     = "alerts"
  notify_when  = "onActiveAlert"
  rule_type_id = "logs.alert.document.count"
  interval     = "1m"
  enabled      = true
  tags         = ["terraform""]

  params = jsonencode({
   // some params here
  })

 # First action
  actions {
    id    = "UUID-1-Connector"
    group = "logs.threshold.fired"
    params = jsonencode({
      // some params here
    })
  }

  # Second Action
  actions {
    id    =  "UUID-2-Connector"
    group = "logs.threshold.fired"
    params = jsonencode({
      // some params here
    })
  }
 ```

The provider was trying to create all the actions using the `UUID-2-Connector`. This is because of the way pointers were used when iterating over `rules.Actions` and creating `alerting.ActionsInner`

This PR fixes the issue :)
