### PR TITLE
Buildkite pipeline to update the Kibana client

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if [[ "${BUILDKITE_PIPELINE_SLUG}" != "terraform-provider-elasticstack-release" ]]; then
+  echo "Skipping pre-command hook for non-release pipeline"
+  exit 0
+fi
+
 RELEASE_VAULT_PATH=kv/ci-shared/terraform-providers
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "terraform-provider-elasticstack-release" ]]; then

--- a/.buildkite/update-kibana-client.yml
+++ b/.buildkite/update-kibana-client.yml
@@ -1,0 +1,7 @@
+agents:
+  image: "golang:1.25.1@sha256:d7098379b7da665ab25b99795465ec320b1ca9d4addb9f77409c4827dc904211"
+steps:
+  - label: Regenerate Kibana client and build provider
+    command:
+      - "make -C generated/kbapi all"
+      - "make build"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -35,3 +35,39 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-terraform-provider-elasticstack-update-kibana-client
+  description: Buildkite Pipeline for updating Kibana client in Terraform provider Elasticstack
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/terraform-provider-elasticstack-update-kibana-client
+
+spec:
+  type: buildkite-pipeline
+  owner: group:control-plane-hosted-applications
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: terraform-provider-elasticstack / Update Kibana client
+      description: Terraform provider Elasticstack - update Kibana client
+    spec:
+      repository: elastic/terraform-provider-elasticstack
+      pipeline_file: ".buildkite/update-kibana-client.yml"
+      provider_settings:
+        build_branches: false
+        build_pull_request_forks: false
+        build_tags: false
+      teams:
+        control-plane-hosted-applications:
+          access_level: MANAGE_BUILD_AND_READ
+        serverless-core:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/1309

We need this merged before we can iterate on this one too much. This PR introduces a basic pipeline which regenerates the Kibana client. By default it will use the spec in main, but the spec from a PR can be validated by setting `github_ref=refs/pull/238558/head`. 