### PR TITLE
Improve error messaging if no Kibana endpoint is configured.

### DIFF
--- a/internal/clients/api_client.go
+++ b/internal/clients/api_client.go
@@ -363,12 +363,14 @@ func (a *ApiClient) ServerVersion(ctx context.Context) (*version.Version, diag.D
 func (a *ApiClient) versionFromKibana() (*version.Version, diag.Diagnostics) {
 	kibClient, err := a.GetKibanaClient()
 	if err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diag.Errorf("failed to get version from Kibana API: %s, "+
+			"please ensure a working 'kibana' endpoint is configured", err.Error())
 	}
 
 	status, err := kibClient.KibanaStatus.Get()
 	if err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diag.Errorf("failed to get version from Kibana API: %s, "+
+			"Please ensure a working 'kibana' endpoint is configured", err.Error())
 	}
 
 	vMap, ok := status["version"].(map[string]interface{})

--- a/internal/fleet/agent_policy/update.go
+++ b/internal/fleet/agent_policy/update.go
@@ -24,6 +24,9 @@ func (r *agentPolicyResource) Update(ctx context.Context, req resource.UpdateReq
 
 	sVersion, e := r.client.ServerVersion(ctx)
 	if e != nil {
+		for _, a := range e {
+			resp.Diagnostics.AddError(a.Summary, a.Detail)
+		}
 		return
 	}
 


### PR DESCRIPTION
Fixes two issues that lead to confusing errors being shown:

- The `agent_policy` resource did not throw an error if getting the stack version fails
- When getting the stack version fails, it only returned the http connection error, not actually stating what it was trying to do.

In combination this will now lead to an error like
> `Error: failed to get version from Kibana API: Get "http://localhost:5601/api/status": dial tcp [::1]:5601: connect: connection refused,  Please ensure a working 'kibana' endpoint is configured.`