### PR TITLE
integration policy: handle NPE in secrets 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Handle NPE in integration policy secrets ([#946](https://github.com/elastic/terraform-provider-elasticstack/pull/946))
 - Support multiple group by fields in SLOs ([#870](https://github.com/elastic/terraform-provider-elasticstack/pull/878))
 - Use the auto-generated OAS schema from elastic/kibana for the Fleet API. ([#834](https://github.com/elastic/terraform-provider-elasticstack/issues/834))
 - Support description in `elasticstack_elasticsearch_security_role` data sources. ([#884](https://github.com/elastic/terraform-provider-elasticstack/pull/884))

--- a/internal/fleet/integration_policy/secrets.go
+++ b/internal/fleet/integration_policy/secrets.go
@@ -104,7 +104,7 @@ func HandleRespSecrets(ctx context.Context, resp *kbapi.PackagePolicy, private p
 	for _, input := range resp.Inputs {
 		handleVars(utils.Deref(input.Vars))
 		for _, stream := range utils.Deref(input.Streams) {
-			handleVars(*stream.Vars)
+			handleVars(utils.Deref(stream.Vars))
 		}
 	}
 


### PR DESCRIPTION
Fixes #907 

Before:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10143df80]
```

After:
```
  # elasticstack_fleet_integration_policy.csmp will be updated in-place
  # (imported from "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
```