### PR TITLE
Document all environment variables used within the provider. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Add support for Kibana SLOs ([#385](https://github.com/elastic/terraform-provider-elasticstack/pull/385))
+- Document all available environment variables ([#405](https://github.com/elastic/terraform-provider-elasticstack/pull/405))
 
 ## [0.6.2] - 2023-06-19
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,9 @@ The following methods are supported:
 
 ### Static credentials
 
-Default static credentials can be provided by adding the `username`, `password` and `endpoints` in `elasticsearch` block:
+#### Elasticsearch
+
+Default static credentials can be provided by adding the `username`, `password` and `endpoints` in the `elasticsearch` block:
 
 ```terraform
 provider "elasticstack" {
@@ -49,16 +51,47 @@ provider "elasticstack" {
 }
 ```
 
+#### Kibana
+
+Default static credentials can be provided by adding the `username`, `password` and `endpoints` in the `kibana` block:
+
+```terraform
+provider "elasticstack" {
+  kibana {
+    username  = "elastic"
+    password  = "changeme"
+    endpoints = ["http://localhost:5601"]
+  }
+}
+```
+
+If no credentials are supplied the provider will fall back to using those provided in the `elasticsearch` block.
+
 ### Environment Variables
 
-You can provide your credentials for the default connection via the `ELASTICSEARCH_USERNAME`, `ELASTICSEARCH_PASSWORD` and comma-separated list `ELASTICSEARCH_ENDPOINTS`,
-environment variables, representing your user, password and Elasticsearch API endpoints respectively.
+The provider configuration can be specified through environment variables.
 
-Alternatively the `ELASTICSEARCH_API_KEY` variable can be specified instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`.
+For Elasticsearch resources, you can use the following variables:
+- `ELASTICSEARCH_USERNAME` - The username to use for Elasticsearch authentication
+- `ELASTICSEARCH_PASSWORD` - The password to use for Elasticsearch authentication
+- `ELASTICSEARCH_ENDPOINTS` - A comma separated list of Elasticsearch hosts to connect to
+- `ELASTICSEARCH_API_KEY` - An Elasticsearch API key to use instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`
+
+Kibana resources will re-use any Elasticsearch credentials specified, these may be overridden with the following variables:
+- `KIBANA_USERNAME` - The username to use for Kibana authentication
+- `KIBANA_PASSWORD` - The password to use for Kibana authentication
+- `KIBANA_ENDPOINT` - The Kibana host to connect to
+
+Fleet resources will re-use any Kibana or Elasticsearch credentials specified, these may be overridden with the following variables:
+- `FLEET_USERNAME` - The username to use for Kibana authentication
+- `FLEET_PASSWORD` - The password to use for Kibana authentication
+- `FLEET_ENDPOINT` - The Kibana host to connect to. ** Note the Fleet API is hosted within Kibana. This must be a Kibana HTTP host **
+- `FLEET_API_KEY` - API key to use for authentication to Fleet
 
 ```terraform
 provider "elasticstack" {
   elasticsearch {}
+  kibana {}
 }
 ```
 

--- a/docs/resources/kibana_action_connector.md
+++ b/docs/resources/kibana_action_connector.md
@@ -14,7 +14,7 @@ Creates or updates a Kibana action connector. See https://www.elastic.co/guide/e
 
 ```terraform
 provider "elasticstack" {
-  elasticsearch {}
+  kibana {}
 }
 
 resource "elasticstack_kibana_action_connector" "example" {

--- a/docs/resources/kibana_alerting_rule.md
+++ b/docs/resources/kibana_alerting_rule.md
@@ -14,7 +14,7 @@ Creates or updates a Kibana alerting rule. See https://www.elastic.co/guide/en/k
 
 ```terraform
 provider "elasticstack" {
-  elasticsearch {}
+  kibana {}
 }
 
 resource "elasticstack_kibana_alerting_rule" "example" {

--- a/docs/resources/kibana_space.md
+++ b/docs/resources/kibana_space.md
@@ -14,7 +14,7 @@ Creates or updates a Kibana space. See https://www.elastic.co/guide/en/kibana/ma
 
 ```terraform
 provider "elasticstack" {
-  elasticsearch {}
+  kibana {}
 }
 
 resource "elasticstack_kibana_space" "example" {

--- a/examples/provider/kibana.tf
+++ b/examples/provider/kibana.tf
@@ -1,0 +1,7 @@
+provider "elasticstack" {
+  kibana {
+    username  = "elastic"
+    password  = "changeme"
+    endpoints = ["http://localhost:5601"]
+  }
+}

--- a/examples/provider/provider-env.tf
+++ b/examples/provider/provider-env.tf
@@ -1,4 +1,4 @@
 provider "elasticstack" {
   elasticsearch {}
+  kibana {}
 }
-

--- a/examples/resources/elasticstack_kibana_action_connector/resource.tf
+++ b/examples/resources/elasticstack_kibana_action_connector/resource.tf
@@ -1,5 +1,5 @@
 provider "elasticstack" {
-  elasticsearch {}
+  kibana {}
 }
 
 resource "elasticstack_kibana_action_connector" "example" {

--- a/examples/resources/elasticstack_kibana_alerting_rule/resource.tf
+++ b/examples/resources/elasticstack_kibana_alerting_rule/resource.tf
@@ -1,5 +1,5 @@
 provider "elasticstack" {
-  elasticsearch {}
+  kibana {}
 }
 
 resource "elasticstack_kibana_alerting_rule" "example" {

--- a/examples/resources/elasticstack_kibana_space/resource.tf
+++ b/examples/resources/elasticstack_kibana_space/resource.tf
@@ -1,5 +1,5 @@
 provider "elasticstack" {
-  elasticsearch {}
+  kibana {}
 }
 
 resource "elasticstack_kibana_space" "example" {

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -668,6 +668,15 @@ func buildFleetClient(d *schema.ResourceData, kibanaCfg kibana.Config) (*fleet.C
 		}
 	}
 
+	if v := os.Getenv("FLEET_ENDPOINT"); v != "" {
+		config.URL = v
+	}
+	if v := os.Getenv("FLEET_USERNAME"); v != "" {
+		config.Username = v
+	}
+	if v := os.Getenv("FLEET_PASSWORD"); v != "" {
+		config.Password = v
+	}
 	if v := os.Getenv("FLEET_API_KEY"); v != "" {
 		config.APIKey = v
 	}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -26,7 +26,9 @@ The following methods are supported:
 
 ### Static credentials
 
-Default static credentials can be provided by adding the `username`, `password` and `endpoints` in `elasticsearch` block:
+#### Elasticsearch
+
+Default static credentials can be provided by adding the `username`, `password` and `endpoints` in the `elasticsearch` block:
 
 {{tffile "examples/provider/provider.tf"}}
 
@@ -34,12 +36,34 @@ Alternatively an `api_key` can be specified instead of `username` and `password`
 
 {{tffile "examples/provider/provider-apikey.tf"}}
 
+#### Kibana
+
+Default static credentials can be provided by adding the `username`, `password` and `endpoints` in the `kibana` block:
+
+{{tffile "examples/provider/kibana.tf"}}
+
+If no credentials are supplied the provider will fall back to using those provided in the `elasticsearch` block.
+
 ### Environment Variables
 
-You can provide your credentials for the default connection via the `ELASTICSEARCH_USERNAME`, `ELASTICSEARCH_PASSWORD` and comma-separated list `ELASTICSEARCH_ENDPOINTS`,
-environment variables, representing your user, password and Elasticsearch API endpoints respectively.
+The provider configuration can be specified through environment variables.
 
-Alternatively the `ELASTICSEARCH_API_KEY` variable can be specified instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`.
+For Elasticsearch resources, you can use the following variables:
+- `ELASTICSEARCH_USERNAME` - The username to use for Elasticsearch authentication
+- `ELASTICSEARCH_PASSWORD` - The password to use for Elasticsearch authentication
+- `ELASTICSEARCH_ENDPOINTS` - A comma separated list of Elasticsearch hosts to connect to
+- `ELASTICSEARCH_API_KEY` - An Elasticsearch API key to use instead of `ELASTICSEARCH_USERNAME` and `ELASTICSEARCH_PASSWORD`
+
+Kibana resources will re-use any Elasticsearch credentials specified, these may be overridden with the following variables:
+- `KIBANA_USERNAME` - The username to use for Kibana authentication
+- `KIBANA_PASSWORD` - The password to use for Kibana authentication
+- `KIBANA_ENDPOINT` - The Kibana host to connect to
+
+Fleet resources will re-use any Kibana or Elasticsearch credentials specified, these may be overridden with the following variables:
+- `FLEET_USERNAME` - The username to use for Kibana authentication
+- `FLEET_PASSWORD` - The password to use for Kibana authentication
+- `FLEET_ENDPOINT` - The Kibana host to connect to. ** Note the Fleet API is hosted within Kibana. This must be a Kibana HTTP host **
+- `FLEET_API_KEY` - API key to use for authentication to Fleet
 
 {{tffile "examples/provider/provider-env.tf"}}
 


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/404
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/380

Does what it says on the tin. We already support configuring all Kibana attributes through environment variables. Added the missing Fleet attributes in and made sure they're all part of the docs. 