### PR TITLE
Add slo_id length validation

### DIFF
--- a/docs/resources/kibana_slo.md
+++ b/docs/resources/kibana_slo.md
@@ -213,7 +213,7 @@ resource "elasticstack_kibana_slo" "custom_metric" {
 - `kql_custom_indicator` (Block List, Max: 1) (see [below for nested schema](#nestedblock--kql_custom_indicator))
 - `metric_custom_indicator` (Block List, Max: 1) (see [below for nested schema](#nestedblock--metric_custom_indicator))
 - `settings` (Block List, Max: 1) The default settings should be sufficient for most users, but if needed, these properties can be overwritten. (see [below for nested schema](#nestedblock--settings))
-- `slo_id` (String) An ID (8 and 36 characters). If omitted, a UUIDv1 will be generated server-side.
+- `slo_id` (String) An ID (8 and 48 characters). If omitted, a UUIDv1 will be generated server-side.
 - `space_id` (String) An identifier for the space. If space_id is not provided, the default space is used.
 - `tags` (List of String) The tags for the SLO.
 

--- a/internal/kibana/slo.go
+++ b/internal/kibana/slo.go
@@ -81,11 +81,12 @@ func getSchema() map[string]*schema.Schema {
 
 	return map[string]*schema.Schema{
 		"slo_id": {
-			Description: "An ID (8 and 36 characters). If omitted, a UUIDv1 will be generated server-side.",
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			ForceNew:    true,
+			Description:  "An ID (8 and 48 characters). If omitted, a UUIDv1 will be generated server-side.",
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringLenBetween(8, 48),
 		},
 		"name": {
 			Description: "The name of the SLO.",


### PR DESCRIPTION
Resolves #1144 
![image](https://github.com/user-attachments/assets/34c822b6-fbee-4352-80fe-fb1a799c76c6)

Wasn't sure if the max length should be 48 as api docs state [36](https://www.elastic.co/docs/api/doc/kibana/operation/operation-createsloop#operation-createsloop-body-application-json-id), but after testing in dev tools it looks like 48 is indeed max at least in 9.0.0
