### PR TITLE
Add proposals to move deterministic behaviour from the schema-coverage workflow into scripts

### DIFF
--- a/openspec/changes/schema-coverage-issue-slot-gating/.openspec.yaml
+++ b/openspec/changes/schema-coverage-issue-slot-gating/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/schema-coverage-issue-slot-gating/design.md
+++ b/openspec/changes/schema-coverage-issue-slot-gating/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The `schema-coverage-rotation` workflow currently spends agent budget on work that can be determined before the prompt is ever delivered: counting open `schema-coverage` issues and calculating how many new issues may be opened in the current run. That logic already has a crisp contract in the markdown workflow and directly controls whether the expensive agent path should run at all.
+
+This change is intentionally narrower than the broader memory-script extraction work. It only moves issue-capacity calculation into deterministic pre-activation behavior and leaves entity discovery, selection, and memory mutation for a separate post-hook change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Compute `open_schema_coverage_issues` and `issue_slots_available` before agent activation using a repository-local script.
+- Move the authored workflow source into `.github/workflows-src/schema-coverage-rotation/` so the deterministic path follows the repository's templated workflow pattern.
+- Expose scalar outputs that downstream jobs and the agent prompt can consume without rediscovering GitHub issue state.
+- Skip the agent job entirely when there are no remaining schema-coverage issue slots.
+- Reduce prompt size and ambiguity by removing issue-counting instructions from the agent workflow text.
+
+**Non-Goals:**
+- Moving entity-list construction or memory-file updates into pre-activation.
+- Changing the `schema-coverage` open-issue cap or issue-label semantics.
+- Changing the schema-coverage analysis rubric or issue body content.
+
+## Decisions
+
+Use a repository-local pre-activation helper script.
+The workflow should call a checked-in script during `pre_activation` rather than embedding the issue query in prompt prose or inline workflow logic. This keeps the behavior reviewable, testable, and reusable across the markdown and compiled workflow artifacts.
+
+Alternative considered: leave issue-slot calculation in the prompt.
+Rejected because the result is deterministic, affects whether the agent should run at all, and costs agent time on runs that may be immediately ineligible.
+
+Author the workflow from `.github/workflows-src/` and keep the inline GitHub-script wrapper thin.
+The `schema-coverage-rotation` workflow should follow the `openspec-verify-label` source pattern: a templated workflow source under `.github/workflows-src/schema-coverage-rotation/`, any `actions/github-script` step using an inline wrapper file, and the reusable issue-slot logic extracted into `.github/workflows-src/lib/` for direct unit testing.
+
+Alternative considered: keep all logic inline in `.github/workflows/schema-coverage-rotation.md`.
+Rejected because inline workflow code is harder to test, easier to duplicate, and inconsistent with the repository's existing templated workflow pattern.
+
+Publish explicit gate outputs for later workflow logic.
+The pre-activation path should emit the open-issue count, slot count, and a short gate status or reason so later job conditions and the prompt can consume the result without rerunning the query.
+
+Alternative considered: only emit `issue_slots_available`.
+Rejected because a human-readable reason and the raw count make skipped runs easier to understand and debug.
+
+Skip the agent job when no slots remain.
+Once the slot count is known, the workflow should short-circuit before the agent job starts. The agent should not be invoked just to produce a deterministic no-op.
+
+Alternative considered: always run the agent and have it call `noop`.
+Rejected because it preserves the most expensive path for a condition the workflow already knows in advance.
+
+Keep the agent prompt focused on analysis-only behavior.
+When the agent does run, the prompt should interpolate the precomputed slot values and should not tell the agent to count issues itself.
+
+Alternative considered: keep the counting instructions as defense in depth.
+Rejected because duplicated logic creates drift risk between the deterministic workflow path and the natural-language instructions.
+
+## Risks / Trade-offs
+
+- GitHub issue search behavior could drift from the intended label semantics -> Keep the script query narrowly scoped to open issues with the `schema-coverage` label and exclude pull requests.
+- The open-issue cap could become duplicated across workflow and script code -> Define the cap once in the scripted path or pass it as an explicit input to avoid mismatches.
+- Skipped runs may provide less visibility than an agent-authored `noop` -> Emit a deterministic gate reason in workflow logs and outputs so operators can see why the agent was skipped.
+- Moving logic into a script adds one more maintained artifact -> Prefer a small single-purpose helper with stable inputs and outputs.
+- Introducing a templated workflow source adds a compile step -> Accept the extra generated/source pairing because it enables unit-tested logic and keeps authored workflow code consistent with existing patterns.
+
+## Migration Plan
+
+1. Add `.github/workflows-src/schema-coverage-rotation/` plus an extracted helper module and unit tests under `.github/workflows-src/lib/`.
+2. Implement the issue-slot calculation in the extracted helper and call it from a thin pre-activation wrapper script in the templated workflow source.
+3. Update the workflow to publish outputs, gate the agent job on the result, and narrow the prompt so it consumes precomputed slot data instead of querying GitHub for issue counts.
+4. Recompile `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml`, then run the relevant OpenSpec and workflow validation checks.
+
+## Open Questions
+
+- Whether the pre-activation helper should emit only step outputs or also write a short job summary for skipped runs.

