### PR TITLE
chore(docs): update elasticstack_kibana_synthetics_private_location example

### DIFF
--- a/docs/resources/kibana_synthetics_private_location.md
+++ b/docs/resources/kibana_synthetics_private_location.md
@@ -31,7 +31,6 @@ resource "elasticstack_fleet_agent_policy" "sample" {
 
 resource "elasticstack_kibana_synthetics_private_location" "example" {
   label           = "example label"
-  space_id        = "default"
   agent_policy_id = elasticstack_fleet_agent_policy.sample.policy_id
   tags            = ["tag-a", "tag-b"]
   geo = {

--- a/examples/resources/elasticstack_kibana_synthetics_private_location/resource.tf
+++ b/examples/resources/elasticstack_kibana_synthetics_private_location/resource.tf
@@ -14,7 +14,6 @@ resource "elasticstack_fleet_agent_policy" "sample" {
 
 resource "elasticstack_kibana_synthetics_private_location" "example" {
   label           = "example label"
-  space_id        = "default"
   agent_policy_id = elasticstack_fleet_agent_policy.sample.policy_id
   tags            = ["tag-a", "tag-b"]
   geo = {


### PR DESCRIPTION
fix removed field `space_id`
related to https://github.com/elastic/terraform-provider-elasticstack/issues/726