### PR TITLE
Don't crash when configuring Serverless projects. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Prevent a provider panic in `elasticstack_kibana_data_view` when a `field_format` does not include a `pattern`. ([#619](https://github.com/elastic/terraform-provider-elasticstack/pull/619/files))
 - Fixed a bug where the `id` attribute for `elasticstack_kibana_slo` resources was ignored by renaming the attribute to `slo_id`. ([#622](https://github.com/elastic/terraform-provider-elasticstack/pull/622))
 - Fixed a bug where the `rule_id` attribute for `elasticstack_kibana_alerting_rule` was ignored. ([#626](https://github.com/elastic/terraform-provider-elasticstack/pull/626))
+- Fix provider crash when running against Serverless projects ([#630](https://github.com/elastic/terraform-provider-elasticstack/pull/630))
 
 ### Added
 

--- a/docs/resources/elasticsearch_index.md
+++ b/docs/resources/elasticsearch_index.md
@@ -94,7 +94,7 @@ If specified, this mapping can include: field names, [field data types](https://
 **NOTE:**
 - Changing datatypes in the existing _mappings_ will force index to be re-created.
 - Removing field will be ignored by default same as elasticsearch. You need to recreate the index to remove field completely.
-- `master_timeout` (String) Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Defaults to `30s`.
+- `master_timeout` (String) Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Defaults to `30s`. This value is ignored when running against Serverless projects.
 - `max_docvalue_fields_search` (Number) The maximum number of `docvalue_fields` that are allowed in a query.
 - `max_inner_result_window` (Number) The maximum value of `from + size` for inner hits definition and top hits aggregations to this index.
 - `max_ngram_diff` (Number) The maximum allowed difference between min_gram and max_gram for NGramTokenizer and NGramTokenFilter.
@@ -130,7 +130,7 @@ If specified, this mapping can include: field names, [field data types](https://
 - `sort_order` (List of String) The direction to sort shards in. Accepts `asc`, `desc`.
 - `timeout` (String) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Defaults to `30s`.
 - `unassigned_node_left_delayed_timeout` (String) Time to delay the allocation of replica shards which become unassigned because a node has left, in time units, e.g. `10s`
-- `wait_for_active_shards` (String) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (number_of_replicas+1). Default: `1`, the primary shard.
+- `wait_for_active_shards` (String) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (number_of_replicas+1). Default: `1`, the primary shard. This value is ignored when running against Serverless projects.
 
 ### Read-Only
 

--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -336,6 +336,15 @@ func (a *ApiClient) ServerVersion(ctx context.Context) (*version.Version, diag.D
 	return serverVersion, nil
 }
 
+func (a *ApiClient) ServerFlavor(ctx context.Context) (string, diag.Diagnostics) {
+	info, diags := a.serverInfo(ctx)
+	if diags.HasError() {
+		return "", diags
+	}
+
+	return info.Version.BuildFlavor, nil
+}
+
 func (a *ApiClient) ClusterID(ctx context.Context) (*string, diag.Diagnostics) {
 	info, diags := a.serverInfo(ctx)
 	if diags.HasError() {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -7,6 +7,29 @@ import (
 	"time"
 )
 
+type BuildDate struct {
+	time.Time
+}
+
+func (b *BuildDate) UnmarshalJSON(dateBytes []byte) error {
+	dateStr := strings.Trim(string(dateBytes), "\"")
+	if dateStr == "null" {
+		b.Time = time.Time{}
+		return nil
+	}
+
+	t, err := time.Parse("2006-01-02T15:04:05Z07:00", dateStr)
+	if err != nil {
+		t, err = time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			return err
+		}
+	}
+
+	b.Time = t
+	return nil
+}
+
 type ClusterInfo struct {
 	Name        string `json:"name"`
 	ClusterName string `json:"cluster_name"`
@@ -16,7 +39,7 @@ type ClusterInfo struct {
 		BuildType                        string    `json:"build_type"`
 		BuildHash                        string    `json:"build_hash"`
 		BuildFlavor                      string    `json:"build_flavor"`
-		BuildDate                        time.Time `json:"build_date"`
+		BuildDate                        BuildDate `json:"build_date"`
 		BuildSnapshot                    bool      `json:"build_snapshot"`
 		LuceneVersion                    string    `json:"lucene_version"`
 		MinimumWireCompatibilityVersion  string    `json:"minimum_wire_compatibility_version"`


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/629

Updates the date parsing logic to support short form dates from Serverless projects. Also avoid some restrictions in managing indices in Serverless projects. 