--- a/openspec/changes/schema-coverage-issue-slot-gating/proposal.md
+++ b/openspec/changes/schema-coverage-issue-slot-gating/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `schema-coverage-rotation` workflow currently asks the agent to count open `schema-coverage` issues and calculate available issue slots before doing any useful work. That gate is deterministic, cost-sensitive, and should run before agent activation so runs with no remaining capacity skip the agent path entirely.
+
+## What Changes
+
+- Add a deterministic pre-activation script and workflow step that counts open `schema-coverage` issues and computes `issue_slots_available`.
+- Require the workflow to be authored from a templated source under `.github/workflows-src/`, following the existing `openspec-verify-label` pattern, with the issue-slot logic extracted into a unit-testable helper module.
+- Require the workflow to publish the open-issue count, slot count, and skip reason as pre-activation outputs for downstream job conditions and prompt interpolation.
+- Gate the agent job on the computed slot count so the workflow skips agent execution entirely when no issue slots remain.
+- Narrow the agent instructions so they consume the precomputed slot information instead of rediscovering GitHub issue state.
+
+## Capabilities
+
+### New Capabilities
+- `ci-schema-coverage-rotation-issue-slots`: deterministically compute schema-coverage issue capacity before agent activation and skip the agent job when capacity is exhausted
+
+### Modified Capabilities
+<!-- None. -->
+
+## Impact
+
+- `.github/workflows/schema-coverage-rotation.md`
+- `.github/workflows/schema-coverage-rotation.lock.yml`
+- `.github/workflows-src/schema-coverage-rotation/` and `.github/workflows-src/lib/`
+- Deterministic pre-activation workflow logic, extracted helper code, and unit tests for the issue-slot calculation path
+- Agent prompt inputs and job conditions for schema-coverage rotation runs

--- a/openspec/changes/schema-coverage-issue-slot-gating/specs/ci-schema-coverage-rotation-issue-slots/spec.md
+++ b/openspec/changes/schema-coverage-issue-slot-gating/specs/ci-schema-coverage-rotation-issue-slots/spec.md
@@ -1,3 +1,11 @@
+# `ci-schema-coverage-rotation-issue-slots` — Deterministic pre-activation issue-slot gating
+
+Workflow implementation: authored source under `.github/workflows-src/schema-coverage-rotation/`, compiled to `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml`.
+
+## Purpose
+
+Define requirements for moving schema-coverage issue-capacity calculation into a deterministic pre-activation workflow path that publishes reusable outputs and skips the agent job entirely when no issue slots remain.
+
 ## ADDED Requirements
 
 ### Requirement: Pre-activation issue-slot calculation

--- a/openspec/changes/schema-coverage-issue-slot-gating/specs/ci-schema-coverage-rotation-issue-slots/spec.md
+++ b/openspec/changes/schema-coverage-issue-slot-gating/specs/ci-schema-coverage-rotation-issue-slots/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Pre-activation issue-slot calculation
+The `schema-coverage-rotation` workflow SHALL run a repository-local script during pre-activation to count currently open repository issues labeled `schema-coverage` (excluding pull requests) and compute `issue_slots_available` as `max(0, 3 - open_schema_coverage_issues)` before agent activation begins.
+
+#### Scenario: Open issue count is below the cap
+- **WHEN** the pre-activation script finds fewer than 3 open `schema-coverage` issues
+- **THEN** it returns the matching `open_schema_coverage_issues` count and a positive `issue_slots_available` value
+
+#### Scenario: Open issue count reaches or exceeds the cap
+- **WHEN** the pre-activation script finds 3 or more open `schema-coverage` issues
+- **THEN** it returns `issue_slots_available = 0`
+
+### Requirement: Workflow source is templated and the gating logic is unit-testable
+The `schema-coverage-rotation` workflow SHALL be authored from a templated source under `.github/workflows-src/schema-coverage-rotation/`, and any inline GitHub-script used for pre-activation issue-slot gating SHALL delegate its decision logic to an extracted helper module under `.github/workflows-src/lib/` that can be unit tested independently of workflow compilation.
+
+#### Scenario: Workflow source is compiled from template
+- **WHEN** maintainers update the schema-coverage rotation workflow
+- **THEN** the authored source lives under `.github/workflows-src/schema-coverage-rotation/` and compiles into the generated workflow artifacts
+
+#### Scenario: Issue-slot logic is tested outside the workflow wrapper
+- **WHEN** maintainers validate the deterministic issue-slot calculation
+- **THEN** they can unit test the extracted helper module without executing the full workflow
+
+### Requirement: Pre-activation outputs expose gate context
+The workflow SHALL publish the pre-activation issue-slot results as downstream-consumable outputs, including the open issue count, the computed slot count, and a short gate status or reason describing whether the agent path remains eligible to run.
+
+#### Scenario: Downstream jobs consume slot outputs
+- **WHEN** pre-activation finishes calculating issue-slot capacity
+- **THEN** later workflow conditions and prompt interpolation can read the published slot outputs without repeating the GitHub issue query
+
+### Requirement: Agent execution is skipped when no slots remain
+The workflow SHALL skip the schema-coverage agent job entirely when `issue_slots_available` is `0`.
+
+#### Scenario: Capacity exhausted
+- **WHEN** pre-activation computes `issue_slots_available = 0`
+- **THEN** the workflow does not start the agent job for that run
+
+### Requirement: Agent instructions consume precomputed slot state
+When the agent job does run, the workflow prompt SHALL provide the precomputed issue-slot context and SHALL NOT instruct the agent to count open `schema-coverage` issues itself.
+
+#### Scenario: Capacity remains available
+- **WHEN** pre-activation computes a positive `issue_slots_available`
+- **THEN** the prompt handed to the agent references the precomputed slot information rather than telling the agent to query GitHub issue counts

