### PR TITLE
Fix cases defaults for 9.4

### DIFF
--- a/internal/clients/kibanaoapi/connector.go
+++ b/internal/clients/kibanaoapi/connector.go
@@ -394,6 +394,10 @@ func connectorConfigWithDefaultsCasesWebhook(plan string) (string, error) {
 	if err := json.Unmarshal([]byte(plan), &custom); err != nil {
 		return "", err
 	}
+	if custom.AuthType == nil {
+		authType := kbapi.WebhookAuthenticationBasic
+		custom.AuthType = &authType
+	}
 	if custom.CreateIncidentMethod == nil {
 		custom.CreateIncidentMethod = new(kbapi.CasesWebhookConfigCreateIncidentMethodPost)
 	}

--- a/internal/clients/kibanaoapi/connector_test.go
+++ b/internal/clients/kibanaoapi/connector_test.go
@@ -18,6 +18,7 @@
 package kibanaoapi_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -421,6 +422,24 @@ func TestConnectorConfigWithDefaults(t *testing.T) {
 			planConfig:      `{"key":"value"}`,
 			expectedError:   true,
 			errorContains:   "unknown connector type ID",
+		},
+		{
+			name:            "cases-webhook without authType gets webhook-authentication-basic (Stack 9.4+ default)",
+			connectorTypeID: ".cases-webhook",
+			planConfig: `{"createIncidentJson":"{}","createIncidentResponseKey":"k",` +
+				`"createIncidentUrl":"https://example.com","getIncidentResponseExternalTitleKey":"t",` +
+				`"getIncidentUrl":"https://example.com","updateIncidentJson":"{}",` +
+				`"updateIncidentUrl":"https://example.com","viewIncidentUrl":"https://example.com"}`,
+			expectedError: false,
+			validateResult: func(t *testing.T, result string) {
+				var m map[string]any
+				require.NoError(t, json.Unmarshal([]byte(result), &m))
+				require.Equal(t, "webhook-authentication-basic", m["authType"])
+				require.Equal(t, true, m["hasAuth"])
+				require.Equal(t, "post", m["createIncidentMethod"])
+				require.Equal(t, "put", m["updateIncidentMethod"])
+				require.Equal(t, "put", m["createCommentMethod"])
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix default `authType` for cases-webhook connector config in Kibana 9.4
When `authType` is omitted from a cases-webhook connector plan, [connector.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2003/files#diff-66a5829b12c16fa993d5ca8cfe4d1c84c415165d0db37899e13a0eabbd27f837) now initializes it to `webhook-authentication-basic` before applying other defaults. Previously, a nil `authType` caused missing defaults for Kibana 9.4. A new test case in [connector_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2003/files#diff-29af8c632f1eda3cf554ea6f402147e7b59e6de34dbb352b0342c5a3764684f2) verifies the full set of defaults: `authType`, `hasAuth`, `createIncidentMethod`, `updateIncidentMethod`, and `createCommentMethod`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff8af45.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->