### PR TITLE
Apply the sys_monitoring attribute during creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix handling of `sys_monitoring` in `elasticstack_fleet_agent_policy` ([#792](https://github.com/elastic/terraform-provider-elasticstack/pull/792))
+
 ## [0.11.7] - 2024-09-20
 
 - Add the `alerts_filter` field to the `actions` in the Create Rule API ([#774](https://github.com/elastic/terraform-provider-elasticstack/pull/774))

--- a/internal/clients/fleet/fleet.go
+++ b/internal/clients/fleet/fleet.go
@@ -66,8 +66,16 @@ func ReadAgentPolicy(ctx context.Context, client *Client, id string) (*fleetapi.
 }
 
 // CreateAgentPolicy creates a new agent policy.
-func CreateAgentPolicy(ctx context.Context, client *Client, req fleetapi.AgentPolicyCreateRequest) (*fleetapi.AgentPolicy, diag.Diagnostics) {
-	resp, err := client.API.CreateAgentPolicyWithResponse(ctx, req)
+func CreateAgentPolicy(ctx context.Context, client *Client, req fleetapi.AgentPolicyCreateRequest, sysMonitoring bool) (*fleetapi.AgentPolicy, diag.Diagnostics) {
+	resp, err := client.API.CreateAgentPolicyWithResponse(ctx, req, func(ctx context.Context, req *http.Request) error {
+		if sysMonitoring {
+			qs := req.URL.Query()
+			qs.Add("sys_monitoring", "true")
+			req.URL.RawQuery = qs.Encode()
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}

--- a/internal/fleet/agent_policy_resource.go
+++ b/internal/fleet/agent_policy_resource.go
@@ -63,6 +63,7 @@ func ResourceAgentPolicy() *schema.Resource {
 			Description: "Enable collection of system logs and metrics.",
 			Type:        schema.TypeBool,
 			Optional:    true,
+			ForceNew:    true,
 		},
 		"monitor_logs": {
 			Description: "Enable collection of agent logs.",
@@ -140,7 +141,8 @@ func resourceAgentPolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	req.MonitoringEnabled = &monitoringValues
 
-	policy, diags := fleet.CreateAgentPolicy(ctx, fleetClient, req)
+	sysMonitoring := d.Get("sys_monitoring").(bool)
+	policy, diags := fleet.CreateAgentPolicy(ctx, fleetClient, req, sysMonitoring)
 	if diags.HasError() {
 		return diags
 	}


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/676

This attribute was being entirely ignored by the resource.  