### PR TITLE
feat(synthetics): add synthetics monitor and private location API support to go-kibana-rest

### DIFF
--- a/libs/go-kibana-rest/docker-compose.yml
+++ b/libs/go-kibana-rest/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
     environment:
       cluster.name: test
       discovery.type: single-node
@@ -23,11 +23,14 @@ services:
       elasticsearch:
         condition: service_started
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.14.1
+    image: docker.elastic.co/kibana/kibana:8.14.3
+    volumes:
+      - ./kibana.yml:/usr/share/kibana/config/kibana.yml
     environment:
       ELASTICSEARCH_HOSTS: http://es:9200
       ELASTICSEARCH_USERNAME: kibana_system
       ELASTICSEARCH_PASSWORD: changeme
+      xpack.security.http.ssl.enabled: false
       xpack.license.self_generated.type: trial
     links:
       - elasticsearch:es

--- a/libs/go-kibana-rest/docker-compose.yml
+++ b/libs/go-kibana-rest/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "9200:9200/tcp"
   set-kibana-password:
-    image: docker.elastic.co/kibana/kibana:8.14.1
+    image: docker.elastic.co/kibana/kibana:8.14.3
     restart: on-failure
     links:
       - elasticsearch

--- a/libs/go-kibana-rest/docker-compose.yml
+++ b/libs/go-kibana-rest/docker-compose.yml
@@ -24,14 +24,13 @@ services:
         condition: service_started
   kibana:
     image: docker.elastic.co/kibana/kibana:8.14.3
-    volumes:
-      - ./kibana.yml:/usr/share/kibana/config/kibana.yml
     environment:
       ELASTICSEARCH_HOSTS: http://es:9200
       ELASTICSEARCH_USERNAME: kibana_system
       ELASTICSEARCH_PASSWORD: changeme
       xpack.security.http.ssl.enabled: false
       xpack.license.self_generated.type: trial
+      XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: min-32-byte-long-strong-encryption-key
     links:
       - elasticsearch:es
     ports:

--- a/libs/go-kibana-rest/go.mod
+++ b/libs/go-kibana-rest/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/go-resty/resty/v2 v2.7.0
+	github.com/google/uuid v1.6.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2

