### PR TITLE
Persist override value during data view read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Handle nil LastExecutionDate's in Kibana alerting rules. ([#508](https://github.com/elastic/terraform-provider-elasticstack/pull/508))
 - Import all relevant attributes during `elasticstack_fleet_output` import ([#522](https://github.com/elastic/terraform-provider-elasticstack/pull/522))
+- Fix issue when setting `override` in `elasticstack_kibana_data_view` resource ([#550](https://github.com/elastic/terraform-provider-elasticstack/pull/550))
 
 ## [0.11.0] - 2023-12-12
 

--- a/internal/kibana/data_view/acc_test.go
+++ b/internal/kibana/data_view/acc_test.go
@@ -33,6 +33,7 @@ func TestAccResourceDataView(t *testing.T) {
 				Config:   testAccResourceDataViewBasicDV(indexName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("elasticstack_kibana_data_view.dv", "id"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_data_view.dv", "override", "true"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_data_view.dv", "data_view.name", indexName),
 					resource.TestCheckResourceAttr("elasticstack_kibana_data_view.dv", "data_view.source_filters.#", "2"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_data_view.dv", "data_view.field_formats.event_time.id", "date_nanos"),
@@ -45,6 +46,7 @@ func TestAccResourceDataView(t *testing.T) {
 				Config:   testAccResourceDataViewBasicDVUpdated(indexName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("elasticstack_kibana_data_view.dv", "id"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_data_view.dv", "override", "false"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_data_view.dv", "data_view.name", indexName),
 					resource.TestCheckNoResourceAttr("elasticstack_kibana_data_view.dv", "data_view.source_filters"),
 					resource.TestCheckNoResourceAttr("elasticstack_kibana_data_view.dv", "data_view.field_formats"),
@@ -80,6 +82,7 @@ resource "elasticstack_elasticsearch_index" "my_index" {
 }
 
 resource "elasticstack_kibana_data_view" "dv" {
+	override = true
 	data_view = {
 		title           = "%s*"
 		name            = "%s"
@@ -121,6 +124,7 @@ resource "elasticstack_elasticsearch_index" "my_index" {
 }
 
 resource "elasticstack_kibana_data_view" "dv" {
+	override = false
 	data_view = {
 		title           = "%s*"
 		name            = "%s"

--- a/internal/kibana/data_view/schema.go
+++ b/internal/kibana/data_view/schema.go
@@ -270,6 +270,7 @@ func (m tfModelV0) FromResponse(ctx context.Context, resp *data_views.DataViewRe
 		ID:       m.ID.ValueString(),
 		SpaceID:  m.SpaceID.ValueString(),
 		DataView: dv,
+		Override: m.Override.ValueBool(),
 	}
 	return model, nil
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/548

Ensures that the override value is correctly persisted when managing data views