### PR TITLE
[DOCS] Change rule and connector links to current

### DIFF
--- a/docs/resources/kibana_action_connector.md
+++ b/docs/resources/kibana_action_connector.md
@@ -3,12 +3,12 @@ subcategory: "Kibana"
 layout: ""
 page_title: "Elasticstack: elasticstack_kibana_action_connector Resource"
 description: |-
-  Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/8.7/action-types.html
+  Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/current/action-types.html
 ---
 
 # Resource: elasticstack_kibana_action_connector
 
-Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/8.7/action-types.html
+Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/current/action-types.html
 
 ## Example Usage
 

--- a/docs/resources/kibana_alerting_rule.md
+++ b/docs/resources/kibana_alerting_rule.md
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: elasticstack_kibana_alerting_rule
 
-Creates or updates a Kibana alerting rule. See https://www.elastic.co/guide/en/kibana/8.6/create-and-manage-rules.html
+Creates or updates a Kibana alerting rule. See https://www.elastic.co/guide/en/kibana/current/create-and-manage-rules.html
 
 ## Example Usage
 

--- a/internal/kibana/connector.go
+++ b/internal/kibana/connector.go
@@ -71,7 +71,7 @@ func ResourceActionConnector() *schema.Resource {
 	}
 
 	return &schema.Resource{
-		Description: "Creates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/8.7/action-types.html",
+		Description: "Creates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/current/action-types.html",
 
 		CreateContext: resourceConnectorCreate,
 		UpdateContext: resourceConnectorUpdate,

--- a/templates/resources/kibana_action_connector.md.tmpl
+++ b/templates/resources/kibana_action_connector.md.tmpl
@@ -3,12 +3,12 @@ subcategory: "Kibana"
 layout: ""
 page_title: "Elasticstack: elasticstack_kibana_action_connector Resource"
 description: |-
-  Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/8.7/action-types.html
+  Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/current/action-types.html
 ---
 
 # Resource: elasticstack_kibana_action_connector
 
-Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/8.7/action-types.html
+Creates or updates a Kibana action connector. See https://www.elastic.co/guide/en/kibana/current/action-types.html
 
 ## Example Usage
 

--- a/templates/resources/kibana_alerting_rule.md.tmpl
+++ b/templates/resources/kibana_alerting_rule.md.tmpl
@@ -8,7 +8,7 @@ description: |-
 
 # Resource: elasticstack_kibana_alerting_rule
 
-Creates or updates a Kibana alerting rule. See https://www.elastic.co/guide/en/kibana/8.6/create-and-manage-rules.html
+Creates or updates a Kibana alerting rule. See https://www.elastic.co/guide/en/kibana/current/create-and-manage-rules.html
 
 ## Example Usage
 


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/158647

This PR updates the links in https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/kibana_action_connector and https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/kibana_alerting_rule to use the "current" version of the documentation.