### PR TITLE
Fix golangci-lint targeting

### DIFF
--- a/openspec/changes/golangci-lint-all-go-code/.openspec.yaml
+++ b/openspec/changes/golangci-lint-all-go-code/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-31

--- a/openspec/changes/golangci-lint-all-go-code/design.md
+++ b/openspec/changes/golangci-lint-all-go-code/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The current canonical `makefile-workflows` spec says the `golangci-lint` target only lints code under `internal/`, but the root `Makefile` already invokes golangci-lint against `./...`. That mismatch leaves the published requirement narrower than the implemented contributor and CI behavior.
+
+This change is intentionally small and localized. It updates the `makefile-workflows` contract so the documented lint scope matches the repository's actual Go module layout and the Makefile behavior used by `make lint` and `make check-lint`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define `golangci-lint` as repository-wide linting over `./...`.
+- Preserve the existing distinction between `lint` fix mode and `check-lint` check-only mode.
+- Keep the spec aligned with the existing Makefile behavior so contributors and CI share the same contract.
+
+**Non-Goals:**
+- Changing which linters are enabled in `.golangci.yaml`.
+- Redesigning `lint` / `check-lint` ordering beyond the scope statement they already inherit.
+- Expanding requirements for non-Go validation steps such as docs, formatting, workflows, or OpenSpec checks.
+
+## Decisions
+
+### Treat `./...` as the observable lint scope
+
+The requirement should describe the `golangci-lint` target in terms of the Go module-wide package pattern `./...`, because that is the observable invocation contract contributors and CI rely on. This makes top-level packages such as `provider/`, `scripts/`, `xpprovider/`, and the module root part of the lint surface instead of implying that only `internal/` matters.
+
+Alternative considered: describe the scope generically as "all repository Go code" without naming `./...`. Rejected because the user explicitly requested the `./...` contract, and the concrete package pattern is the clearest externally visible behavior.
+
+### Preserve config-driven exclusions rather than restating them in the spec
+
+The spec should require repository-wide linting while allowing golangci-lint's configured exclusions to continue shaping which paths are actually analyzed. That keeps the contract aligned with `.golangci.yaml` without hardcoding every excluded path into the requirement text.
+
+Alternative considered: enumerate excluded directories in the requirement. Rejected because exclusions are configuration details that may evolve independently, while the stable contract is that the target runs from `./...` under repository configuration.
+
+## Risks / Trade-offs
+
+- Repository-wide linting may surface issues in packages outside `internal/` that were not previously captured by the old spec text -> Mitigation: this is the intended correction, and the Makefile already reflects the broader scope today.
+- Referring to `./...` depends on Go package discovery semantics rather than a hand-maintained directory list -> Mitigation: that is the standard Go module-wide contract and better matches contributor expectations than a narrower hardcoded path.

--- a/openspec/changes/golangci-lint-all-go-code/proposal.md
+++ b/openspec/changes/golangci-lint-all-go-code/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The current `makefile-workflows` requirements say the `golangci-lint` target only scans `internal/`, which no longer matches the intended repository-wide linting contract for a Go module with code in multiple top-level packages. The spec should require `golangci-lint` to evaluate all Go packages under `./...` so contributor and CI validation cover the full repository.
+
+## What Changes
+
+- Update the `makefile-workflows` requirements so the `golangci-lint` target is specified against repository-wide Go code (`./...`) rather than only `internal/`.
+- Clarify the observable behavior of `lint` and `check-lint` so both paths inherit that full-repository lint scope, with `lint` still enabling fix mode and `check-lint` remaining check-only.
+- Align the Makefile implementation with the updated requirement so local and CI lint runs cover all Go packages in the module.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `makefile-workflows`: Change the golangci-lint requirement from `internal/`-only linting to repository-wide `./...` linting for all Go code.
+
+## Impact
+
+Affected areas include the canonical `makefile-workflows` spec, the root `Makefile` lint recipes, and any contributor or CI workflows that rely on `make lint` or `make check-lint` for Go validation.

