### PR TITLE
Update go version in go-kibana-rest

### DIFF
--- a/libs/go-kibana-rest/go.mod
+++ b/libs/go-kibana-rest/go.mod
@@ -1,6 +1,8 @@
 module github.com/disaster37/go-kibana-rest/v8
 
-go 1.22
+go 1.23.0
+
+toolchain go1.23.4
 
 require (
 	github.com/go-resty/resty/v2 v2.16.0


### PR DESCRIPTION
Fixes up a CodeQL [warning](https://github.com/elastic/terraform-provider-elasticstack/security/code-scanning/tools/CodeQL/status/configurations/automatic/9445a9b2f6b346be84f3a711a0c0ef1743cdf05171593e2af3ecc8315d828f3b)