### PR TITLE
Add description to security_role resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Fix secret handling `elasticstack_fleet_integration_policy` resource. ([#821](https://github.com/elastic/terraform-provider-elasticstack/pull/821))
+- Add `description` attribute to `elasticstack_elasticsearch_security_role` resource. ([#824](https://github.com/elastic/terraform-provider-elasticstack/pull/824))
 
 ## [0.11.8] - 2024-10-02
 

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -18,8 +18,9 @@ provider "elasticstack" {
 }
 
 resource "elasticstack_elasticsearch_security_role" "role" {
-  name    = "testrole"
-  cluster = ["all"]
+  name        = "testrole"
+  description = "Role for testing"
+  cluster     = ["all"]
 
   indices {
     names      = ["index1", "index2"]
@@ -55,6 +56,7 @@ output "role" {
 
 - `applications` (Block Set) A list of application privilege entries. (see [below for nested schema](#nestedblock--applications))
 - `cluster` (Set of String) A list of cluster privileges. These privileges define the cluster level actions that users with this role are able to execute.
+- `description` (String) The description of the role.
 - `elasticsearch_connection` (Block List, Max: 1, Deprecated) Elasticsearch connection configuration block. This property will be removed in a future provider version. Configure the Elasticsearch connection via the provider configuration instead. (see [below for nested schema](#nestedblock--elasticsearch_connection))
 - `global` (String) An object defining global privileges.
 - `indices` (Block Set) A list of indices permissions entries. (see [below for nested schema](#nestedblock--indices))

--- a/examples/resources/elasticstack_elasticsearch_security_role/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_security_role/resource.tf
@@ -3,8 +3,9 @@ provider "elasticstack" {
 }
 
 resource "elasticstack_elasticsearch_security_role" "role" {
-  name    = "testrole"
-  cluster = ["all"]
+  name        = "testrole"
+  description = "Role for testing"
+  cluster     = ["all"]
 
   indices {
     names      = ["index1", "index2"]

--- a/internal/elasticsearch/security/role.go
+++ b/internal/elasticsearch/security/role.go
@@ -18,6 +18,7 @@ import (
 )
 
 var minSupportedRemoteIndicesVersion = version.Must(version.NewVersion("8.10.0"))
+var minSupportedDescriptionVersion = version.Must(version.NewVersion("8.15.0"))
 
 func ResourceRole() *schema.Resource {
 	roleSchema := map[string]*schema.Schema{
@@ -266,6 +267,11 @@ func resourceSecurityRolePut(ctx context.Context, d *schema.ResourceData, meta i
 
 	// Add description to the role
 	if v, ok := d.GetOk("description"); ok {
+		// Return an error if the server version is less than the minimum supported version
+		if serverVersion.LessThan(minSupportedDescriptionVersion) {
+			return diag.FromErr(fmt.Errorf("'description' is supported only for Elasticsearch v%s and above", minSupportedDescriptionVersion.String()))
+		}
+
 		description := v.(string)
 		role.Description = &description
 	}

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -29,6 +29,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 				Config: testAccResourceSecurityRoleCreate(roleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "description", "test description"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "indices.0.allow_restricted_indices", "true"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "indices.*.names.*", "index1"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "indices.*.names.*", "index2"),
@@ -41,6 +42,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 				Config: testAccResourceSecurityRoleUpdate(roleName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "description", "updated test description"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "indices.*.names.*", "index1"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "indices.*.names.*", "index2"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "cluster.*", "all"),
@@ -92,7 +94,9 @@ provider "elasticstack" {
 }
 
 resource "elasticstack_elasticsearch_security_role" "test" {
-  name    = "%s"
+  name        = "%s"
+  description = "test description"
+
   cluster = ["all"]
 
   indices {
@@ -123,7 +127,9 @@ provider "elasticstack" {
 }
 
 resource "elasticstack_elasticsearch_security_role" "test" {
-  name    = "%s"
+  name        = "%s"
+  description = "updated test description"
+  
   cluster = ["all"]
 
   indices {
@@ -234,7 +240,7 @@ func checkResourceSecurityRoleDestroy(s *terraform.State) error {
 		}
 
 		if res.StatusCode != 404 {
-			return fmt.Errorf("Role (%s) still exists", compId.ResourceId)
+			return fmt.Errorf("role (%s) still exists", compId.ResourceId)
 		}
 	}
 	return nil

--- a/internal/elasticsearch/security/role_test.go
+++ b/internal/elasticsearch/security/role_test.go
@@ -143,8 +143,7 @@ provider "elasticstack" {
 
 resource "elasticstack_elasticsearch_security_role" "test" {
   name        = "%s"
-  description = "updated test description"
-  
+
   cluster = ["all"]
 
   indices {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -74,6 +74,7 @@ type UserPassword struct {
 
 type Role struct {
 	Name          string                 `json:"-"`
+	Description   *string                `json:"description,omitempty"`
 	Applications  []Application          `json:"applications,omitempty"`
 	Global        map[string]interface{} `json:"global,omitempty"`
 	Cluster       []string               `json:"cluster,omitempty"`


### PR DESCRIPTION
Adds the "description" attribute to elasticstack_elasticsearch_security_role resource.

Should resolve #822 