### PR TITLE
Add Kibana CA Certs optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- Add new optional `ca_certs` attribute for Kibana ([#507](https://github.com/elastic/terraform-provider-elasticstack/pull/507))
+
 ### Fixed
 - Handle nil LastExecutionDate's in Kibana alerting rules. ([#508](https://github.com/elastic/terraform-provider-elasticstack/pull/508))
 - Import all relevant attributes during `elasticstack_fleet_output` import ([#522](https://github.com/elastic/terraform-provider-elasticstack/pull/522))

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,6 +185,7 @@ Optional:
 Optional:
 
 - `api_key` (String, Sensitive) API Key to use for authentication to Kibana
+- `ca_certs` (List of String) A list of paths to CA certificates to validate the certificate presented by the Kibana server.
 - `endpoints` (List of String, Sensitive) A comma-separated list of endpoints where the terraform provider will point to, this must include the http(s) schema and port number.
 - `insecure` (Boolean) Disable TLS certificate validation
 - `password` (String, Sensitive) Password to use for API authentication to Kibana.

--- a/internal/clients/config/kibana_test.go
+++ b/internal/clients/config/kibana_test.go
@@ -57,7 +57,8 @@ func Test_newKibanaConfigFromSDK(t *testing.T) {
 								"endpoints": []interface{}{"example.com/kibana"},
 								"username":  "kibana",
 								"password":  "baltic",
-								"insecure":  true,
+								"ca_certs":  []interface{}{"internal", "lets_decrypt"},
+								"insecure":  false,
 							},
 						},
 					},
@@ -65,7 +66,8 @@ func Test_newKibanaConfigFromSDK(t *testing.T) {
 						Address:          "example.com/kibana",
 						Username:         "kibana",
 						Password:         "baltic",
-						DisableVerifySSL: true,
+						CAs:              []string{"internal", "lets_decrypt"},
+						DisableVerifySSL: false,
 					},
 				}
 			},
@@ -86,6 +88,7 @@ func Test_newKibanaConfigFromSDK(t *testing.T) {
 								"endpoints": []interface{}{"example.com/kibana"},
 								"username":  "kibana",
 								"password":  "baltic",
+								"ca_certs":  []interface{}{"internal", "lets_decrypt"},
 								"insecure":  true,
 							},
 						},
@@ -95,12 +98,14 @@ func Test_newKibanaConfigFromSDK(t *testing.T) {
 						"KIBANA_USERNAME": "elastic",
 						"KIBANA_PASSWORD": "thin-lines",
 						"KIBANA_INSECURE": "false",
+						"KIBANA_CA_CERTS": "black,sea",
 					},
 					expectedConfig: kibanaConfig{
 						Address:          "example.com/cabana",
 						Username:         "elastic",
 						Password:         "thin-lines",
 						DisableVerifySSL: false,
+						CAs:              []string{"black", "sea"},
 					},
 				}
 			},
@@ -114,6 +119,7 @@ func Test_newKibanaConfigFromSDK(t *testing.T) {
 			os.Unsetenv("KIBANA_ENDPOINT")
 			os.Unsetenv("KIBANA_INSECURE")
 			os.Unsetenv("KIBANA_API_KEY")
+			os.Unsetenv("KIBANA_CA_CERTS")
 
 			args := tt.args()
 			rd := schema.TestResourceDataRaw(t, map[string]*schema.Schema{
@@ -177,7 +183,11 @@ func Test_newKibanaConfigFromFramework(t *testing.T) {
 								Endpoints: types.ListValueMust(types.StringType, []attr.Value{
 									types.StringValue("example.com/kibana"),
 								}),
-								Insecure: types.BoolValue(true),
+								CACerts: types.ListValueMust(types.StringType, []attr.Value{
+									types.StringValue("internal"),
+									types.StringValue("lets_decrypt"),
+								}),
+								Insecure: types.BoolValue(false),
 							},
 						},
 					},
@@ -185,7 +195,8 @@ func Test_newKibanaConfigFromFramework(t *testing.T) {
 						Address:          "example.com/kibana",
 						Username:         "kibana",
 						Password:         "baltic",
-						DisableVerifySSL: true,
+						CAs:              []string{"internal", "lets_decrypt"},
+						DisableVerifySSL: false,
 					},
 				}
 			},
