### PR TITLE
Prevent a provider panic when the referenced snapshot repo does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Fix a provider panic when `elasticstack_kibana_action_connector` reads a non-existant connector ([#729](https://github.com/elastic/terraform-provider-elasticstack/pull/729))
 - Add support for `remote_indicies` to `elasticstack_elasticsearch_security_role` & `elasticstack_kibana_security_role` (#723)[https://github.com/elastic/terraform-provider-elasticstack/pull/723]
 - Fix error handling in `elasticstack_kibana_import_saved_objects` ([#738](https://github.com/elastic/terraform-provider-elasticstack/pull/738))
-- Remove `space_id` parameter from private locations to fix inconsistent state for `elasticstack_kibana_synthetics_private_location` `space_id` ([#733](https://github.com/elastic/terraform-provider-elasticstack/pull/733))  
+- Remove `space_id` parameter from private locations to fix inconsistent state for `elasticstack_kibana_synthetics_private_location` `space_id` ([#733](https://github.com/elastic/terraform-provider-elasticstack/pull/733))
+- Prevent a provider panic when the repository referenced in an `elasticstack_elasticsearch_snapshot_repository` does not exist ([#758](https://github.com/elastic/terraform-provider-elasticstack/pull/758))
 
 ## [0.11.6] - 2024-08-20
 

--- a/internal/elasticsearch/cluster/snapshot_repository_data_source.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_data_source.go
@@ -272,6 +272,16 @@ func dataSourceSnapRepoRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diags
 	}
 
+	d.SetId(id.String())
+	if currentRepo == nil {
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Could not find snapshot repository [%s]", repoName),
+			},
+		}
+	}
+
 	// get the schema of the Elem of the current repo type
 	schemaSettings := DataSourceSnapshotRespository().Schema[currentRepo.Type].Elem.(*schema.Resource).Schema
 	settings, err := flattenRepoSettings(currentRepo, schemaSettings)
@@ -291,6 +301,5 @@ func dataSourceSnapRepoRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	d.SetId(id.String())
 	return diags
 }

--- a/internal/elasticsearch/cluster/snapshot_repository_data_source_test.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_data_source_test.go
@@ -9,6 +9,27 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func TestAccDataSourceSnapRepoMissing(t *testing.T) {
+	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.Providers,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+data "elasticstack_elasticsearch_snapshot_repository" "test_fs_repo" {
+  name = "%s"
+}`, name),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceSnapRepoFs(t *testing.T) {
 	name := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/605