--- a/openspec/changes/golangci-lint-all-go-code/specs/makefile-workflows/spec.md
+++ b/openspec/changes/golangci-lint-all-go-code/specs/makefile-workflows/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: golangci-lint execution (REQ-041–REQ-043)
+
+The `tools` target SHALL provision golangci-lint at the **version pinned in the repository**. The `golangci-lint` target SHALL lint Go code across the repository module using `./...`, while still honoring repository-configured golangci-lint exclusions, with zero tolerance for duplicate identical issues unless `GOLANGCIFLAGS` alters behavior. The `lint` target SHALL enable auto-fix behavior where supported; `check-lint` SHALL not depend on that fix mode for golangci-lint.
+
+#### Scenario: Lint without fix
+
+- GIVEN `make check-lint`
+- WHEN golangci-lint runs
+- THEN it SHALL report issues without the fix-only mode used by `lint`
+
+#### Scenario: Repository-wide Go lint scope
+
+- GIVEN `make golangci-lint`
+- WHEN the target invokes golangci-lint
+- THEN it SHALL run against `./...`
+- AND Go packages outside `internal/` SHALL be part of the lint scope unless excluded by repository golangci-lint configuration

--- a/openspec/changes/golangci-lint-all-go-code/tasks.md
+++ b/openspec/changes/golangci-lint-all-go-code/tasks.md
@@ -1,0 +1,11 @@
+## 1. Align the lint contract
+
+- [ ] 1.1 Update the canonical `openspec/specs/makefile-workflows/spec.md` requirement for `golangci-lint` so it defines repository-wide `./...` linting instead of `internal/`-only linting.
+- [ ] 1.2 Keep the requirement text explicit that `lint` uses fix mode while `check-lint` remains check-only for golangci-lint.
+
+## 2. Align implementation and verification
+
+- [ ] 2.1 Update the root `Makefile` if needed so the `golangci-lint` target runs against `./...` and the aggregate lint targets inherit that scope.
+- [ ] 2.2 Run `make lint` after the lint-scope change so the broader repository-wide target is exercised end to end.
+- [ ] 2.3 Fix any lint errors surfaced by `make lint` so the repository passes under the expanded Go package scope.
+- [ ] 2.4 Run the relevant OpenSpec and lint-oriented checks to confirm the updated spec and Makefile stay aligned with repository behavior.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix golangci-lint to target all Go packages with `./...`
- Adds an OpenSpec change manifest, design doc, proposal, requirements spec, and task list to drive the fix
- Updates the lint requirements (REQ-041–REQ-043) to mandate `./...` scope, distinguish `lint` (fix mode) from `check-lint` (check-only mode), and rely on `.golangci.yml` exclusions rather than path narrowing
- Behavioral Change: lint now runs across the entire repository instead of a subset of packages, which may surface previously hidden lint violations

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f82089f. 11 files reviewed, 4 issues evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>scripts/auto-approve/evaluator_test.go — 0 comments posted, 2 evaluated, 1 filtered</summary>

- [line 44](https://github.com/elastic/terraform-provider-elasticstack/blob/f82089fbbdc5ce38df86452d8d318bf4e2ee6370/scripts/auto-approve/evaluator_test.go#L44): Every `new(value)` call introduced by this diff is a **compile error**. Go's builtin `new` takes a **type**, not a value (e.g., `new(string)` is valid, but `new("open")`, `new(false)`, `new(120)`, and `new(login)` where `login` is a variable are all invalid). The original `github.Ptr(value)` calls were correct — `github.Ptr` is a generic helper `func Ptr[T any](v T) *T` that returns a pointer to the given value. Replacing them with `new(value)` makes the entire test file fail to compile. For example, `new("open")` at line 44 tries to pass a string literal as a type argument to `new`, which is a syntax error. <b>[ Posting failed ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->