### PR TITLE
Add URL support to data_view field_formats

### DIFF
--- a/docs/resources/kibana_data_view.md
+++ b/docs/resources/kibana_data_view.md
@@ -88,7 +88,9 @@ Optional:
 
 Optional:
 
+- `labeltemplate` (String)
 - `pattern` (String)
+- `urltemplate` (String)
 
 
 

--- a/internal/kibana/data_view/schema.go
+++ b/internal/kibana/data_view/schema.go
@@ -147,6 +147,12 @@ func getSchema() schema.Schema {
 										"pattern": schema.StringAttribute{
 											Optional: true,
 										},
+										"urltemplate": schema.StringAttribute{
+											Optional: true,
+										},
+										"labeltemplate": schema.StringAttribute{
+											Optional: true,
+										},
 									},
 								},
 							},
@@ -334,8 +340,15 @@ func dataViewFromResponse(resp data_views.DataViewResponseObjectDataView) apiDat
 
 		if params, ok := formatMap["params"]; ok {
 			if paramsMap, ok := params.(map[string]interface{}); ok {
+				fieldFormatParams := apiFieldFormatParams{}
 				if pattern, ok := paramsMap["pattern"]; ok {
-					apiFormat.Params = &apiFieldFormatParams{Pattern: pattern.(string)}
+					fieldFormatParams.Pattern = pattern.(string)
+				}
+				if urltemplate, ok := paramsMap["urlTemplate"]; ok {
+					fieldFormatParams.Urltemplate = urltemplate.(string)
+				}
+				if labeltemplate, ok := paramsMap["labelTemplate"]; ok {
+					fieldFormatParams.Labeltemplate = labeltemplate.(string)
 				}
 			}
 		}
@@ -600,7 +613,9 @@ func tfFieldFormatsToAPI(ctx context.Context, fieldFormats types.Map) (map[strin
 			}
 
 			apiParams = &apiFieldFormatParams{
-				Pattern: tfParams.Pattern.ValueString(),
+				Pattern:       tfParams.Pattern.ValueString(),
+				Urltemplate:   tfParams.Urltemplate.ValueString(),
+				Labeltemplate: tfParams.Labeltemplate.ValueString(),
 			}
 		}
 
@@ -658,9 +673,13 @@ type apiFieldFormat struct {
 }
 
 type tfFieldFormatParamsV0 struct {
-	Pattern types.String `tfsdk:"pattern"`
+	Pattern       types.String `tfsdk:"pattern"`
+	Urltemplate   types.String `tfsdk:"urltemplate"`
+	Labeltemplate types.String `tfsdk:"labeltemplate"`
 }
 
 type apiFieldFormatParams struct {
-	Pattern string `tfsdk:"pattern" json:"pattern"`
+	Pattern       string `tfsdk:"pattern" json:"pattern,omitempty"`
+	Urltemplate   string `tfsdk:"urltemplate" json:"urlTemplate,omitempty"`
+	Labeltemplate string `tfsdk:"labeltemplate" json:"labelTemplate,omitempty"`
 }

