### PR TITLE
Secured release pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,11 +6,11 @@ echo "--- Golang version:"
 export GO_VERSION="1.21"
 echo "${GO_VERSION}"
 
-VAULT_PATH=secret/ci/elastic-terraform-provider-elasticstack/terraform-provider-secrets
+RELEASE_VAULT_PATH=kv/ci-shared/terraform-providers
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "terraform-provider-elasticstack-release" ]]; then
-  export GPG_PRIVATE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_private ${VAULT_PATH})
-  export GPG_PASSPHRASE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_passphrase ${VAULT_PATH})
-  export GPG_FINGERPRINT_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_fingerprint ${VAULT_PATH})
-  export GITHUB_TOKEN=$(scripts/retry.sh 5 vault kv get -field gh_personal_access_token ${VAULT_PATH})
+  export GPG_PRIVATE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_private ${RELEASE_VAULT_PATH})
+  export GPG_PASSPHRASE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_passphrase ${RELEASE_VAULT_PATH})
+  export GPG_FINGERPRINT_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_fingerprint ${RELEASE_VAULT_PATH})
+  export GITHUB_TOKEN=$(scripts/retry.sh 5 vault kv get -field gh_personal_access_token ${RELEASE_VAULT_PATH})
 fi

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -12,4 +12,4 @@ echo "--- Caching GPG passphrase"
 echo "$GPG_PASSPHRASE_SECRET" | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback
 
 echo "--- Release the binaries"
-make release-no-publish
+make release


### PR DESCRIPTION
This change, related to https://github.com/elastic/ci/pull/2506 updates the release script to read the PGP keys from a more secured location shared with less folks. The GPG key information is now in a secured shared location accessible only to members of the GH group `terraform-providers-admins` and to the CI pipelines of this repository and terraform-provider-elasticstack.

Note - I also updated the pipeline to actual release the binary (it was set to `-no-publish` before).

Related change: https://github.com/elastic/terraform-provider-ec/pull/758