### PR TITLE
Proposal adding space_id to private locations

### DIFF
--- a/openspec/changes/add-private-location-space-id/.openspec.yaml
+++ b/openspec/changes/add-private-location-space-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-04

--- a/openspec/changes/add-private-location-space-id/design.md
+++ b/openspec/changes/add-private-location-space-id/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Private location CRUD in `libs/go-kibana-rest/kbapi` builds URLs with `basePath("", privateLocationsSuffix)`, which resolves to the default space (`spaceBasesPath` treats `""` and `"default"` as the non-prefixed path). Synthetics monitors already pass a `space` string into `basePath(space, monitorsSuffix)`, producing `/s/<space_id>/api/synthetics/...` when the space is not default. The Terraform resource `elasticstack_kibana_synthetics_private_location` does not expose a space attribute, so non-default spaces are unreachable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add optional `space_id` on the private location resource, aligned with naming and semantics used by `elasticstack_kibana_synthetics_monitor` (`space_id` optional; empty string means default space).
+- Thread the chosen space through `KibanaSynthetics.PrivateLocation` Create, Get, and Delete so all requests hit the correct space-scoped API paths.
+- Document replacement behavior when `space_id` changes and keep import behavior coherent (import id remains the Kibana private location id; practitioners set `space_id` to match the location’s space).
+
+**Non-Goals:**
+
+- Changing composite import id format to embed space (unless existing patterns in the repo require it—prefer keeping import id as today plus explicit `space_id` in configuration).
+- In-place update support (still unsupported).
+- OpenAPI/generated `kbapi` client migration for this resource.
+
+## Decisions
+
+1. **Extend legacy `kbapi` private location functions with a `space string` parameter** (same order and semantics as monitor APIs: empty and `"default"` map to the default path). **Rationale:** Centralizes URL rules in `spaceBasesPath` and matches established monitor behavior. **Alternatives considered:** Per-request REST path override in the resource only (duplicates logic and risks drift).
+
+2. **`space_id` uses `RequiresReplace` and is stored in state** after create/read. **Rationale:** Changing space implies a different API namespace; same as other identity-related attributes on this resource. **Alternatives considered:** Suppressing replace (would leave state inconsistent with API).
+
+3. **Default when unset:** Omit attribute or set to `""` → default space, consistent with monitor resource patterns in tests and docs.
+
+## Risks / Trade-offs
+
+- **[Risk] Signature change in `kbapi` breaks callers** → **Mitigation:** Update all call sites in-repo (provider + tests under `libs/go-kibana-rest`); run `make build` and targeted tests.
+
+- **[Risk] Acceptance tests may not always create a secondary Kibana space** → **Mitigation:** Follow existing monitor acceptance patterns for space-scoped tests; if stack fixtures lack a second space, document manual verification or skip conditions consistent with `testing.md`.
+
+- **[Risk] Import without `space_id` assumes default space** → **Mitigation:** Document that imported locations in non-default spaces require `space_id` in configuration before refresh; 404 on wrong space surfaces as remove-from-state per existing read behavior.
+
+## Migration Plan
+
+- **Deploy:** Provider upgrade is backward compatible when `space_id` is omitted (default space behavior unchanged).
+- **Rollback:** Revert provider version; state may contain `space_id` attributes—older provider versions may ignore unknown attributes depending on Terraform version and schema; practitioners can remove the attribute from config if needed.
+
+## Open Questions
+
+- None blocking implementation; confirm Elastic version support for space-scoped Synthetics private location APIs matches the existing minimum Kibana version gate for this resource (`8.12.0` in acceptance tests).

