### PR TITLE
Add optional preventInitialBackfill for SLO API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Migrate `elasticstack_kibana_action_connector` to the Terraform plugin framework ([#1269](https://github.com/elastic/terraform-provider-elasticstack/pull/1269))
 - Migrate `elasticstack_elasticsearch_security_role_mapping` resource and data source to Terraform Plugin Framework ([#1279](https://github.com/elastic/terraform-provider-elasticstack/pull/1279))
 - Add support for `inactivity_timeout` in `elasticstack_fleet_agent_policy` ([#641](https://github.com/elastic/terraform-provider-elasticstack/issues/641))
+- Add support for `prevent_initial_backfill` to `elasticstack_kibana_slo` ([#1071](https://github.com/elastic/terraform-provider-elasticstack/pull/1071))
 
 ## [0.11.17] - 2025-07-21
 

--- a/docs/resources/kibana_slo.md
+++ b/docs/resources/kibana_slo.md
@@ -439,6 +439,7 @@ Optional:
 Optional:
 
 - `frequency` (String)
+- `prevent_initial_backfill` (Boolean) Prevents the underlying ES transform from attempting to backfill data on start, which can sometimes be resource-intensive or time-consuming and unnecessary
 - `sync_delay` (String)
 
 

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -890,7 +890,7 @@ func resourceSloCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 			return diag.Errorf("The 'prevent_initial_backfill' setting requires Elastic Stack version %s or higher.", SLOSupportsPreventInitialBackfillMinVersion)
 		}
 	}
-  
+
 	// Version check for data_view_id support
 	if !serverVersion.GreaterThanOrEqual(SLOSupportsDataViewIDMinVersion) {
 		// Check all indicator types that support data_view_id

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -596,14 +596,6 @@ func transformOrNil[T any](path string, d *schema.ResourceData, transform func(i
 	return nil
 }
 
-func getOrNilBool(path string, d *schema.ResourceData) *bool {
-	if v, ok := d.GetOk(path); ok {
-		b := v.(bool)
-		return &b
-	}
-	return nil
-}
-
 func getSloFromResourceData(d *schema.ResourceData) (models.Slo, diag.Diagnostics) {
 	var diags diag.Diagnostics
 

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -542,7 +542,7 @@ func getSchema() map[string]*schema.Schema {
 						Optional: true,
 						Computed: true,
 					},
-					"preventInitialBackfill": {
+					"prevent_initial_backfill": {
 						Description: 	"Prevents the underlying ES transform from attempting to backfill data on start, which can sometimes be resource-intensive or time-consuming and unnecessary",
 						Type: 		schema.BoolAttribute,
 						Optional: 	true,

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -542,6 +542,11 @@ func getSchema() map[string]*schema.Schema {
 						Optional: true,
 						Computed: true,
 					},
+					"preventInitialBackfill": {
+						Description: 	"Prevents the underlying ES transform from attempting to backfill data on start, which can sometimes be resource-intensive or time-consuming and unnecessary",
+						Type: 		schema.BoolAttribute,
+						Optional: 	true,
+					}
 				},
 			},
 		},

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -860,7 +860,7 @@ func resourceSloCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	// Version check for prevent_initial_backfill
-	if _, ok := d.GetOk("settings.0.prevent_initial_backfill"); ok {
+	if slo.Settings.PreventInitialBackfill != nil {
 		if !serverVersion.GreaterThanOrEqual(SLOSupportsPreventInitialBackfillMinVersion) {
 			return diag.Errorf("The 'prevent_initial_backfill' setting requires Elastic Stack version %s or higher.", SLOSupportsPreventInitialBackfillMinVersion)
 		}
@@ -899,13 +899,9 @@ func resourceSloUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	// Version check for prevent_initial_backfill
-	if d.Get("settings.0.prevent_initial_backfill") != nil {
-		if v, ok := d.GetOk("settings.0.prevent_initial_backfill"); ok {
-			if vBool, ok := v.(bool); ok && vBool {
-				if !serverVersion.GreaterThanOrEqual(SLOSupportsPreventInitialBackfillMinVersion) {
-					return diag.Errorf("The 'prevent_initial_backfill' setting requires Elastic Stack version %s or higher.", SLOSupportsPreventInitialBackfillMinVersion)
-				}
-			}
+	if slo.Settings.PreventInitialBackfill != nil {
+		if !serverVersion.GreaterThanOrEqual(SLOSupportsPreventInitialBackfillMinVersion) {
+			return diag.Errorf("The 'prevent_initial_backfill' setting requires Elastic Stack version %s or higher.", SLOSupportsPreventInitialBackfillMinVersion)
 		}
 	}
 

--- a/internal/kibana/slo_test.go
+++ b/internal/kibana/slo_test.go
@@ -825,7 +825,7 @@ type sloVars struct {
 	tags                          []string
 	groupBy                       []string
 	useSingleElementGroupBy       bool
-	includeDataViewID       bool
+	includeDataViewID             bool
 	includePreventInitialBackfill bool
 }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/1070

Docs for this option are here: https://www.elastic.co/docs/api/doc/serverless/operation/operation-createsloop#operation-createsloop-body-application-json-settings-preventinitialbackfill

I've not done any Terraform additions like this one, so there is a good chance the syntax here is wrong — I see that this new setting likely needs to be added in a few additional places to make use of it after it's been added to the schema, so I'd appreciate guidance on where that needs to happen, exactly. 

At any rate, it would be great to add this field, and as it's a new, optional field, it shouldn't have any breaking change consequences whatsoever.

UPDATE: I re-generated the SLO model files with openapi-generator, hoping it would only produce a small scope of changes in those files. It seems to have produced a LOT of changes, so I'll wait for guidance on how to handle that.