### PR TITLE
fix package policy secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix secret handling `elasticstack_fleet_integration_policy` resource. ([#821](https://github.com/elastic/terraform-provider-elasticstack/pull/821))
+
 ## [0.11.8] - 2024-10-02
 
 - Add key_id to the `elasticstack_elasticsearch_api_key` resource. ([#789](https://github.com/elastic/terraform-provider-elasticstack/pull/789))

--- a/internal/fleet/integration_policy/create.go
+++ b/internal/fleet/integration_policy/create.go
@@ -34,7 +34,7 @@ func (r *integrationPolicyResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	diags = handleReqRespSecrets(ctx, body, policy, resp.Private)
+	diags = HandleReqRespSecrets(ctx, body, policy, resp.Private)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/fleet/integration_policy/read.go
+++ b/internal/fleet/integration_policy/read.go
@@ -34,7 +34,7 @@ func (r *integrationPolicyResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	diags = handleRespSecrets(ctx, policy, resp.Private)
+	diags = HandleRespSecrets(ctx, policy, resp.Private)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/fleet/integration_policy/secrets_test.go
+++ b/internal/fleet/integration_policy/secrets_test.go
@@ -89,12 +89,8 @@ func TestHandleRespSecrets(t *testing.T) {
 				SecretReferences: secretRefs,
 				Inputs: map[string]fleetapi.PackagePolicyInput{
 					"input1": {
-						Streams: &Map{
-							"stream1": Map{
-								"vars": maps.Clone(tt.input),
-							},
-						},
-						Vars: utils.Pointer(maps.Clone(tt.input)),
+						Streams: &Map{"stream1": Map{"vars": maps.Clone(tt.input)}},
+						Vars:    utils.Pointer(maps.Clone(tt.input)),
 					},
 				},
 				Vars: utils.Pointer(maps.Clone(tt.input)),
@@ -102,12 +98,8 @@ func TestHandleRespSecrets(t *testing.T) {
 			wants := fleetapi.PackagePolicy{
 				Inputs: map[string]fleetapi.PackagePolicyInput{
 					"input1": {
-						Streams: &Map{
-							"stream1": Map{
-								"vars": tt.want,
-							},
-						},
-						Vars: &tt.want,
+						Streams: &Map{"stream1": Map{"vars": tt.want}},
+						Vars:    &tt.want,
 					},
 				},
 				Vars: &tt.want,
@@ -115,34 +107,22 @@ func TestHandleRespSecrets(t *testing.T) {
 
 			diags := integration_policy.HandleRespSecrets(ctx, &resp, &private)
 			// Policy vars
-			if !reflect.DeepEqual(
-				*resp.Vars,
-				*wants.Vars,
-			) {
-				t.Errorf("HandleRespSecrets() policy-vars = %#v, want %#v",
-					*resp.Vars,
-					*wants.Vars,
-				)
+			got := *resp.Vars
+			want := *wants.Vars
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HandleRespSecrets() policy-vars = %#v, want %#v", got, want)
 			}
 			// Input vars
-			if !reflect.DeepEqual(
-				*resp.Inputs["input1"].Vars,
-				*wants.Inputs["input1"].Vars,
-			) {
-				t.Errorf("HandleRespSecrets() input-vars = %#v, want %#v",
-					*resp.Inputs["input1"].Vars,
-					*wants.Inputs["input1"].Vars,
-				)
+			got = *resp.Inputs["input1"].Vars
+			want = *wants.Inputs["input1"].Vars
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HandleRespSecrets() input-vars = %#v, want %#v", got, want)
 			}
 			// Stream vars
-			if !reflect.DeepEqual(
-				(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-				(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-			) {
-				t.Errorf("HandleRespSecrets() stream-vars = %#v, want %#v",
-					(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-					(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-				)
+			got = (*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
+			want = (*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HandleRespSecrets() stream-vars = %#v, want %#v", got, want)
 			}
 			for _, d := range diags.Errors() {
 				t.Errorf("HandleRespSecrets() diagnostic: %s: %s", d.Summary(), d.Detail())
@@ -222,12 +202,8 @@ func TestHandleReqRespSecrets(t *testing.T) {
 			req := fleetapi.PackagePolicyRequest{
 				Inputs: &map[string]fleetapi.PackagePolicyRequestInput{
 					"input1": {
-						Streams: &map[string]fleetapi.PackagePolicyRequestInputStream{
-							"stream1": {
-								Vars: utils.Pointer(maps.Clone(tt.reqInput)),
-							},
-						},
-						Vars: utils.Pointer(maps.Clone(tt.reqInput)),
+						Streams: &map[string]fleetapi.PackagePolicyRequestInputStream{"stream1": {Vars: utils.Pointer(maps.Clone(tt.reqInput))}},
+						Vars:    utils.Pointer(maps.Clone(tt.reqInput)),
 					},
 				},
 				Vars: utils.Pointer(maps.Clone(tt.reqInput)),
@@ -236,12 +212,8 @@ func TestHandleReqRespSecrets(t *testing.T) {
 				SecretReferences: secretRefs,
 				Inputs: map[string]fleetapi.PackagePolicyInput{
 					"input1": {
-						Streams: &Map{
-							"stream1": Map{
-								"vars": maps.Clone(tt.respInput),
-							},
-						},
-						Vars: utils.Pointer(maps.Clone(tt.respInput)),
+						Streams: &Map{"stream1": Map{"vars": maps.Clone(tt.respInput)}},
+						Vars:    utils.Pointer(maps.Clone(tt.respInput)),
 					},
 				},
 				Vars: utils.Pointer(maps.Clone(tt.respInput)),
@@ -249,12 +221,8 @@ func TestHandleReqRespSecrets(t *testing.T) {
 			wants := fleetapi.PackagePolicy{
 				Inputs: map[string]fleetapi.PackagePolicyInput{
 					"input1": {
-						Streams: &Map{
-							"stream1": Map{
-								"vars": tt.want,
-							},
-						},
-						Vars: &tt.want,
+						Streams: &Map{"stream1": Map{"vars": tt.want}},
+						Vars:    &tt.want,
 					},
 				},
 				Vars: &tt.want,
@@ -263,34 +231,22 @@ func TestHandleReqRespSecrets(t *testing.T) {
 			private := privateData{}
 			diags := integration_policy.HandleReqRespSecrets(ctx, req, &resp, &private)
 			// Policy vars
-			if !reflect.DeepEqual(
-				*resp.Vars,
-				*wants.Vars,
-			) {
-				t.Errorf("HandleReqRespSecrets() policy-vars = %#v, want %#v",
-					*resp.Vars,
-					*wants.Vars,
-				)
+			got := *resp.Vars
+			want := *wants.Vars
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HandleReqRespSecrets() policy-vars = %#v, want %#v", got, want)
 			}
 			// Input vars
-			if !reflect.DeepEqual(
-				*resp.Inputs["input1"].Vars,
-				*wants.Inputs["input1"].Vars,
-			) {
-				t.Errorf("HandleReqRespSecrets() input-vars = %#v, want %#v",
-					*resp.Inputs["input1"].Vars,
-					*wants.Inputs["input1"].Vars,
-				)
+			got = *resp.Inputs["input1"].Vars
+			want = *wants.Inputs["input1"].Vars
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HandleReqRespSecrets() input-vars = %#v, want %#v", got, want)
 			}
 			// Stream vars
-			if !reflect.DeepEqual(
-				(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-				(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-			) {
-				t.Errorf("HandleReqRespSecrets() stream-vars = %#v, want %#v",
-					(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-					(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
-				)
+			got = (*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
+			want = (*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("HandleReqRespSecrets() stream-vars = %#v, want %#v", got, want)
 			}
 			for _, d := range diags.Errors() {
 				t.Errorf("HandleReqRespSecrets() diagnostic: %s: %s", d.Summary(), d.Detail())

--- a/internal/fleet/integration_policy/secrets_test.go
+++ b/internal/fleet/integration_policy/secrets_test.go
@@ -1,0 +1,313 @@
+package integration_policy_test
+
+import (
+	"context"
+	"maps"
+	"reflect"
+	"testing"
+
+	fleetapi "github.com/elastic/terraform-provider-elasticstack/generated/fleet"
+	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/integration_policy"
+	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+type privateData map[string]string
+
+func (p *privateData) GetKey(ctx context.Context, key string) ([]byte, diag.Diagnostics) {
+	if val, ok := (*p)[key]; ok {
+		return []byte(val), nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (p *privateData) SetKey(ctx context.Context, key string, value []byte) diag.Diagnostics {
+	(*p)[key] = string(value)
+	return nil
+}
+
+type Map = map[string]any
+
+func TestHandleRespSecrets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	private := privateData{"secrets": `{"known-secret":"secret"}`}
+
+	secretRefs := &[]struct {
+		Id *string `json:"id,omitempty"`
+	}{
+		{Id: utils.Pointer("known-secret")},
+	}
+
+	tests := []struct {
+		name  string
+		input Map
+		want  Map
+	}{
+		{
+			name:  "converts plain",
+			input: Map{"k": "v"},
+			want:  Map{"k": "v"},
+		},
+		{
+			name:  "converts wrapped",
+			input: Map{"k": Map{"type": "string", "value": "v"}},
+			want:  Map{"k": "v"},
+		},
+		{
+			name:  "converts wrapped nil",
+			input: Map{"k": Map{"type": "string"}},
+			want:  Map{},
+		},
+		{
+			name:  "converts secret",
+			input: Map{"k": Map{"isSecretRef": true, "id": "known-secret"}},
+			want:  Map{"k": "secret"},
+		},
+		{
+			name:  "converts wrapped secret",
+			input: Map{"k": Map{"type": "password", "value": Map{"isSecretRef": true, "id": "known-secret"}}},
+			want:  Map{"k": "secret"},
+		},
+		{
+			name:  "converts unknown secret",
+			input: Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+			want:  Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+		},
+		{
+			name:  "converts wrapped unknown secret",
+			input: Map{"k": Map{"type": "password", "value": Map{"isSecretRef": true, "id": "unknown-secret"}}},
+			want:  Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := fleetapi.PackagePolicy{
+				SecretReferences: secretRefs,
+				Inputs: map[string]fleetapi.PackagePolicyInput{
+					"input1": {
+						Streams: &Map{
+							"stream1": Map{
+								"vars": maps.Clone(tt.input),
+							},
+						},
+						Vars: utils.Pointer(maps.Clone(tt.input)),
+					},
+				},
+				Vars: utils.Pointer(maps.Clone(tt.input)),
+			}
+			wants := fleetapi.PackagePolicy{
+				Inputs: map[string]fleetapi.PackagePolicyInput{
+					"input1": {
+						Streams: &Map{
+							"stream1": Map{
+								"vars": tt.want,
+							},
+						},
+						Vars: &tt.want,
+					},
+				},
+				Vars: &tt.want,
+			}
+
+			diags := integration_policy.HandleRespSecrets(ctx, &resp, &private)
+			// Policy vars
+			if !reflect.DeepEqual(
+				*resp.Vars,
+				*wants.Vars,
+			) {
+				t.Errorf("HandleRespSecrets() policy-vars = %#v, want %#v",
+					*resp.Vars,
+					*wants.Vars,
+				)
+			}
+			// Input vars
+			if !reflect.DeepEqual(
+				*resp.Inputs["input1"].Vars,
+				*wants.Inputs["input1"].Vars,
+			) {
+				t.Errorf("HandleRespSecrets() input-vars = %#v, want %#v",
+					*resp.Inputs["input1"].Vars,
+					*wants.Inputs["input1"].Vars,
+				)
+			}
+			// Stream vars
+			if !reflect.DeepEqual(
+				(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+				(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+			) {
+				t.Errorf("HandleRespSecrets() stream-vars = %#v, want %#v",
+					(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+					(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+				)
+			}
+			for _, d := range diags.Errors() {
+				t.Errorf("HandleRespSecrets() diagnostic: %s: %s", d.Summary(), d.Detail())
+			}
+			// privateData
+			privateWants := privateData{"secrets": `{"known-secret":"secret"}`}
+			if !reflect.DeepEqual(private, privateWants) {
+				t.Errorf("HandleRespSecrets() privateData = %#v, want %#v", private, privateWants)
+			}
+		})
+	}
+}
+
+func TestHandleReqRespSecrets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	secretRefs := &[]struct {
+		Id *string `json:"id,omitempty"`
+	}{
+		{Id: utils.Pointer("known-secret")},
+	}
+
+	tests := []struct {
+		name      string
+		reqInput  Map
+		respInput Map
+		want      Map
+	}{
+		{
+			name:      "converts plain",
+			reqInput:  Map{"k": "v"},
+			respInput: Map{"k": "v"},
+			want:      Map{"k": "v"},
+		},
+		{
+			name:      "converts wrapped",
+			reqInput:  Map{"k": "v"},
+			respInput: Map{"k": Map{"type": "string", "value": "v"}},
+			want:      Map{"k": "v"},
+		},
+		{
+			name:      "converts wrapped nil",
+			reqInput:  Map{"k": nil},
+			respInput: Map{"k": Map{"type": "string"}},
+			want:      Map{},
+		},
+		{
+			name:      "converts secret",
+			reqInput:  Map{"k": "secret"},
+			respInput: Map{"k": Map{"isSecretRef": true, "id": "known-secret"}},
+			want:      Map{"k": "secret"},
+		},
+		{
+			name:      "converts wrapped secret",
+			reqInput:  Map{"k": "secret"},
+			respInput: Map{"k": Map{"type": "password", "value": Map{"isSecretRef": true, "id": "known-secret"}}},
+			want:      Map{"k": "secret"},
+		},
+		{
+			name:      "converts unknown secret",
+			reqInput:  Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+			respInput: Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+			want:      Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+		},
+		{
+			name:      "converts wrapped unknown secret",
+			reqInput:  Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+			respInput: Map{"k": Map{"type": "password", "value": Map{"isSecretRef": true, "id": "unknown-secret"}}},
+			want:      Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := fleetapi.PackagePolicyRequest{
+				Inputs: &map[string]fleetapi.PackagePolicyRequestInput{
+					"input1": {
+						Streams: &map[string]fleetapi.PackagePolicyRequestInputStream{
+							"stream1": {
+								Vars: utils.Pointer(maps.Clone(tt.reqInput)),
+							},
+						},
+						Vars: utils.Pointer(maps.Clone(tt.reqInput)),
+					},
+				},
+				Vars: utils.Pointer(maps.Clone(tt.reqInput)),
+			}
+			resp := fleetapi.PackagePolicy{
+				SecretReferences: secretRefs,
+				Inputs: map[string]fleetapi.PackagePolicyInput{
+					"input1": {
+						Streams: &Map{
+							"stream1": Map{
+								"vars": maps.Clone(tt.respInput),
+							},
+						},
+						Vars: utils.Pointer(maps.Clone(tt.respInput)),
+					},
+				},
+				Vars: utils.Pointer(maps.Clone(tt.respInput)),
+			}
+			wants := fleetapi.PackagePolicy{
+				SecretReferences: secretRefs,
+				Inputs: map[string]fleetapi.PackagePolicyInput{
+					"input1": {
+						Streams: &Map{
+							"stream1": Map{
+								"vars": tt.want,
+							},
+						},
+						Vars: &tt.want,
+					},
+				},
+				Vars: &tt.want,
+			}
+
+			private := privateData{}
+			diags := integration_policy.HandleReqRespSecrets(ctx, req, &resp, &private)
+			// Policy vars
+			if !reflect.DeepEqual(
+				*resp.Vars,
+				*wants.Vars,
+			) {
+				t.Errorf("HandleReqRespSecrets() policy-vars = %#v, want %#v",
+					*resp.Vars,
+					*wants.Vars,
+				)
+			}
+			// Input vars
+			if !reflect.DeepEqual(
+				*resp.Inputs["input1"].Vars,
+				*wants.Inputs["input1"].Vars,
+			) {
+				t.Errorf("HandleReqRespSecrets() input-vars = %#v, want %#v",
+					*resp.Inputs["input1"].Vars,
+					*wants.Inputs["input1"].Vars,
+				)
+			}
+			// Stream vars
+			if !reflect.DeepEqual(
+				(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+				(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+			) {
+				t.Errorf("HandleReqRespSecrets() stream-vars = %#v, want %#v",
+					(*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+					(*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"],
+				)
+			}
+			for _, d := range diags.Errors() {
+				t.Errorf("HandleReqRespSecrets() diagnostic: %s: %s", d.Summary(), d.Detail())
+			}
+
+			if v, ok := (*req.Vars)["k"]; ok && v == "secret" {
+				privateWants := privateData{"secrets": `{"known-secret":"secret"}`}
+				if !reflect.DeepEqual(private, privateWants) {
+					t.Errorf("HandleReqRespSecrets() privateData = %#v, want %#v", private, privateWants)
+				}
+			} else {
+				privateWants := privateData{"secrets": `{}`}
+				if !reflect.DeepEqual(private, privateWants) {
+					t.Errorf("HandleReqRespSecrets() privateData = %#v, want %#v", private, privateWants)
+				}
+			}
+		})
+	}
+}

--- a/internal/fleet/integration_policy/secrets_test.go
+++ b/internal/fleet/integration_policy/secrets_test.go
@@ -247,7 +247,6 @@ func TestHandleReqRespSecrets(t *testing.T) {
 				Vars: utils.Pointer(maps.Clone(tt.respInput)),
 			}
 			wants := fleetapi.PackagePolicy{
-				SecretReferences: secretRefs,
 				Inputs: map[string]fleetapi.PackagePolicyInput{
 					"input1": {
 						Streams: &Map{

--- a/internal/fleet/integration_policy/secrets_test.go
+++ b/internal/fleet/integration_policy/secrets_test.go
@@ -3,13 +3,13 @@ package integration_policy_test
 import (
 	"context"
 	"maps"
-	"reflect"
 	"testing"
 
 	fleetapi "github.com/elastic/terraform-provider-elasticstack/generated/fleet"
 	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/integration_policy"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/require"
 )
 
 type privateData map[string]string
@@ -106,32 +106,25 @@ func TestHandleRespSecrets(t *testing.T) {
 			}
 
 			diags := integration_policy.HandleRespSecrets(ctx, &resp, &private)
+			require.Empty(t, diags)
 			// Policy vars
 			got := *resp.Vars
 			want := *wants.Vars
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("HandleRespSecrets() policy-vars = %#v, want %#v", got, want)
-			}
+			require.Equal(t, want, got)
+
 			// Input vars
 			got = *resp.Inputs["input1"].Vars
 			want = *wants.Inputs["input1"].Vars
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("HandleRespSecrets() input-vars = %#v, want %#v", got, want)
-			}
+			require.Equal(t, want, got)
+
 			// Stream vars
 			got = (*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
 			want = (*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("HandleRespSecrets() stream-vars = %#v, want %#v", got, want)
-			}
-			for _, d := range diags.Errors() {
-				t.Errorf("HandleRespSecrets() diagnostic: %s: %s", d.Summary(), d.Detail())
-			}
+			require.Equal(t, want, got)
+
 			// privateData
 			privateWants := privateData{"secrets": `{"known-secret":"secret"}`}
-			if !reflect.DeepEqual(private, privateWants) {
-				t.Errorf("HandleRespSecrets() privateData = %#v, want %#v", private, privateWants)
-			}
+			require.Equal(t, privateWants, private)
 		})
 	}
 }
@@ -230,38 +223,29 @@ func TestHandleReqRespSecrets(t *testing.T) {
 
 			private := privateData{}
 			diags := integration_policy.HandleReqRespSecrets(ctx, req, &resp, &private)
+			require.Empty(t, diags)
+
 			// Policy vars
 			got := *resp.Vars
 			want := *wants.Vars
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("HandleReqRespSecrets() policy-vars = %#v, want %#v", got, want)
-			}
+			require.Equal(t, want, got)
+
 			// Input vars
 			got = *resp.Inputs["input1"].Vars
 			want = *wants.Inputs["input1"].Vars
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("HandleReqRespSecrets() input-vars = %#v, want %#v", got, want)
-			}
+			require.Equal(t, want, got)
+
 			// Stream vars
 			got = (*resp.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
 			want = (*wants.Inputs["input1"].Streams)["stream1"].(Map)["vars"].(Map)
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("HandleReqRespSecrets() stream-vars = %#v, want %#v", got, want)
-			}
-			for _, d := range diags.Errors() {
-				t.Errorf("HandleReqRespSecrets() diagnostic: %s: %s", d.Summary(), d.Detail())
-			}
+			require.Equal(t, want, got)
 
 			if v, ok := (*req.Vars)["k"]; ok && v == "secret" {
 				privateWants := privateData{"secrets": `{"known-secret":"secret"}`}
-				if !reflect.DeepEqual(private, privateWants) {
-					t.Errorf("HandleReqRespSecrets() privateData = %#v, want %#v", private, privateWants)
-				}
+				require.Equal(t, privateWants, private)
 			} else {
 				privateWants := privateData{"secrets": `{}`}
-				if !reflect.DeepEqual(private, privateWants) {
-					t.Errorf("HandleReqRespSecrets() privateData = %#v, want %#v", private, privateWants)
-				}
+				require.Equal(t, privateWants, private)
 			}
 		})
 	}

--- a/internal/fleet/integration_policy/update.go
+++ b/internal/fleet/integration_policy/update.go
@@ -35,7 +35,7 @@ func (r *integrationPolicyResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	diags = handleReqRespSecrets(ctx, body, policy, resp.Private)
+	diags = HandleReqRespSecrets(ctx, body, policy, resp.Private)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
I migrated work to 0.11.8, and any secret refs were removed in the state after apply.

During testing, it looked like responses either came in the format of 
```{"k1": "v1", ...}``` or ```{"k1": {"type": "string", "value": "v2"}, ...}```. Any time a secretRef was seen, it was inside the latter format. Apparently they can also show up in the former. This fixes the oversight, unit test didn't catch it :( 