### PR TITLE
Fixup acceptance tests in 8.11

### DIFF
--- a/internal/versionutils/testutils.go
+++ b/internal/versionutils/testutils.go
@@ -22,3 +22,18 @@ func CheckIfVersionIsUnsupported(minSupportedVersion *version.Version) func() (b
 		return serverVersion.LessThan(minSupportedVersion), nil
 	}
 }
+
+func CheckIfVersionMeetsConstraints(constraints version.Constraints) func() (bool, error) {
+	return func() (b bool, err error) {
+		client, err := clients.NewAcceptanceTestingClient()
+		if err != nil {
+			return false, err
+		}
+		serverVersion, diags := client.ServerVersion(context.Background())
+		if diags.HasError() {
+			return false, fmt.Errorf("failed to parse the elasticsearch version %v", diags)
+		}
+
+		return !constraints.Check(serverVersion), nil
+	}
+}


### PR DESCRIPTION
Skip the SLO test on 8.11.x, there's an internal Kibana error being triggered by this test which has been fixed in 8.12. 