### PR TITLE
Fix output inconsistent result (default_integrations/monitoring)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changes
 
+- Fix inconsistent output errors in `elasticstack_fleet_output` for `default_integrations` and `default_monitoring`. ([#841](https://github.com/elastic/terraform-provider-elasticstack/pull/841))
 - Fix secret handling `elasticstack_fleet_integration_policy` resource. ([#821](https://github.com/elastic/terraform-provider-elasticstack/pull/821))
 - Fix merge values for `elasticstack_kibana_synthetics_monitor` monitor locations ([#823](https://github.com/elastic/terraform-provider-elasticstack/pull/823))
 - Migrate to a v8 Elasticsearch client ([#832](https://github.com/elastic/terraform-provider-elasticstack/pull/832))
@@ -14,7 +15,6 @@
 - Add `description` attribute to `elasticstack_elasticsearch_security_role` resource. ([#824](https://github.com/elastic/terraform-provider-elasticstack/pull/824))
 - Fix merge values for `elasticstack_kibana_synthetics_monitor` monitor locations ([#823](https://github.com/elastic/terraform-provider-elasticstack/pull/823)
 - Add `elasticstack_elasticsearch_index_template` data source ([#828](https://github.com/elastic/terraform-provider-elasticstack/pull/828))
-
 
 ## [0.11.8] - 2024-10-02
 

--- a/internal/fleet/output/schema.go
+++ b/internal/fleet/output/schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -67,11 +68,15 @@ func getSchema() schema.Schema {
 			},
 			"default_integrations": schema.BoolAttribute{
 				Description: "Make this output the default for agent integrations.",
+				Computed:    true,
 				Optional:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"default_monitoring": schema.BoolAttribute{
 				Description: "Make this output the default for agent monitoring.",
+				Computed:    true,
 				Optional:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"config_yaml": schema.StringAttribute{
 				Description: "Advanced YAML configuration. YAML settings here will be added to the output section of each agent policy.",


### PR DESCRIPTION
Fixes #840 
Add default: False to default_integrations and default_monitoring.

This was not found by the tests because both fields are set in each test.