### PR TITLE
Expose experimental resources in acceptance tests

### DIFF
--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -15,7 +15,7 @@ import (
 var Providers map[string]func() (tfprotov6.ProviderServer, error)
 
 func init() {
-	providerServerFactory, err := provider.ProtoV6ProviderServerFactory(context.Background(), "dev")
+	providerServerFactory, err := provider.ProtoV6ProviderServerFactory(context.Background(), provider.AccTestVersion)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/provider/plugin_framework.go
+++ b/provider/plugin_framework.go
@@ -49,7 +49,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-const IncludeExperimentalEnvVar = "TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL"
+const (
+	IncludeExperimentalEnvVar = "TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL"
+	AccTestVersion            = "acctest"
+)
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
@@ -103,7 +106,7 @@ func (p *Provider) Configure(ctx context.Context, req fwprovider.ConfigureReques
 func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	datasources := p.dataSources(ctx)
 
-	if os.Getenv(IncludeExperimentalEnvVar) == "true" {
+	if p.version == AccTestVersion || os.Getenv(IncludeExperimentalEnvVar) == "true" {
 		datasources = append(datasources, p.experimentalDataSources(ctx)...)
 	}
 
@@ -113,7 +116,7 @@ func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSour
 func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
 	resources := p.resources(ctx)
 
-	if os.Getenv(IncludeExperimentalEnvVar) == "true" {
+	if p.version == AccTestVersion || os.Getenv(IncludeExperimentalEnvVar) == "true" {
 		resources = append(resources, p.experimentalResources(ctx)...)
 	}
 


### PR DESCRIPTION
Does what it says on the tin. I can see some value in being able to do this more selectively so we could have a test to ensure these aren't exposed by default but I think this is enough for now.