### PR TITLE
Support API Keys with data_view resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Add new optional `ca_certs` attribute for Kibana ([#507](https://github.com/elastic/terraform-provider-elasticstack/pull/507))
+- Support API key authentication in `elasticstack_kibana_data_view` resource ([#549](https://github.com/elastic/terraform-provider-elasticstack/pull/549))
 
 ### Fixed
 - Handle nil LastExecutionDate's in Kibana alerting rules. ([#508](https://github.com/elastic/terraform-provider-elasticstack/pull/508))

--- a/generated/data_views/README.md
+++ b/generated/data_views/README.md
@@ -135,10 +135,10 @@ r, err := client.Service.Operation(auth, args)
 ### apiKeyAuth
 
 - **Type**: API key
-- **API key parameter name**: ApiKey
+- **API key parameter name**: Authorization
 - **Location**: HTTP header
 
-Note, each API key must be added to a map of `map[string]APIKey` where the key is: ApiKey and passed in as the auth context for each request.
+Note, each API key must be added to a map of `map[string]APIKey` where the key is: Authorization and passed in as the auth context for each request.
 
 Example
 
@@ -147,7 +147,7 @@ auth := context.WithValue(
 		context.Background(),
 		sw.ContextAPIKeys,
 		map[string]sw.APIKey{
-			"ApiKey": {Key: "API_KEY_STRING"},
+			"Authorization": {Key: "API_KEY_STRING"},
 		},
 	)
 r, err := client.Service.Operation(auth, args)

--- a/generated/data_views/api/openapi.yaml
+++ b/generated/data_views/api/openapi.yaml
@@ -2472,6 +2472,7 @@ components:
       scheme: basic
       type: http
     apiKeyAuth:
+      description: "e.g. Authorization: ApiKey base64AccessApiKey"
       in: header
-      name: ApiKey
+      name: Authorization
       type: apiKey

--- a/generated/data_views/api_data_views.go
+++ b/generated/data_views/api_data_views.go
@@ -323,7 +323,7 @@ func (a *DataViewsAPIService) CreateDataViewExecute(r ApiCreateDataViewRequest) 
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -470,7 +470,7 @@ func (a *DataViewsAPIService) CreateRuntimeFieldExecute(r ApiCreateRuntimeFieldR
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -601,7 +601,7 @@ func (a *DataViewsAPIService) CreateUpdateRuntimeFieldExecute(r ApiCreateUpdateR
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -737,7 +737,7 @@ func (a *DataViewsAPIService) DeleteDataViewExecute(r ApiDeleteDataViewRequest) 
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -857,7 +857,7 @@ func (a *DataViewsAPIService) DeleteRuntimeFieldExecute(r ApiDeleteRuntimeFieldR
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -972,7 +972,7 @@ func (a *DataViewsAPIService) GetAllDataViewsExecute(r ApiGetAllDataViewsRequest
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1100,7 +1100,7 @@ func (a *DataViewsAPIService) GetDataViewExecute(r ApiGetDataViewRequest) (*Data
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1224,7 +1224,7 @@ func (a *DataViewsAPIService) GetDefaultDataViewExecute(r ApiGetDefaultDataViewR
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1356,7 +1356,7 @@ func (a *DataViewsAPIService) GetRuntimeFieldExecute(r ApiGetRuntimeFieldRequest
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1502,7 +1502,7 @@ func (a *DataViewsAPIService) SetDefaultDatailViewExecute(r ApiSetDefaultDatailV
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1652,7 +1652,7 @@ func (a *DataViewsAPIService) UpdateDataViewExecute(r ApiUpdateDataViewRequest) 
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1802,7 +1802,7 @@ func (a *DataViewsAPIService) UpdateFieldsMetadataExecute(r ApiUpdateFieldsMetad
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}
@@ -1942,7 +1942,7 @@ func (a *DataViewsAPIService) UpdateRuntimeFieldExecute(r ApiUpdateRuntimeFieldR
 				} else {
 					key = apiKey.Key
 				}
-				localVarHeaderParams["ApiKey"] = key
+				localVarHeaderParams["Authorization"] = key
 			}
 		}
 	}

--- a/generated/data_views/bundled.yaml
+++ b/generated/data_views/bundled.yaml
@@ -477,7 +477,8 @@ components:
     apiKeyAuth:
       type: apiKey
       in: header
-      name: ApiKey
+      name: Authorization
+      description: 'e.g. Authorization: ApiKey base64AccessApiKey'
   examples:
     get_data_views_response:
       summary: The get all data views API returns a list of data views.

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -267,10 +267,18 @@ func (a *ApiClient) SetAlertingAuthContext(ctx context.Context) context.Context 
 }
 
 func (a *ApiClient) SetDataviewAuthContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, data_views.ContextBasicAuth, data_views.BasicAuth{
-		UserName: a.kibanaConfig.Username,
-		Password: a.kibanaConfig.Password,
-	})
+	if a.kibanaConfig.ApiKey != "" {
+		return context.WithValue(ctx, data_views.ContextAPIKeys, map[string]data_views.APIKey{
+			"apiKeyAuth": {
+				Prefix: "ApiKey",
+				Key:    a.kibanaConfig.ApiKey,
+			}})
+	} else {
+		return context.WithValue(ctx, data_views.ContextBasicAuth, data_views.BasicAuth{
+			UserName: a.kibanaConfig.Username,
+			Password: a.kibanaConfig.Password,
+		})
+	}
 }
 
 func (a *ApiClient) ID(ctx context.Context, resourceId string) (*CompositeId, diag.Diagnostics) {


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/529

Does what it says on the tin, adds support for API key auth into the data view resource. 