--- a/openspec/changes/schema-coverage-issue-slot-gating/tasks.md
+++ b/openspec/changes/schema-coverage-issue-slot-gating/tasks.md
@@ -1,0 +1,15 @@
+## 1. Add deterministic issue-slot gating
+
+- [ ] 1.1 Add `.github/workflows-src/schema-coverage-rotation/` and author the workflow there using the same templated pattern as `.github/workflows-src/openspec-verify-label/`.
+- [ ] 1.2 Extract the issue-slot calculation into a helper module under `.github/workflows-src/lib/`, add a thin inline wrapper for `actions/github-script`, and cover the helper with unit tests.
+- [ ] 1.3 Update the templated schema-coverage rotation workflow source to run the helper in pre-activation and publish the open-count, slot-count, and gate-reason outputs.
+
+## 2. Gate the agent job and simplify the prompt
+
+- [ ] 2.1 Update the workflow job conditions so the schema-coverage agent path is skipped entirely when `issue_slots_available` is `0`.
+- [ ] 2.2 Remove issue-counting instructions from the agent prompt and replace them with references to the precomputed slot outputs.
+
+## 3. Rebuild and verify workflow artifacts
+
+- [ ] 3.1 Recompile `.github/workflows/schema-coverage-rotation.lock.yml` from the markdown workflow source.
+- [ ] 3.2 Run the relevant OpenSpec and workflow validation checks for the new pre-activation gating path and skipped-agent behavior.

--- a/openspec/changes/schema-coverage-memory-scripts/.openspec.yaml
+++ b/openspec/changes/schema-coverage-memory-scripts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-11

--- a/openspec/changes/schema-coverage-memory-scripts/design.md
+++ b/openspec/changes/schema-coverage-memory-scripts/design.md
@@ -30,7 +30,7 @@ Alternative considered: keep the memory logic in prompt prose.
 Rejected because it duplicates deterministic behavior in natural language, increases prompt size, and exposes the internal memory schema as part of the agent contract.
 
 Use a command-oriented interface rather than documenting the JSON schema to the agent.
-The scripts should expose a small set of operations, such as preparing the canonical inventory and selecting entities, then recording analysis completion. The prompt can name those commands and expected outputs without describing the structure of the memory JSON itself.
+The scripts should expose a small set of operations, such as preparing the canonical inventory and selecting entities, then recording analysis completion. Each command should accept the live working memory file path as an argument, the selection command should emit a machine-readable JSON contract, and the prompt can name those commands and outputs without describing the structure of the memory JSON itself.
 
 Alternative considered: continue documenting the memory format and let the agent edit JSON directly.
 Rejected because direct JSON editing is more error-prone and makes future memory-shape changes harder.
@@ -45,7 +45,7 @@ Alternative considered: maintain the tracked entity inventory only in the seed f
 Rejected because the canonical entity set must follow the current provider registrations on each run.
 
 Return machine-readable selection results.
-The selection command should emit structured output that includes entity names and types so the agent can iterate deterministically without reparsing memory internals.
+The selection command should emit a stable JSON array that includes entity names and types so the agent can iterate deterministically without reparsing memory internals. When timestamps are equal, ties should break deterministically by type then name.
 
 Alternative considered: emit only plain-text names.
 Rejected because the agent also needs entity type and should not infer it from naming conventions after selection.
