### PR TITLE
Proposal to migrate to litellm

### DIFF
--- a/openspec/changes/openspec-verify-label-litellm-proxy/.openspec.yaml
+++ b/openspec/changes/openspec-verify-label-litellm-proxy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/openspec-verify-label-litellm-proxy/design.md
+++ b/openspec/changes/openspec-verify-label-litellm-proxy/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The `openspec-verify-label` workflow is already structured around GitHub Agentic Workflows with deterministic pre-activation gates, a Copilot engine, and GitHub-native review and archive safe outputs. Today, the workflow frontmatter still selects a GitHub-hosted Copilot model directly, which means the repository cannot centralize model routing, observability, or provider policy through the Elastic LiteLLM gateway.
+
+This change is intentionally narrow: it affects only the verification workflow and only the model-inference path. The repository wants to preserve the existing `copilot` engine contract while routing Copilot CLI through the OpenAI-compatible LiteLLM endpoint `https://elastic.litellm-prod.ai/v1` and updating the workflow model selector to `llm-gateway/gpt-5.4`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep `openspec-verify-label` on the `copilot` engine rather than redesigning the workflow around a different GH AW engine.
+- Route verification-model traffic through the Elastic LiteLLM proxy using documented Copilot CLI BYOK provider settings.
+- Change the workflow model selection to `llm-gateway/gpt-5.4`.
+- Make the required provider endpoint, secret-backed auth handoff, and AWF network allowlist explicit in the OpenSpec contract.
+- Preserve existing GitHub review, archive, push, and label-cleanup behavior.
+
+**Non-Goals:**
+- Migrating other GH AW workflows, including `schema-coverage-rotation`, in the same change.
+- Changing review disposition rules, archive gating, or the deterministic pull-request classification logic.
+- Switching the workflow to `codex`, `claude`, or another non-Copilot engine.
+- Introducing `COPILOT_OFFLINE` mode or otherwise attempting to remove all GitHub connectivity from the run.
+
+## Decisions
+
+### 1. Use Copilot CLI BYOK provider settings instead of switching engines
+
+The workflow should keep `engine.id: copilot` and route inference through LiteLLM by setting Copilot CLI BYOK provider configuration in `engine.env`. The intended shape is:
+
+- `engine.id: copilot`
+- `engine.model: llm-gateway/gpt-5.4`
+- `engine.env.COPILOT_PROVIDER_TYPE: openai`
+- `engine.env.COPILOT_PROVIDER_BASE_URL: https://elastic.litellm-prod.ai/v1`
+- `engine.env.COPILOT_PROVIDER_API_KEY` sourced from a GitHub Actions secret-backed expression
+
+Why:
+- It preserves the workflow's existing Copilot-specific execution path and GH AW semantics.
+- Copilot CLI documents BYOK provider configuration for OpenAI-compatible endpoints, which matches LiteLLM cleanly.
+- It separates the stable repository-facing model alias (`llm-gateway/gpt-5.4`) from whatever provider routing LiteLLM performs behind the endpoint.
+
+Alternatives considered:
+- Switch the workflow engine to `codex` or another OpenAI-native engine: rejected because the requested migration explicitly keeps Copilot as the engine.
+- Use a Copilot base-URL proxy override instead of BYOK provider settings: rejected because the BYOK provider path is the documented OpenAI-compatible configuration and makes provider auth explicit.
+
+### 2. Treat the LiteLLM host as part of the AWF review-environment contract
+
+The workflow should extend its existing AWF network policy to allow `elastic.litellm-prod.ai` alongside the current review-environment dependencies (`defaults`, `node`, and `go`).
+
+Why:
+- The current verification workflow already declares an explicit AWF allowlist.
+- Routing inference through LiteLLM will fail unless the review job can reach that hostname.
+- Encoding the host in the spec keeps the workflow observable and testable rather than burying the dependency in implementation detail.
+
+Alternative considered:
+- Rely on an implicit or broader network allowance: rejected because it weakens the current least-privilege posture and makes the routing dependency harder to audit.
+
+### 3. Preserve GitHub-native workflow behavior and auth boundaries
+
+This change should reroute only model inference. It should not alter the workflow's GitHub tools, safe outputs, or deterministic pre-activation steps, and it should not require offline mode. The workflow may continue to use GitHub authentication and GitHub-managed review/archive operations while sourcing LiteLLM provider auth separately.
+
+Why:
+- Review comments, review submission, label removal, and archive push are GitHub operations, not model-provider operations.
+- Keeping those paths unchanged minimizes migration risk.
+- Avoiding offline mode reduces the chance of accidentally breaking existing Copilot or GH AW behavior that still expects GitHub connectivity.
+
+Alternative considered:
+- Enable `COPILOT_OFFLINE` and try to fully isolate the run to LiteLLM: rejected because this workflow still depends on GitHub-native capabilities and the user request only requires routing the model path.
+
+## Risks / Trade-offs
+
+- [LiteLLM endpoint availability becomes part of verify-openspec reliability] -> Mitigation: keep the change limited to one workflow first and make the dependency explicit in both spec and workflow frontmatter.
+- [A secret-backed provider auth contract adds one more operational prerequisite] -> Mitigation: require secret-backed configuration in the workflow contract and document the expected provider env handoff in the change artifacts.
+- [The configured model alias may not match the final LiteLLM catalog forever] -> Mitigation: encode the requested model string in the workflow contract now; if the router naming changes later, capture that as a follow-up change.
+- [Copilot-specific behavior could still differ slightly when using BYOK routing] -> Mitigation: keep the engine unchanged, use the documented BYOK provider configuration, and validate on a representative verify-openspec run before considering broader rollout.
+
+## Migration Plan
+
+1. Update `.github/workflows-src/openspec-verify-label/workflow.md.tmpl` to set the new model and provider environment variables, and to allow the LiteLLM host in `network.allowed`.
+2. Recompile `.github/workflows/openspec-verify-label.md` and `.github/workflows/openspec-verify-label.lock.yml`.
+3. Sync the `ci-aw-openspec-verification` canonical spec with the approved routing and network requirements.
+4. Validate the change artifacts and run or inspect a representative `verify-openspec` workflow execution that uses the LiteLLM-backed configuration.
+
+## Open Questions
+
+- None for the requested migration. Secret naming can be chosen during implementation as long as the provider API key is sourced from a GitHub Actions secret expression rather than a checked-in literal.

