### PR TITLE
Add proposal to deterministically setup the agent env

### DIFF
--- a/openspec/changes/bootstrap-verify-openspec-review-env/.openspec.yaml
+++ b/openspec/changes/bootstrap-verify-openspec-review-env/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-27

--- a/openspec/changes/bootstrap-verify-openspec-review-env/design.md
+++ b/openspec/changes/bootstrap-verify-openspec-review-env/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The `ci-aw-openspec-verification` workflow currently relies on markdown instructions to prepare the review environment, and those instructions only cover `npm ci` plus `npx openspec`. That was sufficient while verification stayed narrowly focused on OpenSpec CLI usage, but it breaks down once agent-driven review work or repo scripts need Go tooling that matches `go.mod` or Terraform tooling that matches normal CI behavior. The repository's `lint` job already defines the expected bootstrap shape: checkout, Node from `package.json` engines, Go from `go.mod`, Terraform CLI, and then repo-native setup commands.
+
+This change should make the review environment runner-independent without turning the verification workflow into a second full lint job. The agent should start from a workspace that already has the required toolchains and repository dependencies available.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the `verify-openspec` review environment able to run repo-standard OpenSpec, Go, and Terraform commands without depending on whatever toolchain the base runner happens to provide.
+- Align the review workflow's bootstrap layers with the `lint` job closely enough that future Go version bumps are picked up automatically from `go.mod`.
+- Keep the agent prompt focused on verification behavior instead of ad hoc environment recovery.
+- Preserve the existing review, archive, and cleanup behavior outside the bootstrap path.
+
+**Non-Goals:**
+- Running the full `lint` job or `make check-lint` as part of review verification.
+- Changing review scoring, approval rules, archive behavior, or label cleanup semantics.
+- Reworking unrelated deterministic gating logic already covered by other `ci-aw-openspec-verification` changes.
+
+## Decisions
+
+Bootstrap the core toolchains in the workflow before agent reasoning.
+The workflow should provision Node using `package.json` engines, Go using `go.mod`, and Terraform CLI in the review job before the agent starts. This mirrors the `lint` job's initial setup while letting the Node version follow the repository's declared engine range, and it removes dependence on runner-default Go versions.
+
+Alternative considered: keep toolchain setup in the prompt.
+Rejected because prompt-only setup is easy to drift from CI, harder to audit, and still leaves the run vulnerable to outdated default toolchains before the agent corrects them.
+
+Run `make setup` in the agent workspace after toolchain setup.
+The workflow should run `make setup` in the same workspace the agent will use, so `npx openspec` resolves locally and Go commands see downloaded module dependencies through the repository's standard bootstrap path. This keeps the review workflow aligned with existing repo setup conventions without escalating all the way to `make check-lint`.
+
+Alternative considered: run only `npm ci` or a narrower custom subset of setup commands.
+Rejected because that fixes OpenSpec CLI availability but does not clearly commit the workflow to the repository's existing bootstrap contract, and it leaves more room for drift from the `make setup` path maintainers already use.
+
+Alternative considered: run `make check-lint`.
+Rejected because it couples review bootstrap to full lint execution, adds significant runtime, and changes the purpose of the verification workflow.
+
+Use repository-standard bootstrap commands instead of bespoke installation logic where practical.
+The workflow should prefer repo-native setup commands or their direct equivalents from `Makefile` so review setup follows the same maintenance path as CI expectations.
+
+Alternative considered: hard-code independent dependency installation commands in the workflow.
+Rejected because it would duplicate bootstrap logic and make future dependency changes easier to miss.
+
+## Risks / Trade-offs
+
+- Extra bootstrap work on each qualifying review run -> Limit setup to the toolchain and dependency steps needed for verification, not the full lint target.
+- Review setup may still drift if `lint` changes substantially -> Anchor the workflow changes to the same Node, Go, and Terraform setup pattern used in `.github/workflows/test.yml`.
+- `make setup` may install slightly more than verification strictly needs -> Accept modest extra setup cost in exchange for lower drift and fewer ad hoc environment failures.
+- Toolchain setup must happen in the agent workspace, not a separate pre-activation job -> Keep dependency installation in the review job so the agent sees the prepared workspace directly.
+
+## Migration Plan
+
+- Update the `ci-aw-openspec-verification` delta spec to require repo-standard runtime provisioning plus `make setup` before agent verification.
+- Update `.github/workflows/openspec-verify-label.md` to add the `lint`-like toolchain setup layers and revise repository setup instructions accordingly.
+- Recompile `.github/workflows/openspec-verify-label.lock.yml` with `gh aw compile`.
+- Validate that the generated workflow still preserves the existing review and cleanup flow while exposing the new bootstrap behavior.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/bootstrap-verify-openspec-review-env/proposal.md
+++ b/openspec/changes/bootstrap-verify-openspec-review-env/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `openspec-verify-label` review workflow currently tells the agent to install only Node dependencies before verification, even though repository checks and agent-invoked commands can rely on Go and Terraform tooling as well. Because the repository now declares `go 1.26.1`, review runs that fall back to the runner's default Go installation can fail before verification work even starts.
+
+## What Changes
+
+- Update the OpenSpec verification workflow contract so the review environment bootstraps the same core toolchain layers as the `lint` job before the agent begins reasoning.
+- Require the review path to provision Node using the version range declared in `package.json` engines, Go from `go.mod`, and Terraform CLI in a way that does not depend on runner-default language versions.
+- Require the review workflow to run `make setup` in the review workspace after those runtimes are installed so `npx openspec` and agent-invoked Go commands can run against repo-standard dependencies.
+- Regenerate the compiled `.github/workflows/openspec-verify-label.lock.yml` after the source workflow is updated.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `ci-aw-openspec-verification`: bootstrap the review environment with repo-standard Node, Go, Terraform, and dependency setup before agent verification starts
+
+## Impact
+
+- `.github/workflows/openspec-verify-label.md`
+- `.github/workflows/openspec-verify-label.lock.yml`
+- Review-environment bootstrap behavior for `verify-openspec` runs
+- Alignment with the `lint` job's initial setup in `.github/workflows/test.yml`
+- Repository bootstrap commands referenced from `Makefile`

