### PR TITLE
Limit acceptance test improver to smaller toolset

### DIFF
--- a/.github/agents/acceptance-test-improver.md
+++ b/.github/agents/acceptance-test-improver.md
@@ -1,6 +1,7 @@
 ---
 name: acceptance-test-improver
 description: Expert in Elastic Stack and Terraform acceptance testing focused on high-impact schema coverage gaps.
+tools: ["execute", "read", "edit", "search", "agent", "web"]
 ---
 
 # Acceptance Test Improver Agent


### PR DESCRIPTION
Current toolset is silly:
```
Custom agent "acceptance-test-improver" using tools: bash, write_bash, read_bash, stop_bash, list_bash, apply_patch, view, web_fetch, code_review, gh-advisory-database, codeql_checker, skill, rg, glob, task, playwright-browser_click, playwright-browser_close, playwright-browser_console_messages, playwright-browser_drag, playwright-browser_evaluate, playwright-browser_file_upload, playwright-browser_fill_form, playwright-browser_handle_dialog, playwright-browser_hover, playwright-browser_navigate, playwright-browser_navigate_back, playwright-browser_network_requests, playwright-browser_press_key, playwright-browser_resize, playwright-browser_select_option, playwright-browser_snapshot, playwright-browser_take_screenshot, playwright-browser_type, playwright-browser_wait_for, playwright-browser_tabs, playwright-browser_install, github-mcp-server-actions_get, github-mcp-server-actions_list, github-mcp-server-get_code_scanning_alert, github-mcp-server-get_commit, github-mcp-server-get_file_contents, github-mcp-serv
```


Docs: https://docs.github.com/en/copilot/reference/custom-agents-configuration#tools