### PR TITLE
Prevent provider panic when referenced script does not exist in ES

### DIFF
--- a/internal/elasticsearch/cluster/script.go
+++ b/internal/elasticsearch/cluster/script.go
@@ -81,6 +81,7 @@ func resourceScriptRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if script == nil && diags == nil {
 		tflog.Warn(ctx, fmt.Sprintf(`Script "%s" not found, removing from state`, compId.ResourceId))
 		d.SetId("")
+		return nil
 	}
 	if diags.HasError() {
 		return diags


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/1215

The provider wasn't returning immediately in the case where a script didn't exist during a read. 