### PR TITLE
fix: elastic indices datasource boolean parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changes
+
+- Fix boolean setting parsing for `elasticstack_elasticsearch_indices` data source. ([#842](https://github.com/elastic/terraform-provider-elasticstack/pull/842))
+
 ## [0.11.9] - 2024-10-14
 
 ### Breaking changes

--- a/internal/elasticsearch/index/indices/models.go
+++ b/internal/elasticsearch/index/indices/models.go
@@ -295,7 +295,7 @@ func setSettingsFromAPI(ctx context.Context, model *indexTfModel, apiModel model
 					}
 				}
 
-				settingsValue = bool(settingBool)
+				settingsValue = settingBool
 			}
 
 			settingBool, ok := settingsValue.(bool)

--- a/internal/elasticsearch/index/indices/models.go
+++ b/internal/elasticsearch/index/indices/models.go
@@ -284,6 +284,20 @@ func setSettingsFromAPI(ctx context.Context, model *indexTfModel, apiModel model
 			}
 			tfValue = basetypes.NewStringValue(settingStr)
 		case types.Bool:
+			if settingStr, ok := settingsValue.(string); ok {
+				settingBool, err := strconv.ParseBool(settingStr)
+				if err != nil {
+					return diag.Diagnostics{
+						diag.NewErrorDiagnostic(
+							"failed to convert setting to bool",
+							fmt.Sprintf("expected setting to be a bool but it was a string. Attempted to parse it but got %s", err.Error()),
+						),
+					}
+				}
+
+				settingsValue = bool(settingBool)
+			}
+
 			settingBool, ok := settingsValue.(bool)
 			if !ok {
 				return diag.Diagnostics{
@@ -300,7 +314,7 @@ func setSettingsFromAPI(ctx context.Context, model *indexTfModel, apiModel model
 					return diag.Diagnostics{
 						diag.NewErrorDiagnostic(
 							"failed to convert setting to int",
-							fmt.Sprintf("expected setting to be an in but it was a string. Attempted to parse it but got %s", err.Error()),
+							fmt.Sprintf("expected setting to be an int but it was a string. Attempted to parse it but got %s", err.Error()),
 						),
 					}
 				}


### PR DESCRIPTION
Hello,

A little fix on the elastic indices datasource. When parsing boolean settings the following error could occur:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: failed to convert setting to bool
│ 
│   with data.elasticstack_elasticsearch_indices.existing_indices["my-indice"],
│   on main.tf line 56, in data "elasticstack_elasticsearch_indices" "existing_indices":
│   56: data "elasticstack_elasticsearch_indices" "existing_indices" {
│ 
│ expected setting to be a bool but got %!t(string=false)
```

@tobio I think a fast review could let it be included in the 0.11.9 version.

Thanks.