### PR TITLE
fix: update component documentation

### DIFF
--- a/docs/resources/elasticsearch_component_template.md
+++ b/docs/resources/elasticsearch_component_template.md
@@ -21,7 +21,7 @@ resource "elasticstack_elasticsearch_component_template" "my_template" {
   name = "my_template"
 
   template {
-    aliases {
+    alias {
       name = "my_template_test"
     }
 

--- a/examples/resources/elasticstack_elasticsearch_component_template/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_component_template/resource.tf
@@ -6,7 +6,7 @@ resource "elasticstack_elasticsearch_component_template" "my_template" {
   name = "my_template"
 
   template {
-    aliases {
+    alias {
       name = "my_template_test"
     }
 


### PR DESCRIPTION
The template block expects an "aliases" block. However, this block is actually supposed to be named "alias".

Fixes #411 