### PR TITLE
Populate policy_id when importing fleet policies and integrations

### DIFF
--- a/internal/fleet/agent_policy_resource.go
+++ b/internal/fleet/agent_policy_resource.go
@@ -220,6 +220,9 @@ func resourceAgentPolicyRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err := d.Set("namespace", agentPolicy.Namespace); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("policy_id", agentPolicy.Id); err != nil {
+		return diag.FromErr(err)
+	}
 	if agentPolicy.Description != nil {
 		if err := d.Set("description", *agentPolicy.Description); err != nil {
 			return diag.FromErr(err)

--- a/internal/fleet/integration_policy_resource.go
+++ b/internal/fleet/integration_policy_resource.go
@@ -305,6 +305,9 @@ func resourceIntegrationPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	if err := d.Set("namespace", pkgPolicy.Namespace); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set("policy_id", pkgPolicy.Id); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := d.Set("integration_name", pkgPolicy.Package.Name); err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Populates policy_id when importing fleet policies and integrations.

This enables to update fleet policies in-place when using an import block.

Solves https://github.com/elastic/terraform-provider-elasticstack/issues/496