### PR TITLE
Set the policy name when importing an SLM policy

### DIFF
--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -256,6 +256,9 @@ func resourceSlmRead(ctx context.Context, d *schema.ResourceData, meta interface
 		return diags
 	}
 
+	if err := d.Set("name", id.ResourceId); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("snapshot_name", slm.Name); err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/elasticsearch/cluster/slm_test.go
+++ b/internal/elasticsearch/cluster/slm_test.go
@@ -42,6 +42,18 @@ func TestAccResourceSLM(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_snapshot_lifecycle.test_slm", "include_global_state", "false"),
 				),
 			},
+			{
+				ResourceName: "elasticstack_elasticsearch_snapshot_lifecycle.test_slm",
+				ImportState:  true,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					importedName := is[0].Attributes["name"]
+					if importedName != name {
+						return fmt.Errorf("expected imported slm policy name [%s] to equal [%s]", importedName, name)
+					}
+
+					return nil
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/360

Does what it says on the tin. Importing an SLM policy currently doesn't set the name property, resulting in the policy being recreated on the next apply. 