@@ -68,6 +68,6 @@ Rejected because a per-entity update is safer if the run stops partway through a
 
 1. Add a Go command under `scripts/schema-coverage-rotation` for memory preparation, entity selection, and timestamp persistence.
 2. Implement canonical entity discovery by importing the provider registrations from the `provider` package and normalizing Plugin Framework and Plugin SDK entities into the same memory model.
-3. Update `.github/workflows/schema-coverage-rotation.md` so the agent instructions tell the agent which Go command(s) to run after repo-memory hooks complete.
+3. Update the authored workflow source under `.github/workflows-src/schema-coverage-rotation/` so the agent instructions tell the agent which Go command(s) to run after repo-memory hooks complete.
 4. Remove the detailed memory JSON schema and hand-authored selection algorithm from the prompt.
-5. Recompile `.github/workflows/schema-coverage-rotation.lock.yml` and validate the OpenSpec and workflow artifacts.
+5. Recompile `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml`, then validate the OpenSpec and workflow artifacts.

--- a/openspec/changes/schema-coverage-memory-scripts/design.md
+++ b/openspec/changes/schema-coverage-memory-scripts/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The `schema-coverage-rotation` workflow currently embeds memory behavior directly in the agent instructions: the prompt describes the JSON layout, how to initialize the repo-memory file, how to rebuild the entity inventory from docs, how to select the next entities by age, and when to write timestamps back. That is brittle because repo memory is materialized only after built-in action hooks complete, so the prompt cannot move this work into pre-activation the way issue-slot gating can.
+
+This change keeps the logic in the agent path but moves it out of prose and into repository-local scripts that run against the live repo-memory workspace after hooks have finished.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Encapsulate schema-coverage memory bootstrap, entity reconciliation, oldest-first selection, and timestamp persistence in a Go command under `scripts/schema-coverage-rotation`.
+- Let the agent invoke those scripts after repo-memory hooks complete instead of reconstructing memory behavior from prompt prose.
+- Build the canonical entity inventory from the provider's registered resources and data sources, not from documentation filenames.
+- Preserve the existing selection semantics: `null` timestamps first, then oldest timestamps across resources and data sources while retaining entity type.
+- Remove detailed memory JSON format instructions from the workflow prompt.
+
+**Non-Goals:**
+- Moving repo-memory-dependent logic into pre-activation.
+- Changing the schema-coverage issue-slot gate or open-issue cap.
+- Changing the schema-coverage analysis rubric, issue body requirements, or safe-output behavior.
+
+## Decisions
+
+Implement the helper as a Go command under `scripts/schema-coverage-rotation`.
+The workflow should direct the agent to run a checked-in Go command after repo-memory hooks finish. Keeping the logic in Go makes it easier to import the provider package, reuse repository types, and test the selection and persistence logic with the normal Go toolchain.
+
+Alternative considered: implement the helper in shell or JavaScript.
+Rejected because the canonical entity list now needs to derive from registered provider entities, which is most directly accessible from Go code in this repository.
+
+Alternative considered: keep the memory logic in prompt prose.
+Rejected because it duplicates deterministic behavior in natural language, increases prompt size, and exposes the internal memory schema as part of the agent contract.
+
+Use a command-oriented interface rather than documenting the JSON schema to the agent.
+The scripts should expose a small set of operations, such as preparing the canonical inventory and selecting entities, then recording analysis completion. The prompt can name those commands and expected outputs without describing the structure of the memory JSON itself.
+
+Alternative considered: continue documenting the memory format and let the agent edit JSON directly.
+Rejected because direct JSON editing is more error-prone and makes future memory-shape changes harder.
+
+Derive the canonical entity list from provider registrations.
+The Go command should import the `provider` package and inspect the registered entities exposed by both `provider/plugin_framework.go` and `provider/provider.go`. For Plugin Framework entities, it should instantiate the provider and resolve registered resource and data source type names from the provider's registrations. For Plugin SDK entities, it should read the registered `ResourcesMap` and `DataSourcesMap`. The command should union those registrations by entity type and name, preserve existing timestamps for still-registered entities, add newly discovered entities with `null`, and remove entities that are no longer registered by either provider implementation.
+
+Alternative considered: continue scanning `docs/resources/*.md` and `docs/data-sources/*.md`.
+Rejected because documentation can lag the implementation, while provider registrations are the source of truth for entities that the provider actually serves.
+
+Alternative considered: maintain the tracked entity inventory only in the seed file.
+Rejected because the canonical entity set must follow the current provider registrations on each run.
+
+Return machine-readable selection results.
+The selection command should emit structured output that includes entity names and types so the agent can iterate deterministically without reparsing memory internals.
+
+Alternative considered: emit only plain-text names.
+Rejected because the agent also needs entity type and should not infer it from naming conventions after selection.
+
+Persist timestamps through a dedicated post-analysis command.
+After each analyzed entity, the agent should call a script command that records the current UTC timestamp regardless of whether an issue was created. That preserves rotation fairness without requiring the agent to hand-edit the memory file.
+
+Alternative considered: batch all timestamp updates at the end of the run.
+Rejected because a per-entity update is safer if the run stops partway through analysis.
+
+## Risks / Trade-offs
+
+- Hiding the memory schema behind scripts can make debugging less obvious -> Ensure the commands produce clear machine-readable output and helpful failure messages.
+- Repo-memory paths are runtime-specific -> Accept the live memory path as an argument so the scripts do not hardcode environment-specific locations.
+- Partial writes could corrupt the memory file -> Use replace-on-success file writes so updates are atomic from the workflow's point of view.
+- Provider-registration discovery spans both Plugin Framework and Plugin SDK implementations -> Normalize both sources into the same `resource` / `data source` inventory model, de-duplicate by fully qualified Terraform type name, and prune entries absent from both sources.
+- Importing the provider package may accidentally include experimental entities -> Use the default provider constructors and environment so the command reflects the repository's normal registered entity set unless the workflow explicitly opts in to experimental registrations later.
+
+## Migration Plan
+
+1. Add a Go command under `scripts/schema-coverage-rotation` for memory preparation, entity selection, and timestamp persistence.
+2. Implement canonical entity discovery by importing the provider registrations from the `provider` package and normalizing Plugin Framework and Plugin SDK entities into the same memory model.
+3. Update `.github/workflows/schema-coverage-rotation.md` so the agent instructions tell the agent which Go command(s) to run after repo-memory hooks complete.
+4. Remove the detailed memory JSON schema and hand-authored selection algorithm from the prompt.
+5. Recompile `.github/workflows/schema-coverage-rotation.lock.yml` and validate the OpenSpec and workflow artifacts.

