### PR TITLE
Populate all relevant attributes during fleet output import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Handle nil LastExecutionDate's in Kibana alerting rules. ([#508](https://github.com/elastic/terraform-provider-elasticstack/pull/508))
+- Import all relevant attributes during `elasticstack_fleet_output` import ([#522](https://github.com/elastic/terraform-provider-elasticstack/pull/522))
 
 ## [0.11.0] - 2023-12-12
 

--- a/internal/fleet/output_resource_test.go
+++ b/internal/fleet/output_resource_test.go
@@ -50,6 +50,7 @@ func TestAccResourceOutputElasticsearch(t *testing.T) {
 				),
 			},
 			{
+				SkipFunc:          versionutils.CheckIfVersionIsUnsupported(minVersionOutput),
 				ResourceName:      "elasticstack_fleet_output.test_output",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/internal/fleet/output_resource_test.go
+++ b/internal/fleet/output_resource_test.go
@@ -49,6 +49,11 @@ func TestAccResourceOutputElasticsearch(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "hosts.0", "https://elasticsearch:9200"),
 				),
 			},
+			{
+				ResourceName:      "elasticstack_fleet_output.test_output",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/506

Uses the returned output type rather than relying on internal state for parsing the response during read/import.