### PR TITLE
Adding ignore_missing_component_templates

### DIFF
--- a/docs/data-sources/elasticsearch_index_template.md
+++ b/docs/data-sources/elasticsearch_index_template.md
@@ -42,6 +42,7 @@ output "template" {
 - `composed_of` (List of String) An ordered list of component template names.
 - `data_stream` (List of Object) If this object is included, the template is used to create data streams and their backing indices. Supports an empty object. (see [below for nested schema](#nestedatt--data_stream))
 - `id` (String) Internal identifier of the resource
+- `ignore_missing_component_templates` (List of String) A list of component template names that are ignored if missing.
 - `index_patterns` (Set of String) Array of wildcard (*) expressions used to match the names of data streams and indices during creation.
 - `metadata` (String) Optional user metadata about the index template.
 - `priority` (Number) Priority to determine index template precedence when a new data stream or index is created.

--- a/docs/resources/elasticsearch_index_template.md
+++ b/docs/resources/elasticsearch_index_template.md
@@ -58,6 +58,7 @@ resource "elasticstack_elasticsearch_index_template" "my_data_stream" {
 - `composed_of` (List of String) An ordered list of component template names.
 - `data_stream` (Block List, Max: 1) If this object is included, the template is used to create data streams and their backing indices. Supports an empty object. (see [below for nested schema](#nestedblock--data_stream))
 - `elasticsearch_connection` (Block List, Max: 1, Deprecated) Elasticsearch connection configuration block. This property will be removed in a future provider version. Configure the Elasticsearch connection via the provider configuration instead. (see [below for nested schema](#nestedblock--elasticsearch_connection))
+- `ignore_missing_component_templates` (List of String) A list of component template names that are ignored if missing.
 - `metadata` (String) Optional user metadata about the index template.
 - `priority` (Number) Priority to determine index template precedence when a new data stream or index is created.
 - `template` (Block List, Max: 1) Template to be applied. It may optionally include an aliases, mappings, lifecycle, or settings configuration. (see [below for nested schema](#nestedblock--template))

--- a/internal/elasticsearch/index/template_data_source.go
+++ b/internal/elasticsearch/index/template_data_source.go
@@ -29,6 +29,14 @@ func DataSourceTemplate() *schema.Resource {
 				Type: schema.TypeString,
 			},
 		},
+		"ignore_missing_component_templates": {
+			Description: "A list of component template names that are ignored if missing.",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"data_stream": {
 			Description: "If this object is included, the template is used to create data streams and their backing indices. Supports an empty object.",
 			Type:        schema.TypeList,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -163,16 +163,17 @@ type Application struct {
 }
 
 type IndexTemplate struct {
-	Name          string                 `json:"-"`
-	Create        bool                   `json:"-"`
-	Timeout       string                 `json:"-"`
-	ComposedOf    []string               `json:"composed_of"`
-	DataStream    *DataStreamSettings    `json:"data_stream,omitempty"`
-	IndexPatterns []string               `json:"index_patterns"`
-	Meta          map[string]interface{} `json:"_meta,omitempty"`
-	Priority      *int                   `json:"priority,omitempty"`
-	Template      *Template              `json:"template,omitempty"`
-	Version       *int                   `json:"version,omitempty"`
+	Name                            string                 `json:"-"`
+	Create                          bool                   `json:"-"`
+	Timeout                         string                 `json:"-"`
+	ComposedOf                      []string               `json:"composed_of"`
+	IgnoreMissingComponentTemplates []string               `json:"ignore_missing_component_templates"`
+	DataStream                      *DataStreamSettings    `json:"data_stream,omitempty"`
+	IndexPatterns                   []string               `json:"index_patterns"`
+	Meta                            map[string]interface{} `json:"_meta,omitempty"`
+	Priority                        *int                   `json:"priority,omitempty"`
+	Template                        *Template              `json:"template,omitempty"`
+	Version                         *int                   `json:"version,omitempty"`
 }
 
 type DataStreamSettings struct {


### PR DESCRIPTION
https://github.com/elastic/terraform-provider-elasticstack/issues/631

Adding the ignore_missing_component_templates based on the composed_of key.