### PR TITLE
Validate space ids meet the API requirements

### DIFF
--- a/internal/kibana/space.go
+++ b/internal/kibana/space.go
@@ -26,7 +26,7 @@ func ResourceSpace() *schema.Resource {
 			Type:         schema.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringMatch(regexp.MustCompile("[a-z0-9_-]+"), "must only contain lowercase letters, numbers, hyphens, and underscores"),
+			ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-z0-9_-]+$"), "must only contain lowercase letters, numbers, hyphens, and underscores"),
 		},
 		"name": {
 			Description: "The display name for the space.",


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/1553

Without this we get a fairly unhelpful 400 API response, it's a nicer UX providing immediate, and specific feedback. 