### PR TITLE
Use the remove-label safe output

### DIFF
--- a/openspec/changes/remove-verify-openspec-label-via-safe-output/.openspec.yaml
+++ b/openspec/changes/remove-verify-openspec-label-via-safe-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-30

--- a/openspec/changes/remove-verify-openspec-label-via-safe-output/design.md
+++ b/openspec/changes/remove-verify-openspec-label-via-safe-output/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The `openspec-verify-label` workflow currently removes `verify-openspec` with a dedicated `completion_cleanup` job that runs `actions/github-script` against a custom inline script. GitHub Agentic Workflows already provide a built-in `remove-labels` safe output for issue and pull request label mutation, so the workflow can express the same behavior declaratively in frontmatter and in the agent prompt instead of carrying a bespoke cleanup job.
+
+This workflow already depends on safe outputs for review submission and branch updates. Folding label cleanup into that same mechanism keeps post-run mutations in one contract, but it also means label removal is requested by the agent rather than guaranteed by a terminal non-agent job.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the dedicated label-removal job and script with the built-in `remove-labels` safe output.
+- Keep label cleanup scoped to the triggering pull request and the single `verify-openspec` label.
+- Update the agent instructions so label removal is part of the workflow's declared safe-output behavior.
+
+**Non-Goals:**
+- Changing review, archive, push, or change-selection semantics.
+- Broadening label mutation beyond `verify-openspec`.
+- Preserving the old terminal-job cleanup behavior for runs that never reach agent completion.
+
+## Decisions
+
+Declare `remove-labels` in workflow safe outputs.
+The workflow should add a `remove-labels` safe-output block with `target: triggering`, `allowed: [verify-openspec]`, and a low `max` suitable for a single cleanup action. This matches the built-in capability described in the GitHub Agentic Workflows safe-outputs reference and constrains the agent to removing only the workflow's trigger label.
+
+Alternative considered: keep the existing `completion_cleanup` job.
+Rejected because it duplicates safe-output behavior with extra workflow YAML, a custom script include, and a separate permission-bearing job.
+
+Move cleanup instructions into the agent prompt.
+The markdown prompt should explicitly tell the agent to emit the `remove-labels` safe output for `verify-openspec` as part of its terminal handling for the triggering pull request. That keeps the cleanup contract visible alongside the existing review and push safe outputs.
+
+Alternative considered: rely on the safe-output declaration without prompt guidance.
+Rejected because the agent needs explicit instructions to actually request the label-removal operation.
+
+Remove the bespoke cleanup implementation.
+The source workflow template and regenerated lock file should no longer define `completion_cleanup` or reference the inline label-removal script. After the change, label mutation should flow only through safe outputs.
+
+Alternative considered: keep the cleanup job as fallback for skipped or failed agent runs.
+Rejected for this change because the requested simplification is specifically to remove the extra job and use `remove-labels` instead.
+
+## Risks / Trade-offs
+
+- Agent-skipped or agent-failed runs will no longer have a separate terminal cleanup path -> Accept this narrower contract for now and document that cleanup occurs through agent-emitted safe outputs rather than an unconditional final job.
+- Safe-output misuse could remove the wrong label -> Constrain the workflow with `allowed: [verify-openspec]` and instruct the agent to remove only that label.
+- Workflow behavior moves from a script to prompt plus frontmatter -> Update the spec delta so future edits treat safe-output cleanup as part of the canonical workflow contract.

--- a/openspec/changes/remove-verify-openspec-label-via-safe-output/proposal.md
+++ b/openspec/changes/remove-verify-openspec-label-via-safe-output/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The `openspec-verify-label` workflow currently removes `verify-openspec` with a separate `completion_cleanup` job and an inline script. That duplicates behavior the agentic workflow can already express through safe outputs, and it keeps the label-cleanup contract outside the agent prompt and safe-output configuration.
+
+## What Changes
+
+- Update the `openspec-verify-label` workflow contract to remove `verify-openspec` through the `remove-labels` safe output instead of a dedicated cleanup job.
+- Instruct the agent prompt to emit the safe output that removes only the triggering `verify-openspec` label when the run finishes handling the PR.
+- Remove the workflow-specific cleanup script/job that exists only to mutate labels after agent execution.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `ci-aw-openspec-verification`: change trigger-label cleanup from a bespoke completion job to the built-in `remove-labels` safe output contract
+
+## Impact
+
+- `.github/workflows-src/openspec-verify-label/workflow.md.tmpl`
+- Compiled `openspec-verify-label` workflow outputs and permissions
+- `ci-aw-openspec-verification` OpenSpec requirements and any prompt text that defines end-of-run cleanup behavior