--- a/libs/go-kibana-rest/go.sum
+++ b/libs/go-kibana-rest/go.sum
@@ -18,6 +18,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/libs/go-kibana-rest/kbapi/api._.go
+++ b/libs/go-kibana-rest/kbapi/api._.go
@@ -121,6 +121,7 @@ func New(c *resty.Client) *API {
 				Add:    newKibanaSyntheticsMonitorAddFunc(c),
 				Delete: newKibanaSyntheticsMonitorDeleteFunc(c),
 				Get:    newKibanaSyntheticsMonitorGetFunc(c),
+				Update: newKibanaSyntheticsMonitorUpdateFunc(c),
 			},
 			PrivateLocation: &KibanaSyntheticsPrivateLocationAPI{
 				Create: newKibanaSyntheticsPrivateLocationCreateFunc(c),

--- a/libs/go-kibana-rest/kbapi/api._.go
+++ b/libs/go-kibana-rest/kbapi/api._.go
@@ -13,6 +13,7 @@ type API struct {
 	KibanaStatus           *KibanaStatusAPI
 	KibanaLogstashPipeline *KibanaLogstashPipelineAPI
 	KibanaShortenURL       *KibanaShortenURLAPI
+	KibanaSynthetics       *KibanaSyntheticsAPI
 }
 
 // KibanaSpacesAPI handle the spaces API
@@ -68,6 +69,11 @@ type KibanaShortenURLAPI struct {
 	Create KibanaShortenURLCreate
 }
 
+type KibanaSyntheticsAPI struct {
+	Monitor         *KibanaSyntheticsMonitorAPI
+	PrivateLocation *KibanaSyntheticsPrivateLocationAPI
+}
+
 // New initialise the API implementation
 func New(c *resty.Client) *API {
 	return &API{
@@ -109,6 +115,18 @@ func New(c *resty.Client) *API {
 		},
 		KibanaShortenURL: &KibanaShortenURLAPI{
 			Create: newKibanaShortenURLCreateFunc(c),
+		},
+		KibanaSynthetics: &KibanaSyntheticsAPI{
+			Monitor: &KibanaSyntheticsMonitorAPI{
+				Add:    newKibanaSyntheticsMonitorAddFunc(c),
+				Delete: newKibanaSyntheticsMonitorDeleteFunc(c),
+				Get:    newKibanaSyntheticsMonitorGetFunc(c),
+			},
+			PrivateLocation: &KibanaSyntheticsPrivateLocationAPI{
+				Create: newKibanaSyntheticsPrivateLocationCreateFunc(c),
+				Delete: newKibanaSyntheticsPrivateLocationDeleteFunc(c),
+				Get:    newKibanaSyntheticsPrivateLocationGetFunc(c),
+			},
 		},
 	}
 }

--- a/libs/go-kibana-rest/kbapi/api.kibana_spaces_test.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_spaces_test.go
@@ -42,7 +42,7 @@ func (s *KBAPITestSuite) TestKibanaSpaces() {
 		Objects: []KibanaSpaceObjectParameter{
 			{
 				Type: "config",
-				ID:   "8.14.1",
+				ID:   "8.14.3",
 			},
 		},
 	}

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
@@ -73,13 +73,13 @@ type KibanaSyntheticsPrivateLocationAPI struct {
 	Get    KibanaSyntheticsPrivateLocationGet
 }
 
+type SyntheticsStatusConfig struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 type MonitorAlertConfig struct {
-	Status struct {
-		Enabled *bool `json:"enabled,omitempty"`
-	} `json:"status,omitempty"`
-	Tls struct {
-		Enabled *bool `json:"enabled,omitempty"`
-	} `json:"tls,omitempty"`
+	Status SyntheticsStatusConfig `json:"status,omitempty"`
+	Tls    SyntheticsStatusConfig `json:"tls,omitempty"`
 }
 
 type HTTPMonitorFields struct {
@@ -119,14 +119,16 @@ type MonitorScheduleConfig struct {
 	Unit   string `json:"unit"`
 }
 
+type SyntheticGeoConfig struct {
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+
 type MonitorLocationConfig struct {
-	Id    string `json:"id"`
-	Label string `json:"label"`
-	Geo   struct {
-		Lat float64 `json:"lat"`
-		Lon float64 `json:"lon"`
-	} `json:"geo"`
-	IsServiceManaged bool `json:"isServiceManaged"`
+	Id               string              `json:"id"`
+	Label            string              `json:"label"`
+	Geo              *SyntheticGeoConfig `json:"geo,omitempty"`
+	IsServiceManaged bool                `json:"isServiceManaged"`
 }
 
 type SyntheticsMonitor struct {
@@ -161,16 +163,11 @@ type SyntheticsMonitor struct {
 	} `json:"__ui,omitempty"`
 }
 
-type Geo struct {
-	Lat float32 `json:"lat"`
-	Lon float32 `json:"lon"`
-}
-
 type PrivateLocationConfig struct {
-	Label         string   `json:"label"`
-	AgentPolicyId string   `json:"agentPolicyId"`
-	Tags          []string `json:"tags,omitempty"`
-	Geo           Geo      `json:"geo,omitempty"`
+	Label         string              `json:"label"`
+	AgentPolicyId string              `json:"agentPolicyId"`
+	Tags          []string            `json:"tags,omitempty"`
+	Geo           *SyntheticGeoConfig `json:"geo,omitempty"`
 }
 
 type PrivateLocation struct {

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
@@ -1,0 +1,323 @@
+package kbapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/go-resty/resty/v2"
+	log "github.com/sirupsen/logrus"
+	"time"
+)
+
+const (
+	basePathKibanaSynthetics = "/api/synthetics" // Base URL to access on Kibana save objects
+	privateLocationsSuffix   = "/private_locations"
+	monitorsSuffix           = "/monitors"
+)
+
+type MonitorID string
+type MonitorType string
+type MonitorLocation string
+type MonitorSchedule int
+type HttpMonitorMode string
+
+type KibanaError struct {
+	Code    int    `json:"statusCode,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type JsonObject map[string]interface{}
+
+const (
+	Http    MonitorType = "http"
+	Tcp     MonitorType = "tcp"
+	Icmp    MonitorType = "icmp"
+	Browser MonitorType = "browser"
+
+	Every1Minute    MonitorSchedule = 1
+	Every2Minutes                   = 2
+	Every3Minutes                   = 3
+	Every5Minutes                   = 5
+	Every10Minutes                  = 10
+	Every15Minutes                  = 15
+	Every20Minutes                  = 20
+	Every30Minutes                  = 30
+	Every60Minutes                  = 60
+	Every120Minutes                 = 120
+	Every240Minutes                 = 240
+
+	Japan         MonitorLocation = "japan"
+	India                         = "india"
+	Singapore                     = "singapore"
+	AustraliaEast                 = "australia_east"
+	UnitedKingdom                 = "united_kingdom"
+	Germany                       = "germany"
+	CanadaEast                    = "canada_east"
+	Brazil                        = "brazil"
+	USEast                        = "us_east"
+	USWest                        = "us_west"
+
+	ModeAll HttpMonitorMode = "all"
+	ModeAny                 = "any"
+)
+
+type KibanaSyntheticsMonitorAPI struct {
+	Add    KibanaSyntheticsMonitorAdd
+	Delete KibanaSyntheticsMonitorDelete
+	Get    KibanaSyntheticsMonitorGet
+}
+
+type KibanaSyntheticsPrivateLocationAPI struct {
+	Create KibanaSyntheticsPrivateLocationCreate
+	Delete KibanaSyntheticsPrivateLocationDelete
+	Get    KibanaSyntheticsPrivateLocationGet
+}
+
+type MonitorAlertConfig struct {
+	Status struct {
+		Enabled *bool `json:"enabled,omitempty"`
+	} `json:"status,omitempty"`
+	Tls struct {
+		Enabled *bool `json:"enabled,omitempty"`
+	} `json:"tls,omitempty"`
+}
+
+type HTTPMonitorFields struct {
+	Url                 string          `json:"url"`
+	SslSetting          JsonObject      `json:"ssl,omitempty"` //https://www.elastic.co/guide/en/beats/heartbeat/current/configuration-ssl.html
+	MaxRedirects        int             `json:"max_redirects,omitempty"`
+	Mode                HttpMonitorMode `json:"mode,omitempty"`
+	Ipv4                *bool           `json:"ipv4,omitempty"`
+	Ipv6                *bool           `json:"ipv6,omitempty"`
+	Username            string          `json:"username,omitempty"`
+	Password            string          `json:"password,omitempty"`
+	ProxyHeader         JsonObject      `json:"proxy_headers,omitempty"`
+	ProxyUrl            string          `json:"proxy_url,omitempty"`
+	Response            JsonObject      `json:"response,omitempty"`
+	ResponseIncludeBody *bool           `json:"response.include_body,omitempty"` //TODO: test with Response
+	Check               JsonObject      `json:"check,omitempty"`
+}
+
+type SyntheticsMonitorConfig struct {
+	Name             string              `json:"name"`
+	Type             MonitorType         `json:"type"`
+	Schedule         MonitorSchedule     `json:"schedule,omitempty"`
+	Locations        []MonitorLocation   `json:"locations,omitempty"`
+	PrivateLocations []string            `json:"private_locations,omitempty"`
+	Enabled          *bool               `json:"enabled,omitempty"`
+	Tags             []string            `json:"tags,omitempty"`
+	Alert            *MonitorAlertConfig `json:"alert,omitempty"`
+	APMServiceName   string              `json:"service.name,omitempty"`
+	TimeoutSeconds   int                 `json:"timeout,omitempty"`
+	Namespace        string              `json:"namespace,omitempty"`
+	Params           string              `json:"params,omitempty"`
+	RetestOnFailure  *bool               `json:"retest_on_failure,omitempty"`
+}
+
+type MonitorScheduleConfig struct {
+	Number string `json:"number"`
+	Unit   string `json:"unit"`
+}
+
+type MonitorLocationConfig struct {
+	Id    string `json:"id"`
+	Label string `json:"label"`
+	Geo   struct {
+		Lat float64 `json:"lat"`
+		Lon float64 `json:"lon"`
+	} `json:"geo"`
+	IsServiceManaged bool `json:"isServiceManaged"`
+}
+
+type SyntheticsMonitor struct {
+	Name                        string                  `json:"name"`
+	Type                        MonitorType             `json:"type"`
+	ConfigId                    MonitorID               `json:"config_id"`
+	Id                          MonitorID               `json:"id"`
+	Mode                        HttpMonitorMode         `json:"mode"`
+	CreatedAt                   time.Time               `json:"created_at"`
+	UpdatedAt                   time.Time               `json:"updated_at"`
+	Namespace                   string                  `json:"namespace"`
+	Enabled                     *bool                   `json:"enabled,omitempty"`
+	Alert                       *MonitorAlertConfig     `json:"alert,omitempty"`
+	Schedule                    *MonitorScheduleConfig  `json:"schedule,omitempty"`
+	Timeout                     string                  `json:"timeout,omitempty"`
+	Locations                   []MonitorLocationConfig `json:"locations,omitempty"`
+	Origin                      string                  `json:"origin,omitempty"`
+	MaxAttempts                 int                     `json:"max_attempts"`
+	MaxRedirects                string                  `json:"max_redirects"`
+	ResponseIncludeBody         string                  `json:"response.include_body"`
+	ResponseIncludeHeaders      bool                    `json:"response.include_headers"`
+	CheckRequestMethod          string                  `json:"check.request.method"`
+	ResponseIncludeBodyMaxBytes string                  `json:"response.include_body_max_bytes,omitempty"`
+	Ipv4                        bool                    `json:"ipv4,omitempty"`
+	Ipv6                        bool                    `json:"ipv6,omitempty"`
+	SslVerificationMode         string                  `json:"ssl.verification_mode,omitempty"`
+	SslSupportedProtocols       []string                `json:"ssl.supported_protocols,omitempty"`
+	Revision                    int                     `json:"revision,omitempty"`
+	Url                         string                  `json:"url,omitempty"`
+	Ui                          struct {
+		IsTlsEnabled bool `json:"is_tls_enabled"`
+	} `json:"__ui,omitempty"`
+}
+
+type Geo struct {
+	Lat float32 `json:"lat"`
+	Lon float32 `json:"lon"`
+}
+
+type PrivateLocationConfig struct {
+	Label         string   `json:"label"`
+	AgentPolicyId string   `json:"agentPolicyId"`
+	Tags          []string `json:"tags,omitempty"`
+	Geo           Geo      `json:"geo,omitempty"`
+}
+
+type PrivateLocation struct {
+	Id string `json:"id"`
+	PrivateLocationConfig
+}
+
+type MonitorDeleteStatus struct {
+	Id      MonitorID `json:"id"`
+	Deleted bool      `json:"deleted"`
+}
+
+type KibanaSyntheticsMonitorAdd func(config SyntheticsMonitorConfig, fields HTTPMonitorFields, namespace string) (*SyntheticsMonitor, error)
+
+type KibanaSyntheticsMonitorGet func(id MonitorID, namespace string) (*SyntheticsMonitor, error)
+
+type KibanaSyntheticsMonitorDelete func(namespace string, ids ...MonitorID) ([]MonitorDeleteStatus, error)
+
+type KibanaSyntheticsPrivateLocationCreate func(pLoc PrivateLocationConfig, namespace string) (*PrivateLocation, error)
+
+type KibanaSyntheticsPrivateLocationGet func(idOrLabel string, namespace string) (*PrivateLocation, error)
+
+type KibanaSyntheticsPrivateLocationDelete func(id string, namespace string) error
+
+func newKibanaSyntheticsPrivateLocationGetFunc(c *resty.Client) KibanaSyntheticsPrivateLocationGet {
+	return func(idOrLabel string, namespace string) (*PrivateLocation, error) {
+
+		path := fmt.Sprintf("%s/%s", basePath(namespace, privateLocationsSuffix), idOrLabel)
+		log.Debugf("URL to get private locations: %s", path)
+		resp, err := c.R().Get(path)
+		if err = handleKibanaError(err, resp); err != nil {
+			return nil, err
+		}
+		return unmarshal(resp, PrivateLocation{})
+	}
+}
+
+func newKibanaSyntheticsPrivateLocationDeleteFunc(c *resty.Client) KibanaSyntheticsPrivateLocationDelete {
+	return func(id string, namespace string) error {
+		path := fmt.Sprintf("%s/%s", basePath(namespace, privateLocationsSuffix), id)
+		log.Debugf("URL to delete private locations: %s", path)
+		resp, err := c.R().Delete(path)
+		err = handleKibanaError(err, resp)
+		return err
+	}
+}
+
+func newKibanaSyntheticsMonitorGetFunc(c *resty.Client) KibanaSyntheticsMonitorGet {
+	return func(id MonitorID, namespace string) (*SyntheticsMonitor, error) {
+		path := fmt.Sprintf("%s/%s", basePath(namespace, monitorsSuffix), id)
+		log.Debugf("URL to create monitor: %s", path)
+
+		resp, err := c.R().Get(path)
+		if err := handleKibanaError(err, resp); err != nil {
+			return nil, err
+		}
+		return unmarshal(resp, SyntheticsMonitor{})
+	}
+}
+
+func newKibanaSyntheticsMonitorDeleteFunc(c *resty.Client) KibanaSyntheticsMonitorDelete {
+	return func(namespace string, ids ...MonitorID) ([]MonitorDeleteStatus, error) {
+		path := basePath(namespace, monitorsSuffix)
+		log.Debugf("URL to delete monitors: %s", path)
+
+		resp, err := c.R().SetBody(map[string]interface{}{
+			"ids": ids,
+		}).Delete(path)
+		if err = handleKibanaError(err, resp); err != nil {
+			return nil, err
+		}
+
+		result, err := unmarshal(resp, []MonitorDeleteStatus{})
+		return *result, err
+	}
+}
+
+func newKibanaSyntheticsPrivateLocationCreateFunc(c *resty.Client) KibanaSyntheticsPrivateLocationCreate {
+	return func(pLoc PrivateLocationConfig, namespace string) (*PrivateLocation, error) {
+
+		path := basePath(namespace, privateLocationsSuffix)
+		log.Debugf("URL to create private locations: %s", path)
+		resp, err := c.R().SetBody(pLoc).Post(path)
+		if err = handleKibanaError(err, resp); err != nil {
+			return nil, err
+		}
+		return unmarshal(resp, PrivateLocation{})
+	}
+}
+
+func newKibanaSyntheticsMonitorAddFunc(c *resty.Client) KibanaSyntheticsMonitorAdd {
+	return func(config SyntheticsMonitorConfig, fields HTTPMonitorFields, namespace string) (*SyntheticsMonitor, error) {
+
+		path := basePath(namespace, monitorsSuffix)
+		log.Debugf("URL to create monitor: %s", path)
+
+		data := struct {
+			SyntheticsMonitorConfig
+			HTTPMonitorFields
+		}{
+			config,
+			fields,
+		}
+
+		resp, err := c.R().SetBody(data).Post(path)
+		if err := handleKibanaError(err, resp); err != nil {
+			return nil, err
+		}
+		return unmarshal(resp, SyntheticsMonitor{})
+	}
+}
+
+func unmarshal[T interface{}](resp *resty.Response, result T) (*T, error) {
+	respBody := resp.Body()
+	err := json.Unmarshal(respBody, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func handleKibanaError(err error, resp *resty.Response) error {
+	if err != nil {
+		return err
+	}
+	log.Debug("Response: ", resp)
+	if resp.StatusCode() >= 300 {
+		kibanaErr := KibanaError{}
+		err := json.Unmarshal(resp.Body(), &kibanaErr)
+		if err != nil {
+			return NewAPIError(resp.StatusCode(), resp.Status(), err)
+		}
+		return NewAPIError(resp.StatusCode(), kibanaErr.Message, kibanaErr.Error)
+	}
+	return nil
+}
+
+func basePath(namespace, suffix string) string {
+	return namespaceBasesPath(namespace, basePathKibanaSynthetics, suffix)
+}
+
+func namespaceBasesPath(namespace, basePath, suffix string) string {
+	if namespace == "" || namespace == "default" {
+		return fmt.Sprintf("%s%s", basePath, suffix)
+	}
+
+	return fmt.Sprintf("/s/%s%s%s", namespace, basePath, suffix)
+}
+
+//TODO: Monitor - Update, Get https://www.elastic.co/guide/en/kibana/current/synthetics-apis.html

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	basePathKibanaSynthetics = "/api/synthetics" // Base URL to access on Kibana save objects
+	basePathKibanaSynthetics = "/api/synthetics"
 	privateLocationsSuffix   = "/private_locations"
 	monitorsSuffix           = "/monitors"
 )
@@ -219,7 +219,7 @@ func newKibanaSyntheticsPrivateLocationDeleteFunc(c *resty.Client) KibanaSynthet
 func newKibanaSyntheticsMonitorGetFunc(c *resty.Client) KibanaSyntheticsMonitorGet {
 	return func(id MonitorID, namespace string) (*SyntheticsMonitor, error) {
 		path := basePathWithId(namespace, monitorsSuffix, id)
-		log.Debugf("URL to create monitor: %s", path)
+		log.Debugf("URL to get monitor: %s", path)
 
 		resp, err := c.R().Get(path)
 		if err := handleKibanaError(err, resp); err != nil {
@@ -263,7 +263,7 @@ func newKibanaSyntheticsMonitorUpdateFunc(c *resty.Client) KibanaSyntheticsMonit
 	return func(id MonitorID, config SyntheticsMonitorConfig, fields HTTPMonitorFields, namespace string) (*SyntheticsMonitor, error) {
 
 		path := basePathWithId(namespace, monitorsSuffix, id)
-		log.Debugf("URL to create monitor: %s", path)
+		log.Debugf("URL to update monitor: %s", path)
 		data := buildMonitorJson(config, fields)
 		resp, err := c.R().SetBody(data).Put(path)
 		if err := handleKibanaError(err, resp); err != nil {

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics.go
@@ -320,4 +320,4 @@ func namespaceBasesPath(namespace, basePath, suffix string) string {
 	return fmt.Sprintf("/s/%s%s%s", namespace, basePath, suffix)
 }
 
-//TODO: Monitor - Update, Get https://www.elastic.co/guide/en/kibana/current/synthetics-apis.html
+//TODO: Monitor - Update https://www.elastic.co/guide/en/kibana/current/synthetics-apis.html

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics_test.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics_test.go
@@ -4,16 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
-
-/*
-TODO: monitor update
-TODO: different input params for monitors
-*/
 
 var (
 	namespaces = []string{"", "default", "testacc"}
@@ -56,55 +52,163 @@ func testWithPolicy(t *testing.T, client *resty.Client, namespace string, f func
 
 func (s *KBAPITestSuite) TestKibanaSyntheticsMonitorAPI() {
 
+	type TestConfig struct {
+		config SyntheticsMonitorConfig
+		fields HTTPMonitorFields
+	}
+
 	for _, n := range namespaces {
 		testUuid := uuid.New().String()
 		space := n
 		syntheticsAPI := s.API.KibanaSynthetics
 
-		s.Run(fmt.Sprintf("TestKibanaSyntheticsMonitorAPI - %s", n), func() {
-			testWithPolicy(s.T(), s.client, space, func(policyId string) {
-				locationConfig := PrivateLocationConfig{
-					Label:         fmt.Sprintf("TestKibanaSyntheticsMonitorAdd %s", testUuid),
-					AgentPolicyId: policyId,
-				}
-				location, err := syntheticsAPI.PrivateLocation.Create(locationConfig, space)
-				assert.NoError(s.T(), err)
-				defer func(id string) {
-					syntheticsAPI.PrivateLocation.Delete(id, space)
-				}(location.Id)
+		testWithPolicy(s.T(), s.client, space, func(policyId string) {
+			locationConfig := PrivateLocationConfig{
+				Label:         fmt.Sprintf("TestKibanaSyntheticsMonitorAdd %s", testUuid),
+				AgentPolicyId: policyId,
+			}
+			location, err := syntheticsAPI.PrivateLocation.Create(locationConfig, space)
+			assert.NoError(s.T(), err)
+			defer func(id string) {
+				syntheticsAPI.PrivateLocation.Delete(id, space)
+			}(location.Id)
 
-				config := SyntheticsMonitorConfig{
-					Name:             fmt.Sprintf("test synthetics monitor %s", testUuid),
-					Type:             Http,
-					PrivateLocations: []string{location.Label},
-				}
-				fields := HTTPMonitorFields{
-					Url: "http://localhost:5601",
-				}
-				monitor, err := syntheticsAPI.Monitor.Add(config, fields, space)
-				assert.NoError(s.T(), err)
-				assert.NotNil(s.T(), monitor)
+			f := new(bool)
+			*f = false
+			t := new(bool)
+			*t = true
 
-				get, err := syntheticsAPI.Monitor.Get(monitor.Id, space)
-				assert.NoError(s.T(), err)
-				assert.Equal(s.T(), monitor, get)
+			testCases := []struct {
+				name   string
+				input  TestConfig
+				update TestConfig
+			}{
+				{
+					name: "bare minimum http monitor",
+					input: TestConfig{
+						config: SyntheticsMonitorConfig{
+							Name:             fmt.Sprintf("test synthetics http monitor %s", testUuid),
+							PrivateLocations: []string{location.Label},
+						},
+						fields: HTTPMonitorFields{
+							Url: "http://localhost:5601",
+						},
+					},
+					update: TestConfig{
+						config: SyntheticsMonitorConfig{},
+						fields: HTTPMonitorFields{
+							Url: "http://localhost:9200",
+						},
+					},
+				},
+				{
+					name: "all fields http monitor",
+					input: TestConfig{
+						config: SyntheticsMonitorConfig{
+							Name:             fmt.Sprintf("test all fields http monitor %s", testUuid),
+							Schedule:         Every10Minutes,
+							PrivateLocations: []string{location.Label},
+							Enabled:          f,
+							Tags:             []string{"aaa", "bbb"},
+							Alert: &MonitorAlertConfig{
+								Status: &SyntheticsStatusConfig{Enabled: t},
+								Tls:    &SyntheticsStatusConfig{Enabled: f},
+							},
+							APMServiceName: "APMServiceName",
+							TimeoutSeconds: 42,
+							Namespace:      space,
+							Params: map[string]interface{}{
+								"param1": "some-params",
+							},
+							RetestOnFailure: f,
+						},
+						fields: HTTPMonitorFields{
+							Url: "http://localhost:5601",
+							SslSetting: map[string]interface{}{
+								"supported_protocols": []string{"TLSv1.0", "TLSv1.1", "TLSv1.2"},
+							},
+							MaxRedirects: "2",
+							Mode:         ModeAny,
+							Ipv4:         t,
+							Ipv6:         f,
+							Username:     "test-user-name",
+							Password:     "test-password",
+							ProxyHeader: map[string]interface{}{
+								"User-Agent": "test",
+							},
+							ProxyUrl: "http://localhost",
+							Response: map[string]interface{}{
+								"include_body":           "always",
+								"include_body_max_bytes": "1024",
+							},
+							Check: map[string]interface{}{
+								"request": map[string]interface{}{
+									"method": "POST",
+									"headers": map[string]interface{}{
+										"Content-Type": "application/x-www-form-urlencoded",
+									},
+									"body": "name=first&email=someemail%40someemailprovider.com",
+								},
+								"response": map[string]interface{}{
+									"status": []int{200, 201},
+									"body": map[string]interface{}{
+										"positive": []string{"foo", "bar"},
+									},
+								},
+							},
+						},
+					},
+					update: TestConfig{
+						config: SyntheticsMonitorConfig{
+							Name:     fmt.Sprintf("update all fields http monitor %s", testUuid),
+							Schedule: Every30Minutes,
+						},
+						fields: HTTPMonitorFields{
+							Url:  "http://localhost:9200",
+							Mode: ModeAll,
+						},
+					},
+				},
+			}
 
-				get, err = syntheticsAPI.Monitor.Get(monitor.ConfigId, space)
-				assert.NoError(s.T(), err)
-				assert.Equal(s.T(), monitor, get)
+			for _, tc := range testCases {
+				s.Run(fmt.Sprintf("TestKibanaSyntheticsMonitorAPI ns [%s] - %s", n, tc.name), func() {
+					config := tc.input.config
+					fields := tc.input.fields
 
-				deleted, err := syntheticsAPI.Monitor.Delete(space, monitor.ConfigId)
-				assert.NoError(s.T(), err)
-				for _, d := range deleted {
-					assert.True(s.T(), d.Deleted)
-				}
+					monitor, err := syntheticsAPI.Monitor.Add(config, fields, space)
+					assert.NoError(s.T(), err)
+					assert.NotNil(s.T(), monitor)
 
-				deleted, err = syntheticsAPI.Monitor.Delete(space, monitor.Id)
-				assert.NoError(s.T(), err)
-				for _, d := range deleted {
-					assert.False(s.T(), d.Deleted)
-				}
-			})
+					get, err := syntheticsAPI.Monitor.Get(monitor.Id, space)
+					assert.NoError(s.T(), err)
+					assert.Equal(s.T(), monitor, get)
+
+					get, err = syntheticsAPI.Monitor.Get(monitor.ConfigId, space)
+					assert.NoError(s.T(), err)
+					assert.Equal(s.T(), monitor, get)
+
+					update, err := syntheticsAPI.Monitor.Update(monitor.Id, tc.update.config, tc.update.fields, space)
+					assert.NoError(s.T(), err)
+
+					get, err = syntheticsAPI.Monitor.Get(monitor.ConfigId, space)
+					assert.NoError(s.T(), err)
+					get.CreatedAt = time.Time{} // update response doesn't have created_at field
+					assert.Equal(s.T(), update, get)
+
+					deleted, err := syntheticsAPI.Monitor.Delete(space, monitor.ConfigId)
+					assert.NoError(s.T(), err)
+					for _, d := range deleted {
+						assert.True(s.T(), d.Deleted)
+					}
+
+					deleted, err = syntheticsAPI.Monitor.Delete(space, monitor.Id)
+					assert.NoError(s.T(), err)
+					for _, d := range deleted {
+						assert.False(s.T(), d.Deleted)
+					}
+				})
+			}
 		})
 	}
 }

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics_test.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics_test.go
@@ -123,7 +123,7 @@ func (s *KBAPITestSuite) TestKibanaSyntheticsPrivateLocationAPI() {
 					Label:         fmt.Sprintf("TestKibanaSyntheticsPrivateLocationAPI %s", testUuid),
 					AgentPolicyId: policyId,
 					Tags:          []string{"a", "b"},
-					Geo: Geo{
+					Geo: &SyntheticGeoConfig{
 						Lat: 12.12,
 						Lon: -42.42,
 					},

--- a/libs/go-kibana-rest/kbapi/api.kibana_synthetics_test.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_synthetics_test.go
@@ -1,0 +1,152 @@
+package kbapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+TODO: monitor update
+TODO: different input params for monitors
+*/
+
+var (
+	namespaces = []string{"", "default", "testacc"}
+)
+
+func testWithPolicy(t *testing.T, client *resty.Client, namespace string, f func(policyId string)) {
+
+	policyName := uuid.New().String()
+	path := namespaceBasesPath(namespace, "/api/fleet", "/agent_policies")
+
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	policyResponse, err := client.R().SetBody(map[string]interface{}{
+		"name":               fmt.Sprintf("Test synthetics monitor policy %s", policyName),
+		"description":        "test policy for synthetics API",
+		"namespace":          namespace,
+		"monitoring_enabled": []string{"logs", "metrics"},
+	}).Post(path)
+	assert.NoError(t, err)
+
+	policy := struct {
+		Item struct {
+			Id   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"item"`
+	}{}
+
+	err = json.Unmarshal(policyResponse.Body(), &policy)
+	assert.NoError(t, err)
+	defer func(policyId string) {
+		client.R().SetBody(map[string]interface{}{
+			"agentPolicyId": policyId,
+		}).Post(fmt.Sprintf("%s/delete", path))
+	}(policy.Item.Id)
+
+	f(policy.Item.Id)
+}
+
+func (s *KBAPITestSuite) TestKibanaSyntheticsMonitorAPI() {
+
+	for _, n := range namespaces {
+		testUuid := uuid.New().String()
+		space := n
+		syntheticsAPI := s.API.KibanaSynthetics
+
+		s.Run(fmt.Sprintf("TestKibanaSyntheticsMonitorAPI - %s", n), func() {
+			testWithPolicy(s.T(), s.client, space, func(policyId string) {
+				locationConfig := PrivateLocationConfig{
+					Label:         fmt.Sprintf("TestKibanaSyntheticsMonitorAdd %s", testUuid),
+					AgentPolicyId: policyId,
+				}
+				location, err := syntheticsAPI.PrivateLocation.Create(locationConfig, space)
+				assert.NoError(s.T(), err)
+				defer func(id string) {
+					syntheticsAPI.PrivateLocation.Delete(id, space)
+				}(location.Id)
+
+				config := SyntheticsMonitorConfig{
+					Name:             fmt.Sprintf("test synthetics monitor %s", testUuid),
+					Type:             Http,
+					PrivateLocations: []string{location.Label},
+				}
+				fields := HTTPMonitorFields{
+					Url: "http://localhost:5601",
+				}
+				monitor, err := syntheticsAPI.Monitor.Add(config, fields, space)
+				assert.NoError(s.T(), err)
+				assert.NotNil(s.T(), monitor)
+
+				get, err := syntheticsAPI.Monitor.Get(monitor.Id, space)
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), monitor, get)
+
+				get, err = syntheticsAPI.Monitor.Get(monitor.ConfigId, space)
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), monitor, get)
+
+				deleted, err := syntheticsAPI.Monitor.Delete(space, monitor.ConfigId)
+				assert.NoError(s.T(), err)
+				for _, d := range deleted {
+					assert.True(s.T(), d.Deleted)
+				}
+
+				deleted, err = syntheticsAPI.Monitor.Delete(space, monitor.Id)
+				assert.NoError(s.T(), err)
+				for _, d := range deleted {
+					assert.False(s.T(), d.Deleted)
+				}
+			})
+		})
+	}
+}
+
+func (s *KBAPITestSuite) TestKibanaSyntheticsPrivateLocationAPI() {
+
+	for _, n := range namespaces {
+		testUuid := uuid.New().String()
+		space := n
+		pAPI := s.API.KibanaSynthetics.PrivateLocation
+
+		s.Run(fmt.Sprintf("TestKibanaSyntheticsPrivateLocationAPI - %s", n), func() {
+			testWithPolicy(s.T(), s.client, space, func(policyId string) {
+
+				cfg := PrivateLocationConfig{
+					Label:         fmt.Sprintf("TestKibanaSyntheticsPrivateLocationAPI %s", testUuid),
+					AgentPolicyId: policyId,
+					Tags:          []string{"a", "b"},
+					Geo: Geo{
+						Lat: 12.12,
+						Lon: -42.42,
+					},
+				}
+				created, err := pAPI.Create(cfg, space)
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), created.Label, cfg.Label)
+				assert.Equal(s.T(), created.AgentPolicyId, cfg.AgentPolicyId)
+
+				get, err := pAPI.Get(created.Id, space)
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), created, get)
+
+				get, err = pAPI.Get(created.Label, space)
+				assert.NoError(s.T(), err)
+				assert.Equal(s.T(), created, get)
+
+				err = pAPI.Delete(created.Id, space)
+				assert.NoError(s.T(), err)
+
+				_, err = pAPI.Get(created.Id, space)
+				assert.Error(s.T(), err)
+			})
+		})
+	}
+}

