### PR TITLE
Fix mapping of webhook connectors that is stored in tfstate

### DIFF
--- a/internal/clients/kibana/connector.go
+++ b/internal/clients/kibana/connector.go
@@ -1465,7 +1465,7 @@ func connectorResponseToModelTines(discriminator, spaceID string, properties con
 }
 
 func connectorResponseToModelWebhook(discriminator, spaceID string, properties connectors.ConnectorResponseProperties) (*models.KibanaActionConnector, error) {
-	resp, err := properties.AsConnectorResponsePropertiesTines()
+	resp, err := properties.AsConnectorResponsePropertiesWebhook()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kibana/connector_test.go
+++ b/internal/kibana/connector_test.go
@@ -1309,7 +1309,7 @@ func TestAccResourceKibanaConnectorWebhook(t *testing.T) {
 	  name         = "%s"
 	  config = jsonencode({
 		url = "https://elastic.co"
-  		hasAuth = True
+  		hasAuth = true
     		method = "post"
 	  })
 	  secrets = jsonencode({})

--- a/internal/kibana/connector_test.go
+++ b/internal/kibana/connector_test.go
@@ -1310,7 +1310,7 @@ func TestAccResourceKibanaConnectorWebhook(t *testing.T) {
 	  config = jsonencode({
 		url = "https://elastic.co"
   		hasAuth = true
-    		method = "post"
+    	method = "post"
 	  })
 	  secrets = jsonencode({})
 	  connector_type_id = ".webhook"
@@ -1329,6 +1329,8 @@ func TestAccResourceKibanaConnectorWebhook(t *testing.T) {
 	  name         = "Updated %s"
 	  config = jsonencode({
 		url = "https://elasticsearch.com"
+		hasAuth = true
+    	method = "post"
 	  })
 	  secrets = jsonencode({})
 	  connector_type_id = ".webhook"

--- a/internal/kibana/connector_test.go
+++ b/internal/kibana/connector_test.go
@@ -1310,7 +1310,7 @@ func TestAccResourceKibanaConnectorWebhook(t *testing.T) {
 	  config = jsonencode({
 		url = "https://elastic.co"
   		hasAuth = true
-    	method = "post"
+  		method = "post"
 	  })
 	  secrets = jsonencode({})
 	  connector_type_id = ".webhook"

--- a/internal/kibana/connector_test.go
+++ b/internal/kibana/connector_test.go
@@ -1309,6 +1309,8 @@ func TestAccResourceKibanaConnectorWebhook(t *testing.T) {
 	  name         = "%s"
 	  config = jsonencode({
 		url = "https://elastic.co"
+  		hasAuth = True
+    		method = "post"
 	  })
 	  secrets = jsonencode({})
 	  connector_type_id = ".webhook"

--- a/internal/kibana/connector_test.go
+++ b/internal/kibana/connector_test.go
@@ -1330,7 +1330,7 @@ func TestAccResourceKibanaConnectorWebhook(t *testing.T) {
 	  config = jsonencode({
 		url = "https://elasticsearch.com"
 		hasAuth = true
-    	method = "post"
+		method = "post"
 	  })
 	  secrets = jsonencode({})
 	  connector_type_id = ".webhook"


### PR DESCRIPTION
Connectors were only properly storing url in the config in the tfstate file as they were being mapped to Tines. 

Fix #388 