--- a/openspec/changes/schema-coverage-memory-scripts/proposal.md
+++ b/openspec/changes/schema-coverage-memory-scripts/proposal.md
@@ -7,7 +7,7 @@ The `schema-coverage-rotation` workflow currently describes entity discovery, se
 - Add a Go helper under `scripts/schema-coverage-rotation` that loads the schema-coverage memory file, bootstraps it from the repository seed when needed, and maintains the canonical entity inventory by reading the provider's registered resources and data sources directly while removing entities that are no longer registered.
 - Add scripted selection logic that chooses the next entities to analyze by oldest timestamp across resources and data sources while preserving entity type.
 - Add scripted memory-update logic so analyzed entities have their timestamps persisted after each run without requiring the prompt to describe the JSON structure in detail.
-- Replace the current detailed memory-format and entity-selection prose in the workflow prompt with concise instructions telling the agent which script commands to run after repo-memory hooks complete.
+- Replace the current detailed memory-format and entity-selection prose in the authored workflow prompt source with concise instructions telling the agent which script commands to run after repo-memory hooks complete.
 
 ## Capabilities
 
@@ -19,6 +19,7 @@ The `schema-coverage-rotation` workflow currently describes entity discovery, se
 
 ## Impact
 
+- `.github/workflows-src/schema-coverage-rotation/`
 - `.github/workflows/schema-coverage-rotation.md`
 - `.github/workflows/schema-coverage-rotation.lock.yml`
 - `scripts/schema-coverage-rotation/`

--- a/openspec/changes/schema-coverage-memory-scripts/proposal.md
+++ b/openspec/changes/schema-coverage-memory-scripts/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `schema-coverage-rotation` workflow currently describes entity discovery, selection order, and memory JSON updates directly in the agent prompt. That logic depends on repo memory that is only available after built-in action hooks, so it should live in workspace scripts the agent can run against the real memory files instead of encoding the memory contract in prompt prose.
+
+## What Changes
+
+- Add a Go helper under `scripts/schema-coverage-rotation` that loads the schema-coverage memory file, bootstraps it from the repository seed when needed, and maintains the canonical entity inventory by reading the provider's registered resources and data sources directly while removing entities that are no longer registered.
+- Add scripted selection logic that chooses the next entities to analyze by oldest timestamp across resources and data sources while preserving entity type.
+- Add scripted memory-update logic so analyzed entities have their timestamps persisted after each run without requiring the prompt to describe the JSON structure in detail.
+- Replace the current detailed memory-format and entity-selection prose in the workflow prompt with concise instructions telling the agent which script commands to run after repo-memory hooks complete.
+
+## Capabilities
+
+### New Capabilities
+- `ci-schema-coverage-rotation-memory`: script-driven schema-coverage entity discovery, selection, and memory persistence for the rotation workflow
+
+### Modified Capabilities
+<!-- None. -->
+
+## Impact
+
+- `.github/workflows/schema-coverage-rotation.md`
+- `.github/workflows/schema-coverage-rotation.lock.yml`
+- `scripts/schema-coverage-rotation/`
+- `provider/plugin_framework.go` and `provider/provider.go`
+- New Go-based schema-coverage helper commands invoked by the agent after repo-memory initialization
+- Memory bootstrap and persistence flow rooted at `.github/aw/memory/schema-coverage.json` and the repo-memory working copy

