### PR TITLE
internal/kibana: fix datasourceConnectorRead error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add the `alert_delay` field to the Create Rule API ([#715](https://github.com/elastic/terraform-provider-elasticstack/pull/715))
 - Add support for data_stream `lifecycle` template settings ([#724](https://github.com/elastic/terraform-provider-elasticstack/pull/724))
+- Fix a provider panic when `elasticstack_kibana_action_connector` reads a non-existant connector ([#729](https://github.com/elastic/terraform-provider-elasticstack/pull/729))
 
 ## [0.11.6] - 2024-08-20
 

--- a/internal/kibana/connector_data_source.go
+++ b/internal/kibana/connector_data_source.go
@@ -76,7 +76,7 @@ func datasourceConnectorRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if len(foundConnectors) == 0 {
-		diag.Errorf("error while creating elasticstack_kibana_action_connector datasource: connector with name [%s/%s] and type [%s] not found", spaceId, connectorName, connectorType)
+		return diag.Errorf("error while creating elasticstack_kibana_action_connector datasource: connector with name [%s/%s] and type [%s] not found", spaceId, connectorName, connectorType)
 	}
 
 	if len(foundConnectors) > 1 {


### PR DESCRIPTION
Make sure that datasourceConnectorRead() returns the appropriate error when no connectors are found.