### PR TITLE
Re-use the http client from the kibana client in the openapi generated clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ website/vendor
 
 terraform-provider-elasticstack
 dist
+certs
 .ci/.gpg_*
 .ci/.github_*
 .terraform.lock.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - Fix authentication for fleet API (using ApiKey instead of Bearer keyword) ([#576](https://github.com/elastic/terraform-provider-elasticstack/pull/576))
+- Ensure all Kibana resources use the supplied `ca_certs` value. ([#585](https://github.com/elastic/terraform-provider-elasticstack/pull/585))
 
 ## [0.11.1] - 2024-02-17
 


### PR DESCRIPTION
This ensures that logging and tls options are consistent across all Kibana endpoints. This mass of openapi clients is a huge pain, I wonder if it would be nicer to bundle the individual openapi specs together and have a single mass client 🤷 

Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/582
