### PR TITLE
Fix fleet_enrollment_tokens returning empty token set in some case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Fix setting `id` for Fleet outputs and servers ([#666](https://github.com/elastic/terraform-provider-elasticstack/pull/666))
+- Fix `elasticstack_fleet_enrollment_tokens` returning empty tokens in some case ([#683](https://github.com/elastic/terraform-provider-elasticstack/pull/683))
 
 ## [0.11.4] - 2024-06-13
 
@@ -160,7 +161,7 @@
 - Add `elasticstack_elasticsearch_watch` for managing Elasticsearch Watches ([#155](https://github.com/elastic/terraform-provider-elasticstack/pull/155))
 - Add `elasticstack_kibana_alerting_rule` for managing Kibana alerting rules ([#292](https://github.com/elastic/terraform-provider-elasticstack/pull/292))
 - Add client for communicating with the Fleet APIs ([#311](https://github.com/elastic/terraform-provider-elasticstack/pull/311)])
-- Add `elasticstack_fleet_enrollment_tokens` and `elasticstack_fleet_agent_policy` for managing Fleet enrollment tokens and agent policies ([#322](https://github.com/elastic/terraform-provider-elasticstack/pull/322)])
+- Add `elasticstack_fleet_enrollment_tokens` and `elasticstack_fleet_agent_policy` for managing Fleet enrollment tokens and agent policies ([#322](https://github.com/elastic/terraform-provider-elasticstack/pull/322))
 - Add `elasticstack_fleet_output` and `elasticstack_fleet_server_host` for managing Fleet outputs and server hosts ([#327](https://github.com/elastic/terraform-provider-elasticstack/pull/327)])
 - Add `elasticstack_kibana_action_connector` for managing Kibana action connectors ([#306](https://github.com/elastic/terraform-provider-elasticstack/pull/306))
 

--- a/internal/clients/fleet/fleet.go
+++ b/internal/clients/fleet/fleet.go
@@ -28,6 +28,25 @@ func AllEnrollmentTokens(ctx context.Context, client *Client) ([]fleetapi.Enroll
 	return nil, reportUnknownError(resp.StatusCode(), resp.Body)
 }
 
+// SearchEnrollmentTokens Get enrollment tokens by given policy ID
+func SearchEnrollmentTokens(ctx context.Context, client *Client, policyID string) ([]fleetapi.EnrollmentApiKey, diag.Diagnostics) {
+	resp, err := client.API.GetEnrollmentApiKeysWithResponse(ctx, func(ctx context.Context, req *http.Request) error {
+		q := req.URL.Query()
+		q.Set("kuery", "policy_id:"+policyID)
+		req.URL.RawQuery = q.Encode()
+
+		return nil
+	})
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	if resp.StatusCode() == http.StatusOK {
+		return resp.JSON200.Items, nil
+	}
+	return nil, reportUnknownError(resp.StatusCode(), resp.Body)
+}
+
 // ReadAgentPolicy reads a specific agent policy from the API.
 func ReadAgentPolicy(ctx context.Context, client *Client, id string) (*fleetapi.AgentPolicy, diag.Diagnostics) {
 	resp, err := client.API.AgentPolicyInfoWithResponse(ctx, id)

--- a/internal/clients/fleet/fleet.go
+++ b/internal/clients/fleet/fleet.go
@@ -28,8 +28,8 @@ func AllEnrollmentTokens(ctx context.Context, client *Client) ([]fleetapi.Enroll
 	return nil, reportUnknownError(resp.StatusCode(), resp.Body)
 }
 
-// SearchEnrollmentTokens Get enrollment tokens by given policy ID
-func SearchEnrollmentTokens(ctx context.Context, client *Client, policyID string) ([]fleetapi.EnrollmentApiKey, diag.Diagnostics) {
+// GetEnrollmentTokensByPolicy Get enrollment tokens by given policy ID
+func GetEnrollmentTokensByPolicy(ctx context.Context, client *Client, policyID string) ([]fleetapi.EnrollmentApiKey, diag.Diagnostics) {
 	resp, err := client.API.GetEnrollmentApiKeysWithResponse(ctx, func(ctx context.Context, req *http.Request) error {
 		q := req.URL.Query()
 		q.Set("kuery", "policy_id:"+policyID)

--- a/internal/fleet/enrollment_tokens_data_source.go
+++ b/internal/fleet/enrollment_tokens_data_source.go
@@ -89,7 +89,7 @@ func dataSourceEnrollmentTokensRead(ctx context.Context, d *schema.ResourceData,
 	if policyID == "" {
 		allTokens, diags = fleet.AllEnrollmentTokens(ctx, fleetClient)
 	} else {
-		allTokens, diags = fleet.SearchEnrollmentTokens(ctx, fleetClient, policyID)
+		allTokens, diags = fleet.GetEnrollmentTokensByPolicy(ctx, fleetClient, policyID)
 	}
 
 	if diags.HasError() {

--- a/internal/fleet/enrollment_tokens_data_source.go
+++ b/internal/fleet/enrollment_tokens_data_source.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"context"
 
+	fleetapi "github.com/elastic/terraform-provider-elasticstack/generated/fleet"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients/fleet"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -83,7 +84,14 @@ func dataSourceEnrollmentTokensRead(ctx context.Context, d *schema.ResourceData,
 	}
 	policyID := d.Id()
 
-	allTokens, diags := fleet.AllEnrollmentTokens(ctx, fleetClient)
+	var allTokens []fleetapi.EnrollmentApiKey
+
+	if policyID == "" {
+		allTokens, diags = fleet.AllEnrollmentTokens(ctx, fleetClient)
+	} else {
+		allTokens, diags = fleet.SearchEnrollmentTokens(ctx, fleetClient, policyID)
+	}
+
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
The data source is not handling pagination at all. This fix the case when kibana server got more than 20 fleet enrollment tokens and the provider is not paginating the result when searching for a match.

Fetching all tokens case (empty policyID in input) is still not handled. Just trying to push a fix with minimum effort for now.

Partially fixes https://github.com/elastic/terraform-provider-elasticstack/issues/528.