### PR TITLE
Support setting solution for 8.16+ on Cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Support `.bedrock` and `.gen-ai` connectors ([#1467](https://github.com/elastic/terraform-provider-elasticstack/pull/1467))
+- Support the `solution` attribute in `elasticstack_kibana_space` from 8.16 ([#1486](https://github.com/elastic/terraform-provider-elasticstack/pull/1486)) 
 
 ## [0.12.2] - 2025-11-19
 - Fix `elasticstack_elasticsearch_snapshot_lifecycle` metadata type conversion causing terraform apply to fail ([#1409](https://github.com/elastic/terraform-provider-elasticstack/issues/1409))

--- a/internal/kibana/space.go
+++ b/internal/kibana/space.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var SpaceSolutionMinVersion = version.Must(version.NewVersion("8.18.0"))
+var spaceSolutionMinVersion = version.Must(version.NewVersion("8.16.0"))
 
 func ResourceSpace() *schema.Resource {
 	apikeySchema := map[string]*schema.Schema{
@@ -108,8 +108,8 @@ func resourceSpaceUpsert(ctx context.Context, d *schema.ResourceData, meta inter
 			return diags
 		}
 
-		if !serverVersion.GreaterThanOrEqual(SpaceSolutionMinVersion) {
-			return diag.Errorf("solution field is not supported in this version of the Elastic Stack. Solution field requires %s or higher", SpaceSolutionMinVersion)
+		if !serverVersion.GreaterThanOrEqual(spaceSolutionMinVersion) {
+			return diag.Errorf("solution field is not supported in this version of the Elastic Stack. Solution field requires %s or higher", spaceSolutionMinVersion)
 		}
 	}
 

--- a/internal/kibana/space_test.go
+++ b/internal/kibana/space_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
-	"github.com/elastic/terraform-provider-elasticstack/internal/kibana"
 	"github.com/elastic/terraform-provider-elasticstack/internal/versionutils"
+	"github.com/hashicorp/go-version"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+var minSelfManagedVersionForSpaceSolution = version.Must(version.NewVersion("8.18.0"))
 
 func TestAccResourceSpace(t *testing.T) {
 	spaceId := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
@@ -43,7 +45,7 @@ func TestAccResourceSpace(t *testing.T) {
 			},
 			{
 				Config:   testAccResourceSpaceWithSolution(spaceId),
-				SkipFunc: versionutils.CheckIfVersionIsUnsupported(kibana.SpaceSolutionMinVersion),
+				SkipFunc: versionutils.CheckIfVersionIsUnsupported(minSelfManagedVersionForSpaceSolution),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_kibana_space.test_space", "space_id", spaceId),
 					resource.TestCheckResourceAttr("elasticstack_kibana_space.test_space", "name", fmt.Sprintf("Solution %s", spaceId)),


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/1468

Kind of annoying, this field is available on Cloud from 8.16, but requires two config settings to be exposed in self-managed instance before 8.18 🤷 