### PR TITLE
Kibana SLOs: use `spaceID`

### DIFF
--- a/internal/clients/kibana/slo.go
+++ b/internal/clients/kibana/slo.go
@@ -19,7 +19,7 @@ func GetSlo(ctx context.Context, apiClient *clients.ApiClient, id, spaceID strin
 	}
 
 	ctxWithAuth := apiClient.SetSloAuthContext(ctx)
-	req := client.GetSloOp(ctxWithAuth, "default", id).KbnXsrf("true")
+	req := client.GetSloOp(ctxWithAuth, spaceID, id).KbnXsrf("true")
 	sloRes, res, err := req.Execute()
 	if res == nil {
 		return nil, diag.FromErr(err)
@@ -33,7 +33,7 @@ func GetSlo(ctx context.Context, apiClient *clients.ApiClient, id, spaceID strin
 
 	defer res.Body.Close()
 
-	return sloResponseToModel("default", sloRes), utils.CheckHttpError(res, "Unable to get slo with ID "+string(id))
+	return sloResponseToModel(spaceID, sloRes), utils.CheckHttpError(res, "Unable to get slo with ID "+string(id))
 }
 
 func DeleteSlo(ctx context.Context, apiClient *clients.ApiClient, sloId string, spaceId string) diag.Diagnostics {


### PR DESCRIPTION
When creating the SLOs against a custom space ID, I'm getting the following errors:

```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to elasticstack_kibana_slo.kibana_http_latency_slo, provider "provider[\"terraform.local/elastic/elasticstack\"]" produced an unexpected new value: Root resource was present, but now absent.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

This is caused because TF is correctly creating it in the indicated space, but retrieving it from the `default` one.