### PR TITLE
Sort Fleet integration policy inputs to ensure consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Rename fleet package objects to `elasticstack_fleet_integration` and `elasticstack_fleet_integration_policy` ([#476](https://github.com/elastic/terraform-provider-elasticstack/pull/476))
 - Fix a provider crash when managing SLOs outside of the default Kibana space. ([#485](https://github.com/elastic/terraform-provider-elasticstack/pull/485))
 - Make input optional for `elasticstack_fleet_integration_policy` ([#493](https://github.com/elastic/terraform-provider-elasticstack/pull/493))
+- Sort Fleet integration policy inputs to ensure consistency ([#494](https://github.com/elastic/terraform-provider-elasticstack/pull/494))
 
 ## [0.10.0] - 2023-11-02
 

--- a/internal/fleet/shared_test.go
+++ b/internal/fleet/shared_test.go
@@ -1,0 +1,63 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SortInputs(t *testing.T) {
+	t.Run("WithExisting", func(t *testing.T) {
+		existing := []any{
+			map[string]any{"input_id": "A", "enabled": true},
+			map[string]any{"input_id": "B", "enabled": true},
+			map[string]any{"input_id": "C", "enabled": true},
+			map[string]any{"input_id": "D", "enabled": true},
+			map[string]any{"input_id": "E", "enabled": true},
+		}
+
+		incoming := []any{
+			map[string]any{"input_id": "G", "enabled": true},
+			map[string]any{"input_id": "F", "enabled": true},
+			map[string]any{"input_id": "B", "enabled": true},
+			map[string]any{"input_id": "E", "enabled": true},
+			map[string]any{"input_id": "C", "enabled": true},
+		}
+
+		want := []any{
+			map[string]any{"input_id": "B", "enabled": true},
+			map[string]any{"input_id": "C", "enabled": true},
+			map[string]any{"input_id": "E", "enabled": true},
+			map[string]any{"input_id": "G", "enabled": true},
+			map[string]any{"input_id": "F", "enabled": true},
+		}
+
+		sortInputs(incoming, existing)
+
+		require.Equal(t, want, incoming)
+	})
+
+	t.Run("WithEmpty", func(t *testing.T) {
+		var existing []any
+
+		incoming := []any{
+			map[string]any{"input_id": "G", "enabled": true},
+			map[string]any{"input_id": "F", "enabled": true},
+			map[string]any{"input_id": "B", "enabled": true},
+			map[string]any{"input_id": "E", "enabled": true},
+			map[string]any{"input_id": "C", "enabled": true},
+		}
+
+		want := []any{
+			map[string]any{"input_id": "G", "enabled": true},
+			map[string]any{"input_id": "F", "enabled": true},
+			map[string]any{"input_id": "B", "enabled": true},
+			map[string]any{"input_id": "E", "enabled": true},
+			map[string]any{"input_id": "C", "enabled": true},
+		}
+
+		sortInputs(incoming, existing)
+
+		require.Equal(t, want, incoming)
+	})
+}


### PR DESCRIPTION
- When new inputs are read from the Fleet API, the list is sorted according to the existing plan. Any new inputs added from the API will be moved to the end of the list. This ensures a consistency of inputs and prevents unnecssary changes from appearing.

Closes #473