### PR TITLE
Update resource.tf for slack and pagerduty action connector

### DIFF
--- a/examples/resources/elasticstack_kibana_action_connector/resource.tf
+++ b/examples/resources/elasticstack_kibana_action_connector/resource.tf
@@ -10,3 +10,22 @@ resource "elasticstack_kibana_action_connector" "example" {
   })
   connector_type_id = ".index"
 }
+
+resource "elasticstack_kibana_action_connector" "pagerduty-connector" {
+  name = "pagerduty"
+  connector_type_id = ".pagerduty"
+  config = jsonencode({
+    apiurl = "https://events.pagerduty.com/v2/enqueue"
+  })
+  secrets = jsonencode({
+    routingKey = pagerduty_service_integration.kibana.integration_key
+  })
+}
+.
+resource "elasticstack_kibana_action_connector" "slack-connector" {
+  name = "slack"
+  connector_type_id = ".slack"
+  secrets = jsonencode({
+    webhookUrl = "<your-webhookUrl>"
+  })
+}


### PR DESCRIPTION
Schema was missing in the official documentation. I implemented this using the trial and error method and found that this is working perfectly. So this can be used by anyone who wants to implement PagerDuty and Slack action connector.