@@ -206,6 +217,7 @@ func Test_newKibanaConfigFromFramework(t *testing.T) {
 								Endpoints: types.ListValueMust(types.StringType, []attr.Value{
 									types.StringValue("example.com/kibana"),
 								}),
+								CACerts:  types.ListValueMust(types.StringType, []attr.Value{}),
 								Insecure: types.BoolValue(true),
 							},
 						},
@@ -236,6 +248,10 @@ func Test_newKibanaConfigFromFramework(t *testing.T) {
 								Endpoints: types.ListValueMust(types.StringType, []attr.Value{
 									types.StringValue("example.com/kibana"),
 								}),
+								CACerts: types.ListValueMust(types.StringType, []attr.Value{
+									types.StringValue("internal"),
+									types.StringValue("lets_decrypt"),
+								}),
 								Insecure: types.BoolValue(true),
 							},
 						},
@@ -245,11 +261,13 @@ func Test_newKibanaConfigFromFramework(t *testing.T) {
 						"KIBANA_USERNAME": "elastic",
 						"KIBANA_PASSWORD": "thin-lines",
 						"KIBANA_INSECURE": "false",
+						"KIBANA_CA_CERTS": "black,sea",
 					},
 					expectedConfig: kibanaConfig{
 						Address:          "example.com/cabana",
 						Username:         "elastic",
 						Password:         "thin-lines",
+						CAs:              []string{"black", "sea"},
 						DisableVerifySSL: false,
 					},
 				}
@@ -263,6 +281,7 @@ func Test_newKibanaConfigFromFramework(t *testing.T) {
 			os.Unsetenv("KIBANA_PASSWORD")
 			os.Unsetenv("KIBANA_API_KEY")
 			os.Unsetenv("KIBANA_ENDPOINT")
+			os.Unsetenv("KIBANA_CA_CERTS")
 			os.Unsetenv("KIBANA_INSECURE")
 
 			args := tt.args()

--- a/internal/clients/config/provider.go
+++ b/internal/clients/config/provider.go
@@ -30,6 +30,7 @@ type KibanaConnection struct {
 	ApiKey    types.String `tfsdk:"api_key"`
 	Endpoints types.List   `tfsdk:"endpoints"`
 	Insecure  types.Bool   `tfsdk:"insecure"`
+	CACerts   types.List   `tfsdk:"ca_certs"`
 }
 
 type FleetConnection struct {

--- a/internal/schema/connection.go
+++ b/internal/schema/connection.go
@@ -163,6 +163,11 @@ func GetKbFWConnectionBlock() fwschema.Block {
 					Sensitive:           true,
 					ElementType:         types.StringType,
 				},
+				"ca_certs": fwschema.ListAttribute{
+					MarkdownDescription: "A list of paths to CA certificates to validate the certificate presented by the Kibana server.",
+					Optional:            true,
+					ElementType:         types.StringType,
+				},
 				"insecure": fwschema.BoolAttribute{
 					MarkdownDescription: "Disable TLS certificate validation",
 					Optional:            true,
@@ -393,6 +398,14 @@ func GetKibanaConnectionSchema() *schema.Schema {
 					Optional:    true,
 					Sensitive:   true,
 					MaxItems:    1, // Current API restriction
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"ca_certs": {
+					Description: "A list of paths to CA certificates to validate the certificate presented by the Kibana server.",
+					Type:        schema.TypeList,
+					Optional:    true,
 					Elem: &schema.Schema{
 						Type: schema.TypeString,
 					},


### PR DESCRIPTION
Fixes #368 

Adds a new optional `ca_certs` Parameter to the Kibana Configuration Block