### PR TITLE
Proposal to setup the Go/Node toolchain pre-agent

### DIFF
--- a/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/.openspec.yaml
+++ b/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/design.md
+++ b/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The `schema-coverage-rotation` workflow now asks the agent to run repository-local Go commands from `scripts/schema-coverage-rotation`, but the authored workflow source under `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` does not provision the repository toolchain before agent reasoning begins. Unlike `openspec-verify-label`, it does not install Go from `go.mod`, export Go path variables for AWF chroot mode, install Node from `package.json`, run `make setup`, or declare the Go and Node ecosystems in `network.allowed`.
+
+That omission makes the workflow depend on runner-default toolchains and package-network policy. The current failure mode is that the default Go toolchain is too old for the repository's Go commands, but the same gap also leaves Node-backed repository bootstrap undefined for future prompt steps.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provision the schema-coverage rotation workflow with the repository's Go and Node toolchains before agent reasoning begins.
+- Export `GOROOT`, `GOPATH`, and `GOMODCACHE` so AWF chroot-mode commands can reuse the configured Go installation and module cache.
+- Run `make setup` deterministically so repository-local CLI and dependency setup is complete before the agent executes `go run ./scripts/schema-coverage-rotation ...`.
+- Allow the `defaults`, `node`, and `go` ecosystems in the workflow network policy so repository bootstrap and agent-invoked commands can access expected package-manager hosts.
+- Keep the bootstrap contract aligned with the existing `openspec-verify-label` workflow where the same repository toolchain pattern is already established.
+
+**Non-Goals:**
+- Changing schema-coverage issue-slot gating, memory selection, or issue-creation behavior.
+- Moving schema-coverage analysis into deterministic pre-activation steps.
+- Adding Terraform CLI setup unless a later implementation detail proves it is actually required for this workflow.
+- Changing the repository's declared Go or Node versions outside the workflow setup behavior.
+
+## Decisions
+
+### Mirror the repository bootstrap pattern already used by `openspec-verify-label`
+
+The schema-coverage rotation workflow should add deterministic setup steps before agent reasoning in the same core order used by `openspec-verify-label`: install Go from `go.mod`, export `GOROOT`, `GOPATH`, and `GOMODCACHE`, install Node from `package.json`, then run `make setup`.
+
+This addresses the immediate Go-version failure while also ensuring the workflow uses the repository's declared toolchain and standard bootstrap path rather than whatever the base runner happens to provide.
+
+Alternative considered: add only `actions/setup-go`.
+Rejected because the workflow also depends on repository bootstrap via `make setup`, which in turn relies on the Node/OpenSpec toolchain and should be prepared deterministically rather than left implicit.
+
+Alternative considered: tell the agent to install toolchains in prompt instructions.
+Rejected because toolchain preparation is deterministic environment setup, not reasoning work, and should complete before the expensive agent path starts.
+
+### Export Go environment variables for AWF chroot mode
+
+The workflow should export `GOROOT`, `GOPATH`, and `GOMODCACHE` to `GITHUB_ENV` immediately after `actions/setup-go`. This matches the existing AWF pattern in `openspec-verify-label` and makes the prepared Go workspace visible to agent-executed commands that run in chroot mode.
+
+Alternative considered: rely on Go defaults after setup-go.
+Rejected because the workflow already has a proven repository pattern for AWF Go-path export, and the schema-coverage workflow should use the same handoff contract.
+
+### Declare ecosystem-based network access for bootstrap and agent commands
+
+The workflow should explicitly set `network.allowed` to include `defaults`, `node`, and `go`. This keeps the policy at the repository's package-ecosystem level instead of depending on ad hoc domain allowlists, and it covers both `make setup` and any agent-invoked Node or Go commands that still need package-manager access.
+
+Alternative considered: allow only `go`.
+Rejected because the requested repository bootstrap includes `make setup`, which depends on the Node ecosystem as well.
+
+## Risks / Trade-offs
+
+- Broader network policy than today -> Keep the allowlist limited to `defaults`, `node`, and `go` rather than introducing arbitrary domains.
+- Slightly longer workflow startup time -> Accept the deterministic setup cost to avoid agent failures and repeated retries caused by missing toolchains.
+- Tight alignment with `openspec-verify-label` could drift if that workflow evolves later -> Keep the schema-coverage requirements focused on the observable bootstrap contract instead of a brittle textual copy.
+
+## Migration Plan
+
+1. Update `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` to add deterministic Go setup, Go path export, Node setup, `make setup`, and `network.allowed: [defaults, node, go]`.
+2. Recompile `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml` from the authored workflow source.
+3. Run the relevant OpenSpec and workflow validation checks to confirm the generated workflow and requirements stay in sync.

