### PR TITLE
Don't force resource replacement when expiration is unset during SDK-PF migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unreleased]
 
 - Allow `elasticstack_kibana_alerting_rule` to be used without Elasticsearch being configured. ([#869](https://github.com/elastic/terraform-provider-elasticstack/pull/869))
-- Add resource `elasticstack_elasticsearch_data_stream_lifecycle` ([838](https://github.com/elastic/terraform-provider-elasticstack/issues/838))
+- Add resource `elasticstack_elasticsearch_data_stream_lifecycle` ([#838](https://github.com/elastic/terraform-provider-elasticstack/issues/838))
+- Ensure API keys are not replaced when upgrading from 0.11.9 or earlier. ([#875](https://github.com/elastic/terraform-provider-elasticstack/pull/875))
 
 ## [0.11.10] - 2024-10-23
 

--- a/internal/clients/elasticsearch/security.go
+++ b/internal/clients/elasticsearch/security.go
@@ -341,7 +341,7 @@ func UpdateApiKey(apiClient *clients.ApiClient, apikey models.ApiKey) fwdiag.Dia
 		return utils.FrameworkDiagFromError(err)
 	}
 	defer res.Body.Close()
-	if diags := utils.CheckError(res, "Unable to create apikey"); diags.HasError() {
+	if diags := utils.CheckError(res, "Unable to update apikey"); diags.HasError() {
 		return utils.FrameworkDiagsFromSDK(diags)
 	}
 

--- a/internal/elasticsearch/security/api_key/resource.go
+++ b/internal/elasticsearch/security/api_key/resource.go
@@ -14,6 +14,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces
 var _ resource.Resource = &Resource{}
 var _ resource.ResourceWithConfigure = &Resource{}
+var _ resource.ResourceWithUpgradeState = &Resource{}
 var (
 	MinVersion                         = version.Must(version.NewVersion("8.0.0")) // Enabled in 8.0
 	MinVersionWithUpdate               = version.Must(version.NewVersion("8.4.0"))

--- a/internal/elasticsearch/security/api_key/schema.go
+++ b/internal/elasticsearch/security/api_key/schema.go
@@ -16,12 +16,15 @@ import (
 	providerschema "github.com/elastic/terraform-provider-elasticstack/internal/schema"
 )
 
+const currentSchemaVersion int64 = 1
+
 func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = r.getSchema()
+	resp.Schema = r.getSchema(currentSchemaVersion)
 }
 
-func (r *Resource) getSchema() schema.Schema {
+func (r *Resource) getSchema(version int64) schema.Schema {
 	return schema.Schema{
+		Version:     version,
 		Description: "Creates an API key for access without requiring basic authentication. See, https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html",
 		Blocks: map[string]schema.Block{
 			"elasticsearch_connection": providerschema.GetEsFWConnectionBlock("elasticsearch_connection", false),

--- a/internal/elasticsearch/security/api_key/state_upgrade.go
+++ b/internal/elasticsearch/security/api_key/state_upgrade.go
@@ -1,0 +1,30 @@
+package api_key
+
+import (
+	"context"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func (r *Resource) UpgradeState(context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: utils.Pointer(r.getSchema(0)),
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				var model tfModel
+				resp.Diagnostics.Append(req.State.Get(ctx, &model)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				if utils.IsKnown(model.Expiration) && model.Expiration.ValueString() == "" {
+					model.Expiration = basetypes.NewStringNull()
+				}
+
+				resp.State.Set(ctx, model)
+			},
+		},
+	}
+}


### PR DESCRIPTION
SDK based api_key resources stored `expiration:""` in state when it's unset in config, however PF based resources more specifically model this as `null`. This is causing TF to force the replacement of API Keys when upgrading from 0.11.10.

This PR updates the RequiresReplace logic to only require replacement when the expiration value actually changes (e.g `1d` -> `null`). It also adds an acceptance test verifying provider behaviour during the migration from SDK->PF, specifically that the underlying API Key is not replaced. 

Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/873 