--- a/openspec/changes/add-private-location-space-id/proposal.md
+++ b/openspec/changes/add-private-location-space-id/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Synthetics private locations are scoped to a Kibana space via the API path (`/s/<space_id>/api/synthetics/...`). The Terraform resource currently issues all Private Location API calls as if the target were the default space, so practitioners cannot manage locations in non-default spaces. Aligning with `elasticstack_kibana_synthetics_monitor` (which already exposes `space_id`) removes that gap and matches how monitors and locations are used together per space.
+
+## What Changes
+
+- Add an optional Terraform attribute `space_id` on `elasticstack_kibana_synthetics_private_location` that selects the Kibana space for create, read, and delete.
+- When `space_id` is unset or empty, behavior remains the default space (same as today).
+- Changing `space_id` after create SHALL require replacement (consistent with other identity-related attributes on this resource).
+- Extend the legacy Kibana client (`kbapi`) private location helpers to accept a space argument for URL construction, mirroring the monitor API pattern.
+- Update acceptance tests and generated documentation as needed.
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `kibana-synthetics-private-location`: Add requirements for `space_id`, space-scoped API usage, and replacement/import behavior involving the chosen space.
+
+## Impact
+
+- **Code**: `internal/kibana/synthetics/privatelocation/` (schema, CRUD), `libs/go-kibana-rest/kbapi/api.kibana_synthetics.go` (private location function signatures and `basePath` usage), possibly `internal/kibana/synthetics/privatelocation/schema_test.go` and `acc_test.go`.
+- **Tests**: `libs/go-kibana-rest/kbapi` tests if API signatures change; private location acceptance tests for default vs non-default space if the stack test setup supports it.
+- **Docs**: Resource docs generation for the new attribute.
+- **Compatibility**: Non-breaking for existing configs if `space_id` is optional with default-space semantics when omitted.

--- a/openspec/changes/add-private-location-space-id/specs/kibana-synthetics-private-location/spec.md
+++ b/openspec/changes/add-private-location-space-id/specs/kibana-synthetics-private-location/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: `space_id` attribute (REQ-010)
+
+The resource SHALL expose an optional `space_id` string attribute that selects the Kibana space used for create, read, and delete. When `space_id` is omitted or set to an empty string, the provider SHALL use the default Kibana space. When `space_id` is set to a non-empty value, the provider SHALL use that Kibana space for all Synthetics Private Location API calls. The attribute SHALL use plan modifiers such that changing `space_id` requires resource replacement. The provider SHALL persist `space_id` in state from configuration (and reflect it on read as applicable).
+
+#### Scenario: Default space when `space_id` omitted
+
+- GIVEN configuration does not set `space_id` or sets it to an empty string
+- WHEN create, read, or delete runs
+- THEN the provider SHALL issue API requests for the default Kibana space
+
+#### Scenario: Non-default space
+
+- GIVEN configuration sets `space_id` to a non-empty Kibana space identifier
+- WHEN create, read, or delete runs
+- THEN the provider SHALL issue API requests scoped to that space
+
+#### Scenario: Replace on `space_id` change
+
+- GIVEN an existing managed private location
+- WHEN `space_id` changes in configuration
+- THEN Terraform SHALL plan replacement for the resource
+
+### Requirement: Import with non-default space (REQ-011)
+
+When the practitioner imports a private location that exists in a non-default Kibana space, they SHALL configure `space_id` to match that space. The import identifier SHALL remain the Kibana private location id (including existing composite id parsing rules when the id contains `/`).
+
+#### Scenario: Import requires matching `space_id` for non-default space
+
+- GIVEN a private location exists only in a non-default Kibana space
+- WHEN the practitioner runs import with the correct Kibana id but omits `space_id` or uses the wrong space
+- THEN subsequent read MAY receive 404 and the provider SHALL apply existing 404 handling (remove from state) or fail as appropriate; the practitioner SHALL set `space_id` to the correct space for a successful read
+
+## MODIFIED Requirements
+
+### Requirement: Synthetics Private Locations API (REQ-001)
+
+The resource SHALL manage private locations through Kibana's Synthetics Private Locations API: create via the legacy Kibana client's `KibanaSynthetics.PrivateLocation.Create`, read via `KibanaSynthetics.PrivateLocation.Get`, and delete via `KibanaSynthetics.PrivateLocation.Delete`. The provider SHALL pass the effective Kibana space derived from `space_id` (per REQ-010) into these operations so that requests use the correct space-scoped API paths.
+
+#### Scenario: CRUD uses Private Locations API
+
+- GIVEN a managed Synthetics private location
+- WHEN create, read, or delete runs
+- THEN the provider SHALL use the corresponding Kibana Synthetics Private Location API operation with the effective space from `space_id`
+
+### Requirement: All mutable fields require replacement (REQ-007)
+
+Changes to `id`, `label`, `agent_policy_id`, `tags`, or `space_id` SHALL each require resource replacement rather than an in-place update. The `geo` block does not carry `RequiresReplace` independently but changes to it in practice trigger replacement through the interaction with REQ-006 (update not supported).
+
+#### Scenario: Replace on `label` change
+
+- GIVEN an existing managed private location
+- WHEN `label` changes in configuration
+- THEN Terraform SHALL plan replacement for the resource
+
+#### Scenario: Replace on `agent_policy_id` change
+
+- GIVEN an existing managed private location
+- WHEN `agent_policy_id` changes in configuration
+- THEN Terraform SHALL plan replacement for the resource
+
+#### Scenario: Replace on `tags` change
+
+- GIVEN an existing managed private location
+- WHEN `tags` changes in configuration
+- THEN Terraform SHALL plan replacement for the resource
+
+#### Scenario: Replace on `space_id` change
+
+- GIVEN an existing managed private location
+- WHEN `space_id` changes in configuration
+- THEN Terraform SHALL plan replacement for the resource

