### PR TITLE
update elasticsearch_security_api_key model/test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove `space_id` parameter from private locations to fix inconsistent state for `elasticstack_kibana_synthetics_private_location` `space_id` ([#733](https://github.com/elastic/terraform-provider-elasticstack/pull/733))  
 - Add the `Frequency` field to the Create Rule API ([#753](https://github.com/elastic/terraform-provider-elasticstack/pull/753))
 - Prevent a provider panic when the repository referenced in an `elasticstack_elasticsearch_snapshot_repository` does not exist ([#758](https://github.com/elastic/terraform-provider-elasticstack/pull/758))
+- Add support for `remote_indicies` to `elasticstack_elasticsearch_security_api_key` (#766)[https://github.com/elastic/terraform-provider-elasticstack/pull/766]
 
 ## [0.11.6] - 2024-08-20
 

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/security"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
+	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/elastic/terraform-provider-elasticstack/internal/versionutils"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -41,21 +42,19 @@ func TestAccResourceSecurityApiKey(t *testing.T) {
 							return err
 						}
 
-						allowRestrictedIndicesF := false
-						allowRestrictedIndicesT := true
 						expectedRoleDescriptor := map[string]models.ApiKeyRoleDescriptor{
 							"role-a": {
 								Cluster: []string{"all"},
 								Indices: []models.IndexPerms{{
 									Names:                  []string{"index-a*"},
 									Privileges:             []string{"read"},
-									AllowRestrictedIndices: &allowRestrictedIndicesF,
+									AllowRestrictedIndices: utils.Pointer(false),
 								}},
 								RemoteIndices: []models.RemoteIndexPerms{{
 									Clusters:               []string{"*"},
 									Names:                  []string{"index-a*"},
 									Privileges:             []string{"read"},
-									AllowRestrictedIndices: &allowRestrictedIndicesT,
+									AllowRestrictedIndices: utils.Pointer(true),
 								}},
 							},
 						}
@@ -204,8 +203,8 @@ resource "elasticstack_elasticsearch_security_api_key" "test" {
         privileges = ["read"]
         allow_restricted_indices = false
       }],
-      restriction = { 
-		workflows = [ "search_application_query"] 
+      restriction = {
+		workflows = [ "search_application_query"]
       }
     }
   })

--- a/internal/elasticsearch/security/api_key_test.go
+++ b/internal/elasticsearch/security/api_key_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"reflect"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
@@ -40,14 +41,21 @@ func TestAccResourceSecurityApiKey(t *testing.T) {
 							return err
 						}
 
-						allowRestrictedIndices := false
+						allowRestrictedIndicesF := false
+						allowRestrictedIndicesT := true
 						expectedRoleDescriptor := map[string]models.ApiKeyRoleDescriptor{
 							"role-a": {
 								Cluster: []string{"all"},
 								Indices: []models.IndexPerms{{
 									Names:                  []string{"index-a*"},
 									Privileges:             []string{"read"},
-									AllowRestrictedIndices: &allowRestrictedIndices,
+									AllowRestrictedIndices: &allowRestrictedIndicesF,
+								}},
+								RemoteIndices: []models.RemoteIndexPerms{{
+									Clusters:               []string{"*"},
+									Names:                  []string{"index-a*"},
+									Privileges:             []string{"read"},
+									AllowRestrictedIndices: &allowRestrictedIndicesT,
 								}},
 							},
 						}
@@ -165,7 +173,13 @@ resource "elasticstack_elasticsearch_security_api_key" "test" {
         privileges = ["read"]
         allow_restricted_indices = false
       }]
-    }
+      remote_indices = [{
+	    clusters = ["*"]
+		names = ["index-a*"]
+		privileges = ["read"]
+		allow_restricted_indices = true
+	  }]
+	}
   })
 
 	expiration = "1d"

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var minSupportedRemoteIndicesVersion = version.Must(version.NewSemver("8.10.0"))
+
 func TestAccResourceSecurityRole(t *testing.T) {
 	// generate a random username
 	roleName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 	roleNameRemoteIndices := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
-	minSupportedRemoteIndicesVersion := version.Must(version.NewSemver("8.10.0"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -202,7 +203,7 @@ resource "elasticstack_elasticsearch_security_role" "test" {
 	names = ["sample2"]
 	privileges = ["create", "read", "write"]
   }
-	
+
   metadata = jsonencode({
     version = 1
   })

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -84,14 +84,15 @@ type Role struct {
 }
 
 type ApiKeyRoleDescriptor struct {
-	Name         string                 `json:"-"`
-	Applications []Application          `json:"applications,omitempty"`
-	Global       map[string]interface{} `json:"global,omitempty"`
-	Cluster      []string               `json:"cluster,omitempty"`
-	Indices      []IndexPerms           `json:"indices,omitempty"`
-	Metadata     map[string]interface{} `json:"metadata,omitempty"`
-	RusAs        []string               `json:"run_as,omitempty"`
-	Restriction  *Restriction           `json:"restriction,omitempty"`
+	Name          string                 `json:"-"`
+	Applications  []Application          `json:"applications,omitempty"`
+	Global        map[string]interface{} `json:"global,omitempty"`
+	Cluster       []string               `json:"cluster,omitempty"`
+	Indices       []IndexPerms           `json:"indices,omitempty"`
+	RemoteIndices []RemoteIndexPerms     `json:"remote_indices,omitempty"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
+	RusAs         []string               `json:"run_as,omitempty"`
+	Restriction   *Restriction           `json:"restriction,omitempty"`
 }
 
 type Restriction struct {
@@ -133,11 +134,12 @@ type IndexPerms struct {
 }
 
 type RemoteIndexPerms struct {
-	FieldSecurity *FieldSecurity `json:"field_security,omitempty"`
-	Names         []string       `json:"names"`
-	Clusters      []string       `json:"clusters"`
-	Privileges    []string       `json:"privileges"`
-	Query         *string        `json:"query,omitempty"`
+	FieldSecurity          *FieldSecurity `json:"field_security,omitempty"`
+	Names                  []string       `json:"names"`
+	Clusters               []string       `json:"clusters"`
+	Privileges             []string       `json:"privileges"`
+	Query                  *string        `json:"query,omitempty"`
+	AllowRestrictedIndices *bool          `json:"allow_restricted_indices,omitempty"`
 }
 
 type FieldSecurity struct {


### PR DESCRIPTION
Solves #765 

- Add `remote_indices` to `models.ApiKeyRoleDescriptor`
- Add `allow_restricted_indices` to `models.RemoteIndexPerms`
- Updated existing test for a remote index entry.