--- a/openspec/changes/schema-coverage-memory-scripts/specs/ci-schema-coverage-rotation-memory/spec.md
+++ b/openspec/changes/schema-coverage-memory-scripts/specs/ci-schema-coverage-rotation-memory/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Agent prompt uses post-hook memory scripts
+The `schema-coverage-rotation` workflow SHALL instruct the agent to run repository-local schema-coverage memory script commands after repo-memory hooks complete, and SHALL NOT require the prompt to describe the memory JSON structure in detail.
+
+#### Scenario: Repo memory is available to the agent
+- **WHEN** the workflow starts the agent after built-in repo-memory hooks have prepared the workspace
+- **THEN** the prompt tells the agent which schema-coverage memory script command or commands to run instead of describing the memory file format
+
+### Requirement: Memory helper is implemented as a Go command
+The schema-coverage memory helper SHALL be implemented as a Go command rooted at `scripts/schema-coverage-rotation` so the workflow can invoke it directly from the repository workspace.
+
+#### Scenario: Workflow invokes the helper
+- **WHEN** the agent needs to prepare memory, select entities, or record analysis completion
+- **THEN** it runs the Go-based helper command from `scripts/schema-coverage-rotation`
+
+### Requirement: Memory preparation bootstraps and reconciles the canonical entity inventory
+The schema-coverage memory preparation command SHALL initialize the working memory file from `.github/aw/memory/schema-coverage.json` when the working file does not exist, SHALL derive the canonical entity inventory by importing the provider registrations exposed through `provider/plugin_framework.go` and `provider/provider.go`, SHALL preserve entity type as `resource` or `data source`, SHALL ensure newly discovered entities are present in memory with either their existing timestamp or `null`, and SHALL remove memory entries for entities that are no longer registered by either provider implementation.
+
+#### Scenario: Working memory file is absent
+- **WHEN** the memory preparation command runs and the working memory file does not yet exist
+- **THEN** it bootstraps the working memory file from `.github/aw/memory/schema-coverage.json` before reconciling the entity inventory
+
+#### Scenario: Provider registration adds a new entity
+- **WHEN** the memory preparation command discovers a registered resource or data source that is not yet present in memory
+- **THEN** it adds that entity under the correct type with a `null` analysis timestamp
+
+#### Scenario: Entity inventory spans both provider implementations
+- **WHEN** the memory preparation command loads the canonical entity inventory
+- **THEN** it unions the registered entities from the Plugin Framework provider and the Plugin SDK provider into one de-duplicated resource/data-source inventory
+
+#### Scenario: Provider registration removes an entity
+- **WHEN** the memory preparation command finds an entity in memory that is no longer registered by either the Plugin Framework provider or the Plugin SDK provider
+- **THEN** it removes that entity from the working memory file during reconciliation
+
+### Requirement: Selection is oldest-first across resources and data sources
+The schema-coverage selection command SHALL choose exactly the requested number of entities across both resources and data sources using oldest-first ordering, where `null` timestamps sort before populated timestamps, and SHALL preserve each selected entity's type in its output.
+
+#### Scenario: Mixed analyzed and never-analyzed entities exist
+- **WHEN** the selection command ranks available entities for a run
+- **THEN** entities with `null` timestamps are selected before entities with populated timestamps, regardless of whether they are resources or data sources
+
+#### Scenario: Selection output is consumed by the agent
+- **WHEN** the agent requests the next entities to analyze
+- **THEN** the command returns structured results that include both entity name and entity type for each selected entry
+
+### Requirement: Timestamp persistence is handled by a script command
+The schema-coverage memory update command SHALL persist the analyzed entity's timestamp as the current UTC time after each analysis, regardless of whether that analysis produced an actionable issue.
+
+#### Scenario: An analyzed entity has actionable gaps
+- **WHEN** the agent finishes analyzing an entity and determines that an issue should be created
+- **THEN** the memory update command records the entity's current UTC analysis timestamp
+
+#### Scenario: An analyzed entity has no actionable gaps
+- **WHEN** the agent finishes analyzing an entity and determines that no issue should be created
+- **THEN** the memory update command still records the entity's current UTC analysis timestamp

--- a/openspec/changes/schema-coverage-memory-scripts/specs/ci-schema-coverage-rotation-memory/spec.md
+++ b/openspec/changes/schema-coverage-memory-scripts/specs/ci-schema-coverage-rotation-memory/spec.md
@@ -1,3 +1,12 @@
+# `ci-schema-coverage-rotation-memory` — Script-driven schema-coverage memory behavior
+
+Workflow implementation: authored source under `.github/workflows-src/schema-coverage-rotation/`, compiled to `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml`.
+Script implementation: `scripts/schema-coverage-rotation/`.
+
+## Purpose
+
+Define requirements for moving schema-coverage memory bootstrap, entity reconciliation, selection, and timestamp persistence out of workflow prompt prose and into repository-local Go commands that the workflow invokes after repo-memory hooks complete.
+
 ## ADDED Requirements
 
 ### Requirement: Agent prompt uses post-hook memory scripts
