### PR TITLE
fix: update GOVERSION in .env to match go.mod requirements

### DIFF
--- a/.env
+++ b/.env
@@ -14,5 +14,5 @@ KIBANA_ENCRYPTION_KEY=GsRtLGKnnuvwVQ3lqSS5kGScdfpmgEDA
 FLEET_CONTAINER_NAME=terraform-elasticstack-fleet
 ACCEPTANCE_TESTS_CONTAINER_NAME=terraform-elasticstack-acceptance-tests
 TOKEN_ACCEPTANCE_TESTS_CONTAINER_NAME=terraform-elasticstack-token-acceptance-tests
-GOVERSION=1.25.1
+GOVERSION=1.25.6
 TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true


### PR DESCRIPTION
## Summary

The `.env` file had `GOVERSION=1.25.1` while `go.mod` requires `>= 1.25.4`.
This caused `make docker-testacc` to fail with:

```
go: go.mod requires go >= 1.25.4 (running go 1.25.1; GOTOOLCHAIN=local)
```

## Changes

- Updated `GOVERSION` from `1.25.1` to `1.25.6` to align with `.buildkite/release.yml`

## Note

It appears Renovate bot updates the Go version in `.buildkite/release.yml` but not in `.env`. This might be worth configuring to keep them in sync automatically.

## Testing

- Verified `make docker-testacc` passes with this change (1314 tests)