### PR TITLE
Fix setting ID for Fleet outputs and servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix setting `id` for Fleet outputs and servers ([#666](https://github.com/elastic/terraform-provider-elasticstack/pull/666))
+
 ## [0.11.4] - 2024-06-13
 
 ### Breaking changes

--- a/internal/fleet/fleet_server_host_resource.go
+++ b/internal/fleet/fleet_server_host_resource.go
@@ -60,12 +60,13 @@ func resourceFleetServerHostCreate(ctx context.Context, d *schema.ResourceData, 
 		return diags
 	}
 
-	if id := d.Get("host_id").(string); id != "" {
-		d.SetId(id)
-	}
-
 	req := fleetapi.PostFleetServerHostsJSONRequestBody{
 		Name: d.Get("name").(string),
+	}
+
+	if id := d.Get("host_id").(string); id != "" {
+		d.SetId(id)
+		req.Id = &id
 	}
 
 	if value := d.Get("hosts").([]interface{}); len(value) > 0 {

--- a/internal/fleet/fleet_server_host_resource_test.go
+++ b/internal/fleet/fleet_server_host_resource_test.go
@@ -30,6 +30,7 @@ func TestAccResourceFleetServerHost(t *testing.T) {
 				Config:   testAccResourceFleetServerHostCreate(policyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "name", fmt.Sprintf("FleetServerHost %s", policyName)),
+					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "id", "fleet-server-host-id"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "default", "false"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "hosts.0", "https://fleet-server:8220"),
 				),
@@ -39,6 +40,7 @@ func TestAccResourceFleetServerHost(t *testing.T) {
 				Config:   testAccResourceFleetServerHostUpdate(policyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "name", fmt.Sprintf("Updated FleetServerHost %s", policyName)),
+					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "id", "fleet-server-host-id"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "default", "false"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_server_host.test_host", "hosts.0", "https://fleet-server:8220"),
 				),
@@ -56,6 +58,7 @@ provider "elasticstack" {
 
 resource "elasticstack_fleet_server_host" "test_host" {
   name               = "%s"
+  host_id            = "fleet-server-host-id"
   default            =  false
   hosts              = [
     "https://fleet-server:8220"
@@ -73,6 +76,7 @@ provider "elasticstack" {
 
 resource "elasticstack_fleet_server_host" "test_host" {
   name               = "%s"
+  host_id            = "fleet-server-host-id"
   default            =  false
   hosts              = [
     "https://fleet-server:8220"

--- a/internal/fleet/output_resource.go
+++ b/internal/fleet/output_resource.go
@@ -133,6 +133,9 @@ func resourceOutputCreateElasticsearch(ctx context.Context, d *schema.ResourceDa
 	if hosts != nil {
 		reqData.Hosts = &hosts
 	}
+	if value, ok := d.Get("output_id").(string); ok && value != "" {
+		reqData.Id = &value
+	}
 	if value := d.Get("default_integrations").(bool); value {
 		reqData.IsDefault = &value
 	}
@@ -192,6 +195,9 @@ func resourceOutputCreateLogstash(ctx context.Context, d *schema.ResourceData, m
 		}
 	}
 	reqData.Hosts = hosts
+	if value, ok := d.Get("output_id").(string); ok && value != "" {
+		reqData.Id = &value
+	}
 	if value := d.Get("default_integrations").(bool); value {
 		reqData.IsDefault = &value
 	}

--- a/internal/fleet/output_resource_test.go
+++ b/internal/fleet/output_resource_test.go
@@ -30,6 +30,7 @@ func TestAccResourceOutputElasticsearch(t *testing.T) {
 				Config:   testAccResourceOutputCreateElasticsearch(policyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "name", fmt.Sprintf("Elasticsearch Output %s", policyName)),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "id", "elasticsearch-output"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "type", "elasticsearch"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "config_yaml", "\"ssl.verification_mode\": \"none\"\n"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "default_integrations", "false"),
@@ -42,6 +43,7 @@ func TestAccResourceOutputElasticsearch(t *testing.T) {
 				Config:   testAccResourceOutputUpdateElasticsearch(policyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "name", fmt.Sprintf("Updated Elasticsearch Output %s", policyName)),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "id", "elasticsearch-output"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "type", "elasticsearch"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "config_yaml", "\"ssl.verification_mode\": \"none\"\n"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "default_integrations", "false"),
@@ -72,6 +74,7 @@ func TestAccResourceOutputLogstash(t *testing.T) {
 				Config:   testAccResourceOutputCreateLogstash(policyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "name", fmt.Sprintf("Logstash Output %s", policyName)),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "id", "logstash-output"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "type", "logstash"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "config_yaml", "\"ssl.verification_mode\": \"none\"\n"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "default_integrations", "false"),
@@ -87,6 +90,7 @@ func TestAccResourceOutputLogstash(t *testing.T) {
 				Config:   testAccResourceOutputLogstashUpdate(policyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "name", fmt.Sprintf("Updated Logstash Output %s", policyName)),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "id", "logstash-output"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "type", "logstash"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "config_yaml", "\"ssl.verification_mode\": \"none\"\n"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "default_integrations", "false"),
@@ -110,6 +114,7 @@ provider "elasticstack" {
 
 resource "elasticstack_fleet_output" "test_output" {
   name                 = "%s"
+  output_id            = "elasticsearch-output"
   type                 = "elasticsearch"
   config_yaml = yamlencode({
     "ssl.verification_mode" : "none"
@@ -132,6 +137,7 @@ provider "elasticstack" {
 
 resource "elasticstack_fleet_output" "test_output" {
   name                 = "%s"
+  output_id            = "elasticsearch-output"
   type                 = "elasticsearch"
   config_yaml = yamlencode({
     "ssl.verification_mode" : "none"
@@ -156,6 +162,7 @@ provider "elasticstack" {
 resource "elasticstack_fleet_output" "test_output" {
   name                 = "%s"
   type                 = "logstash"
+  output_id            = "logstash-output"
   config_yaml = yamlencode({
     "ssl.verification_mode" : "none"
   })
@@ -183,6 +190,7 @@ provider "elasticstack" {
 resource "elasticstack_fleet_output" "test_output" {
   name                 = "%s"
   type                 = "logstash"
+  output_id            = "logstash-output"
   config_yaml = yamlencode({
     "ssl.verification_mode" : "none"
   })


### PR DESCRIPTION
Currently the **output_id** setting is ignored in **elasticstack_fleet_output** as does the **host_id** for the **elasticstack_fleet_server_host** resource 

This is getting fixed with this pull request.