### PR TITLE
Add `max_primary_shard_docs` condition to ILM rollover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add `max_primary_shard_docs` condition to ILM rollover ([#845](https://github.com/elastic/terraform-provider-elasticstack/pull/845))
+
 ## [0.11.13] - 2025-01-09
 
 - Support 8.15.5 in acc tests ([#963](https://github.com/elastic/terraform-provider-elasticstack/pull/963)).
@@ -11,7 +13,7 @@
 
 ### Breaking changes
 
-- Support multiple group by fields in SLOs ([#870](https://github.com/elastic/terraform-provider-elasticstack/pull/878)). This changes to type of the `group_by` attribute of the `elasticstack_kibana_slo` resource from a String to a list of Strings. Any existing SLO defintions will need to update `group_by = "field"` to `group_by = ["field"]`. 
+- Support multiple group by fields in SLOs ([#870](https://github.com/elastic/terraform-provider-elasticstack/pull/878)). This changes to type of the `group_by` attribute of the `elasticstack_kibana_slo` resource from a String to a list of Strings. Any existing SLO defintions will need to update `group_by = "field"` to `group_by = ["field"]`.
 
 ### Changes
 - Handle NPE in integration policy secrets ([#946](https://github.com/elastic/terraform-provider-elasticstack/pull/946))

--- a/docs/resources/elasticsearch_index_lifecycle.md
+++ b/docs/resources/elasticsearch_index_lifecycle.md
@@ -288,6 +288,7 @@ Optional:
 
 - `max_age` (String) Triggers rollover after the maximum elapsed time from index creation is reached.
 - `max_docs` (Number) Triggers rollover after the specified maximum number of documents is reached.
+- `max_primary_shard_docs` (Number) Triggers rollover when the largest primary shard in the index reaches a certain number of documents. Supported from Elasticsearch version **8.2**
 - `max_primary_shard_size` (String) Triggers rollover when the largest primary shard in the index reaches a certain size.
 - `max_size` (String) Triggers rollover when the index reaches a certain size.
 - `min_age` (String) Prevents rollover until after the minimum elapsed time from index creation is reached. Supported from Elasticsearch version **8.4**

--- a/internal/elasticsearch/index/data_stream_test.go
+++ b/internal/elasticsearch/index/data_stream_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccResourceDataStream(t *testing.T) {
-	// generate renadom name
+	// generate random name
 	dsName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlpha)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -567,7 +567,11 @@ func expandPhase(p map[string]interface{}, serverVersion *version.Version) (*mod
 	return &phase, diags
 }
 
-var RolloverMinConditionsMinSupportedVersion = version.Must(version.NewVersion("8.4.0"))
+var (
+	RolloverMinConditionsMinSupportedVersion = version.Must(version.NewVersion("8.4.0"))
+	MaxPrimaryShardDocsMinSupportedVersion   = version.Must(version.NewVersion("8.2.0"))
+)
+
 var ilmActionSettingOptions = map[string]struct {
 	skipEmptyCheck bool
 	def            interface{}
@@ -576,7 +580,7 @@ var ilmActionSettingOptions = map[string]struct {
 	"allow_write_after_shrink": {def: false, minVersion: version.Must(version.NewVersion("8.14.0"))},
 	"number_of_replicas":       {skipEmptyCheck: true},
 	"priority":                 {skipEmptyCheck: true},
-	"max_primary_shard_docs":   {minVersion: version.Must(version.NewVersion("8.2.0"))},
+	"max_primary_shard_docs":   {minVersion: MaxPrimaryShardDocsMinSupportedVersion},
 	"min_age":                  {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_docs":                 {def: 0, minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_size":                 {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -268,6 +268,11 @@ var supportedActions = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
+				"max_primary_shard_docs": {
+					Description: "Triggers rollover when the largest primary shard in the index reaches a certain number of documents. Supported from Elasticsearch version **8.2**",
+					Type:        schema.TypeInt,
+					Optional:    true,
+				},
 				"max_primary_shard_size": {
 					Description: "Triggers rollover when the largest primary shard in the index reaches a certain size.",
 					Type:        schema.TypeString,
@@ -288,14 +293,14 @@ var supportedActions = map[string]*schema.Schema{
 					Type:        schema.TypeString,
 					Optional:    true,
 				},
-				"min_primary_shard_size": {
-					Description: "Prevents rollover until the largest primary shard in the index reaches a certain size. Supported from Elasticsearch version **8.4**",
-					Type:        schema.TypeString,
-					Optional:    true,
-				},
 				"min_primary_shard_docs": {
 					Description: "Prevents rollover until the largest primary shard in the index reaches a certain number of documents. Supported from Elasticsearch version **8.4**",
 					Type:        schema.TypeInt,
+					Optional:    true,
+				},
+				"min_primary_shard_size": {
+					Description: "Prevents rollover until the largest primary shard in the index reaches a certain size. Supported from Elasticsearch version **8.4**",
+					Type:        schema.TypeString,
 					Optional:    true,
 				},
 			},
@@ -529,7 +534,7 @@ func expandPhase(p map[string]interface{}, serverVersion *version.Version) (*mod
 					}
 				}
 			case "rollover":
-				actions[actionName], diags = expandAction(a, serverVersion, "max_age", "max_docs", "max_size", "max_primary_shard_size", "min_age", "min_docs", "min_size", "min_primary_shard_size", "min_primary_shard_docs")
+				actions[actionName], diags = expandAction(a, serverVersion, "max_age", "max_docs", "max_size", "max_primary_shard_docs", "max_primary_shard_size", "min_age", "min_docs", "min_size", "min_primary_shard_docs", "min_primary_shard_size")
 			case "searchable_snapshot":
 				actions[actionName], diags = expandAction(a, serverVersion, "snapshot_repository", "force_merge_index")
 			case "set_priority":
@@ -568,15 +573,16 @@ var ilmActionSettingOptions = map[string]struct {
 	def            interface{}
 	minVersion     *version.Version
 }{
+	"allow_write_after_shrink": {def: false, minVersion: version.Must(version.NewVersion("8.14.0"))},
 	"number_of_replicas":       {skipEmptyCheck: true},
-	"total_shards_per_node":    {skipEmptyCheck: true, def: -1, minVersion: version.Must(version.NewVersion("7.16.0"))},
 	"priority":                 {skipEmptyCheck: true},
+	"max_primary_shard_docs":   {minVersion: version.Must(version.NewVersion("8.2.0"))},
 	"min_age":                  {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_docs":                 {def: 0, minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_size":                 {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
-	"min_primary_shard_size":   {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_primary_shard_docs":   {def: 0, minVersion: RolloverMinConditionsMinSupportedVersion},
-	"allow_write_after_shrink": {def: false, minVersion: version.Must(version.NewVersion("8.14.0"))},
+	"min_primary_shard_size":   {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
+	"total_shards_per_node":    {skipEmptyCheck: true, def: -1, minVersion: version.Must(version.NewVersion("7.16.0"))},
 }
 
 func expandAction(a []interface{}, serverVersion *version.Version, settings ...string) (map[string]interface{}, diag.Diagnostics) {

--- a/internal/elasticsearch/index/ilm.go
+++ b/internal/elasticsearch/index/ilm.go
@@ -580,7 +580,7 @@ var ilmActionSettingOptions = map[string]struct {
 	"allow_write_after_shrink": {def: false, minVersion: version.Must(version.NewVersion("8.14.0"))},
 	"number_of_replicas":       {skipEmptyCheck: true},
 	"priority":                 {skipEmptyCheck: true},
-	"max_primary_shard_docs":   {minVersion: MaxPrimaryShardDocsMinSupportedVersion},
+	"max_primary_shard_docs":   {def: 0, minVersion: MaxPrimaryShardDocsMinSupportedVersion},
 	"min_age":                  {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_docs":                 {def: 0, minVersion: RolloverMinConditionsMinSupportedVersion},
 	"min_size":                 {def: "", minVersion: RolloverMinConditionsMinSupportedVersion},

--- a/internal/elasticsearch/index/ilm_test.go
+++ b/internal/elasticsearch/index/ilm_test.go
@@ -128,6 +128,14 @@ func TestAccResourceILMRolloverConditions(t *testing.T) {
 		ProtoV6ProviderFactories: acctest.Providers,
 		Steps: []resource.TestStep{
 			{
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(index.MaxPrimaryShardDocsMinSupportedVersion),
+				Config:   testAccResourceILMCreateWithMaxPrimaryShardDocs(policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "name", policyName),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_primary_shard_docs", "5000"),
+				),
+			},
+			{
 				SkipFunc: versionutils.CheckIfVersionIsUnsupported(index.RolloverMinConditionsMinSupportedVersion),
 				Config:   testAccResourceILMCreateWithRolloverConditions(policyName),
 				Check: resource.ComposeTestCheckFunc(
@@ -135,7 +143,7 @@ func TestAccResourceILMRolloverConditions(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_age", "7d"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_docs", "10000"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_size", "100gb"),
-					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_docs", "5000"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_primary_shard_docs", "5000"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_primary_shard_size", "50gb"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_age", "3d"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_docs", "1000"),
@@ -281,6 +289,30 @@ resource "elasticstack_elasticsearch_index_lifecycle" "test_rollover" {
       min_size = "50gb"
       min_primary_shard_docs = 500
       min_primary_shard_size = "25gb"
+    }
+
+    readonly {}
+  }
+
+  delete {
+    delete {}
+  }
+}
+ `, name)
+}
+
+func testAccResourceILMCreateWithMaxPrimaryShardDocs(name string) string {
+	return fmt.Sprintf(`
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index_lifecycle" "test_rollover" {
+  name = "%s"
+
+  hot {
+    rollover {
+      max_primary_shard_docs = 5000
     }
 
     readonly {}

--- a/internal/elasticsearch/index/ilm_test.go
+++ b/internal/elasticsearch/index/ilm_test.go
@@ -135,12 +135,13 @@ func TestAccResourceILMRolloverConditions(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_age", "7d"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_docs", "10000"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_size", "100gb"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_docs", "5000"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.max_primary_shard_size", "50gb"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_age", "3d"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_docs", "1000"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_size", "50gb"),
-					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_size", "25gb"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_docs", "500"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test_rollover", "hot.0.rollover.0.min_primary_shard_size", "25gb"),
 				),
 			},
 		},
@@ -273,12 +274,13 @@ resource "elasticstack_elasticsearch_index_lifecycle" "test_rollover" {
       max_age = "7d"
       max_docs = 10000
       max_size = "100gb"
+      max_primary_shard_docs = 5000
       max_primary_shard_size = "50gb"
       min_age = "3d"
       min_docs = 1000
       min_size = "50gb"
-      min_primary_shard_size = "25gb"
       min_primary_shard_docs = 500
+      min_primary_shard_size = "25gb"
     }
 
     readonly {}


### PR DESCRIPTION
* Add `max_primary_shard_docs` condition to rollover (closes  #794)

* Update test for rollover `max_primary_shard_docs` condition

* Specify min version in the description

* Update CHANGELOG.md