### PR TITLE
Don't regenerate workflows on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ check-workflows: ## Check generated workflow markdown sources
 	@ go run ./scripts/compile-workflow-sources --manifest .github/workflows-src/manifest.json --check
 
 .PHONY: gen
-gen: docs-generate workflow-generate ## Generate the code and documentation
+gen: docs-generate ## Generate the code and documentation
 	@ go generate ./...
 
 .PHONY: clean
@@ -172,7 +172,7 @@ golangci-lint: golangci-lint-custom
 
 .PHONY: lint
 lint: GOLANGCIFLAGS += --fix
-lint: setup golangci-lint fmt docs-generate workflow-generate ## Run lints to check the spelling and common go patterns
+lint: setup golangci-lint fmt docs-generate ## Run lints to check the spelling and common go patterns
 
 .PHONY: check-lint
 check-lint: setup check-openspec golangci-lint workflow-test check-workflows check-fmt check-docs

--- a/openspec/specs/makefile-workflows/spec.md
+++ b/openspec/specs/makefile-workflows/spec.md
@@ -38,7 +38,7 @@ Environment variables consumed by underlying tools (for example Terraform loggin
 - **Dependencies & build:** `vendor`, `build-ci`, `build`, `clean`, `install`
 - **Tests:** `test`, `testacc`, `testacc-vs-docker`, `docker-testacc`, `docker-testacc-with-token`
 - **Docker & HTTP helpers:** `docker-elasticsearch`, `docker-kibana`, `docker-fleet`, `docker-clean`, `copy-kibana-ca`, `set-kibana-password`, `setup-synthetics`, `create-es-api-key`, `create-es-bearer-token`, `setup-kibana-fleet`
-- **Lint, format, docs, OpenSpec:** `tools`, `golangci-lint`, `lint`, `check-lint`, `fmt`, `check-fmt`, `docs-generate`, `check-docs`, `setup-openspec`, `check-openspec`, `setup`
+- **Lint, format, docs, OpenSpec:** `tools`, `golangci-lint`, `lint`, `check-lint`, `fmt`, `check-fmt`, `docs-generate`, `workflow-generate`, `workflow-test`, `check-workflows`, `check-docs`, `setup-openspec`, `check-openspec`, `setup`
 - **Release & maintenance:** `release-snapshot`, `release-no-publish`, `release`, `check-sign-release`, `check-publish-release`, `release-notes`, `renovate-post-upgrade`, `notice`
 - **Codegen:** `gen`, `generate-slo-client`, `generate-clients`
 ## Requirements
@@ -214,15 +214,27 @@ The `copy-kibana-ca` target SHALL copy the Kibana TLS CA certificate from the ru
 - WHEN `make copy-kibana-ca` runs
 - THEN `kibana-ca.pem` SHALL exist in the working tree with the CA material from the Kibana container
 
-### Requirement: Documentation and code generation (REQ-038–REQ-040)
+### Requirement: Documentation, workflow, and code generation (REQ-038–REQ-042)
 
-The `docs-generate` target SHALL regenerate Terraform provider website/markdown documentation using **HashiCorp `terraform-plugin-docs`** (`tfplugindocs`) for provider name `terraform-provider-elasticstack`. The `gen` target SHALL run documentation generation and `go generate` for the repository.
+The `docs-generate` target SHALL regenerate Terraform provider website/markdown documentation using **HashiCorp `terraform-plugin-docs`** (`tfplugindocs`) for provider name `terraform-provider-elasticstack`. The `workflow-generate` target SHALL regenerate the checked-in GitHub workflow artifacts from the repository-authored workflow sources, and it SHALL run only when explicitly requested. Aggregate targets such as `gen`, `lint`, and `build` SHALL NOT depend on `workflow-generate`. The `workflow-test` target SHALL run the repository tests that cover workflow source generation. The `check-workflows` target SHALL verify that generated workflow artifacts are up to date without regenerating them. The `gen` target SHALL run documentation generation and `go generate` for the repository.
 
 #### Scenario: Docs generation
 
 - GIVEN `make docs-generate`
 - WHEN it succeeds
 - THEN `tfplugindocs` SHALL have regenerated provider docs to match the current schema
+
+#### Scenario: Manual workflow generation
+
+- GIVEN `make workflow-generate`
+- WHEN it succeeds
+- THEN the checked-in workflow artifacts SHALL be regenerated from the repository-authored workflow sources
+
+#### Scenario: Workflow drift check without regeneration
+
+- GIVEN generated workflow sources are out of date with their checked-in templates
+- WHEN `make check-workflows` runs
+- THEN it SHALL fail without regenerating workflow artifacts
 
 ### Requirement: golangci-lint execution (REQ-041–REQ-043)
 
@@ -242,7 +254,7 @@ The `tools` target SHALL provision golangci-lint at the **version pinned in the 
 - AND Go packages outside `internal/` SHALL be part of the lint scope unless excluded by repository golangci-lint configuration
 
 ### Requirement: Lint aggregate targets (REQ-044–REQ-045)
-The `lint` target SHALL run setup, golangci-lint (with fix), formatting, and documentation generation. The `check-lint` target SHALL run setup, OpenSpec structural validation, golangci-lint (check mode), workflow generation checks, format check, and documentation freshness check.
+The `lint` target SHALL run setup, golangci-lint (with fix), formatting, and documentation generation, and it SHALL NOT invoke workflow generation. The `check-lint` target SHALL run setup, OpenSpec structural validation, golangci-lint (check mode), workflow generation checks, format check, and documentation freshness check.
 
 #### Scenario: Lint matches contributor workflow
 - GIVEN `make lint`


### PR DESCRIPTION
This isn't working, it forces all contributors to have the same version of the gh-aw extension installed and is overly burdensome. 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove workflow generation from `make gen` and `make lint` targets
> - `make gen` now runs only docs generation and `go generate`; workflow generation is no longer triggered automatically.
> - `make lint` no longer includes workflow generation as a dependency.
> - The [Makefile spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2157/files#diff-cc652d51dfbef8941c267118e8726b4f6f86abb1262985a76a0db887d5b0dddd) is updated to document workflow generation as a manual-only step, with explicit targets and drift-check behavior.
> - Behavioral Change: workflow files can now drift from their sources if `make gen` or `make lint` are run without separately invoking the workflow generation target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b6f28e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->