### PR TITLE
Fix inconsistent state error with alert_delay 

### DIFF
--- a/internal/kibana/alerting_rule/acc_test.go
+++ b/internal/kibana/alerting_rule/acc_test.go
@@ -360,3 +360,52 @@ func checkResourceAlertingRuleDestroy(s *terraform.State) error {
 	}
 	return nil
 }
+
+func TestAccResourceAlertingRuleAlertDelay(t *testing.T) {
+	minSupportedVersion := version.Must(version.NewSemver("8.13.0"))
+
+	t.Setenv("KIBANA_API_KEY", "")
+
+	ruleName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceAlertingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minSupportedVersion),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(ruleName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "name", ruleName),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "consumer", "alerts"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "rule_type_id", ".es-query"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "interval", "1m"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "enabled", "true"),
+					resource.TestCheckTypeSetElemAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "tags.*", "autoops"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "alert_delay", "1"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minSupportedVersion),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(ruleName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "name", ruleName),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "consumer", "alerts"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "rule_type_id", ".es-query"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "interval", "1m"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "enabled", "true"),
+					resource.TestCheckTypeSetElemAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "tags.*", "autoops"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_alerting_rule.autoops_service_crashloopbackoff", "alert_delay", "1"),
+				),
+			},
+		},
+	})
+}

--- a/internal/kibana/alerting_rule/schema.go
+++ b/internal/kibana/alerting_rule/schema.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -137,7 +138,11 @@ func getSchema() schema.Schema {
 			},
 			"alert_delay": schema.Int64Attribute{
 				Description: "A number that indicates how many consecutive runs need to meet the rule conditions for an alert to occur.",
+				Computed:    true,
 				Optional:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{

--- a/internal/kibana/alerting_rule/testdata/TestAccResourceAlertingRuleAlertDelay/create/main.tf
+++ b/internal/kibana/alerting_rule/testdata/TestAccResourceAlertingRuleAlertDelay/create/main.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  type = string
+}
+
+resource "elasticstack_kibana_alerting_rule" "autoops_service_crashloopbackoff" {
+  name         = var.name
+  rule_type_id = ".es-query"
+  consumer     = "alerts"
+  enabled      = true
+  interval     = "1m"
+  tags         = ["autoops"]
+  alert_delay  = 1
+
+  params = jsonencode({
+    aggType                    = "count",
+    esQuery                    = "{\n    \"query\": {\n        \"bool\": {\n            \"filter\": [\n                {\n                    \"term\": {\n                        \"data_stream.dataset\": \"kubernetes.state_container\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"kubernetes.container.status.reason\": \"CrashLoopBackOff\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"kubernetes.namespace\": \"autoops\"\n                   }\n                }\n            ]\n        }\n    }\n}",
+    excludeHitsFromPreviousRun = true,
+    groupBy                    = "top",
+    index                      = ["metrics-*,metrics-*:metrics-*"],
+    searchType                 = "esQuery",
+    size                       = 1,
+    termField                  = ["kubernetes.pod.name", "orchestrator.cluster.name"],
+    termSize                   = 10,
+    threshold                  = [10],
+    thresholdComparator        = ">",
+    timeField                  = "@timestamp",
+    timeWindowSize             = 10,
+    timeWindowUnit             = "m",
+    sourceFields = [
+      { label = "container.id", searchPath = "container.id" },
+      { label = "host.hostname", searchPath = "host.hostname" },
+      { label = "host.id", searchPath = "host.id" },
+      { label = "host.name", searchPath = "host.name" },
+      { label = "kubernetes.pod.uid", searchPath = "kubernetes.pod.uid" }
+    ]
+  })
+}

--- a/internal/kibana/alerting_rule/testdata/TestAccResourceAlertingRuleAlertDelay/update/main.tf
+++ b/internal/kibana/alerting_rule/testdata/TestAccResourceAlertingRuleAlertDelay/update/main.tf
@@ -1,0 +1,36 @@
+variable "name" {
+  type = string
+}
+
+resource "elasticstack_kibana_alerting_rule" "autoops_service_crashloopbackoff" {
+  name         = var.name
+  rule_type_id = ".es-query"
+  consumer     = "alerts"
+  enabled      = true
+  interval     = "1m"
+  tags         = ["autoops"]
+
+  params = jsonencode({
+    aggType                    = "count",
+    esQuery                    = "{\n    \"query\": {\n        \"bool\": {\n            \"filter\": [\n                {\n                    \"term\": {\n                        \"data_stream.dataset\": \"kubernetes.state_container\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"kubernetes.container.status.reason\": \"CrashLoopBackOff\"\n                    }\n                },\n                {\n                    \"term\": {\n                        \"kubernetes.namespace\": \"autoops\"\n                   }\n                }\n            ]\n        }\n    }\n}",
+    excludeHitsFromPreviousRun = true,
+    groupBy                    = "top",
+    index                      = ["metrics-*,metrics-*:metrics-*"],
+    searchType                 = "esQuery",
+    size                       = 1,
+    termField                  = ["kubernetes.pod.name", "orchestrator.cluster.name"],
+    termSize                   = 10,
+    threshold                  = [10],
+    thresholdComparator        = ">",
+    timeField                  = "@timestamp",
+    timeWindowSize             = 10,
+    timeWindowUnit             = "m",
+    sourceFields = [
+      { label = "container.id", searchPath = "container.id" },
+      { label = "host.hostname", searchPath = "host.hostname" },
+      { label = "host.id", searchPath = "host.id" },
+      { label = "host.name", searchPath = "host.name" },
+      { label = "kubernetes.pod.uid", searchPath = "kubernetes.pod.uid" }
+    ]
+  })
+}


### PR DESCRIPTION
The alerting_rule resource is causing a state consistency error when the underlying rule in Kibana has an alert delay configured, but alert_delay is not defined in TF. 