### PR TITLE
Expose some internal structures for Crossplane provider

### DIFF
--- a/xpprovider/xpprovider.go
+++ b/xpprovider/xpprovider.go
@@ -1,0 +1,30 @@
+package xpprovider
+
+import (
+	"context"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/config"
+	fwdiags "github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Package xpprovider exports needed internal types and functions used by Crossplane for instantiating, interacting and
+// configuring the underlying Terraform Elasticstack providers.
+
+// XPApiClient exports the internal type clients.ApiClient of the Terraform provider
+type XPApiClient = clients.ApiClient
+
+// XPProviderConfiguration exports the internal type config.ProviderConfiguration of the Terraform provider
+type XPProviderConfiguration = config.ProviderConfiguration
+
+// XPElasticsearchConnection exports the internal type config.ElasticsearchConnection of the Terraform provider
+type XPElasticsearchConnection = config.ElasticsearchConnection
+
+// XPKibanaConnection exports the internal type config.KibanaConnection of the Terraform provider
+type XPKibanaConnection = config.KibanaConnection
+
+// XPFleetConnection exports the internal type config.FleetConnection of the Terraform provider
+type XPFleetConnection = config.FleetConnection
+
+func NewApiClientFromFramework(ctx context.Context, config XPProviderConfiguration, version string) (*XPApiClient, fwdiags.Diagnostics) {
+	return clients.NewApiClientFromFramework(ctx, config, version)
+}


### PR DESCRIPTION
This PR exposes some internal objects that are needed to build a Crossplane Elasticstack provider.

During initialization, the provider must instantiate a new `ApiClient` to use this Terraform provider as a library.

This is used like this in the Crossplane provider:

```go

import (
...
	"github.com/elastic/terraform-provider-elasticstack/provider"
	"github.com/elastic/terraform-provider-elasticstack/xpprovider"
...
)

// TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
// returns Terraform provider setup configuration
func TerraformSetupBuilder(version, providerSource, providerVersion string) terraform.SetupFn {
	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
...
		apiClient, diag := xpprovider.NewApiClientFromFramework(ctx, fwpc, version)
		if diag.HasError() {
			return ps, errors.Errorf("%v", diag.Errors())
		}
		ps.Meta = apiClient
...
```

This patch is currently sitting in a branch from my fork that I use to build the Crossplane provider.  It has been successfully used to create a PoC of a Crossplane Elasticstack provider.