### PR TITLE
Support `restriction` in `elasticstack_elasticsearch_security_api_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix setting `id` for Fleet outputs and servers ([#666](https://github.com/elastic/terraform-provider-elasticstack/pull/666))
 - Fix `elasticstack_fleet_enrollment_tokens` returning empty tokens in some case ([#683](https://github.com/elastic/terraform-provider-elasticstack/pull/683))
 - Add support for Kibana synthetics private locations ([#696](https://github.com/elastic/terraform-provider-elasticstack/pull/696))
+- Support setting `restriction` in `elasticstack_elasticsearch_security_api_key` role definitions ([#577](https://github.com/elastic/terraform-provider-elasticstack/pull/577))
 
 ## [0.11.4] - 2024-06-13
 

--- a/docs/resources/elasticsearch_security_api_key.md
+++ b/docs/resources/elasticsearch_security_api_key.md
@@ -41,10 +41,10 @@ resource "elasticstack_elasticsearch_security_api_key" "api_key" {
   })
 }
 
+# restriction on a role descriptor for an API key is supported since Elastic 8.9
 resource "elasticstack_elasticsearch_security_api_key" "api_key_with_restriction" {
   # Set the name
   name = "My API key"
-
   # Set the role descriptors
   role_descriptors = jsonencode({
     role-a = {

--- a/docs/resources/elasticsearch_security_api_key.md
+++ b/docs/resources/elasticsearch_security_api_key.md
@@ -56,7 +56,7 @@ resource "elasticstack_elasticsearch_security_api_key" "api_key_with_restriction
         }
       ],
       restriction = {
-        workflows = [ "search_application_query" ]
+        workflows = ["search_application_query"]
       }
     }
   })

--- a/docs/resources/elasticsearch_security_api_key.md
+++ b/docs/resources/elasticsearch_security_api_key.md
@@ -41,6 +41,37 @@ resource "elasticstack_elasticsearch_security_api_key" "api_key" {
   })
 }
 
+resource "elasticstack_elasticsearch_security_api_key" "api_key_with_restriction" {
+  # Set the name
+  name = "My API key"
+
+  # Set the role descriptors
+  role_descriptors = jsonencode({
+    role-a = {
+      cluster = ["all"],
+      indices = [
+        {
+          names      = ["index-a*"],
+          privileges = ["read"]
+        }
+      ],
+      restriction = {
+        workflows = [ "search_application_query" ]
+      }
+    }
+  })
+
+  # Set the expiration for the API key
+  expiration = "1d"
+
+  # Set the custom metadata for this user
+  metadata = jsonencode({
+    "env"    = "testing"
+    "open"   = false
+    "number" = 49
+  })
+}
+
 output "api_key" {
   value     = elasticstack_elasticsearch_security_api_key.api_key
   sensitive = true

--- a/examples/resources/elasticstack_elasticsearch_security_api_key/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_security_api_key/resource.tf
@@ -41,7 +41,7 @@ resource "elasticstack_elasticsearch_security_api_key" "api_key_with_restriction
         }
       ],
       restriction = {
-        workflows = [ "search_application_query" ]
+        workflows = ["search_application_query"]
       }
     }
   })

--- a/examples/resources/elasticstack_elasticsearch_security_api_key/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_security_api_key/resource.tf
@@ -26,6 +26,37 @@ resource "elasticstack_elasticsearch_security_api_key" "api_key" {
   })
 }
 
+# restriction on a role descriptor for an API key is supported since Elastic 8.9
+resource "elasticstack_elasticsearch_security_api_key" "api_key_with_restriction" {
+  # Set the name
+  name = "My API key"
+  # Set the role descriptors
+  role_descriptors = jsonencode({
+    role-a = {
+      cluster = ["all"],
+      indices = [
+        {
+          names      = ["index-a*"],
+          privileges = ["read"]
+        }
+      ],
+      restriction = {
+        workflows = [ "search_application_query" ]
+      }
+    }
+  })
+
+  # Set the expiration for the API key
+  expiration = "1d"
+
+  # Set the custom metadata for this user
+  metadata = jsonencode({
+    "env"    = "testing"
+    "open"   = false
+    "number" = 49
+  })
+}
+
 output "api_key" {
   value     = elasticstack_elasticsearch_security_api_key.api_key
   sensitive = true

--- a/internal/elasticsearch/security/api_key.go
+++ b/internal/elasticsearch/security/api_key.go
@@ -107,7 +107,7 @@ func resourceSecurityApiKeyCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if v, ok := d.GetOk("role_descriptors"); ok {
-		role_descriptors := map[string]models.Role{}
+		role_descriptors := map[string]models.ApiKeyRoleDescriptor{}
 		if err := json.NewDecoder(strings.NewReader(v.(string))).Decode(&role_descriptors); err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/elasticsearch/security/api_key.go
+++ b/internal/elasticsearch/security/api_key.go
@@ -16,7 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var APIKeyMinVersion = version.Must(version.NewVersion("8.0.0")) // Enabled in 8.0
+var APIKeyMinVersion = version.Must(version.NewVersion("8.0.0"))                // Enabled in 8.0
+var APIKeyWithRestrictionMinVersion = version.Must(version.NewVersion("8.9.0")) // Enabled in 8.0
 
 func ResourceApiKey() *schema.Resource {
 	apikeySchema := map[string]*schema.Schema{

--- a/internal/elasticsearch/security/api_key.go
+++ b/internal/elasticsearch/security/api_key.go
@@ -140,7 +140,7 @@ func resourceSecurityApiKeyCreate(ctx context.Context, d *schema.ResourceData, m
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			if isSupported {
+			if !isSupported {
 				return diag.Errorf("Specifying `restriction` on an API key role description is not supported in this version of Elasticsearch. Role descriptor(s) %s", strings.Join(keysWithRestrictions, ", "))
 			}
 		}

--- a/internal/elasticsearch/security/api_key.go
+++ b/internal/elasticsearch/security/api_key.go
@@ -92,16 +92,6 @@ func ResourceApiKey() *schema.Resource {
 	}
 }
 
-type esVersion struct {
-	Number      string `json:"number"`
-	BuildFlavor string `json:"build_flavor"`
-}
-
-type info struct {
-	Version esVersion `json:"version"`
-	Tagline string    `json:"tagline"`
-}
-
 func resourceSecurityApiKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, diags := clients.NewApiClientFromSDKResource(d, meta)
 	if diags.HasError() {

--- a/internal/elasticsearch/security/api_key.go
+++ b/internal/elasticsearch/security/api_key.go
@@ -156,8 +156,8 @@ func resourceSecurityApiKeyCreate(ctx context.Context, d *schema.ResourceData, m
 					return diag.FromErr(err)
 				}
 
-				supportedVersion, err := version.NewVersion("8.9.0")
-
+				supportedVersion, _ := version.NewVersion("8.9.0")
+				
 				if currentVersion.LessThan(supportedVersion) && hasRestriction {
 					return diag.Errorf(`Specifying "restriction" on an API key role description is not supported in this version of Elasticsearch. API keys: %s, role descriptor(s) %s`, apikey.Name, strings.Join(keysWithRestrictions, ", "))
 				}

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -74,7 +74,7 @@ func TestAccResourceSecurityApiKeyWithWorkflowRestriction(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{
 			{
-				SkipFunc: versionutils.CheckIfVersionIsUnsupported(security.APIKeyMinVersion),
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(security.APIKeyWithRestrictionMinVersion),
 				Config:   testAccResourceSecurityApiKeyCreateWithWorkflowRestriction(apiKeyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_api_key.test", "name", apiKeyName),

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccResourceSecuritApiKey(t *testing.T) {
+func TestAccResourceSecurityApiKey(t *testing.T) {
 	// generate a random name
 	apiKeyName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
@@ -28,17 +28,17 @@ func TestAccResourceSecuritApiKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				SkipFunc: versionutils.CheckIfVersionIsUnsupported(security.APIKeyMinVersion),
-				Config:   testAccResourceSecuritApiKeyCreate(apiKeyName),
+				Config:   testAccResourceSecurityApiKeyCreate(apiKeyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_api_key.test", "name", apiKeyName),
 					resource.TestCheckResourceAttrWith("elasticstack_elasticsearch_security_api_key.test", "role_descriptors", func(testValue string) error {
-						var testRoleDescriptor map[string]models.Role
+						var testRoleDescriptor map[string]models.ApiKeyRoleDescriptor
 						if err := json.Unmarshal([]byte(testValue), &testRoleDescriptor); err != nil {
 							return err
 						}
 
 						allowRestrictedIndices := false
-						expectedRoleDescriptor := map[string]models.Role{
+						expectedRoleDescriptor := map[string]models.ApiKeyRoleDescriptor{
 							"role-a": {
 								Cluster: []string{"all"},
 								Indices: []models.IndexPerms{{
@@ -64,7 +64,55 @@ func TestAccResourceSecuritApiKey(t *testing.T) {
 	})
 }
 
-func testAccResourceSecuritApiKeyCreate(apiKeyName string) string {
+func TestAccResourceSecurityApiKeyWithWorkflowRestriction(t *testing.T) {
+	// generate a random name
+	apiKeyName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		CheckDestroy:             checkResourceSecurityApiKeyDestroy,
+		ProtoV6ProviderFactories: acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(security.APIKeyMinVersion),
+				Config:   testAccResourceSecurityApiKeyCreateWithWorkflowRestriction(apiKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_api_key.test", "name", apiKeyName),
+					resource.TestCheckResourceAttrWith("elasticstack_elasticsearch_security_api_key.test", "role_descriptors", func(testValue string) error {
+						var testRoleDescriptor map[string]models.ApiKeyRoleDescriptor
+						if err := json.Unmarshal([]byte(testValue), &testRoleDescriptor); err != nil {
+							return err
+						}
+
+						allowRestrictedIndices := false
+						expectedRoleDescriptor := map[string]models.ApiKeyRoleDescriptor{
+							"role-a": {
+								Cluster: []string{"all"},
+								Indices: []models.IndexPerms{{
+									Names:                  []string{"index-a*"},
+									Privileges:             []string{"read"},
+									AllowRestrictedIndices: &allowRestrictedIndices,
+								}},
+								Restriction: &models.Restriction{Workflows: []string{"search_application_query"}},
+							},
+						}
+
+						if !reflect.DeepEqual(testRoleDescriptor, expectedRoleDescriptor) {
+							return fmt.Errorf("%v doesn't match %v", testRoleDescriptor, expectedRoleDescriptor)
+						}
+
+						return nil
+					}),
+					resource.TestCheckResourceAttrSet("elasticstack_elasticsearch_security_api_key.test", "expiration"),
+					resource.TestCheckResourceAttrSet("elasticstack_elasticsearch_security_api_key.test", "api_key"),
+					resource.TestCheckResourceAttrSet("elasticstack_elasticsearch_security_api_key.test", "encoded"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceSecurityApiKeyCreate(apiKeyName string) string {
 	return fmt.Sprintf(`
 provider "elasticstack" {
   elasticsearch {}
@@ -81,6 +129,34 @@ resource "elasticstack_elasticsearch_security_api_key" "test" {
         privileges = ["read"]
         allow_restricted_indices = false
       }]
