### PR TITLE
Use label_command rather than a filtered PR trigger

### DIFF
--- a/openspec/changes/verify-openspec-label-command/.openspec.yaml
+++ b/openspec/changes/verify-openspec-label-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-06

--- a/openspec/changes/verify-openspec-label-command/design.md
+++ b/openspec/changes/verify-openspec-label-command/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The current `openspec-verify-label` workflow is written as a filtered `pull_request` `labeled` trigger, then performs an explicit pre-activation label check and later asks the agent to remove `verify-openspec` through `remove-labels`. That was necessary when the workflow modeled the label as normal PR state, but it now duplicates behavior provided by GitHub Agentic Workflows `label_command`.
+
+This change needs to preserve the rest of the workflow contract: PR-only activation, deterministic active-change selection, review submission, and archive/push behavior. The change should narrow scope to trigger mechanics and cleanup semantics without altering verification behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Use `label_command` as the canonical trigger for `verify-openspec`.
+- Keep activation limited to pull requests only.
+- Remove workflow configuration and prompt instructions that only exist to clean up the trigger label manually.
+- Preserve change-selection, review, archive, and push behavior once the workflow is activated.
+
+**Non-Goals:**
+- Changing how the workflow selects an active OpenSpec change from PR files.
+- Changing approval vs comment-only disposition rules.
+- Changing archive, commit, or push behavior after review submission.
+- Expanding the trigger to issues or discussions.
+
+## Decisions
+
+Use `label_command` with the `verify-openspec` label and `events: [pull_request]`.
+This makes the workflow explicitly model `verify-openspec` as a one-shot command on pull requests instead of a generic `labeled` event plus custom filtering. It keeps PR-only behavior while letting the compiler inject the label-removal flow automatically.
+
+Alternative considered: keep `pull_request.types: [labeled]` with `names: [verify-openspec]`.
+Rejected because it preserves the old custom trigger path and manual cleanup contract instead of using the built-in command semantics.
+
+Remove the dedicated label-verification gate from pre-activation outputs.
+Because `label_command` already matches the target label, the workflow should no longer need a custom `verify_label` step, corresponding outputs, or an agent-job condition that depends on them. The remaining deterministic gate should be active-change selection eligibility.
+
+Alternative considered: keep the explicit label verification step as defense in depth.
+Rejected because it duplicates the trigger contract, adds prompt and output complexity, and increases maintenance burden without changing the allowed activation surface.
+
+Remove `remove-labels` from safe outputs and delete end-of-run cleanup instructions from the prompt.
+Under `label_command`, label removal is managed by workflow activation behavior rather than by terminal agent outputs. The prompt should therefore stop instructing the agent to emit label cleanup, and the workflow should no longer request label-removal authority for the agent.
+
+Alternative considered: retain `remove-labels` as a fallback cleanup path.
+Rejected because it would overlap with `label_command` and keep unnecessary permission and prompt surface area.
+
+Preserve the rest of the workflow body and generated outputs unless they depend specifically on label verification or manual cleanup.
+The active-change selection step, review instructions, review safe outputs, archive behavior, and push behavior should remain intact so the change is low risk and easy to verify.
+
+Alternative considered: refactor broader workflow structure while touching the trigger.
+Rejected because it would increase risk and make it harder to validate that only trigger semantics changed.
+
+## Risks / Trade-offs
+
+- `label_command` compilation may inject slightly different generated workflow structure than the current hand-authored trigger model -> Regenerate the compiled workflow and review both the markdown source and `.lock.yml` for unexpected permission or activation changes.
+- Removing the old label-verification step could hide assumptions in prompt text or job conditions -> Update the prompt and pre-activation outputs together so no references to `label_verified` remain.
+- Automatic label removal now happens as part of trigger handling rather than agent terminal outputs -> Capture that contract explicitly in the OpenSpec delta so future changes do not reintroduce manual cleanup.