@@ -14,8 +23,15 @@ The schema-coverage memory helper SHALL be implemented as a Go command rooted at
 - **WHEN** the agent needs to prepare memory, select entities, or record analysis completion
 - **THEN** it runs the Go-based helper command from `scripts/schema-coverage-rotation`
 
+### Requirement: Memory commands use a caller-supplied working file path
+The schema-coverage memory preparation, selection, and update commands SHALL accept the live working memory file path as an explicit input parameter and SHALL operate on that supplied path rather than hardcoding a runtime-specific repo-memory location.
+
+#### Scenario: Workflow passes the live repo-memory path
+- **WHEN** the workflow invokes a schema-coverage memory command against the current repo-memory workspace
+- **THEN** it provides the working memory file path as a command input and the command operates on that supplied file
+
 ### Requirement: Memory preparation bootstraps and reconciles the canonical entity inventory
-The schema-coverage memory preparation command SHALL initialize the working memory file from `.github/aw/memory/schema-coverage.json` when the working file does not exist, SHALL derive the canonical entity inventory by importing the provider registrations exposed through `provider/plugin_framework.go` and `provider/provider.go`, SHALL preserve entity type as `resource` or `data source`, SHALL ensure newly discovered entities are present in memory with either their existing timestamp or `null`, and SHALL remove memory entries for entities that are no longer registered by either provider implementation.
+The schema-coverage memory preparation command SHALL use the caller-supplied working memory file path, SHALL initialize that file from `.github/aw/memory/schema-coverage.json` when the supplied path does not exist, SHALL derive the canonical entity inventory by importing the provider registrations exposed through `provider/plugin_framework.go` and `provider/provider.go`, SHALL preserve entity type as `resource` or `data source`, SHALL ensure newly discovered entities are present in memory with either their existing timestamp or `null`, SHALL remove memory entries for entities that are no longer registered by either provider implementation, and SHALL write reconciled results via an atomic replace-on-success rename.
 
 #### Scenario: Working memory file is absent
 - **WHEN** the memory preparation command runs and the working memory file does not yet exist
@@ -34,7 +50,7 @@ The schema-coverage memory preparation command SHALL initialize the working memo
 - **THEN** it removes that entity from the working memory file during reconciliation
 
 ### Requirement: Selection is oldest-first across resources and data sources
-The schema-coverage selection command SHALL choose exactly the requested number of entities across both resources and data sources using oldest-first ordering, where `null` timestamps sort before populated timestamps, and SHALL preserve each selected entity's type in its output.
+The schema-coverage selection command SHALL choose exactly the requested number of entities across both resources and data sources using oldest-first ordering, where `null` timestamps sort before populated timestamps, ties on equal timestamp state and value are broken by lexicographic `type` then `name`, and SHALL emit a JSON array on stdout whose entries use stable `type` and `name` fields for each selected entity.
 
 #### Scenario: Mixed analyzed and never-analyzed entities exist
 - **WHEN** the selection command ranks available entities for a run
@@ -42,10 +58,14 @@ The schema-coverage selection command SHALL choose exactly the requested number 
 
 #### Scenario: Selection output is consumed by the agent
 - **WHEN** the agent requests the next entities to analyze
-- **THEN** the command returns structured results that include both entity name and entity type for each selected entry
+- **THEN** the command returns a JSON array whose entries include both stable `type` and `name` fields for each selected entity
+
+#### Scenario: Multiple entities share the same timestamp
+- **WHEN** two or more candidate entities have the same timestamp state and value during selection
+- **THEN** the command orders those tied entities by lexicographic `type` and then lexicographic `name`
 
 ### Requirement: Timestamp persistence is handled by a script command
-The schema-coverage memory update command SHALL persist the analyzed entity's timestamp as the current UTC time after each analysis, regardless of whether that analysis produced an actionable issue.
+The schema-coverage memory update command SHALL accept the caller-supplied working memory file path, SHALL persist the analyzed entity's timestamp as the current UTC time after each analysis, regardless of whether that analysis produced an actionable issue, and SHALL update the memory file via an atomic replace-on-success rename.
 
 #### Scenario: An analyzed entity has actionable gaps
 - **WHEN** the agent finishes analyzing an entity and determines that an issue should be created

--- a/openspec/changes/schema-coverage-memory-scripts/tasks.md
+++ b/openspec/changes/schema-coverage-memory-scripts/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Add schema-coverage memory helper commands
 
