### PR TITLE
Use ephemeral github token for build.

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -12,5 +12,5 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "terraform-provider-elasticstack-release" ]]
   export GPG_PRIVATE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_private ${RELEASE_VAULT_PATH})
   export GPG_PASSPHRASE_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_passphrase ${RELEASE_VAULT_PATH})
   export GPG_FINGERPRINT_SECRET=$(scripts/retry.sh 5 vault kv get -field gpg_fingerprint ${RELEASE_VAULT_PATH})
-  export GITHUB_TOKEN=$(scripts/retry.sh 5 vault kv get -field gh_personal_access_token ${RELEASE_VAULT_PATH})
+  export GITHUB_TOKEN="${VAULT_GITHUB_TOKEN}"
 fi

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -12,4 +12,5 @@ echo "--- Caching GPG passphrase"
 echo "$GPG_PASSPHRASE_SECRET" | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback
 
 echo "--- Release the binaries"
+export GITHUB_TOKEN="${VAULT_GITHUB_TOKEN}"
 make release

--- a/.buildkite/scripts/release.sh
+++ b/.buildkite/scripts/release.sh
@@ -12,5 +12,4 @@ echo "--- Caching GPG passphrase"
 echo "$GPG_PASSPHRASE_SECRET" | gpg --armor --detach-sign --passphrase-fd 0 --pinentry-mode loopback
 
 echo "--- Release the binaries"
-export GITHUB_TOKEN="${VAULT_GITHUB_TOKEN}"
 make release


### PR DESCRIPTION
The `VAULT_GITHUB_TOKEN` env var contains the token with permissions to create releases. Goreleaser on the other hand will only use `GITHUB_TOKEN` for the release.