### PR TITLE
fix(alertingrule): allow searchConfiguration in .es-query rule params validation

### DIFF
--- a/internal/kibana/alertingrule/validate.go
+++ b/internal/kibana/alertingrule/validate.go
@@ -155,11 +155,17 @@ var ruleTypeAdditionalAllowedParamsKeys = map[string][]string{
 	// currently missing from generated `.es-query` params models.
 	// TODO: remove when upstream Kibana schema includes this key.
 	// Tracking: https://github.com/elastic/kibana/issues/252451
+	// UI-created .es-query rules using searchSource form carry searchConfiguration
+	// with nested filter arrays. The generated Filter.Meta.Params type is
+	// map[string]interface{} which cannot decode a JSON array (combined/phrases
+	// filter types); stripping the field before validation avoids false failures.
+	// The raw field is preserved in the API payload so push_rules is unaffected.
+	// TODO: remove when the generated Filter.Meta.Params type supports array values.
 	// Kibana's runtime API accepts termField for ESQL rules (per-group alerting),
 	// but the generated ESQL params struct omits it.
 	// TODO: remove when upstream Kibana schema includes this key.
 	// Tracking: https://github.com/elastic/kibana/issues/252451
-	".es-query": {"sourceFields"},
+	".es-query": {"sourceFields", "searchConfiguration"},
 	// Kibana accepts this convenience field alongside filterQuery in metrics
 	// threshold rules.
 	"metrics.alert.threshold": {"filterQueryText"},

--- a/internal/kibana/alertingrule/validate_test.go
+++ b/internal/kibana/alertingrule/validate_test.go
@@ -698,3 +698,36 @@ func TestValidateRuleParamsFixturesFromClusterMgmtCustomers(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateRuleParamsEsQuerySearchSource verifies that .es-query rules using
+// searchType=searchSource pass validation even when searchConfiguration contains
+// combined/phrases filters whose meta.params field is a JSON array rather than
+// the map[string]interface{} the generated struct expects.
+func TestValidateRuleParamsEsQuerySearchSource(t *testing.T) {
+	params := map[string]any{
+		"aggType": "count", "excludeHitsFromPreviousRun": false, "groupBy": "all",
+		"searchType": "searchSource", "size": float64(100), "sourceFields": []any{},
+		"termSize": float64(5), "threshold": []any{float64(3)},
+		"thresholdComparator": ">", "timeField": "@timestamp",
+		"timeWindowSize": float64(1), "timeWindowUnit": "m",
+		"searchConfiguration": map[string]any{
+			"index": "98ae3207", "query": map[string]any{"language": "lucene", "query": ""},
+			"filter": []any{map[string]any{
+				"$state": map[string]any{"store": "appState"}, "query": map[string]any{},
+				"meta": map[string]any{
+					"alias": nil, "disabled": false, "negate": false,
+					"index": "98ae3207", "relation": "AND", "type": "combined",
+					"params": []any{
+						map[string]any{"meta": map[string]any{"type": "phrase", "key": "service.environment"}, "query": map[string]any{}},
+						map[string]any{"meta": map[string]any{"type": "phrase", "key": "service.name"}, "query": map[string]any{}},
+					},
+				},
+			}},
+		},
+	}
+	errs := validateRuleParams(".es-query", params)
+	if len(errs) > 0 {
+		raw, _ := json.Marshal(params)
+		t.Fatalf("expected no validation errors for searchSource rule with combined filter, got: %v\nparams: %s", errs, string(raw))
+	}
+}


### PR DESCRIPTION
## Problem

When a `.es-query` alert rule is created or managed via the Kibana UI using
`searchType=searchSource`, Kibana stores the rule with a `searchConfiguration`
field in its params. This field contains a nested `filter` array where each
filter's `meta.params` can be a JSON array (produced by `combined` and `phrases`
filter types).

The generated `Filter.Meta.Params` type is `map[string]interface{}`, which
cannot unmarshal a JSON array. As a result, `terraform plan` fails with:

    params do not match expected generated schema: json: cannot unmarshal
    array into Go struct field .searchConfiguration.filter.meta.params

This affects any user who created an ES query alert rule using the Kibana UI
filter builder with compound filter conditions, then attempts to manage that
rule through terraform.

## Fix

Add `searchConfiguration` to the `ruleTypeAdditionalAllowedParamsKeys` allowlist
for `.es-query`, alongside the existing `sourceFields` entry. The `stripKeys`
function removes the field before the params are unmarshalled into the generated
struct, avoiding the type mismatch. The raw field value is preserved in the API
payload, so the actual rule definition sent to Kibana is unaffected.

This follows the same pattern already used for `sourceFields` (and `filterQueryText`
for metrics threshold rules).

## Root cause

The generated `Filter.Meta.Params` type does not support array values. A proper
fix would require updating the generated Kibana client types to handle the
`combined`/`phrases` filter case. This workaround should be removed once the
generated Filter.Meta.Params type supports array values.

## Testing

Added `TestValidateRuleParamsEsQuerySearchSource` to `validate_test.go`. The test
constructs a realistic `.es-query` rule payload with `searchType=searchSource` and
a `combined` filter whose `meta.params` is a JSON array, and asserts that
`validateRuleParams` returns no errors.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `searchConfiguration` in `.es-query` alerting rule params validation
> Adds `searchConfiguration` to the list of allowed top-level params for `.es-query` rules in [validate.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2073/files#diff-7f8501f204f49b0d3988128ad04d3424ca2ffdeebeb9a0e4823f6586b88ce9ce). UI-created `.es-query` rules using `searchSource` include this field, which previously caused validation to flag it as an unexpected parameter. A new test covers the `searchType=searchSource` payload with a nested `searchConfiguration` containing a filter where `meta.params` is an array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9aef227.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->