### PR TITLE
Fix Kibana SLO panic `histogram_custom_indicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Add support for the `.slack_api` connector type for Kibana action connectors ([#419](https://github.com/elastic/terraform-provider-elasticstack/pull/419))
+- resource `elasticstack_kibana_slo`: Update `histogram_custom_indicator` `from` and `to` fields to float ([#XXX](https://github.com/elastic/terraform-provider-elasticstack/pull/XXX))
 
 ## [0.7.0] - 2023-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 - Add support for the `.slack_api` connector type for Kibana action connectors ([#419](https://github.com/elastic/terraform-provider-elasticstack/pull/419))
-- resource `elasticstack_kibana_slo`: Update `histogram_custom_indicator` `from` and `to` fields to float ([#XXX](https://github.com/elastic/terraform-provider-elasticstack/pull/XXX))
+- resource `elasticstack_kibana_slo`: Update `histogram_custom_indicator` `from` and `to` fields to float ([#430](https://github.com/elastic/terraform-provider-elasticstack/pull/430))
 
 ## [0.7.0] - 2023-08-22
 

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -180,11 +180,11 @@ func ResourceSlo() *schema.Resource {
 									Optional: true,
 								},
 								"from": {
-									Type:     schema.TypeInt, //TODO: validate this is set if aggregation is range
+									Type:     schema.TypeFloat,
 									Optional: true,
 								},
 								"to": {
-									Type:     schema.TypeInt, //TODO: validate this is set if aggregation is range
+									Type:     schema.TypeFloat,
 									Optional: true,
 								},
 							},

--- a/internal/kibana/slo_test.go
+++ b/internal/kibana/slo_test.go
@@ -88,19 +88,21 @@ func TestAccResourceSlo(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc: versionutils.CheckIfVersionIsUnsupported(version.Must(version.NewSemver("8.10.0-SNAPSHOT"))), //TODO: once 8.10.0 is released, move to 8.10.0
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(version.Must(version.NewSemver("8.10.0"))),
 				Config:   getSLOConfig(sloName, "histogram_custom_indicator", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.index", "my-index"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.field", "test"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.aggregation", "value_count"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.filter", "latency < 300"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.from", "0"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.to", "10"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.total.0.field", "test"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.total.0.aggregation", "value_count"),
 				),
 			},
 			{
-				SkipFunc: versionutils.CheckIfVersionIsUnsupported(version.Must(version.NewSemver("8.10.0-SNAPSHOT"))), //TODO: once 8.10.0 is released, move to 8.10.0
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(version.Must(version.NewSemver("8.10.0"))),
 				Config:   getSLOConfig(sloName, "metric_custom_indicator", true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "metric_custom_indicator.0.index", "my-index"),
@@ -340,6 +342,8 @@ func getSLOConfig(name string, indicatorType string, settingsEnabled bool) strin
 				field = "test"
 				aggregation = "supdawg"
 				filter = "latency < 300"
+				from = 0
+				to = 10
 			}
 			total {
 				field = "test"


### PR DESCRIPTION
Fixes a Kibana SLO panic due to incorrect field type on the Kibana SLO histogram_custom_indicator `to` and `from` fields.

Closes #429