### PR TITLE
Add SDK->PF skill

### DIFF
--- a/.agents/skills/sdk-to-pf-migration/SKILL.md
+++ b/.agents/skills/sdk-to-pf-migration/SKILL.md
@@ -60,7 +60,7 @@ Create `internal/<domain>/<resource>/` (path mirrors where the SDK resource live
 
 ### 3. Provider Wiring
 
-- **Add**: `provider/plugin_framework.go` — register `NewResource` in `resources()`.
+- **Update**: `provider/plugin_framework.go` — register `NewResource` in `resources()` following the existing registration pattern.
 - **Remove**: `provider/provider.go` — remove the type from `ResourcesMap`.
 
 ### 4. Move Acceptance Tests


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/482

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SDK-to-Plugin Framework migration skill guide
> Adds [SKILL.md](https://github.com/elastic/terraform-provider-elasticstack/pull/1967/files#diff-15b4592be534631ada6ba96ded93cdad9650d673b2702f13d9edc700dea2c940), a step-by-step guide for migrating Terraform resources from Plugin SDK to Plugin Framework. Covers prerequisites, client diagnostics strategy, provider wiring, schema coverage, acceptance tests, upgrade tests, and verification steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73c7b6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->