### PR TITLE
Update the system_user acceptance tests to utilise the config directory pattern

### DIFF
--- a/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUser/create/system_user.tf
+++ b/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUser/create/system_user.tf
@@ -1,0 +1,12 @@
+variable "username" {
+  description = "The system username"
+  type        = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_security_system_user" "remote_monitoring_user" {
+  username = var.username
+}

--- a/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUser/update/system_user.tf
+++ b/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUser/update/system_user.tf
@@ -1,0 +1,18 @@
+variable "username" {
+  description = "The system username"
+  type        = string
+}
+
+variable "password" {
+  description = "The password for the system user"
+  type        = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_security_system_user" "remote_monitoring_user" {
+  username = var.username
+  password = var.password
+}

--- a/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUserFromSDK/system_user.tf
+++ b/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUserFromSDK/system_user.tf
@@ -1,0 +1,12 @@
+variable "username" {
+  description = "The system username"
+  type        = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_security_system_user" "remote_monitoring_user" {
+  username = var.username
+}

--- a/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUserNotFound/system_user.tf
+++ b/internal/elasticsearch/security/system_user/testdata/TestAccResourceSecuritySystemUserNotFound/system_user.tf
@@ -1,0 +1,18 @@
+variable "username" {
+  description = "The system username"
+  type        = string
+}
+
+variable "password" {
+  description = "The password for the system user"
+  type        = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_security_system_user" "test" {
+  username = var.username
+  password = var.password
+}


### PR DESCRIPTION
We want to standardise on this, since this resource is being held up as an example to follow we should ensure to follows the desired design