--- a/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/proposal.md
+++ b/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `schema-coverage-rotation` workflow now relies on repository-local Go scripts and Node-based repository setup, but it still depends on the runner's default toolchain. Recent failures show that this is not sufficient: the default Go toolchain is too old to execute the memory helper commands reliably, so the workflow needs the same repository toolchain bootstrap pattern already used by `openspec-verify-label`.
+
+## What Changes
+
+- Add deterministic repository toolchain setup steps to the `schema-coverage-rotation` workflow before agent reasoning begins: install Go from `go.mod`, export `GOROOT`, `GOPATH`, and `GOMODCACHE`, install Node from `package.json`, and run `make setup`.
+- Allow the schema-coverage rotation workflow's AWF network policy to use the repository's required ecosystems for this bootstrap path, including Go and Node alongside the default allowlist.
+- Update the workflow requirements so schema-coverage rotation runs its repository-local commands against the provisioned repo toolchain instead of relying on runner-default versions.
+
+## Capabilities
+
+### New Capabilities
+- `ci-schema-coverage-rotation-toolchain`: repository toolchain bootstrap and AWF network allowances for the schema-coverage rotation workflow
+
+### Modified Capabilities
+<!-- None. -->
+
+## Impact
+
+- `.github/workflows-src/schema-coverage-rotation/`
+- `.github/workflows/schema-coverage-rotation.md`
+- `.github/workflows/schema-coverage-rotation.lock.yml`
+- OpenSpec requirements for schema-coverage rotation workflow bootstrap behavior

--- a/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/specs/ci-schema-coverage-rotation-toolchain/spec.md
+++ b/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/specs/ci-schema-coverage-rotation-toolchain/spec.md
@@ -35,4 +35,4 @@ The `schema-coverage-rotation` workflow prompt SHALL rely on deterministic workf
 
 #### Scenario: Prompt begins after bootstrap is complete
 - **WHEN** the agent receives the schema-coverage rotation prompt
-- **THEN** the workflow SHALL already have completed the repository toolchain setup needed for `go run ./scripts/schema-coverage-rotation ...` and `make setup`
+- **THEN** the workflow SHALL already have completed the repository toolchain setup needed for `go run ./scripts/schema-coverage-rotation ...`

