### PR TITLE
Accept API keys for running acceptance tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -42,8 +42,8 @@ func PreCheck(t *testing.T) {
 		t.Fatal("KIBANA_ENDPOINT must be set for acceptance tests to run")
 	}
 
-	usernamePasswordOk := (userOk && passOk) || (kbUserOk && kbPassOk) || apiKeyOk || kbApiKeyOk
-	if !usernamePasswordOk {
-		t.Fatal("ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD or KIBANA_USERNAME and KIBANA_PASSWORD must be set for acceptance tests to run")
+	authOk := (userOk && passOk) || (kbUserOk && kbPassOk) || apiKeyOk || kbApiKeyOk
+	if !authOk {
+		t.Fatal("ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD, or KIBANA_USERNAME and KIBANA_PASSWORD, or ELASTICSEARCH_API_KEY, or KIBANA_API_KEY must be set for acceptance tests to run")
 	}
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -29,8 +29,10 @@ func PreCheck(t *testing.T) {
 	_, kibanaEndpointOk := os.LookupEnv("KIBANA_ENDPOINT")
 	_, userOk := os.LookupEnv("ELASTICSEARCH_USERNAME")
 	_, passOk := os.LookupEnv("ELASTICSEARCH_PASSWORD")
+	_, apiKeyOk := os.LookupEnv("ELASTICSEARCH_API_KEY")
 	_, kbUserOk := os.LookupEnv("KIBANA_USERNAME")
 	_, kbPassOk := os.LookupEnv("KIBANA_PASSWORD")
+	_, kbApiKeyOk := os.LookupEnv("KIBANA_API_KEY")
 
 	if !elasticsearchEndpointsOk {
 		t.Fatal("ELASTICSEARCH_ENDPOINTS must be set for acceptance tests to run")
@@ -40,8 +42,7 @@ func PreCheck(t *testing.T) {
 		t.Fatal("KIBANA_ENDPOINT must be set for acceptance tests to run")
 	}
 
-	// Technically ES tests can use the API Key, however username/password is required for Kibana tests.
-	usernamePasswordOk := (userOk && passOk) || (kbUserOk && kbPassOk)
+	usernamePasswordOk := (userOk && passOk) || (kbUserOk && kbPassOk) || apiKeyOk || kbApiKeyOk
 	if !usernamePasswordOk {
 		t.Fatal("ELASTICSEARCH_USERNAME and ELASTICSEARCH_PASSWORD or KIBANA_USERNAME and KIBANA_PASSWORD must be set for acceptance tests to run")
 	}


### PR DESCRIPTION
The current acceptance setup code was not allowing me to use an API key even if it's now supported by Kibana.

This PR makes it to use api keys to run acceptance tests.

I didn't run the full acceptance test suite with this. Acceptance is passing for #948 with an API key.