### PR TITLE
Bugfix for query param reuse (#1050)

### DIFF
--- a/libs/go-kibana-rest/kbapi/api.kibana_role_management.go
+++ b/libs/go-kibana-rest/kbapi/api.kibana_role_management.go
@@ -154,11 +154,14 @@ func newKibanaRoleManagementCreateOrUpdateFunc(c *resty.Client) KibanaRoleManage
 		if err != nil {
 			return nil, err
 		}
-		r := c.R()
+		var resp *resty.Response
+		var err error
 		if kibanaRole.CreateOnly {
-			r = r.SetQueryParam("createOnly", "true")
+			resp, err = c.R().SetBody(jsonData).SetQueryParam("createOnly", "true").Put(path)
+		} else {
+			// The createOnly query param defaults to false, so no need to set it.
+			resp, err = c.R().SetBody(jsonData).Put(path)
 		}
-		resp, err := r.SetBody(jsonData).Put(path)
 		if err != nil {
 			return nil, err
 		}
@@ -167,7 +170,7 @@ func newKibanaRoleManagementCreateOrUpdateFunc(c *resty.Client) KibanaRoleManage
 			return nil, NewAPIError(resp.StatusCode(), resp.Status())
 		}
 
-		// Retrive the object to return it
+		// Retrieve the object to return it
 		kibanaRole, err = newKibanaRoleManagementGetFunc(c)(roleName)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Proposed fix for issue raised in #1050. Would appreciate a maintainer taking a look.

Yes we could just unset the query param but that feels like the wrong approach, we shouldn't be statically modifying this context object if its going to be used for both requests I feel... happy to hear dissent though!

Please do comment on code quality/style also. Happy to conform to whatever standards you guys prefer.

Nb. I had difficulties getting your `Makefile` to run on my machine as I work in an environment with a restrictive network policy. I'd really appreciate someone taking the time to run this locally to validate it works. Really more of a candidate fix as a starting point for someone else, I've no idea if this is going to do the trick.