### PR TITLE
Add ids handler

### DIFF
--- a/internal/fleet/integration_policy/secrets_test.go
+++ b/internal/fleet/integration_policy/secrets_test.go
@@ -79,6 +79,26 @@ func TestHandleRespSecrets(t *testing.T) {
 			input: Map{"k": Map{"type": "password", "value": Map{"isSecretRef": true, "id": "unknown-secret"}}},
 			want:  Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
 		},
+		{
+			name:  "converts list secret",
+			input: Map{"k": Map{"isSecretRef": true, "ids": []any{"known-secret"}}},
+			want:  Map{"k": []any{"secret"}},
+		},
+		{
+			name:  "converts multiple list secrets",
+			input: Map{"k": Map{"isSecretRef": true, "ids": []any{"known-secret", "known-secret"}}},
+			want:  Map{"k": []any{"secret", "secret"}},
+		},
+		{
+			name:  "converts mixed list secrets",
+			input: Map{"k": Map{"isSecretRef": true, "ids": []any{"known-secret", "unknown-secret"}}},
+			want:  Map{"k": []any{"secret"}},
+		},
+		{
+			name:  "converts wrapped list secret",
+			input: Map{"k": Map{"type": "array", "value": Map{"isSecretRef": true, "ids": []any{"known-secret"}}}},
+			want:  Map{"k": []any{"secret"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +204,30 @@ func TestHandleReqRespSecrets(t *testing.T) {
 			respInput: Map{"k": Map{"type": "password", "value": Map{"isSecretRef": true, "id": "unknown-secret"}}},
 			want:      Map{"k": Map{"isSecretRef": true, "id": "unknown-secret"}},
 		},
+		{
+			name:      "converts list secret",
+			reqInput:  Map{"k": []any{"secret1", "secret2"}},
+			respInput: Map{"k": Map{"isSecretRef": true, "ids": []any{"ref1", "ref2"}}},
+			want:      Map{"k": []any{"secret1", "secret2"}},
+		},
+		{
+			name:      "converts wrapped list secret",
+			reqInput:  Map{"k": []any{"secret1", "secret2"}},
+			respInput: Map{"k": Map{"type": "array", "value": Map{"isSecretRef": true, "ids": []any{"ref1", "ref2"}}}},
+			want:      Map{"k": []any{"secret1", "secret2"}},
+		},
+		{
+			name:      "converts partial list secret",
+			reqInput:  Map{"k": []any{"secret1"}},
+			respInput: Map{"k": Map{"isSecretRef": true, "ids": []any{"ref1", "ref2"}}},
+			want:      Map{"k": []any{"secret1"}},
+		},
+		{
+			name:      "converts empty list secret",
+			reqInput:  Map{"k": []any{}},
+			respInput: Map{"k": Map{"isSecretRef": true, "ids": []any{"ref1"}}},
+			want:      Map{"k": []any{}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -236,13 +280,209 @@ func TestHandleReqRespSecrets(t *testing.T) {
 			want = *(*wants.Inputs["input1"].Streams)["stream1"].Vars
 			require.Equal(t, want, got)
 
-			if v, ok := (*req.Vars)["k"]; ok && v == "secret" {
+			// Check private data expectations based on test case
+			switch tt.name {
+			case "converts secret", "converts wrapped secret":
 				privateWants := privateData{"secrets": `{"known-secret":"secret"}`}
 				require.Equal(t, privateWants, private)
-			} else {
+			case "converts list secret", "converts wrapped list secret":
+				privateWants := privateData{"secrets": `{"ref1":"secret1","ref2":"secret2"}`}
+				require.Equal(t, privateWants, private)
+			case "converts partial list secret":
+				privateWants := privateData{"secrets": `{"ref1":"secret1"}`}
+				require.Equal(t, privateWants, private)
+			case "converts empty list secret":
+				privateWants := privateData{"secrets": `{}`}
+				require.Equal(t, privateWants, private)
+			default:
 				privateWants := privateData{"secrets": `{}`}
 				require.Equal(t, privateWants, private)
 			}
 		})
 	}
+}
+
+func TestEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("handles deeply nested secret references", func(t *testing.T) {
+		private := privateData{"secrets": `{"nested-ref":"nested-secret"}`}
+
+		resp := &kbapi.PackagePolicy{
+			SecretReferences: &[]kbapi.PackagePolicySecretRef{{Id: "nested-ref"}},
+			Vars: &map[string]any{
+				"level1": map[string]any{
+					"type": "object",
+					"value": map[string]any{
+						"level2": map[string]any{
+							"isSecretRef": true,
+							"id":          "nested-ref",
+						},
+					},
+				},
+			},
+		}
+
+		diags := integration_policy.HandleRespSecrets(ctx, resp, &private)
+		require.Empty(t, diags)
+
+		expected := map[string]any{
+			"level1": map[string]any{
+				"level2": "nested-secret",
+			},
+		}
+		require.Equal(t, expected, *resp.Vars)
+	})
+
+	t.Run("handles multiple input streams", func(t *testing.T) {
+		private := privateData{"secrets": `{"stream1-ref":"stream1-secret","stream2-ref":"stream2-secret"}`}
+
+		resp := &kbapi.PackagePolicy{
+			SecretReferences: &[]kbapi.PackagePolicySecretRef{
+				{Id: "stream1-ref"}, {Id: "stream2-ref"},
+			},
+			Inputs: map[string]kbapi.PackagePolicyInput{
+				"input1": {
+					Streams: &map[string]kbapi.PackagePolicyInputStream{
+						"stream1": {
+							Vars: &map[string]any{
+								"secret1": map[string]any{"isSecretRef": true, "id": "stream1-ref"},
+							},
+						},
+						"stream2": {
+							Vars: &map[string]any{
+								"secret2": map[string]any{"isSecretRef": true, "id": "stream2-ref"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		diags := integration_policy.HandleRespSecrets(ctx, resp, &private)
+		require.Empty(t, diags)
+
+		streams := *resp.Inputs["input1"].Streams
+		require.Equal(t, "stream1-secret", (*streams["stream1"].Vars)["secret1"])
+		require.Equal(t, "stream2-secret", (*streams["stream2"].Vars)["secret2"])
+	})
+
+	t.Run("handles invalid JSON in private data", func(t *testing.T) {
+		private := privateData{"secrets": `{"invalid": json}`}
+
+		resp := &kbapi.PackagePolicy{
+			SecretReferences: &[]kbapi.PackagePolicySecretRef{},
+			Vars:             &map[string]any{},
+		}
+
+		diags := integration_policy.HandleRespSecrets(ctx, resp, &private)
+		require.True(t, diags.HasError(), "Expected error diagnostics")
+	})
+}
+
+func TestMigrationScenarios(t *testing.T) {
+	t.Parallel()
+
+	// Test pre-0.11.7 migration scenarios mentioned in HandleReqRespSecrets
+	ctx := context.Background()
+
+	t.Run("handles importing existing secret refs", func(t *testing.T) {
+		// Simulate importing a resource that already has secret refs in request
+		req := kbapi.PackagePolicyRequest{
+			Vars: &map[string]any{
+				"existing_secret": map[string]any{
+					"isSecretRef": true,
+					"id":          "existing-ref",
+				},
+			},
+		}
+
+		resp := &kbapi.PackagePolicy{
+			SecretReferences: &[]kbapi.PackagePolicySecretRef{{Id: "new-ref"}},
+			Vars: &map[string]any{
+				"existing_secret": map[string]any{
+					"isSecretRef": true,
+					"id":          "new-ref",
+				},
+			},
+		}
+
+		private := privateData{}
+		diags := integration_policy.HandleReqRespSecrets(ctx, req, resp, &private)
+		require.Empty(t, diags)
+
+		// Should preserve the original secret ref structure since original is also a secret ref
+		expected := map[string]any{
+			"existing_secret": map[string]any{
+				"isSecretRef": true,
+				"id":          "existing-ref",
+			},
+		}
+		require.Equal(t, expected, *resp.Vars)
+	})
+
+	t.Run("handles migration from plain text to secret ref", func(t *testing.T) {
+		// Simulate migration where plain text becomes secret ref
+		req := kbapi.PackagePolicyRequest{
+			Vars: &map[string]any{
+				"password": "plain-text-password",
+			},
+		}
+
+		resp := &kbapi.PackagePolicy{
+			SecretReferences: &[]kbapi.PackagePolicySecretRef{{Id: "password-ref"}},
+			Vars: &map[string]any{
+				"password": map[string]any{
+					"isSecretRef": true,
+					"id":          "password-ref",
+				},
+			},
+		}
+
+		private := privateData{}
+		diags := integration_policy.HandleReqRespSecrets(ctx, req, resp, &private)
+		require.Empty(t, diags)
+
+		// Should replace secret ref with original plain text
+		expected := map[string]any{"password": "plain-text-password"}
+		require.Equal(t, expected, *resp.Vars)
+
+		// Should save the mapping for future use
+		expectedPrivate := `{"password-ref":"plain-text-password"}`
+		require.Equal(t, expectedPrivate, private["secrets"])
+	})
+
+	t.Run("handles list migration scenarios", func(t *testing.T) {
+		req := kbapi.PackagePolicyRequest{
+			Vars: &map[string]any{
+				"hosts": []any{"host1.example.com", "host2.example.com", "host3.example.com"},
+			},
+		}
+
+		resp := &kbapi.PackagePolicy{
+			SecretReferences: &[]kbapi.PackagePolicySecretRef{
+				{Id: "host-ref-1"}, {Id: "host-ref-2"}, {Id: "host-ref-3"},
+			},
+			Vars: &map[string]any{
+				"hosts": map[string]any{
+					"isSecretRef": true,
+					"ids":         []any{"host-ref-1", "host-ref-2", "host-ref-3"},
+				},
+			},
+		}
+
+		private := privateData{}
+		diags := integration_policy.HandleReqRespSecrets(ctx, req, resp, &private)
+		require.Empty(t, diags)
+
+		// Should replace list secret refs with original array
+		expected := map[string]any{"hosts": []any{"host1.example.com", "host2.example.com", "host3.example.com"}}
+		require.Equal(t, expected, *resp.Vars)
+
+		// Should save individual mappings
+		expectedPrivate := `{"host-ref-1":"host1.example.com","host-ref-2":"host2.example.com","host-ref-3":"host3.example.com"}`
+		require.Equal(t, expectedPrivate, private["secrets"])
+	})
 }


### PR DESCRIPTION
This change implements support for lists of secret values in fleet integration policies. There are two ways a secret value can be defined:

- Just a simple string
  - `"password": "secret"` <-> `"password": {"id": "Zgr3ZJgBz9OcmZgWR1vo", "isSecretRef": true}`
- A list of strings 
  - `"hosts" : ["root:test@tcp(127.0.0.1:3306)/"]` <-> `"hosts": {"ids": ["Zgr3ZJgBz9OcmZgWR1vo], "isSecretRef": true}`

The code now correctly maps between both cases. (It used to only handle the simple string)

The bug report actually contains a second bug that shows when using `vars_json = "{}",`. Since the API always responds with a `nil` value, it generates a diff between the config and the actual state. The solution here is to map `nil` to `"{}"` if the local config contains `"{}"`.

Related issue: https://github.com/elastic/terraform-provider-elasticstack/issues/1232