### PR TITLE
Ignore MasterTimeout for serverless deployment

### DIFF
--- a/internal/elasticsearch/index/index/models.go
+++ b/internal/elasticsearch/index/index/models.go
@@ -286,11 +286,11 @@ func (model tfModel) toPutIndexParams(serverFlavor string) models.PutIndexParams
 	timeout, _ := model.Timeout.Parse()
 
 	params := models.PutIndexParams{
-		MasterTimeout: masterTimeout,
-		Timeout:       timeout,
+		Timeout: timeout,
 	}
 
 	if serverFlavor != "serverless" {
+		params.MasterTimeout = masterTimeout
 		params.WaitForActiveShards = model.WaitForActiveShards.ValueString()
 	}
 

--- a/internal/elasticsearch/index/index/models_test.go
+++ b/internal/elasticsearch/index/index/models_test.go
@@ -365,6 +365,7 @@ func Test_tfModel_toPutIndexParams(t *testing.T) {
 			if isServerless {
 				flavor = "serverless"
 				expectedParams.WaitForActiveShards = ""
+				expectedParams.MasterTimeout = 0
 			}
 
 			params := model.toPutIndexParams(flavor)


### PR DESCRIPTION
According to [the docs](https://github.com/elastic/terraform-provider-elasticstack/blob/061e52ce9c1c34a6e4ccecf5bf8ca7096f29e3b7/docs/data-sources/elasticsearch_indices.md?plain=1#L79), the `master_timeout` attribute should be ignored when creating a serverless deployment. However, this isn't currently happening in practice. When trying to create an index, the apply fails with this error:

```
│ Error: Unable to create index: fietslanduo
│
│   with module.elasticstack["test.fietsplan"].elasticstack_elasticsearch_index.this["fietslanduo"],
│   on modules/ec-elasticstack/indices.tf line 2, in resource "elasticstack_elasticsearch_index" "this":
│    2: resource "elasticstack_elasticsearch_index" "this" {
│
│ Failed with: {"error":{"root_cause":[{"type":"status_exception","reason":"Parameter validation
│ failed for [/fietslanduo]: The http parameter [master_timeout] (with value [30000ms]) is not
│ permitted when running in serverless mode"}],"type":"status_exception","reason":"Parameter
│ validation failed for [/fietslanduo]: The http parameter [master_timeout] (with value
│ [30000ms]) is not permitted when running in serverless mode"},"status":400}
```

I'm proposing to handle this parameter the same way it's handled as `WaitForActiveShards`, which is already being properly omitted in serverless deployments. I've tested this fix by building the provider locally, and it works as expected.