--- a/libs/go-kibana-rest/kbapi/api_test.go
+++ b/libs/go-kibana-rest/kbapi/api_test.go
@@ -75,7 +75,7 @@ func (s *KBAPITestSuite) SetupSuite() {
 
 func (s *KBAPITestSuite) SetupTest() {
 
-	// Do something before each test
+	// Do somethink before each test
 
 }
 

--- a/libs/go-kibana-rest/kbapi/api_test.go
+++ b/libs/go-kibana-rest/kbapi/api_test.go
@@ -23,6 +23,7 @@ func (s *KBAPITestSuite) SetupSuite() {
 	// Init logger
 	logrus.SetFormatter(new(prefixed.TextFormatter))
 	logrus.SetLevel(logrus.DebugLevel)
+	restyDebug := os.Getenv("DEBUG") != ""
 
 	address := os.Getenv("KIBANA_URL")
 	username := os.Getenv("KIBANA_USERNAME")
@@ -36,7 +37,8 @@ func (s *KBAPITestSuite) SetupSuite() {
 		SetBaseURL(address).
 		SetBasicAuth(username, password).
 		SetHeader("kbn-xsrf", "true").
-		SetHeader("Content-Type", "application/json")
+		SetHeader("Content-Type", "application/json").
+		SetDebug(restyDebug)
 
 	s.client = restyClient
 	s.API = New(restyClient)
@@ -73,7 +75,7 @@ func (s *KBAPITestSuite) SetupSuite() {
 
 func (s *KBAPITestSuite) SetupTest() {
 
-	// Do somethink before each test
+	// Do something before each test
 
 }
 

--- a/libs/go-kibana-rest/kbapi/api_test.go
+++ b/libs/go-kibana-rest/kbapi/api_test.go
@@ -75,7 +75,7 @@ func (s *KBAPITestSuite) SetupSuite() {
 
 func (s *KBAPITestSuite) SetupTest() {
 
-	// Do somethink before each test
+	// Do something before each test
 
 }
 

--- a/libs/go-kibana-rest/kibana.yml
+++ b/libs/go-kibana-rest/kibana.yml
@@ -1,8 +1,0 @@
-server.host: "0.0.0.0"
-server.shutdownTimeout: "5s"
-elasticsearch.hosts: [ "http://es:9200" ]
-
-xpack.encryptedSavedObjects:
-  encryptionKey: "min-32-byte-long-strong-encryption-key"
-
-server.oas.enabled: true

--- a/libs/go-kibana-rest/kibana.yml
+++ b/libs/go-kibana-rest/kibana.yml
@@ -1,0 +1,8 @@
+server.host: "0.0.0.0"
+server.shutdownTimeout: "5s"
+elasticsearch.hosts: [ "http://es:9200" ]
+
+xpack.encryptedSavedObjects:
+  encryptionKey: "min-32-byte-long-strong-encryption-key"
+
+server.oas.enabled: true


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/610

This PR adds support for synthetic `http` Monitor and PrivateLocation APIs. 

Main doc: https://www.elastic.co/guide/en/kibana/current/synthetics-apis.html

Notes: 
1. new `uuid` dependency for testing purposes
2. proposed way to model monitor API. Different monitor kinds has different set of parameters. 
3. updated to `8.14.3`
4. added kibana config for docker compose