--- a/openspec/changes/openspec-verify-label-litellm-proxy/proposal.md
+++ b/openspec/changes/openspec-verify-label-litellm-proxy/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `openspec-verify-label` workflow currently runs GitHub Agentic Workflows with a GitHub-hosted Copilot model selection baked into the workflow frontmatter. The repository now wants that verification path to keep using the Copilot engine while routing model inference through the Elastic OpenAI-compatible LiteLLM proxy at `https://elastic.litellm-prod.ai/v1`, with the model set to `llm-gateway/gpt-5.4`.
+
+## What Changes
+
+- Update the `openspec-verify-label` workflow contract so the verification job keeps `engine.id: copilot` while configuring Copilot CLI BYOK provider settings for an OpenAI-compatible LiteLLM endpoint.
+- Change the workflow model selection from `gpt-5.4` to `llm-gateway/gpt-5.4`.
+- Require the workflow network policy to allow the LiteLLM host in addition to the existing review-environment dependencies.
+- Document the secret-backed provider-auth contract needed for the LiteLLM proxy without changing the workflow's GitHub-native review, archive, or safe-output behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `ci-aw-openspec-verification`: Change the verification-engine requirements so `openspec-verify-label` keeps the Copilot engine but routes model traffic through the OpenAI-compatible LiteLLM endpoint `https://elastic.litellm-prod.ai/v1` using model `llm-gateway/gpt-5.4`.
+
+## Impact
+
+- Authored workflow source under `.github/workflows-src/openspec-verify-label/`
+- Generated workflow artifacts under `.github/workflows/openspec-verify-label.*`
+- Copilot engine environment and AWF network policy for the verification job
+- OpenSpec requirements for `ci-aw-openspec-verification`

