### PR TITLE
Fix `alert_delay` update in Update Rule API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Fix bug updating alert delay ([#859](https://github.com/elastic/terraform-provider-elasticstack/pull/859))
 - Support updating `elasticstack_elasticsearch_security_api_key` when supported by the backing cluster ([#843](https://github.com/elastic/terraform-provider-elasticstack/pull/843))
 - Fix validation of `throttle`, and `interval` attributes in `elasticstack_kibana_alerting_rule` allowing all Elastic duration values ([#846](https://github.com/elastic/terraform-provider-elasticstack/pull/846))
 - Fix boolean setting parsing for `elasticstack_elasticsearch_indices` data source. ([#842](https://github.com/elastic/terraform-provider-elasticstack/pull/842))

--- a/internal/clients/kibana/alerting.go
+++ b/internal/clients/kibana/alerting.go
@@ -219,6 +219,16 @@ func UpdateAlertingRule(ctx context.Context, apiClient ApiClient, rule models.Al
 
 	ctxWithAuth := apiClient.SetAlertingAuthContext(ctx)
 
+	var alertDelay *alerting.AlertDelay
+
+	if alerting.IsNil(rule.AlertDelay) {
+		alertDelay = nil
+	} else {
+		alertDelay = &alerting.AlertDelay{
+			Active: *rule.AlertDelay,
+		}
+	}
+
 	reqModel := alerting.UpdateRuleRequest{
 		Actions:    ruleActionsToActionsInner((rule.Actions)),
 		Name:       rule.Name,
@@ -227,8 +237,9 @@ func UpdateAlertingRule(ctx context.Context, apiClient ApiClient, rule models.Al
 		Schedule: alerting.Schedule{
 			Interval: &rule.Schedule.Interval,
 		},
-		Tags:     rule.Tags,
-		Throttle: *alerting.NewNullableString(rule.Throttle),
+		Tags:       rule.Tags,
+		Throttle:   *alerting.NewNullableString(rule.Throttle),
+		AlertDelay: alertDelay,
 	}
 
 	req := client.UpdateRule(ctxWithAuth, rule.RuleID, rule.SpaceID).KbnXsrf("true").UpdateRuleRequest(reqModel)

--- a/internal/kibana/alerting_test.go
+++ b/internal/kibana/alerting_test.go
@@ -179,7 +179,7 @@ func TestAccResourceAlertingRule(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "actions.0.frequency.0.summary", "true"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "actions.0.frequency.0.notify_when", "onActionGroupChange"),
 					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "actions.0.frequency.0.throttle", "10m"),
-					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "alert_delay", "4"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.test_rule", "alert_delay", "10"),
 				),
 			},
 		},
@@ -639,7 +639,7 @@ resource "elasticstack_kibana_alerting_rule" "test_rule" {
     }
   }
 
-  alert_delay  = 4
+  alert_delay  = 10
 }
 	`, name)
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/196797

## Description

The `alert_delay` field was being created properly but not updated.