+    }
+  })
+
+	expiration = "1d"
+}
+	`, apiKeyName)
+}
+
+func testAccResourceSecurityApiKeyCreateWithWorkflowRestriction(apiKeyName string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_security_api_key" "test" {
+  name = "%s"
+
+  role_descriptors = jsonencode({
+    role-a = {
+      cluster = ["all"]
+      indices = [{
+        names = ["index-a*"]
+        privileges = ["read"]
+        allow_restricted_indices = false
+      }],
+      restriction = { 
+		workflows = [ "search_application_query"] 
+      }
     }
   })
 

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -139,13 +139,12 @@ func SkipWhenApiKeysAreNotSupportedOrRestrictionsAreSupported(minApiKeySupported
 		if err != nil {
 			return false, err
 		}
-		_, diags := client.ServerVersion(context.Background())
+		serverVersion, diags := client.ServerVersion(context.Background())
 		if diags.HasError() {
 			return false, fmt.Errorf("failed to parse the elasticsearch version %v", diags)
 		}
 
-		return false, nil
-		// return serverVersion.LessThan(minApiKeySupportedVersion) || serverVersion.GreaterThanOrEqual(minRestrictionSupportedVersion), nil
+		return serverVersion.LessThan(minApiKeySupportedVersion) || serverVersion.GreaterThanOrEqual(minRestrictionSupportedVersion), nil
 	}
 }
 

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -127,7 +127,7 @@ func TestAccResourceSecurityApiKeyWithWorkflowRestrictionOnElasticPre8_9_x(t *te
 			{
 				SkipFunc:    SkipWhenApiKeysAreNotSupportedOrRestrictionsAreSupported(security.APIKeyMinVersion, security.APIKeyWithRestrictionMinVersion),
 				Config:      testAccResourceSecurityApiKeyCreateWithWorkflowRestriction(apiKeyName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Error: Specifying "restriction" on an API key role description is not supported in this version of Elasticsearch. Role descriptor(s) %s`, "role-a")),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(".*Error: Specifying `restriction` on an API key role description is not supported in this version of Elasticsearch. Role descriptor\\(s\\) %s.*", "role-a")),
 			},
 		},
 	})

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -127,7 +127,7 @@ func TestAccResourceSecurityApiKeyWithWorkflowRestrictionOnElasticPre8_9_x(t *te
 			{
 				SkipFunc:    SkipWhenApiKeysAreNotSupportedOrRestrictionsAreSupported(security.APIKeyMinVersion, security.APIKeyWithRestrictionMinVersion),
 				Config:      testAccResourceSecurityApiKeyCreateWithWorkflowRestriction(apiKeyName),
-				ExpectError: regexp.MustCompile(fmt.Sprintf(`Specifying "restriction" on an API key role description is not supported in this version of Elasticsearch. API keys: %s, role descriptor(s) %s`, apiKeyName, "role-a")),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`Error: Specifying "restriction" on an API key role description is not supported in this version of Elasticsearch. Role descriptor(s) %s`, "role-a")),
 			},
 		},
 	})