--- a/openspec/changes/add-private-location-space-id/tasks.md
+++ b/openspec/changes/add-private-location-space-id/tasks.md
@@ -1,0 +1,17 @@
+## 1. API client (`kbapi`)
+
+- [ ] 1.1 Add a `space string` parameter to `KibanaSyntheticsPrivateLocationCreate`, `Get`, and `Delete` function types and implementations, passing it into `basePath` / `basePathWithId` instead of a hard-coded empty string.
+- [ ] 1.2 Update `libs/go-kibana-rest/kbapi` tests that call private location APIs to pass space (including default-space cases).
+- [ ] 1.3 Run targeted tests for `kbapi` package and fix any compile errors at other call sites.
+
+## 2. Terraform resource
+
+- [ ] 2.1 Add optional `space_id` to `tfModelV0` and `privateLocationSchema()` with `RequiresReplace` and documentation consistent with synthetics monitor `space_id`.
+- [ ] 2.2 Thread `space_id` into Create, Read, and Delete via the updated `kbapi` functions; map read response to state including `space_id`.
+- [ ] 2.3 Extend `schema_test.go` (and any model round-trips) for `space_id` default and non-empty values.
+- [ ] 2.4 Add or extend acceptance test coverage for default vs non-default space per project testing conventions (`dev-docs/high-level/testing.md`).
+
+## 3. Documentation and validation
+
+- [ ] 3.1 Regenerate or update resource documentation so `space_id` appears in the provider docs.
+- [ ] 3.2 Run `make build` and `make check-openspec` (or `openspec validate` for this change) before merge.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add optional `space_id` attribute to `elasticstack_kibana_synthetics_private_location`
- Adds a design proposal and OpenSpec change set for introducing an optional `space_id` field on the Synthetics private location resource.
- New requirements (REQ-010, REQ-011) define selection semantics, replace-on-change behavior, and import constraints requiring a matching space.
- Existing requirements REQ-001 and REQ-007 are updated to use the space-scoped Private Locations API and replacement semantics when `space_id` changes.
- Includes a task list covering `kbapi` signature changes, Terraform schema/resource updates, tests, and documentation.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized fba957f.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->