### PR TITLE
Do not set LastExecutionDate if it is `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Handle nil LastExecutionDate's in Kibana alerting rules. ([#508](https://github.com/elastic/terraform-provider-elasticstack/pull/508))
+
 ## [0.11.0] - 2023-12-12
 
 ### Added

--- a/internal/kibana/alerting.go
+++ b/internal/kibana/alerting.go
@@ -325,8 +325,10 @@ func resourceRuleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	if err := d.Set("last_execution_status", rule.ExecutionStatus.Status); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("last_execution_date", rule.ExecutionStatus.LastExecutionDate.Format("2006-01-02 15:04:05.999 -0700 MST")); err != nil {
-		return diag.FromErr(err)
+	if rule.ExecutionStatus.LastExecutionDate != nil {
+		if err := d.Set("last_execution_date", rule.ExecutionStatus.LastExecutionDate.Format("2006-01-02 15:04:05.999 -0700 MST")); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	params, err := json.Marshal(rule.Params)


### PR DESCRIPTION
`NilPointer` can happen if we try to read and update rules which have not been executed.
This PR protects the code in that scenario.