### PR TITLE
Fix buildkite release pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,3 +5,12 @@ set -euo pipefail
 echo "--- Golang version:"
 export GO_VERSION="1.20"
 echo "${GO_VERSION}"
+
+VAULT_PATH=secret/ci/elastic-terraform-provider-elasticstack/terraform-provider-secrets
+
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "terraform-provider-elasticstack-release" ]]; then
+  export GPG_PRIVATE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_private ${VAULT_PATH})
+  export GPG_PASSPHRASE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_passphrase ${VAULT_PATH})
+  export GPG_FINGERPRINT_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_fingerprint ${VAULT_PATH})
+  export GITHUB_TOKEN=$(scripts/retry.sh 5 vault kv get -field gh_personal_access_token ${VAULT_PATH})
+fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "--- Golang version:"
-export GO_VERSION="1.20"
+export GO_VERSION="1.21"
 echo "${GO_VERSION}"
 
 VAULT_PATH=secret/ci/elastic-terraform-provider-elasticstack/terraform-provider-secrets

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -2,5 +2,7 @@ steps:
   - label: Release
     agents:
       image: golang:${GO_VERSION}
+      cpu: "8"
+      memory: "4G"
     command:
       - ".buildkite/scripts/release.sh"

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -2,45 +2,14 @@
 
 set -euo pipefail
 
-cleanup() {
-    ARG=${?}
-    echo  "--- Clean up"
-
-    unset GPG_FINGERPRINT_SECRET
-    # unset GITHUB_TOKEN
-    rm -rf dist bin
-    exit ${ARG}
-}
-
-trap cleanup EXIT
-
 echo "--- Download dependencies"
 make vendor
 
-echo "--- Import gpg key"
+echo "--- Importing GPG key"
+echo -n "$GPG_PRIVATE_SECRET" | base64 --decode | gpg --import --batch --yes --passphrase "$GPG_PASSPHRASE_SECRET"
 
-GITHUB_ORGANIZATION=elastic
-REPO_NAME=terraform-provider-elasticstack
-VAULT_PATH=secret/ci/${GITHUB_ORGANIZATION}-${REPO_NAME}
-
-GPG_PRIVATE_SECRET=$(vault read -field=gpg_private ${VAULT_PATH}  | base64 -d)
-
-GPG_PASSPHRASE_SECRET=$(vault read -field=gpg_passphrase ${VAULT_PATH})
-
-cat ${GPG_PASSPHRASE_SECRET} | gpg --import --batch --yes --passphrase-fd 0 ${GPG_PRIVATE_SECRET}
-
-echo "--- Cache GPG key and release the binaries"
-
-cat ${GPG_PASSPHRASE_SECRET} | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback
+echo "--- Caching GPG passphrase"
+echo "$GPG_PASSPHRASE_SECRET" | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback
 
 echo "--- Release the binaries"
-
-# 'make release' calls 'goreleaser' that needs GPG_FINGERPRINT_SECRET and GITHUB_TOKEN env vars
-export GPG_FINGERPRINT_SECRET=$(vault read -field=gpg_fingerprint ${VAULT_PATH} | xargs)
-
-## TODO
-## goreleaser needs GH token to publish binaries to GH
-## it's commented out while the BK pipeline is being tested 
-# export GITHUB_TOKEN=$(vault read -field=github_release_token ${VAULT_PATH} | xargs)
-
-make release
+make release-no-publish

--- a/.ci/pipelines/release.Jenkinsfile
+++ b/.ci/pipelines/release.Jenkinsfile
@@ -28,7 +28,7 @@ node('docker && gobld/machineType:n1-highcpu-8') {
             stage("Cache GPG key and release the binaries") {
                 script {
                     env.GITHUB_TOKEN = readFile(".ci/.github_token").trim()
-                    env.GPG_FINGERPRINT = readFile(".ci/.gpg_fingerprint").trim()
+                    env.GPG_FINGERPRINT_SECRET = readFile(".ci/.gpg_fingerprint").trim()
                 }
                 sh 'pwd; make -C .ci cache-gpg-passphrase; make release'
             }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,15 +16,15 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-    #    - freebsd
+    - freebsd
     - windows
-      #    - linux
-      #    - darwin
+    - linux
+    - darwin
   goarch:
+    - '386'
+    - arm
+    - arm64
     - amd64
-      #    - '386'
-      #    - arm
-      #    - arm64
   ignore:
     - goos: darwin
       goarch: '386'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,15 +16,15 @@ builds:
   ldflags:
     - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
   goos:
-    - freebsd
+    #    - freebsd
     - windows
-    - linux
-    - darwin
+      #    - linux
+      #    - darwin
   goarch:
     - amd64
-    - '386'
-    - arm
-    - arm64
+      #    - '386'
+      #    - arm
+      #    - arm64
   ignore:
     - goos: darwin
       goarch: '386'

--- a/Makefile
+++ b/Makefile
@@ -212,18 +212,18 @@ release-snapshot: tools ## Make local-only test release to see if it works using
 
 .PHONY: release-no-publish
 release-no-publish: tools check-sign-release ## Make a release without publishing artifacts
-	@ $(GOBIN)/goreleaser release --skip-publish --skip-announce --skip-validate
+	@ $(GOBIN)/goreleaser release --skip-publish --skip-announce --skip-validate  --parallelism=4
 
 
 .PHONY: release
 release: tools check-sign-release check-publish-release ## Build, sign, and upload your release
-	@ $(GOBIN)/goreleaser release --clean
+	@ $(GOBIN)/goreleaser release --clean  --parallelism=4
 
 
 .PHONY: check-sign-release
 check-sign-release:
-ifndef GPG_FINGERPRINT
-	$(error GPG_FINGERPRINT is undefined, but required for signing the release)
+ifndef GPG_FINGERPRINT_SECRET
+	$(error GPG_FINGERPRINT_SECRET is undefined, but required for signing the release)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ release-snapshot: tools ## Make local-only test release to see if it works using
 
 .PHONY: release-no-publish
 release-no-publish: tools check-sign-release ## Make a release without publishing artifacts
-	@ $(GOBIN)/goreleaser release --skip=publish,announce,validate  --parallelism=4
+	@ $(GOBIN)/goreleaser release --skip=publish,announce,validate  --parallelism=2
 
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ release-snapshot: tools ## Make local-only test release to see if it works using
 
 .PHONY: release-no-publish
 release-no-publish: tools check-sign-release ## Make a release without publishing artifacts
-	@ $(GOBIN)/goreleaser release --skip-publish --skip-announce --skip-validate  --parallelism=4
+	@ $(GOBIN)/goreleaser release --skip=publish,announce,validate  --parallelism=4
 
 
 .PHONY: release

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,6 +22,12 @@ spec:
     spec:
       repository: elastic/terraform-provider-elasticstack
       pipeline_file: ".buildkite/release.yml"
+      provider_settings:
+        build_branches: false
+        build_pull_request_forks: false
+        build_tags: true
+        filter_condition: 'build.tag =~ /^v[0-9.]+$/'
+        filter_enabled: true
       teams:
         control-plane-stateful-applications:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
Fixes the release pipeline:
* uses the proper vault path (there was no value defined previously)
* fixes go version discrepancy
* limit parralelism to avoid build failure
* proper secrets handling


Note: atm, this is just running `make release-no-publish` until we can have the job run only on tag pushes.