### PR TITLE
secret field as mandatory, adding the secret field to the example

### DIFF
--- a/docs/resources/kibana_action_connector.md
+++ b/docs/resources/kibana_action_connector.md
@@ -24,7 +24,7 @@ resource "elasticstack_kibana_action_connector" "example" {
     refresh = true
   })
   connector_type_id = ".index"
-  secrets = jsonencode({})
+  secrets           = jsonencode({})
 }
 
 resource "elasticstack_kibana_action_connector" "pagerduty-connector" {

--- a/docs/resources/kibana_action_connector.md
+++ b/docs/resources/kibana_action_connector.md
@@ -24,6 +24,7 @@ resource "elasticstack_kibana_action_connector" "example" {
     refresh = true
   })
   connector_type_id = ".index"
+  secrets = jsonencode({})
 }
 
 resource "elasticstack_kibana_action_connector" "pagerduty-connector" {
@@ -53,12 +54,12 @@ resource "elasticstack_kibana_action_connector" "slack-connector" {
 
 - `connector_type_id` (String) The ID of the connector type, e.g. `.index`.
 - `name` (String) The name of the connector. While this name does not have to be unique, a distinctive name can help you identify a connector.
+- `secrets` (String) The secrets configuration for the connector. Secrets configuration properties vary depending on the connector type.
 
 ### Optional
 
 - `config` (String) The configuration for the connector. Configuration properties vary depending on the connector type.
 - `connector_id` (String) A UUID v1 or v4 to use instead of a randomly generated ID.
-- `secrets` (String) The secrets configuration for the connector. Secrets configuration properties vary depending on the connector type.
 - `space_id` (String) An identifier for the space. If space_id is not provided, the default space is used.
 
 ### Read-Only

--- a/examples/resources/elasticstack_kibana_action_connector/resource.tf
+++ b/examples/resources/elasticstack_kibana_action_connector/resource.tf
@@ -9,6 +9,7 @@ resource "elasticstack_kibana_action_connector" "example" {
     refresh = true
   })
   connector_type_id = ".index"
+  secrets = jsonencode({})
 }
 
 resource "elasticstack_kibana_action_connector" "pagerduty-connector" {

--- a/examples/resources/elasticstack_kibana_action_connector/resource.tf
+++ b/examples/resources/elasticstack_kibana_action_connector/resource.tf
@@ -9,7 +9,7 @@ resource "elasticstack_kibana_action_connector" "example" {
     refresh = true
   })
   connector_type_id = ".index"
-  secrets = jsonencode({})
+  secrets           = jsonencode({})
 }
 
 resource "elasticstack_kibana_action_connector" "pagerduty-connector" {

--- a/internal/kibana/connector.go
+++ b/internal/kibana/connector.go
@@ -49,7 +49,6 @@ func ResourceActionConnector() *schema.Resource {
 		"secrets": {
 			Description:      "The secrets configuration for the connector. Secrets configuration properties vary depending on the connector type.",
 			Type:             schema.TypeString,
-			Optional:         true,
 			DiffSuppressFunc: utils.DiffJsonSuppress,
 			ValidateFunc:     validation.StringIsJSON,
 		},

--- a/internal/kibana/connector.go
+++ b/internal/kibana/connector.go
@@ -49,6 +49,7 @@ func ResourceActionConnector() *schema.Resource {
 		"secrets": {
 			Description:      "The secrets configuration for the connector. Secrets configuration properties vary depending on the connector type.",
 			Type:             schema.TypeString,
+			Required:         true,
 			DiffSuppressFunc: utils.DiffJsonSuppress,
 			ValidateFunc:     validation.StringIsJSON,
 		},


### PR DESCRIPTION
A small improvement in the documentation should make it easier for new users to use the provider.

https://github.com/elastic/terraform-provider-elasticstack/issues/397