### PR TITLE
Pass ref in workflow dispatch

### DIFF
--- a/.github/workflows/auto-approve-copilot-workflows.yml
+++ b/.github/workflows/auto-approve-copilot-workflows.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           branch="${{ github.event.workflow_run.head_branch }}"
           echo "Triggering test.yml on branch: $branch"
-          gh workflow run test.yml --repo "${{ github.repository }}" --ref "$branch"
+          gh workflow run test.yml --repo "${{ github.repository }}" -f ref="$branch"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ on:
       - 'README.md'
       - 'CHANGELOG.md'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref (branch/tag/SHA) to checkout and test'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -24,6 +29,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: 'go.mod'
@@ -40,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: 'go.mod'
@@ -158,6 +167,8 @@ jobs:
           sudo rm -rf /usr/local/lib/android
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
Fix issue
```
Triggering test.yml on branch: copilot/improve-acceptance-test-coverage-another-one
could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger (https://api.github.com/repos/elastic/terraform-provider-elasticstack/actions/workflows/38886707/dispatches)
Error: Process completed with exit code 1.

```