### PR TITLE
Make input optional for Fleet integration policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Rename fleet package objects to `elasticstack_fleet_integration` and `elasticstack_fleet_integration_policy` ([#476](https://github.com/elastic/terraform-provider-elasticstack/pull/476))
 - Fix a provider crash when managing SLOs outside of the default Kibana space. ([#485](https://github.com/elastic/terraform-provider-elasticstack/pull/485))
+- Make input optional for `elasticstack_fleet_integration_policy` ([#493](https://github.com/elastic/terraform-provider-elasticstack/pull/493))
 
 ## [0.10.0] - 2023-11-02
 

--- a/docs/resources/fleet_integration_policy.md
+++ b/docs/resources/fleet_integration_policy.md
@@ -83,7 +83,6 @@ resource "elasticstack_fleet_integration_policy" "sample" {
 ### Required
 
 - `agent_policy_id` (String) ID of the agent policy.
-- `input` (Block List, Min: 1) (see [below for nested schema](#nestedblock--input))
 - `integration_name` (String) The name of the integration package.
 - `integration_version` (String) The version of the integration package.
 - `name` (String) The name of the integration policy.
@@ -94,6 +93,7 @@ resource "elasticstack_fleet_integration_policy" "sample" {
 - `description` (String) The description of the integration policy.
 - `enabled` (Boolean) Enable the integration policy.
 - `force` (Boolean) Force operations, such as creation and deletion, to occur.
+- `input` (Block List) (see [below for nested schema](#nestedblock--input))
 - `policy_id` (String) Unique identifier of the integration policy.
 - `vars_json` (String, Sensitive) Integration-level variables as JSON.
 

--- a/internal/fleet/integration_policy_resource.go
+++ b/internal/fleet/integration_policy_resource.go
@@ -64,7 +64,7 @@ func ResourceIntegrationPolicy() *schema.Resource {
 		},
 		"input": {
 			Type:     schema.TypeList,
-			Required: true,
+			Optional: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"input_id": {


### PR DESCRIPTION
- Relaxed the requirement for input for Fleet integration policies.
- Certain integrations, such as the Elastic Agent integration, do not require any additional configuration, which means an input would not be provided.

Closes #486 