### PR TITLE
Alerting fields should be Elastic durations, not Golang durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix validation of `throttle`, and `interval` attributes in `elasticstack_kibana_alerting_rule` allowing all Elastic duration values ([#846](https://github.com/elastic/terraform-provider-elasticstack/pull/846))
+
 ## [0.11.9] - 2024-10-14
 
 ### Breaking changes

--- a/internal/fleet/integration_policy/resource_test.go
+++ b/internal/fleet/integration_policy/resource_test.go
@@ -2,6 +2,7 @@ package integration_policy_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"testing"
@@ -12,12 +13,22 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/elastic/terraform-provider-elasticstack/internal/versionutils"
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 var minVersionIntegrationPolicy = version.Must(version.NewVersion("8.10.0"))
+
+func TestJsonTypes(t *testing.T) {
+	mapBytes, err := json.Marshal(map[string]string{})
+	require.NoError(t, err)
+	equal, diags := jsontypes.NewNormalizedValue(`{"a": "b"}`).StringSemanticEquals(context.Background(), jsontypes.NewNormalizedValue(string(mapBytes)))
+	require.Empty(t, diags)
+	require.False(t, equal)
+}
 
 func TestAccResourceIntegrationPolicy(t *testing.T) {
 	policyName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)

--- a/internal/kibana/alerting.go
+++ b/internal/kibana/alerting.go
@@ -26,7 +26,7 @@ var alertDelayMinSupportedVersion = version.Must(version.NewVersion("8.13.0"))
 //
 //nolint:staticcheck
 func stringIsAlertingDuration() schema.SchemaValidateFunc {
-	r := regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)?(?:d|h|m|s)$`)
+	r := regexp.MustCompile(`^[1-9][0-9]*(?:d|h|m|s)$`)
 	return validation.StringMatch(r, "string is not a valid Alerting duration in seconds (s), minutes (m), hours (h), or days (d)")
 }
 

--- a/internal/kibana/alerting.go
+++ b/internal/kibana/alerting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
@@ -20,6 +21,12 @@ import (
 var frequencyMinSupportedVersion = version.Must(version.NewVersion("8.6.0"))
 var alertsFilterMinSupportedVersion = version.Must(version.NewVersion("8.9.0"))
 var alertDelayMinSupportedVersion = version.Must(version.NewVersion("8.13.0"))
+
+//nolint:staticcheck Avoid lint error on deprecated SchemaValidateFunc usage.
+func stringIsAlertingDuration() schema.SchemaValidateFunc {
+	r := regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)?(?:d|h|m|s)$`)
+	return validation.StringMatch(r, "string is not a valid Alerting duration in seconds (s), minutes (m), hours (h), or days (d)")
+}
 
 func ResourceAlertingRule() *schema.Resource {
 	apikeySchema := map[string]*schema.Schema{
@@ -71,7 +78,7 @@ func ResourceAlertingRule() *schema.Resource {
 			Description:  "The check interval, which specifies how frequently the rule conditions are checked. The interval must be specified in seconds, minutes, hours or days.",
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: utils.StringIsElasticDuration,
+			ValidateFunc: stringIsAlertingDuration(),
 		},
 		"actions": {
 			Description: "An action that runs under defined conditions.",
@@ -120,7 +127,7 @@ func ResourceAlertingRule() *schema.Resource {
 									Description:  "Defines how often an alert generates repeated actions. This custom action interval must be specified in seconds, minutes, hours, or days. For example, 10m or 1h. This property is applicable only if `notify_when` is `onThrottleInterval`. NOTE: This is a rule level property; if you update the rule in Kibana, it is automatically changed to use action-specific `throttle` values.",
 									Type:         schema.TypeString,
 									Optional:     true,
-									ValidateFunc: utils.StringIsElasticDuration,
+									ValidateFunc: stringIsAlertingDuration(),
 								},
 							},
 						},
@@ -198,7 +205,7 @@ func ResourceAlertingRule() *schema.Resource {
 			Description:  "Deprecated in 8.13.0. Defines how often an alert generates repeated actions. This custom action interval must be specified in seconds, minutes, hours, or days. For example, 10m or 1h. This property is applicable only if `notify_when` is `onThrottleInterval`. NOTE: This is a rule level property; if you update the rule in Kibana, it is automatically changed to use action-specific `throttle` values.",
 			Type:         schema.TypeString,
 			Optional:     true,
-			ValidateFunc: utils.StringIsElasticDuration,
+			ValidateFunc: stringIsAlertingDuration(),
 		},
 		"scheduled_task_id": {
 			Description: "ID of the scheduled task that will execute the alert.",

--- a/internal/kibana/alerting.go
+++ b/internal/kibana/alerting.go
@@ -22,7 +22,9 @@ var frequencyMinSupportedVersion = version.Must(version.NewVersion("8.6.0"))
 var alertsFilterMinSupportedVersion = version.Must(version.NewVersion("8.9.0"))
 var alertDelayMinSupportedVersion = version.Must(version.NewVersion("8.13.0"))
 
-//nolint:staticcheck Avoid lint error on deprecated SchemaValidateFunc usage.
+// Avoid lint error on deprecated SchemaValidateFunc usage.
+//
+//nolint:staticcheck
 func stringIsAlertingDuration() schema.SchemaValidateFunc {
 	r := regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)?(?:d|h|m|s)$`)
 	return validation.StringMatch(r, "string is not a valid Alerting duration in seconds (s), minutes (m), hours (h), or days (d)")

--- a/internal/kibana/alerting.go
+++ b/internal/kibana/alerting.go
@@ -71,7 +71,7 @@ func ResourceAlertingRule() *schema.Resource {
 			Description:  "The check interval, which specifies how frequently the rule conditions are checked. The interval must be specified in seconds, minutes, hours or days.",
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: utils.StringIsDuration,
+			ValidateFunc: utils.StringIsElasticDuration,
 		},
 		"actions": {
 			Description: "An action that runs under defined conditions.",
@@ -120,7 +120,7 @@ func ResourceAlertingRule() *schema.Resource {
 									Description:  "Defines how often an alert generates repeated actions. This custom action interval must be specified in seconds, minutes, hours, or days. For example, 10m or 1h. This property is applicable only if `notify_when` is `onThrottleInterval`. NOTE: This is a rule level property; if you update the rule in Kibana, it is automatically changed to use action-specific `throttle` values.",
 									Type:         schema.TypeString,
 									Optional:     true,
-									ValidateFunc: utils.StringIsDuration,
+									ValidateFunc: utils.StringIsElasticDuration,
 								},
 							},
 						},
@@ -198,7 +198,7 @@ func ResourceAlertingRule() *schema.Resource {
 			Description:  "Deprecated in 8.13.0. Defines how often an alert generates repeated actions. This custom action interval must be specified in seconds, minutes, hours, or days. For example, 10m or 1h. This property is applicable only if `notify_when` is `onThrottleInterval`. NOTE: This is a rule level property; if you update the rule in Kibana, it is automatically changed to use action-specific `throttle` values.",
 			Type:         schema.TypeString,
 			Optional:     true,
-			ValidateFunc: utils.StringIsDuration,
+			ValidateFunc: utils.StringIsElasticDuration,
 		},
 		"scheduled_task_id": {
 			Description: "ID of the scheduled task that will execute the alert.",

--- a/internal/kibana/alerting_test.go
+++ b/internal/kibana/alerting_test.go
@@ -52,7 +52,7 @@ func TestAccResourceAlertingRule(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "consumer", "alerts"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "notify_when", "onActiveAlert"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "rule_type_id", ".index-threshold"),
-					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "interval", "10m"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "interval", "1d"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "enabled", "false"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "tags.0", "first"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "tags.1", "second"),
@@ -244,7 +244,7 @@ resource "elasticstack_kibana_alerting_rule" "test_rule" {
 	termField           = "name"
   })
   rule_type_id = ".index-threshold"
-  interval     = "10m"
+  interval     = "1d"
   enabled      = false
   tags         = ["first", "second"]
 }
@@ -439,7 +439,7 @@ resource "elasticstack_kibana_alerting_rule" "test_rule" {
         days        = [1,2,3]
       timezone    = "Africa/Accra"
       hours_start = "01:00"
-      hours_end   = "07:00" 
+      hours_end   = "07:00"
       }
     }
   }
@@ -514,7 +514,7 @@ resource "elasticstack_kibana_alerting_rule" "test_rule" {
         days        = [7]
       timezone    = "Pacific/Honolulu"
       hours_start = "02:00"
-      hours_end   = "03:00" 
+      hours_end   = "03:00"
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/829
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/770

Updates validation to check attributes are Elastic durations, not Golang durations. 