--- a/openspec/changes/bootstrap-verify-openspec-review-env/specs/ci-aw-openspec-verification/spec.md
+++ b/openspec/changes/bootstrap-verify-openspec-review-env/specs/ci-aw-openspec-verification/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Review environment bootstraps repository toolchains
+The workflow SHALL provision the same core toolchain layers as the `lint` job before agent verification begins. At a minimum, the review environment SHALL set up Node using the version range declared in `package.json` engines, Go using the version declared in `go.mod`, and Terraform CLI with wrapper behavior disabled so agent-executed commands do not depend on runner-default toolchains.
+
+#### Scenario: Node toolchain follows the repository declaration
+- **GIVEN** the repository declares a Node version range in `package.json` engines
+- **WHEN** the `verify-openspec` review environment is prepared
+- **THEN** the Node runtime available to the agent SHALL satisfy that declared engine range
+
+#### Scenario: Go toolchain follows the repository declaration
+- **GIVEN** the repository declares a Go version in `go.mod`
+- **WHEN** the `verify-openspec` review environment is prepared
+- **THEN** the Go toolchain available to the agent SHALL satisfy the version declared in `go.mod`
+
+#### Scenario: Terraform CLI matches repository CI expectations
+- **GIVEN** the review workflow uses repository scripts or commands that require Terraform CLI behavior consistent with CI
+- **WHEN** the review environment is prepared
+- **THEN** Terraform SHALL be available in that environment without wrapper behavior enabled
+
+### Requirement: Review environment installs repository dependencies before verification
+Before the agent performs verification, the workflow SHALL run `make setup` in the agent workspace after runtime provisioning completes. This bootstrap SHALL make `npx openspec` available locally and SHALL prepare repository Go dependencies needed by agent-invoked Go commands through the repository's standard setup path.
+
+#### Scenario: Review workspace runs repository setup
+- **GIVEN** a qualifying `verify-openspec` run reaches the review job after Node, Go, and Terraform have been provisioned
+- **WHEN** the workflow prepares the repository for agent verification
+- **THEN** it SHALL run `make setup` in the review workspace before agent reasoning begins
+
+#### Scenario: OpenSpec CLI is ready in the agent workspace
+- **GIVEN** a qualifying `verify-openspec` run reaches the review job
+- **WHEN** `make setup` completes
+- **THEN** the agent SHALL be able to run `npx openspec status --change "<id>"` without first performing ad hoc dependency installation in the prompt
+
+#### Scenario: Agent-invoked Go commands use prepared dependencies
+- **GIVEN** verification work invokes `go test` or another repository Go command
+- **WHEN** `make setup` has completed in the review workspace
+- **THEN** that command SHALL run against the provisioned Go toolchain and repository dependencies instead of failing solely because the base runner lacked the required Go version or module setup

--- a/openspec/changes/bootstrap-verify-openspec-review-env/tasks.md
+++ b/openspec/changes/bootstrap-verify-openspec-review-env/tasks.md
@@ -1,0 +1,14 @@
+## 1. Update the workflow contract
+
+- [ ] 1.1 Update `.github/workflows/openspec-verify-label.md` so the review job provisions Node from `package.json` engines, Go from `go.mod`, and Terraform CLI in the same shape as the `lint` job bootstrap.
+- [ ] 1.2 Revise the workflow's repository setup instructions and job steps so the review workspace runs `make setup` after runtime provisioning instead of relying on `npm ci` alone.
+
+## 2. Regenerate generated workflow artifacts
+
+- [ ] 2.1 Recompile `.github/workflows/openspec-verify-label.lock.yml` from the markdown source with `gh aw compile`.
+- [ ] 2.2 Inspect the regenerated lock file to confirm the review job includes the expected toolchain bootstrap and dependency-preparation steps.
+
+## 3. Validate the change
+
+- [ ] 3.1 Run the relevant OpenSpec validation checks for the new change artifacts.
+- [ ] 3.2 Verify the updated review workflow no longer depends on the runner's default Go installation and that `make setup` completes successfully before agent-invoked repository commands run.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add proposal to deterministically provision the agent review environment before OpenSpec verification
Adds a design proposal and specification for bootstrapping the `verify-openspec` review environment before agent reasoning runs. The proposal requires provisioning Node (from `package.json` engines), Go (from `go.mod`), and Terraform CLI, then running `make setup` in the agent workspace so that `npx openspec` and Go commands use prepared dependencies rather than runner defaults. Includes a [design doc](https://github.com/elastic/terraform-provider-elasticstack/pull/2035/files#diff-09b5a9245b8f27019d1d5da6aed182f390b36a7df18e9b222e173bc1bbe3b4bd), [proposal](https://github.com/elastic/terraform-provider-elasticstack/pull/2035/files#diff-6cfc6c919c288e0167d59be4beddcffe14f5230bfff539eb1222b039a8031b36), [spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2035/files#diff-e24882a2117cb3f01740cd3350ab0d27d14226c908c85068c8cc4f6091afb599), and a [task checklist](https://github.com/elastic/terraform-provider-elasticstack/pull/2035/files#diff-88d282225cc9333f7382286615681f8a5895c9aab8e9fa93b917a5a46cbea7bc) for updating and regenerating the affected workflow artifacts.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff57099.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->