### PR TITLE
feat: use ApiKey instead of Bearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.11.2] - 2024-02-29
+
+### Fixed
+
+- Fix authentication for fleet API (using ApiKey instead of Bearer keyword) ([#576](https://github.com/elastic/terraform-provider-elasticstack/pull/576))
+
 ## [0.11.1] - 2024-02-17
 
 ### Added

--- a/internal/clients/fleet/client.go
+++ b/internal/clients/fleet/client.go
@@ -99,7 +99,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	if t.APIKey != "" {
-		req.Header.Add("Authorization", "Bearer "+t.APIKey)
+		req.Header.Add("Authorization", "ApiKey "+t.APIKey)
 	}
 
 	return t.next.RoundTrip(req)


### PR DESCRIPTION
as this part of the documentation says https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html