### PR TITLE
Restore support for non-composite data view ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix a provider crash when interacting with elasticstack_kibana_data_view resources created with 0.11.0. ([#979](https://github.com/elastic/terraform-provider-elasticstack/pull/979))
+
 ## [0.11.13] - 2025-01-09
 
 - Support 8.15.5 in acc tests ([#963](https://github.com/elastic/terraform-provider-elasticstack/pull/963)).
@@ -11,7 +13,7 @@
 
 ### Breaking changes
 
-- Support multiple group by fields in SLOs ([#870](https://github.com/elastic/terraform-provider-elasticstack/pull/878)). This changes to type of the `group_by` attribute of the `elasticstack_kibana_slo` resource from a String to a list of Strings. Any existing SLO defintions will need to update `group_by = "field"` to `group_by = ["field"]`. 
+- Support multiple group by fields in SLOs ([#870](https://github.com/elastic/terraform-provider-elasticstack/pull/878)). This changes to type of the `group_by` attribute of the `elasticstack_kibana_slo` resource from a String to a list of Strings. Any existing SLO defintions will need to update `group_by = "field"` to `group_by = ["field"]`.
 
 ### Changes
 - Handle NPE in integration policy secrets ([#946](https://github.com/elastic/terraform-provider-elasticstack/pull/946))

--- a/internal/kibana/data_view/models.go
+++ b/internal/kibana/data_view/models.go
@@ -232,10 +232,16 @@ func convertSourceFilter(item string, meta utils.ListMeta) kbapi.DataViewsSource
 }
 
 func (model dataViewModel) getViewIDAndSpaceID() (viewID string, spaceID string) {
+	viewID = model.ID.ValueString()
+	spaceID = model.SpaceID.ValueString()
+
 	resourceID := model.ID.ValueString()
-	composite, _ := clients.CompositeIdFromStr(resourceID)
-	viewID = composite.ResourceId
-	spaceID = composite.ClusterId
+	maybeCompositeID, _ := clients.CompositeIdFromStr(resourceID)
+	if maybeCompositeID != nil {
+		viewID = maybeCompositeID.ResourceId
+		spaceID = maybeCompositeID.ClusterId
+	}
+
 	return
 }
 

--- a/internal/kibana/data_view/models_test.go
+++ b/internal/kibana/data_view/models_test.go
@@ -352,3 +352,38 @@ func TestToAPIUpdateModel(t *testing.T) {
 		})
 	}
 }
+
+func Test_dataViewModel_getViewIDAndSpaceID(t *testing.T) {
+	tests := []struct {
+		name            string
+		model           dataViewModel
+		expectedViewID  string
+		expectedSpaceID string
+	}{
+		{
+			name: "gets the view and space id from the composite id if set",
+			model: dataViewModel{
+				ID: types.StringValue("space-id/view-id"),
+			},
+			expectedViewID:  "view-id",
+			expectedSpaceID: "space-id",
+		},
+		{
+			name: "gets the view and space id from the data view if id is not a valid composite id",
+			model: dataViewModel{
+				ID:      types.StringValue("view-id"),
+				SpaceID: types.StringValue("space-id"),
+			},
+			expectedViewID:  "view-id",
+			expectedSpaceID: "space-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viewID, spaceID := tt.model.getViewIDAndSpaceID()
+			require.Equal(t, tt.expectedViewID, viewID)
+			require.Equal(t, tt.expectedSpaceID, spaceID)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/975

Basically restores the old implementation for [this function](https://github.com/elastic/terraform-provider-elasticstack/pull/881/files#diff-6ee1b4568dae9bbeea095558f5ebfd094ba702a77d3eda1e3a5f90f385def37dL278-L288). A previous provider version didn't include the composite ID and so we need to continue support. We could in theory write a state migration but that's a lot more work. 