### PR TITLE
Support CSV indices in SLM policy definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix authentication for fleet API (using ApiKey instead of Bearer keyword) ([#576](https://github.com/elastic/terraform-provider-elasticstack/pull/576))
 - Ensure all Kibana resources use the supplied `ca_certs` value. ([#585](https://github.com/elastic/terraform-provider-elasticstack/pull/585))
+- Don't panic when SLM indices are specified as a CSV string rather than an array ([#593](https://github.com/elastic/terraform-provider-elasticstack/pull/593))
 
 ## [0.11.1] - 2024-02-17
 

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -1,0 +1,56 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringSliceOrCSV_UnmarshalJSON9(t *testing.T) {
+	tests := []struct {
+		name           string
+		jsonString     string
+		expectedResult StringSliceOrCSV
+		expectedErr    error
+	}{
+		{
+			name:           "should handle json arrays",
+			jsonString:     `["a", "b", "c"]`,
+			expectedResult: StringSliceOrCSV{"a", "b", "c"},
+		},
+		{
+			name:           "should handle csv strings",
+			jsonString:     `"a,b,c"`,
+			expectedResult: StringSliceOrCSV{"a", "b", "c"},
+		},
+		{
+			name:       "should handle explicit nulls",
+			jsonString: `null`,
+		},
+		{
+			name:       "should handle empty strings",
+			jsonString: `""`,
+		},
+		{
+			name:        "should fail on invalid data",
+			jsonString:  "true",
+			expectedErr: ErrInvalidStringSliceOrCSV,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actualModel StringSliceOrCSV
+			err := json.Unmarshal([]byte(tt.jsonString), &actualModel)
+
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.expectedErr)
+			}
+
+			require.Equal(t, tt.expectedResult, actualModel)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/439

Elasticsearch supports both a string array (what the provider has been expecting) and a CSV list for the `indices` field on an SLM policy. This PR customises the JSON marshaller to ensure both formats are parsed into a Go slice. 