### PR TITLE
Update Logstash pipeline create example.

### DIFF
--- a/docs/resources/elasticsearch_logstash_pipeline.md
+++ b/docs/resources/elasticsearch_logstash_pipeline.md
@@ -50,7 +50,7 @@ EOF
 }
 
 output "pipeline" {
-  value = elasticstack_elasticsearch_logstash_pipeline.example.pipeline_id
+  value = elasticstack_elasticsearch_logstash_pipeline_example_pipeline_id
 }
 ```
 

--- a/examples/resources/elasticstack_elasticsearch_logstash_pipeline/resource.tf
+++ b/examples/resources/elasticstack_elasticsearch_logstash_pipeline/resource.tf
@@ -34,5 +34,5 @@ EOF
 }
 
 output "pipeline" {
-  value = elasticstack_elasticsearch_logstash_pipeline.example.pipeline_id
+  value = elasticstack_elasticsearch_logstash_pipeline_example_pipeline_id
 }


### PR DESCRIPTION
Kibana and Elasticsearch APIs start validating pipeline IDs after the following changes:
- https://github.com/elastic/kibana/pull/236347
- https://github.com/elastic/elasticsearch/pull/135378
The `examples/resources/elasticstack_elasticsearch_logstash_pipeline/resource.tf` example will not be valid anymore.
This PR updates the example to align with pipeline ID restriction changes.