@@ -139,12 +139,13 @@ func SkipWhenApiKeysAreNotSupportedOrRestrictionsAreSupported(minApiKeySupported
 		if err != nil {
 			return false, err
 		}
-		serverVersion, diags := client.ServerVersion(context.Background())
+		_, diags := client.ServerVersion(context.Background())
 		if diags.HasError() {
 			return false, fmt.Errorf("failed to parse the elasticsearch version %v", diags)
 		}
 
-		return serverVersion.LessThan(minApiKeySupportedVersion) || serverVersion.GreaterThanOrEqual(minRestrictionSupportedVersion), nil
+		return false, nil
+		// return serverVersion.LessThan(minApiKeySupportedVersion) || serverVersion.GreaterThanOrEqual(minRestrictionSupportedVersion), nil
 	}
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -82,6 +82,21 @@ type Role struct {
 	RusAs        []string               `json:"run_as,omitempty"`
 }
 
+type ApiKeyRoleDescriptor struct {
+	Name         string                 `json:"-"`
+	Applications []Application          `json:"applications,omitempty"`
+	Global       map[string]interface{} `json:"global,omitempty"`
+	Cluster      []string               `json:"cluster,omitempty"`
+	Indices      []IndexPerms           `json:"indices,omitempty"`
+	Metadata     map[string]interface{} `json:"metadata,omitempty"`
+	RusAs        []string               `json:"run_as,omitempty"`
+	Restriction  *Restriction           `json:"restriction,omitempty"`
+}
+
+type Restriction struct {
+	Workflows []string `json:"workflows,omitempty"`
+}
+
 type RoleMapping struct {
 	Name          string                   `json:"-"`
 	Enabled       bool                     `json:"enabled"`
@@ -92,20 +107,20 @@ type RoleMapping struct {
 }
 
 type ApiKey struct {
-	Name             string                 `json:"name"`
-	RolesDescriptors map[string]Role        `json:"role_descriptors,omitempty"`
-	Expiration       string                 `json:"expiration,omitempty"`
-	Metadata         map[string]interface{} `json:"metadata,omitempty"`
+	Name             string                          `json:"name"`
+	RolesDescriptors map[string]ApiKeyRoleDescriptor `json:"role_descriptors,omitempty"`
+	Expiration       string                          `json:"expiration,omitempty"`
+	Metadata         map[string]interface{}          `json:"metadata,omitempty"`
 }
 
 type ApiKeyResponse struct {
 	ApiKey
-	RolesDescriptors map[string]Role `json:"role_descriptors,omitempty"`
-	Expiration       int64           `json:"expiration,omitempty"`
-	Id               string          `json:"id,omitempty"`
-	Key              string          `json:"api_key,omitempty"`
-	EncodedKey       string          `json:"encoded,omitempty"`
-	Invalidated      bool            `json:"invalidated,omitempty"`
+	RolesDescriptors map[string]ApiKeyRoleDescriptor `json:"role_descriptors,omitempty"`
+	Expiration       int64                           `json:"expiration,omitempty"`
+	Id               string                          `json:"id,omitempty"`
+	Key              string                          `json:"api_key,omitempty"`
+	EncodedKey       string                          `json:"encoded,omitempty"`
+	Invalidated      bool                            `json:"invalidated,omitempty"`
 }
 
 type IndexPerms struct {


### PR DESCRIPTION
In its current form the provider is unable to provision API keys that have a restriction specified in the role descriptors.
For example, given this terraform:

```terraform
resource "elasticstack_elasticsearch_security_api_key" "api_key_with_restriction" {
  name = "restricted-key"

  role_descriptors = jsonencode({
    role-a = {
      indices = [
        {
          names      = ["index-a*"],
          privileges = ["read"]
        }
      ],
      restriction = {
        workflows = [ "search_application_query" ]
      }
    }
  })
}
```

The provider will happily create an API key named `restricted-key` however the `restriction` field is not persisted in Elasticsearch.

On the next `terraform plan`, this API key will be marked as needing replacement due to the fact that the comparison between the local terraform definition and the response from the Elasicsearch API are different. That is because the local terraform definition serializes to JSON and will contain `restriction` while the JSON for the existing API key does not have that field.

This PR adds the `restriction` to the model structs necessary to provision the API keys.

In order to achieve that, the `Role` struct was duplicated to an API key specific struct `ApiKeyRoleDescriptor`. Previously `Role` was shared between the `elasticstack_elasticsearch_security_api_key` _resource_ and the `elasticstack_elasticsearch_security_role` _data source_.

In Elasticsearch, the `restriction` is only available from 8.9.x and up. To provide some feedback to users, an error will be generated during plan/apply time when the target Elasticsearch is below 8.9 and the user has specified a `restriction` in their local terraform definition:

> Error: Specifying `restriction` on an API key role description is not supported in this version of Elasticsearch. Role descriptor(s) role-a

This is currently making a call directly to the Elasticsearch instance which is probably not ideal, however I could not find a reference to the current version in the code. If that's available that would be a much better option.