--- a/openspec/changes/verify-openspec-label-command/proposal.md
+++ b/openspec/changes/verify-openspec-label-command/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The `openspec-verify-label` workflow currently models `verify-openspec` as a filtered `pull_request:labeled` event and then asks the agent to remove that label through `remove-labels` safe output cleanup. GitHub Agentic Workflows already provide `label_command` for this pattern, so the workflow can use the built-in one-shot label trigger and drop redundant cleanup behavior from both frontmatter and prompt instructions.
+
+## What Changes
+
+- Change the `openspec-verify-label` workflow trigger from filtered `pull_request` `labeled` events to `label_command` for the `verify-openspec` label.
+- Restrict the new trigger to pull requests only so the workflow keeps its current PR-only activation behavior.
+- Remove the explicit trigger-label verification and cleanup contract that exists only to support the old `labeled` trigger path.
+- Remove the `remove-labels` safe output and any agent instructions that tell the workflow to clean up `verify-openspec` at the end of a run.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `ci-aw-openspec-verification`: change the verify workflow from a filtered `labeled` trigger plus agent-managed cleanup to a PR-only `label_command` trigger with built-in label removal
+
+## Impact
+
+- `.github/workflows-src/openspec-verify-label/workflow.md.tmpl`
+- Generated `openspec-verify-label` workflow artifacts under `.github/workflows/`
+- `openspec/specs/ci-aw-openspec-verification/spec.md`
+- Any workflow prompt text or deterministic setup that currently depends on explicit trigger-label verification or `remove-labels`

