### PR TITLE
Use renovate for evergreen Kibana clients

### DIFF
--- a/generated/kbapi/Makefile
+++ b/generated/kbapi/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-github_ref ?= refs/heads/main
+github_ref ?= 5c4f76696e63bf9e9a53d55521f4c18faa02ccf2
 oas_url    := https://raw.githubusercontent.com/elastic/kibana/$(github_ref)/oas_docs/output/kibana.yaml
 
 .PHONY: all

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,21 @@
   "extends": [
     "local>elastic/renovate-config"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^generated/kbapi/Makefile$/"],
+      "matchStrings": ["github_ref \\?= (?<currentDigest>.*?)\\n"],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "kibana-openapi-spec",
+      "packageNameTemplate": "https://github.com/elastic/kibana",
+      "datasourceTemplate": "git-refs"
+    }
+  ],
+  "postUpgradeTasks": {
+    "commands": ["make -C generated/kbapi all"],
+    "fileFilters": ["generated/kbapi/Makefile"]
+  },
   "automerge": true,
   "automergeStrategy": "squash",
   "automergeType": "branch",


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/1309

Ideally we want to track Kibana spec changes, we already have a tool which track dependency updates, we should use that to keep the Kibana client up to date. 

There's some benefits here:
* We don't have to manage another set of GH permissions for making commits to repos
* We don't have to re-build the core Renovate functionality (automerge, PR tracking...)
* We're not building a Rube Goldberg set of Buildkite triggers

There's some downsides though:
* We're not tracking *every* commit into Kibana/main. If something breaks we need to check potentially a range of commits to track down the breaking change. It also means this can't be used as a status check on a Kibana PR, https://github.com/elastic/terraform-provider-elasticstack/pull/1356 introduces a simple Buildkite pipeline that can be used for that though. I think using both means that the overall solution is simpler, Renovate handles bumping _all_ dependencies, and there's a Buildkite pipeline available as a simple validity check. 
* It's hard to skip no-op changes. Any commit to Kibana will result in the digest being updated, even if there are no changes to the OpenAPI spec. Assuming automerge works properly, this really just means a noisy Git history in the provider. I don't _like_ that, but I'm not sure it's an actual issue. 