--- a/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/specs/ci-schema-coverage-rotation-toolchain/spec.md
+++ b/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/specs/ci-schema-coverage-rotation-toolchain/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Schema-coverage rotation bootstraps repository toolchains before agent execution
+The `schema-coverage-rotation` workflow SHALL provision the repository toolchains before agent reasoning begins. At a minimum, it SHALL set up Go using `actions/setup-go` with `go-version-file: go.mod`, SHALL export `GOROOT`, `GOPATH`, and `GOMODCACHE` after Go setup for AWF chroot mode, SHALL set up Node using `actions/setup-node` with `node-version-file: package.json`, and SHALL run `make setup` at the repository root before the agent executes repository-local schema-coverage commands.
+
+#### Scenario: Go toolchain follows go.mod
+- **WHEN** the schema-coverage rotation workflow prepares the runner environment for repository-local Go commands
+- **THEN** it SHALL configure `actions/setup-go` with `go-version-file: go.mod`
+
+#### Scenario: AWF chroot mode receives configured Go paths
+- **WHEN** the workflow has installed Go for schema-coverage rotation
+- **THEN** it SHALL export `GOROOT=$(go env GOROOT)` to `GITHUB_ENV`
+- **AND** it SHALL export `GOPATH=$(go env GOPATH)` to `GITHUB_ENV`
+- **AND** it SHALL export `GOMODCACHE=$(go env GOMODCACHE)` to `GITHUB_ENV`
+
+#### Scenario: Node toolchain follows package.json
+- **WHEN** the schema-coverage rotation workflow prepares the repository bootstrap environment
+- **THEN** it SHALL configure `actions/setup-node` with `node-version-file: package.json`
+
+#### Scenario: Repository setup completes before agent reasoning
+- **WHEN** the workflow finishes provisioning Go and Node for schema-coverage rotation
+- **THEN** it SHALL run `make setup` before the agent begins executing the prompt instructions
+
+### Requirement: Schema-coverage rotation allows repository bootstrap ecosystems
+The `schema-coverage-rotation` workflow SHALL declare an AWF network policy that allows the repository bootstrap path to use the default allowlist plus the Node and Go ecosystems.
+
+#### Scenario: Workflow frontmatter allows required ecosystems
+- **WHEN** maintainers inspect the schema-coverage rotation workflow frontmatter
+- **THEN** `network.allowed` SHALL include `defaults`
+- **AND** `network.allowed` SHALL include `node`
+- **AND** `network.allowed` SHALL include `go`
+
+### Requirement: Agent instructions rely on deterministic bootstrap
+The `schema-coverage-rotation` workflow prompt SHALL rely on deterministic workflow setup for repository toolchain provisioning and SHALL NOT require the agent to install or discover the required Go or Node toolchains itself before running repository-local commands.
+
+#### Scenario: Prompt begins after bootstrap is complete
+- **WHEN** the agent receives the schema-coverage rotation prompt
+- **THEN** the workflow SHALL already have completed the repository toolchain setup needed for `go run ./scripts/schema-coverage-rotation ...` and `make setup`

--- a/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/tasks.md
+++ b/openspec/changes/schema-coverage-rotation-toolchain-bootstrap/tasks.md
@@ -1,0 +1,14 @@
+## 1. Add deterministic repository bootstrap to schema-coverage rotation
+
+- [ ] 1.1 Update `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` to install Go from `go.mod`, export `GOROOT`, `GOPATH`, and `GOMODCACHE`, install Node from `package.json`, and run `make setup` before agent reasoning begins.
+- [ ] 1.2 Update the schema-coverage rotation workflow frontmatter so `network.allowed` includes `defaults`, `node`, and `go`, and ensure the prompt relies on the preconfigured toolchain rather than instructing the agent to install it.
+
+## 2. Rebuild generated workflow artifacts
+
+- [ ] 2.1 Recompile `.github/workflows/schema-coverage-rotation.md` from the authored workflow source.
+- [ ] 2.2 Recompile `.github/workflows/schema-coverage-rotation.lock.yml` and verify the generated artifacts reflect the new bootstrap steps and network policy.
+
+## 3. Validate the change
+
+- [ ] 3.1 Run the relevant OpenSpec validation for `schema-coverage-rotation-toolchain-bootstrap` and address any structural issues in the proposal artifacts.
+- [ ] 3.2 Run the relevant workflow compilation or repository checks needed to confirm the schema-coverage rotation workflow remains valid after the bootstrap changes.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec proposal to bootstrap Go and Node toolchains before agent execution in schema-coverage-rotation
- Adds a design document, proposal, spec, and task checklist under `openspec/changes/schema-coverage-rotation-toolchain-bootstrap/` to define how the `schema-coverage-rotation` workflow should set up toolchains before agent reasoning begins.
- Specifies installing Go via `actions/setup-go` (from `go.mod`), exporting `GOROOT`/`GOPATH`/`GOMODCACHE` to `GITHUB_ENV`, installing Node via `actions/setup-node` (from `package.json`), and running `make setup`.
- Mirrors the pattern already used by `openspec-verify-label` and declares a new `ci-schema-coverage-rotation-toolchain` capability.
- Expands the AWF network policy to allow `defaults`, `node`, and `go` ecosystems so toolchain installation can succeed in chroot mode.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3df956d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->