### PR TITLE
fix: update team name - control-plane-hosted-applications

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:control-plane-stateful-applications
+  owner: group:control-plane-hosted-applications
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -29,7 +29,7 @@ spec:
         filter_condition: 'build.tag =~ /^v[0-9.]+$/'
         filter_enabled: true
       teams:
-        control-plane-stateful-applications:
+        control-plane-hosted-applications:
           access_level: MANAGE_BUILD_AND_READ
         serverless-core-architecture:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
The `control-plane-stateful-applications` team was renamed to `control-plane-hosted-applications`. This change needs to be reflected in this `catalog-info.yaml` as well.