--- a/openspec/changes/remove-verify-openspec-label-via-safe-output/specs/ci-aw-openspec-verification/spec.md
+++ b/openspec/changes/remove-verify-openspec-label-via-safe-output/specs/ci-aw-openspec-verification/spec.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: Permissions for read, review, and push (REQ-003)
+
+The workflow SHALL request permissions sufficient to read the repository, submit pull request reviews and review comments, push commits to the pull request branch via `push-to-pull-request-branch`, and remove the `verify-openspec` label from the triggering pull request via the `remove-labels` safe output. At minimum this SHALL include `contents: write`, `pull-requests: write`, and `issues: write` unless the agentic compiler emits a narrower equivalent that still allows those operations.
+
+#### Scenario: Push safe output and label cleanup are permitted
+
+- GIVEN the agent archives the change and produces a commit on the PR branch
+- WHEN `push-to-pull-request-branch` and `remove-labels` safe outputs run
+- THEN the token SHALL have authority to push to the PR head branch and mutate the triggering pull request label set under normal repository settings
+
+### Requirement: Safe outputs for review and push (REQ-004)
+
+The workflow SHALL declare safe outputs for:
+
+- `create-pull-request-review-comment` with `max` large enough for verification and unassociated-file commentary.
+- `submit-pull-request-review` with `max: 1` and `target` appropriate to the triggering pull request.
+- `push-to-pull-request-branch` with `max: 1` (or documented policy) and `target: triggering`, plus any `checkout` `fetch` / `title-prefix` / `labels` required by repository policy and [GitHub Agentic Workflows - Push to PR branch](https://github.github.io/gh-aw/reference/safe-outputs-pull-requests/#push-to-pr-branch-push-to-pull-request-branch).
+- `remove-labels` with `target: triggering`, `allowed` constrained to `verify-openspec`, and a `max` that permits the single trigger-label cleanup action.
+
+#### Scenario: One review decision per run
+
+- GIVEN one workflow run completes verification
+- WHEN reviews are submitted
+- THEN at most one final submitted pull request review SHALL represent the approval decision before any archive push
+
+#### Scenario: Cleanup output is limited to the trigger label
+
+- GIVEN the workflow requests label cleanup through safe outputs
+- WHEN `remove-labels` is evaluated
+- THEN the workflow configuration SHALL allow removal of `verify-openspec` and SHALL NOT require broader label-removal authority
+
+### Requirement: Remove trigger label after workflow completion (REQ-015)
+
+For a run triggered by applying the `verify-openspec` label, the workflow SHALL instruct the agent to request removal of that same label from the triggering pull request through the `remove-labels` safe output before the agent concludes its handling of the pull request. The cleanup request SHALL remove only `verify-openspec`; it SHALL NOT remove unrelated pull request labels, and the workflow SHALL NOT rely on a separate post-agent cleanup script or job for this behavior.
+
+#### Scenario: Approved run requests trigger label cleanup
+
+- GIVEN a `verify-openspec`-triggered run submits an `APPROVE` review and completes archive or push handling as applicable
+- WHEN the agent emits its final safe outputs for the run
+- THEN those outputs SHALL include removal of the `verify-openspec` label from the triggering pull request
+
+#### Scenario: Non-approval run requests trigger label cleanup
+
+- GIVEN a `verify-openspec`-triggered run ends with `COMMENT` or `noop` after agent handling begins
+- WHEN the agent emits its final safe outputs for the run
+- THEN those outputs SHALL include removal of the `verify-openspec` label from the triggering pull request

--- a/openspec/changes/remove-verify-openspec-label-via-safe-output/tasks.md
+++ b/openspec/changes/remove-verify-openspec-label-via-safe-output/tasks.md
@@ -1,0 +1,15 @@
+## 1. Replace bespoke label cleanup in the workflow source
+
+- [ ] 1.1 Update `.github/workflows-src/openspec-verify-label/workflow.md.tmpl` to declare `remove-labels` safe output for the triggering pull request, constrained to `verify-openspec`.
+- [ ] 1.2 Revise the workflow prompt so the agent requests `remove-labels` cleanup as part of its terminal safe outputs and remove prompt text that assumes a separate completion cleanup phase.
+- [ ] 1.3 Remove the dedicated `completion_cleanup` job and any inline-script references that exist only to remove `verify-openspec`.
+
+## 2. Regenerate derived workflow artifacts
+
+- [ ] 2.1 Recompile the generated `openspec-verify-label` workflow outputs so the committed lock file matches the updated markdown template.
+- [ ] 2.2 Delete or stop compiling any obsolete helper artifact that existed only for the removed label-cleanup script path.
+
+## 3. Validate the new cleanup contract
+
+- [ ] 3.1 Run the relevant OpenSpec and workflow validation checks to confirm the delta spec, workflow source, and compiled outputs stay aligned.
+- [ ] 3.2 Verify the updated workflow still has the permissions needed for review submission, push-to-PR-branch, and `remove-labels` cleanup without the old completion job.


### PR DESCRIPTION
The script isn't working because of permissions, this is a more clearly supported path

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `completion_cleanup` job with `remove-labels` safe output in openspec verification workflow
> - Replaces the bespoke `completion_cleanup` job and inline script with the built-in `remove-labels` safe output to remove the `verify-openspec` label after a run.
> - Declares `remove-labels` in the workflow with `target: triggering` and `allowed: [verify-openspec]`, and moves cleanup instructions into the agent prompt.
> - Adds spec requirements (REQ-003, REQ-004, REQ-015) covering permissions, safe output declaration, and agent behavior for both approval and non-approval runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f655d7c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->