### PR TITLE
Support for custom endpoint configuration in snapshot repository setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Add `headers` for the provider connection ([#1057](https://github.com/elastic/terraform-provider-elasticstack/pull/1057))
+- Add custom `endpoint` configuration support for snapshot repository setup ([#1158](https://github.com/elastic/terraform-provider-elasticstack/pull/1158))
 
 ## [0.11.15] - 2025-04-23
 

--- a/docs/resources/elasticsearch_snapshot_repository.md
+++ b/docs/resources/elasticsearch_snapshot_repository.md
@@ -166,6 +166,7 @@ Optional:
 - `chunk_size` (String) Maximum size of files in snapshots.
 - `client` (String) The name of the S3 client to use to connect to S3.
 - `compress` (Boolean) If true, metadata files, such as index mappings and settings, are compressed in snapshots.
+- `endpoint` (String) Custom S3 service endpoint, useful when using VPC endpoints or non-default S3 URLs.
 - `max_restore_bytes_per_sec` (String) Maximum snapshot restore rate per node.
 - `max_snapshot_bytes_per_sec` (String) Maximum snapshot creation rate per node.
 - `path_style_access` (Boolean) If true, path style access pattern will be used.


### PR DESCRIPTION
This PR introduces support for specifying a custom endpoint in the S3-based snapshot repository configuration. It allows users to define a custom S3-compatible storage endpoint instead of relying solely on AWS defaults.

✅ Changes
- Added support for endpoint configuration in snapshot repository settings.
- Enables use of custom or on-prem S3-compatible storage services.

🔧 Use Case
Useful for setups involving:
- MinIO or other S3-compatible backends
- VPC endpoints

🔗 Related Issue
Potentially fixes #1096