--- a/internal/kibana/data_view/schema.go
+++ b/internal/kibana/data_view/schema.go
@@ -674,8 +674,8 @@ type apiFieldFormat struct {
 
 type tfFieldFormatParamsV0 struct {
 	Pattern       types.String `tfsdk:"pattern"`
-	Urltemplate   types.String `tfsdk:"urltemplate"`
-	Labeltemplate types.String `tfsdk:"labeltemplate"`
+	UrlTemplate   types.String `tfsdk:"urltemplate"`
+	LabelTemplate types.String `tfsdk:"labeltemplate"`
 }
 
 type apiFieldFormatParams struct {

--- a/internal/kibana/data_view/schema.go
+++ b/internal/kibana/data_view/schema.go
@@ -340,15 +340,15 @@ func dataViewFromResponse(resp data_views.DataViewResponseObjectDataView) apiDat
 
 		if params, ok := formatMap["params"]; ok {
 			if paramsMap, ok := params.(map[string]interface{}); ok {
-				fieldFormatParams := apiFieldFormatParams{}
+				apiFormat.Params = &apiFieldFormatParams{}
 				if pattern, ok := paramsMap["pattern"]; ok {
-					fieldFormatParams.Pattern = pattern.(string)
+					apiFormat.Params.Pattern = utils.Pointer(pattern.(string))
 				}
 				if urltemplate, ok := paramsMap["urlTemplate"]; ok {
-					fieldFormatParams.Urltemplate = urltemplate.(string)
+					apiFormat.Params.UrlTemplate = utils.Pointer(urltemplate.(string))
 				}
 				if labeltemplate, ok := paramsMap["labelTemplate"]; ok {
-					fieldFormatParams.Labeltemplate = labeltemplate.(string)
+					apiFormat.Params.LabelTemplate = utils.Pointer(labeltemplate.(string))
 				}
 			}
 		}
@@ -613,9 +613,9 @@ func tfFieldFormatsToAPI(ctx context.Context, fieldFormats types.Map) (map[strin
 			}
 
 			apiParams = &apiFieldFormatParams{
-				Pattern:       tfParams.Pattern.ValueString(),
-				Urltemplate:   tfParams.Urltemplate.ValueString(),
-				Labeltemplate: tfParams.Labeltemplate.ValueString(),
+				Pattern:       tfParams.Pattern.ValueStringPointer(),
+				UrlTemplate:   tfParams.UrlTemplate.ValueStringPointer(),
+				LabelTemplate: tfParams.LabelTemplate.ValueStringPointer(),
 			}
 		}
 
@@ -679,7 +679,7 @@ type tfFieldFormatParamsV0 struct {
 }
 
 type apiFieldFormatParams struct {
-	Pattern       string `tfsdk:"pattern" json:"pattern,omitempty"`
-	UrlTemplate   string `tfsdk:"urltemplate" json:"urlTemplate,omitempty"`
-	LabelTemplate string `tfsdk:"labeltemplate" json:"labelTemplate,omitempty"`
+	Pattern       *string `tfsdk:"pattern" json:"pattern,omitempty"`
+	UrlTemplate   *string `tfsdk:"urltemplate" json:"urlTemplate,omitempty"`
+	LabelTemplate *string `tfsdk:"labeltemplate" json:"labelTemplate,omitempty"`
 }

--- a/internal/kibana/data_view/schema.go
+++ b/internal/kibana/data_view/schema.go
@@ -680,6 +680,6 @@ type tfFieldFormatParamsV0 struct {
 
 type apiFieldFormatParams struct {
 	Pattern       string `tfsdk:"pattern" json:"pattern,omitempty"`
-	Urltemplate   string `tfsdk:"urltemplate" json:"urlTemplate,omitempty"`
-	Labeltemplate string `tfsdk:"labeltemplate" json:"labelTemplate,omitempty"`
+	UrlTemplate   string `tfsdk:"urltemplate" json:"urlTemplate,omitempty"`
+	LabelTemplate string `tfsdk:"labeltemplate" json:"labelTemplate,omitempty"`
 }

--- a/internal/kibana/data_view/schema_test.go
+++ b/internal/kibana/data_view/schema_test.go
@@ -44,7 +44,9 @@ func Test_tfModelV0_ToCreateRequest(t *testing.T) {
 						"field1": {
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern: "0.00",
+								Pattern:       "0.00",
+								Urltemplate:   "https://test.com/{{value}}",
+								Labeltemplate: "{{value}}",
 							},
 						},
 					},
@@ -66,7 +68,9 @@ func Test_tfModelV0_ToCreateRequest(t *testing.T) {
 						"field1": apiFieldFormat{
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern: "0.00",
+								Pattern:       "0.00",
+								Urltemplate:   "https://test.com/{{value}}",
+								Labeltemplate: "{{value}}",
 							},
 						},
 					},
@@ -161,7 +165,9 @@ func Test_tfModelV0_ToUpdateRequest(t *testing.T) {
 						"field1": {
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern: "0.00",
+								Pattern:       "0.00",
+								Urltemplate:   "https://test.com/{{value}}",
+								Labeltemplate: "{{value}}",
 							},
 						},
 					},
@@ -176,7 +182,9 @@ func Test_tfModelV0_ToUpdateRequest(t *testing.T) {
 						"field1": apiFieldFormat{
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern: "0.00",
+								Pattern:       "0.00",
+								Urltemplate:   "https://test.com/{{value}}",
+								Labeltemplate: "{{value}}",
 							},
 						},
 					},

--- a/internal/kibana/data_view/schema_test.go
+++ b/internal/kibana/data_view/schema_test.go
@@ -44,9 +44,9 @@ func Test_tfModelV0_ToCreateRequest(t *testing.T) {
 						"field1": {
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern:       "0.00",
-								Urltemplate:   "https://test.com/{{value}}",
-								Labeltemplate: "{{value}}",
+								Pattern:       utils.Pointer("0.00"),
+								UrlTemplate:   utils.Pointer("https://test.com/{{value}}"),
+								LabelTemplate: utils.Pointer("{{value}}"),
 							},
 						},
 					},
@@ -68,9 +68,9 @@ func Test_tfModelV0_ToCreateRequest(t *testing.T) {
 						"field1": apiFieldFormat{
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern:       "0.00",
-								Urltemplate:   "https://test.com/{{value}}",
-								Labeltemplate: "{{value}}",
+								Pattern:       utils.Pointer("0.00"),
+								UrlTemplate:   utils.Pointer("https://test.com/{{value}}"),
+								LabelTemplate: utils.Pointer("{{value}}"),
 							},
 						},
 					},
@@ -165,9 +165,9 @@ func Test_tfModelV0_ToUpdateRequest(t *testing.T) {
 						"field1": {
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern:       "0.00",
-								Urltemplate:   "https://test.com/{{value}}",
-								Labeltemplate: "{{value}}",
+								Pattern:       utils.Pointer("0.00"),
+								UrlTemplate:   utils.Pointer("https://test.com/{{value}}"),
+								LabelTemplate: utils.Pointer("{{value}}"),
 							},
 						},
 					},
@@ -182,9 +182,9 @@ func Test_tfModelV0_ToUpdateRequest(t *testing.T) {
 						"field1": apiFieldFormat{
 							ID: "field1",
 							Params: &apiFieldFormatParams{
-								Pattern:       "0.00",
-								Urltemplate:   "https://test.com/{{value}}",
-								Labeltemplate: "{{value}}",
+								Pattern:       utils.Pointer("0.00"),
+								UrlTemplate:   utils.Pointer("https://test.com/{{value}}"),
+								LabelTemplate: utils.Pointer("{{value}}"),
 							},
 						},
 					},


### PR DESCRIPTION
This PR adds support for the `urlTemplate` and `labelTemplate` attributes when specifying a field in a Data View as type URL, as well as adding functionality to account for when any available `field_formats.params.attributes` don't exist.

By specifying that all fields in `apiFieldFormatParams` are optional, other custom field format types (colour, key/value, etc.) can be added much easier.