--- a/openspec/changes/openspec-verify-label-litellm-proxy/specs/ci-aw-openspec-verification/spec.md
+++ b/openspec/changes/openspec-verify-label-litellm-proxy/specs/ci-aw-openspec-verification/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Verification engine uses Copilot BYOK LiteLLM routing
+The `openspec-verify-label` workflow SHALL keep `engine.id: copilot`, SHALL set `engine.model` to `llm-gateway/gpt-5.4`, and SHALL configure Copilot CLI to use an OpenAI-compatible BYOK provider for model inference by setting `COPILOT_PROVIDER_TYPE` to `openai` and `COPILOT_PROVIDER_BASE_URL` to `https://elastic.litellm-prod.ai/v1`. Any provider credential passed as `COPILOT_PROVIDER_API_KEY` SHALL be sourced from a GitHub Actions secret-backed expression rather than from a checked-in literal.
+
+#### Scenario: Authored workflow preserves the Copilot engine
+- **WHEN** maintainers inspect the authored `openspec-verify-label` workflow source
+- **THEN** `engine.id` SHALL be `copilot`
+- **AND** `engine.model` SHALL be `llm-gateway/gpt-5.4`
+
+#### Scenario: Copilot BYOK provider targets the Elastic LiteLLM endpoint
+- **WHEN** maintainers inspect the verification workflow's engine environment
+- **THEN** `COPILOT_PROVIDER_TYPE` SHALL be `openai`
+- **AND** `COPILOT_PROVIDER_BASE_URL` SHALL be `https://elastic.litellm-prod.ai/v1`
+
+#### Scenario: Provider authentication is secret-backed
+- **WHEN** maintainers inspect the authored workflow source
+- **THEN** any configured `COPILOT_PROVIDER_API_KEY` value SHALL come from a GitHub Actions secret expression rather than a literal API key value committed to the repository
+
+## MODIFIED Requirements
+
+### Requirement: Review environment bootstraps repository toolchains
+The workflow SHALL provision the same core toolchain layers as the `lint` job before agent verification begins. At a minimum, it SHALL set up Node using `actions/setup-node` with `node-version-file: package.json`, SHALL configure Go in the runner environment through `actions/setup-go` with `go-version-file: go.mod`, SHALL export `GOROOT`, `GOPATH`, and `GOMODCACHE` after Go setup for AWF chroot mode, SHALL allow the Go ecosystem and `elastic.litellm-prod.ai` in the workflow's AWF network policy, and SHALL NOT use workflow frontmatter `runtimes.go` for Go provisioning.
+
+#### Scenario: Node toolchain follows package.json
+- **GIVEN** the repository declares the supported Node version in `package.json`
+- **WHEN** the `verify-openspec` review environment is prepared in workspace mode
+- **THEN** the workflow SHALL configure `actions/setup-node` with `node-version-file: package.json`
+
+#### Scenario: Go toolchain follows go.mod
+- **GIVEN** the workflow prepares the runner environment for repository setup steps in workspace mode
+- **WHEN** the Go toolchain is installed
+- **THEN** the workflow SHALL configure `actions/setup-go` with `go-version-file: go.mod`
+
+#### Scenario: AWF chroot mode receives the configured Go paths
+- **GIVEN** the review workflow has installed Go from `go.mod` in workspace mode
+- **WHEN** the agent environment is prepared for AWF chroot mode
+- **THEN** the workflow SHALL export `GOROOT=$(go env GOROOT)` to `GITHUB_ENV`
+- **AND** the workflow SHALL export `GOPATH=$(go env GOPATH)` to `GITHUB_ENV`
+- **AND** the workflow SHALL export `GOMODCACHE=$(go env GOMODCACHE)` to `GITHUB_ENV`
+
+#### Scenario: AWF network policy allows the Go ecosystem and LiteLLM host
+- **GIVEN** agent-executed verification commands may need Go module network access and LiteLLM provider access
+- **WHEN** maintainers inspect the workflow frontmatter
+- **THEN** `network.allowed` SHALL include `go`
+- **AND** `network.allowed` SHALL include `elastic.litellm-prod.ai`
+
+#### Scenario: Review bootstrap does not use runtimes.go
+- **GIVEN** the review workflow bootstrap is implemented
+- **WHEN** maintainers inspect the authored workflow source
+- **THEN** it SHALL provision Go from `go.mod` and SHALL NOT declare `runtimes.go`
+
+#### Scenario: Terraform CLI matches repository CI expectations
+- **GIVEN** the review workflow uses repository scripts or commands that require Terraform CLI behavior consistent with CI
+- **WHEN** the review environment is prepared in workspace mode
+- **THEN** Terraform SHALL be available in that environment without wrapper behavior enabled

--- a/openspec/changes/openspec-verify-label-litellm-proxy/tasks.md
+++ b/openspec/changes/openspec-verify-label-litellm-proxy/tasks.md
@@ -1,0 +1,15 @@
+## 1. Update the verify workflow routing
+
+- [ ] 1.1 Update `.github/workflows-src/openspec-verify-label/workflow.md.tmpl` so the verification job keeps `engine.id: copilot`, sets `engine.model` to `llm-gateway/gpt-5.4`, and configures Copilot CLI BYOK provider environment variables for `https://elastic.litellm-prod.ai/v1`.
+- [ ] 1.2 Extend the workflow's AWF network policy so `network.allowed` includes `elastic.litellm-prod.ai` alongside the existing review-environment dependencies.
+- [ ] 1.3 Regenerate `.github/workflows/openspec-verify-label.md` and `.github/workflows/openspec-verify-label.lock.yml` from the authored workflow source.
+
+## 2. Align requirements and workflow contract
+
+- [ ] 2.1 Sync the `ci-aw-openspec-verification` canonical spec with the approved LiteLLM routing and review-environment network requirements from this delta spec.
+- [ ] 2.2 Ensure the workflow sources any `COPILOT_PROVIDER_API_KEY` value from a GitHub Actions secret-backed expression rather than a checked-in literal.
+
+## 3. Validate the migration
+
+- [ ] 3.1 Validate the new change and the updated specs with `npx openspec validate --change openspec-verify-label-litellm-proxy` or an equivalent repository OpenSpec check.
+- [ ] 3.2 Run or inspect a representative `verify-openspec` workflow execution on a branch that includes the LiteLLM configuration to confirm the review job can reach `https://elastic.litellm-prod.ai/v1` and starts with model `llm-gateway/gpt-5.4`.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add proposal to route `openspec-verify-label` Copilot engine through LiteLLM proxy
- Adds a design document, proposal, delta spec, and task list for migrating the `openspec-verify-label` workflow's Copilot engine to use a LiteLLM endpoint (`https://elastic.litellm-prod.ai/v1`) with model `llm-gateway/gpt-5.4`.
- Keeps `engine.id: copilot` but configures a BYOK OpenAI-compatible provider via `COPILOT_PROVIDER_TYPE`, `COPILOT_PROVIDER_BASE_URL`, and a secret-backed `COPILOT_PROVIDER_API_KEY`.
- Requires updating the AWF network allowlist to permit `elastic.litellm-prod.ai` and regenerating workflow artifacts.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6223dfe.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->