--- a/openspec/changes/verify-openspec-label-command/specs/ci-aw-openspec-verification/spec.md
+++ b/openspec/changes/verify-openspec-label-command/specs/ci-aw-openspec-verification/spec.md
@@ -1,0 +1,75 @@
+## MODIFIED Requirements
+
+### Requirement: Label trigger (REQ-002)
+The workflow SHALL use `label_command` for the `verify-openspec` label and SHALL restrict that command to `pull_request` events only. Applying `verify-openspec` to a pull request SHALL activate the workflow's verification path for that pull request, and labels other than `verify-openspec` SHALL NOT activate this workflow. The workflow SHALL NOT rely on a separate deterministic label-verification step to confirm the trigger label after activation.
+
+#### Scenario: Correct label runs automation on pull requests
+- **GIVEN** a pull request receives the label `verify-openspec`
+- **WHEN** the `label_command` trigger activates
+- **THEN** the workflow SHALL mark the run eligible for the agentic verification path subject to the remaining deterministic change-selection gate
+
+#### Scenario: Other labels do not start verification
+- **GIVEN** a pull request receives a label other than `verify-openspec`
+- **WHEN** pull request labeling activity occurs
+- **THEN** this workflow SHALL NOT activate for that label
+
+#### Scenario: Non-pull-request items are out of scope
+- **GIVEN** an issue or discussion receives the label `verify-openspec`
+- **WHEN** labeling activity occurs
+- **THEN** this workflow SHALL NOT activate because the command is configured for pull requests only
+
+### Requirement: Permissions for read, review, and push (REQ-003)
+
+The workflow SHALL request permissions sufficient to read the repository, submit pull request reviews and review comments, push commits to the pull request branch via `push-to-pull-request-branch`, and allow `label_command` activation to remove the `verify-openspec` label from the triggering pull request automatically. At minimum this SHALL include `contents: write`, `pull-requests: write`, and any additional compiler-required scope for automatic trigger-label removal on pull requests.
+
+#### Scenario: Push safe output and trigger-label cleanup are permitted
+
+- GIVEN the agent archives the change and produces a commit on the PR branch
+- WHEN `push-to-pull-request-branch` runs and `label_command` activation removes the trigger label
+- THEN the workflow token SHALL have authority to push to the PR head branch and mutate the triggering pull request label set under normal repository settings
+
+### Requirement: Safe outputs for review and push (REQ-004)
+
+The workflow SHALL declare safe outputs for:
+
+- `create-pull-request-review-comment` with `max` large enough for verification and unassociated-file commentary.
+- `submit-pull-request-review` with `max: 1` and `target` appropriate to the triggering pull request.
+- `push-to-pull-request-branch` with `max: 1` (or documented policy) and `target: triggering`, plus any `checkout` `fetch` / `title-prefix` / `labels` required by repository policy and [GitHub Agentic Workflows - Push to PR branch](https://github.github.io/gh-aw/reference/safe-outputs-pull-requests/#push-to-pr-branch-push-to-pull-request-branch).
+
+The workflow SHALL NOT declare a `remove-labels` safe output for `verify-openspec` cleanup because trigger-label removal is handled by `label_command` activation.
+
+#### Scenario: One review decision per run
+
+- GIVEN one workflow run completes verification
+- WHEN reviews are submitted
+- THEN at most one final submitted pull request review SHALL represent the approval decision before any archive push
+
+#### Scenario: No redundant label-cleanup safe output is declared
+
+- GIVEN maintainers inspect the workflow frontmatter
+- WHEN they review the configured safe outputs
+- THEN the workflow SHALL omit `remove-labels` for `verify-openspec` cleanup
+
+### Requirement: Remove trigger label after workflow completion (REQ-015)
+
+For a run triggered by applying the `verify-openspec` label to a pull request, the workflow SHALL rely on `label_command` automatic removal of that same label from the triggering pull request as part of activation rather than instructing the agent to request `remove-labels` before it concludes handling. The cleanup SHALL remove only `verify-openspec`; it SHALL NOT remove unrelated pull request labels, and the workflow SHALL NOT rely on terminal agent safe outputs or a separate post-agent cleanup job for this behavior.
+
+#### Scenario: Activation removes the trigger label automatically
+
+- GIVEN a pull request receives the `verify-openspec` label
+- WHEN the `label_command` workflow activates
+- THEN the triggering pull request SHALL lose the `verify-openspec` label without requiring an agent-emitted `remove-labels` output
+
+#### Scenario: Comment or skipped runs do not require agent cleanup
+
+- GIVEN a `verify-openspec`-triggered run later submits `COMMENT` or is skipped by deterministic gating before agent execution
+- WHEN workflow activation has completed
+- THEN trigger-label cleanup SHALL already be handled without waiting for terminal agent safe outputs
+
+### Requirement: Deterministic gates may skip agent execution
+The workflow SHALL use deterministic pre-activation outputs to decide whether the expensive agent job runs. When change-selection gating determines that the pull request is not eligible for verification, the workflow SHALL skip the agent job rather than starting it only to emit a no-op result. Trigger-label cleanup for `verify-openspec` SHALL already be handled by `label_command` activation and SHALL NOT depend on whether the agent job runs.
+
+#### Scenario: Ineligible run skips agent job
+- **GIVEN** deterministic gating concludes the pull request is not eligible for verification
+- **WHEN** downstream job conditions are evaluated
+- **THEN** the workflow SHALL skip the agent job

--- a/openspec/changes/verify-openspec-label-command/tasks.md
+++ b/openspec/changes/verify-openspec-label-command/tasks.md
@@ -1,0 +1,14 @@
+## 1. Update workflow trigger and cleanup semantics
+
+- [ ] 1.1 Change `.github/workflows-src/openspec-verify-label/workflow.md.tmpl` to use `label_command` for `verify-openspec`, restricted to pull requests.
+- [ ] 1.2 Remove source-workflow logic, outputs, permissions, and prompt instructions that only support explicit label verification or `remove-labels` cleanup.
+
+## 2. Regenerate and align generated artifacts
+
+- [ ] 2.1 Regenerate the compiled workflow artifacts for `openspec-verify-label` so the committed `.md` and `.lock.yml` match the updated source.
+- [ ] 2.2 Review the generated workflow for expected trigger, automatic label-removal handling, and any permission changes introduced by compilation.
+
+## 3. Validate requirements coverage
+
+- [ ] 3.1 Confirm the implementation matches the updated `ci-aw-openspec-verification` requirements for `label_command`, automatic cleanup, and skipped-run behavior.
+- [ ] 3.2 Run the relevant OpenSpec validation/check command(s) for the change and resolve any issues needed to make the workflow apply-ready.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace filtered `pull_request` trigger with `label_command` for openspec verification workflow
- Switches the CI openspec verification workflow from a `pull_request labeled` event trigger (with manual label checks) to a `label_command` trigger scoped to PRs only.
- Removes explicit trigger-label verification logic and the `remove-labels` safe output, delegating label cleanup to `label_command` automatically.
- Adds OpenSpec change manifest, design doc, proposal, updated requirements spec, and task list under [openspec/changes/verify-openspec-label-command/](https://github.com/elastic/terraform-provider-elasticstack/pull/2154/files#diff-06ad39f8ef938a887cfd5fab46d9194985ed74f930878bfe77da7cff2f347e8e).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e6b9c4d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->