### PR TITLE
Don't panic when the template is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Prevent a provider panic when an `elasticstack_elasticsearch_template` or `elasticstack_elasticsearch_component_template` includes an empty `template` (`template {}`) block. ([#598](https://github.com/elastic/terraform-provider-elasticstack/pull/598))
+
 ## [0.11.2] - 2024-03-13
 
 ### Fixed

--- a/internal/elasticsearch/index/template_test.go
+++ b/internal/elasticsearch/index/template_test.go
@@ -111,6 +111,8 @@ resource "elasticstack_elasticsearch_index_template" "test2" {
   data_stream {
     hidden = false
   }
+
+  template {}
 }
 	`, name, name, name)
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/417

Adds a checked cast to catch the panic when the `template` block is nil. Also removes the duplicate code from the `component_template` resource to fix the same panic there. 