-- [ ] 1.1 Add a Go command under `scripts/schema-coverage-rotation` that bootstraps the working memory file and reconciles the canonical entity inventory from the provider's registered resources and data sources, including pruning entities that are no longer registered.
+- [ ] 1.1 Add a Go command under `scripts/schema-coverage-rotation` that accepts the live working memory file path, bootstraps that file when needed, reconciles the canonical entity inventory from the provider's registered resources and data sources, and writes updated memory atomically.
 - [ ] 1.2 Implement provider-backed entity discovery by importing the `provider` package, reading Plugin Framework registrations from `provider/plugin_framework.go`, reading Plugin SDK registrations from `provider/provider.go`, and normalizing both into one de-duplicated inventory.
-- [ ] 1.3 Add command support for selecting the next entities by oldest timestamp while preserving entity type, and for recording an analyzed entity's current UTC timestamp after each analysis run.
+- [ ] 1.3 Add command support for selecting the next entities by oldest timestamp with stable JSON output and deterministic tie-breaking while preserving entity type, and for recording an analyzed entity's current UTC timestamp after each analysis run.
 - [ ] 1.4 Add focused Go tests for inventory building, oldest-first selection, and timestamp persistence behavior.
 
 ## 2. Update the workflow prompt to use scripts
 
-- [ ] 2.1 Update `.github/workflows/schema-coverage-rotation.md` so the agent is instructed to run the Go helper command(s) after repo-memory hooks complete instead of following inline memory-format and selection prose.
+- [ ] 2.1 Update the authored workflow prompt source under `.github/workflows-src/schema-coverage-rotation/` so the agent is instructed to run the Go helper command(s) after repo-memory hooks complete instead of following inline memory-format and selection prose.
 - [ ] 2.2 Ensure the prompt-to-script contract preserves the current bootstrap, selection, and post-analysis timestamp-update semantics without exposing the JSON memory structure in detail.
 
 ## 3. Rebuild and verify workflow artifacts
 
-- [ ] 3.1 Recompile `.github/workflows/schema-coverage-rotation.lock.yml` from the markdown workflow source.
+- [ ] 3.1 Recompile `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml` from the authored workflow source under `.github/workflows-src/schema-coverage-rotation/`.
 - [ ] 3.2 Run the relevant OpenSpec and workflow validation checks for memory bootstrap, entity selection, prompt integration, and timestamp persistence behavior.

--- a/openspec/changes/schema-coverage-memory-scripts/tasks.md
+++ b/openspec/changes/schema-coverage-memory-scripts/tasks.md
@@ -1,0 +1,16 @@
+## 1. Add schema-coverage memory helper commands
+
+- [ ] 1.1 Add a Go command under `scripts/schema-coverage-rotation` that bootstraps the working memory file and reconciles the canonical entity inventory from the provider's registered resources and data sources, including pruning entities that are no longer registered.
+- [ ] 1.2 Implement provider-backed entity discovery by importing the `provider` package, reading Plugin Framework registrations from `provider/plugin_framework.go`, reading Plugin SDK registrations from `provider/provider.go`, and normalizing both into one de-duplicated inventory.
+- [ ] 1.3 Add command support for selecting the next entities by oldest timestamp while preserving entity type, and for recording an analyzed entity's current UTC timestamp after each analysis run.
+- [ ] 1.4 Add focused Go tests for inventory building, oldest-first selection, and timestamp persistence behavior.
+
+## 2. Update the workflow prompt to use scripts
+
+- [ ] 2.1 Update `.github/workflows/schema-coverage-rotation.md` so the agent is instructed to run the Go helper command(s) after repo-memory hooks complete instead of following inline memory-format and selection prose.
+- [ ] 2.2 Ensure the prompt-to-script contract preserves the current bootstrap, selection, and post-analysis timestamp-update semantics without exposing the JSON memory structure in detail.
+
+## 3. Rebuild and verify workflow artifacts
+
+- [ ] 3.1 Recompile `.github/workflows/schema-coverage-rotation.lock.yml` from the markdown workflow source.
+- [ ] 3.2 Run the relevant OpenSpec and workflow validation checks for memory bootstrap, entity selection, prompt integration, and timestamp persistence behavior.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec proposals to move schema-coverage deterministic behaviour into scripts
- Adds two OpenSpec change-sets under `openspec/changes/`: `schema-coverage-issue-slot-gating` and `schema-coverage-memory-scripts`, each with a proposal, design doc, formal spec, and task checklist.
- `schema-coverage-issue-slot-gating` proposes extracting open issue counting and slot calculation (capped at 3) into a deterministic pre-activation step, gating the agent job when no slots remain.
- `schema-coverage-memory-scripts` proposes replacing prompt-prose memory management with repository-local Go scripts under `scripts/schema-coverage-rotation` for bootstrapping, entity reconciliation, oldest-first selection, and atomic timestamp updates.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0aa5ac.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->