### PR TITLE
Ensure clients have a valid endpoint

### DIFF
--- a/openspec/changes/validate-component-client-endpoints/.openspec.yaml
+++ b/openspec/changes/validate-component-client-endpoints/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-04-13
+

--- a/openspec/changes/validate-component-client-endpoints/design.md
+++ b/openspec/changes/validate-component-client-endpoints/design.md
@@ -1,0 +1,81 @@
+## Context
+
+Provider configuration is intentionally component-optional, so the provider cannot require Elasticsearch, Kibana, and Fleet endpoints up front during provider configuration. The current `*clients.APIClient` accessors only check whether the underlying client pointer is `nil`, which means missing endpoint configuration is discovered later and with low-signal errors.
+
+This is especially visible for Kibana-family access:
+- the legacy Kibana client can be constructed with an empty address and will default to `http://localhost:5601`
+- the Kibana OpenAPI and Fleet clients can be constructed with empty URLs and fail later when used
+- `APIClient` currently retains `kibanaConfig` for SLO auth, but it does not retain resolved Elasticsearch or Fleet endpoint state for validation
+
+The change therefore needs a provider-internal design that preserves optional component configuration while letting entities fail early, at the point where they request a component client, with an actionable configuration error.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `*clients.APIClient` accessors the single enforcement point for missing component endpoints.
+- Validate against the effective resolved endpoint values after provider config and environment overrides have already been applied.
+- Preserve existing provider behavior that allows users to configure only the components they use.
+- Preserve existing Fleet endpoint inheritance from Kibana configuration.
+- Apply the same validation semantics to the normal provider constructors and the acceptance-test client constructor.
+
+**Non-Goals:**
+- Adding authentication validation for username/password, API key, or bearer token fields.
+- Changing provider schema requirements or making component endpoints mandatory at provider configure time.
+- Redesigning config resolution order or the existing Kibana-to-Fleet endpoint inheritance behavior.
+- Changing entity-level code paths beyond their existing accessor usage.
+
+## Decisions
+
+Validate at accessor entry, not during provider configuration or client construction.
+The accessors are the first point where the provider knows which component a resource or data source is trying to use. Validating there preserves the current component-optional provider contract while replacing downstream transport failures with targeted configuration errors.
+
+Alternative considered: validate in provider schema or provider `Configure`.
+Rejected because it would force all components to be configured even for users who only manage Elasticsearch or only manage Kibana-backed resources.
+
+Store resolved endpoint snapshots on `APIClient`.
+`APIClient` should retain the effective endpoint state needed by the accessors, separate from the constructed client objects. The minimal design is to store resolved Elasticsearch endpoint presence, resolved Kibana endpoint, and resolved Fleet endpoint alongside the existing clients and `kibanaConfig`.
+
+Alternative considered: infer configuration state from the constructed clients.
+Rejected because the client implementations are inconsistent. The legacy Kibana client masks missing configuration by defaulting to localhost, while the OpenAPI and Fleet clients do not provide a reliable, uniform signal for "configured but empty".
+
+Populate endpoint snapshots from resolved `config.Client` values.
+The snapshot should be taken after config resolution has already folded together provider input and environment overrides. For Fleet, the stored value should reflect the already-resolved `cfg.Fleet` endpoint, which may have been inherited from the Kibana-derived config path. This keeps the accessor checks aligned with the provider's existing resolution semantics instead of reimplementing them.
+
+Alternative considered: recompute Fleet fallback inside `GetFleetClient()`.
+Rejected because it would duplicate config resolution rules in the accessor layer and create drift risk between config building and validation.
+
+Keep endpoint validation separate from the `nil` client safety guard.
+The accessors should use endpoint validation for user-facing configuration problems and retain the current `nil` checks as an internal safety net. In practice, missing endpoints should produce the new actionable errors, while unexpected construction gaps can still surface as internal "client not found" failures.
+
+Alternative considered: replace the `nil` guards entirely.
+Rejected because the `nil` checks still provide value for unexpected internal states and make the change less risky.
+
+Unify constructor behavior enough that all `APIClient` creation paths carry validation metadata.
+The normal provider constructors already flow through `newAPIClientFromConfig(...)`; the acceptance-test constructor currently builds the clients inline. The implementation should ensure both paths populate the same endpoint snapshot state so tests and production code see the same accessor behavior.
+
+Alternative considered: leave `NewAcceptanceTestingClient()` as a special case.
+Rejected because it would make accessor behavior differ between production and acceptance-test client setup, which weakens regression coverage for this change.
+
+Limit the new validation to endpoint presence only.
+The change should check only whether a component has an effective endpoint. If an endpoint is present, the accessor should not fail solely because auth fields are empty.
+
+Alternative considered: validate endpoint and auth together.
+Rejected because that broadens the behavior change beyond issue #355 and would interfere with deployments that rely on proxy-managed or anonymous auth behavior.
+
+## Risks / Trade-offs
+
+- [Risk] Eager client construction still happens before accessor validation, so some misconfigured clients may still be instantiated internally -> Mitigation: keep this change scoped to access-time validation and rely on the accessor boundary to prevent misleading runtime request errors.
+- [Risk] Future config-builder changes could update endpoint resolution without updating the stored snapshot fields -> Mitigation: snapshot directly from the resolved `config.Client` values in the shared construction path and add focused tests for each accessor.
+- [Risk] Wrapper diagnostics such as `unable to get kibana client` will still add their own summary around the new errors -> Mitigation: make the accessor error strings self-contained and actionable so the composed diagnostic remains clear.
+
+## Migration Plan
+
+1. Extend `APIClient` to retain the resolved endpoint state needed for Elasticsearch, Kibana, and Fleet validation.
+2. Populate that state from resolved `config.Client` values in the shared constructor path and in the acceptance-test client path.
+3. Update `GetESClient()`, `GetKibanaClient()`, `GetKibanaOapiClient()`, `GetSloClient()`, and `GetFleetClient()` to perform endpoint validation before returning the client.
+4. Add focused unit coverage for missing-endpoint failures, Fleet endpoint inheritance, and the legacy Kibana localhost fallback case.
+
+## Open Questions
+
+- None. The remaining work is implementation and focused test coverage.
+

--- a/openspec/changes/validate-component-client-endpoints/proposal.md
+++ b/openspec/changes/validate-component-client-endpoints/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Provider configuration is intentionally component-optional: practitioners should be able to configure only Elasticsearch, only Kibana, or only the components their Terraform resources actually use. The current provider client accessors do not enforce that the required endpoint for a specific component is actually present before returning a client, so missing component configuration leaks through as low-signal downstream failures such as `unsupported protocol scheme ""` or misleading localhost behavior from the legacy Kibana client.
+
+Issue [#355](https://github.com/elastic/terraform-provider-elasticstack/issues/355) asks for more relevant errors when the provider is not correctly configured. The narrow fix here is to validate endpoint presence only, at the point where an entity asks for a component client, and return an actionable message before any request is attempted.
+
+## What Changes
+
+- Add endpoint-present validation to `*clients.APIClient` component accessors before they return Elasticsearch, Kibana, Kibana OpenAPI, SLO, or Fleet clients.
+- Require `GetESClient()` to fail with an actionable error when no effective Elasticsearch endpoint is configured.
+- Require `GetKibanaClient()`, `GetKibanaOapiClient()`, and `GetSloClient()` to fail with an actionable error when no effective Kibana endpoint is configured.
+- Require `GetFleetClient()` to fail with an actionable error when no effective Fleet endpoint is configured, including the case where Fleet relies on Kibana-derived endpoint resolution.
+- Keep scope limited to endpoint validation only; do not introduce authentication validation or new provider-schema requirements in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-component-client-accessors`: provider client accessors SHALL reject missing component endpoints with component-specific, actionable configuration errors before entity operations send requests.
+
+### Modified Capabilities
+
+- _(none)_
+
+## Impact
+
+- Specs: delta spec under `openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md`
+- Provider client accessors and resolved configuration handling in `internal/clients/api_client.go`
+- Accessor-level tests and any targeted entity regression coverage needed to verify the new diagnostics
+

--- a/openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md
+++ b/openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Elasticsearch accessor requires an effective endpoint
+`(*clients.APIClient).GetESClient()` SHALL validate that an effective Elasticsearch endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce an Elasticsearch endpoint, the accessor SHALL return an error instead of returning a usable client.
+
+#### Scenario: Missing Elasticsearch endpoint returns actionable error
+- **GIVEN** a provider client whose effective Elasticsearch endpoint configuration is empty
+- **WHEN** `GetESClient()` is called
+- **THEN** the accessor SHALL return no client
+- **AND** it SHALL return the error `provider Elasticsearch client is not configured: set elasticsearch.endpoints or ELASTICSEARCH_ENDPOINTS`
+
+### Requirement: Kibana-family accessors require an effective Kibana endpoint
+`(*clients.APIClient).GetKibanaClient()`, `GetKibanaOapiClient()`, and `GetSloClient()` SHALL validate that an effective Kibana endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce a Kibana endpoint, each accessor SHALL return an error instead of returning a usable client.
+
+#### Scenario: Missing Kibana endpoint returns actionable error for the legacy Kibana client
+- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **WHEN** `GetKibanaClient()` is called
+- **THEN** the accessor SHALL return no client
+- **AND** it SHALL return the error `provider Kibana client is not configured: set kibana.endpoints or KIBANA_ENDPOINT`
+
+#### Scenario: Missing Kibana endpoint returns actionable error for the Kibana OpenAPI client
+- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **WHEN** `GetKibanaOapiClient()` is called
+- **THEN** the accessor SHALL return no client
+- **AND** it SHALL return the error `provider Kibana OpenAPI client is not configured: set kibana.endpoints or KIBANA_ENDPOINT`
+
+#### Scenario: Missing Kibana endpoint returns actionable error for the SLO client
+- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **WHEN** `GetSloClient()` is called
+- **THEN** the accessor SHALL return no client
+- **AND** it SHALL return the error `provider SLO client is not configured: set kibana.endpoints or KIBANA_ENDPOINT`
+
+#### Scenario: Legacy Kibana accessor does not fall back to localhost when unconfigured
+- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **WHEN** `GetKibanaClient()` is called
+- **THEN** the accessor SHALL fail before a request can target a default localhost endpoint
+
+### Requirement: Fleet accessor requires an effective Fleet endpoint
+`(*clients.APIClient).GetFleetClient()` SHALL validate that an effective Fleet endpoint is configured before returning a client. The effective Fleet endpoint MAY come from explicit Fleet configuration or from the existing Fleet-from-Kibana endpoint resolution path. If neither resolution path produces a Fleet endpoint, the accessor SHALL return an error instead of returning a usable client.
+
+#### Scenario: Fleet accessor accepts Kibana-derived endpoint resolution
+- **GIVEN** a provider client whose explicit Fleet endpoint is empty
+- **AND** whose effective Kibana endpoint configuration is present and is the source of the Fleet endpoint
+- **WHEN** `GetFleetClient()` is called
+- **THEN** the accessor SHALL return the Fleet client without a missing-endpoint error
+
+#### Scenario: Missing Fleet endpoint returns actionable error
+- **GIVEN** a provider client whose effective Fleet endpoint configuration is empty after explicit Fleet and Kibana-derived resolution are evaluated
+- **WHEN** `GetFleetClient()` is called
+- **THEN** the accessor SHALL return no client
+- **AND** it SHALL return the error `provider Fleet client is not configured: set fleet.endpoint or FLEET_ENDPOINT, or configure kibana.endpoints or KIBANA_ENDPOINT for inherited Fleet endpoint resolution`
+
+### Requirement: Endpoint validation is limited to endpoint presence
+Component accessor validation introduced by this capability SHALL enforce endpoint presence only. Accessors SHALL NOT reject a client solely because username/password, API key, or bearer token values are absent.
+
+#### Scenario: Endpoint-only validation does not add authentication gating
+- **GIVEN** a provider client whose effective component endpoint is present
+- **AND** whose authentication fields are empty
+- **WHEN** the corresponding component accessor is called
+- **THEN** the accessor SHALL NOT fail solely because authentication fields are empty
+

--- a/openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md
+++ b/openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md
@@ -10,7 +10,7 @@
 - **AND** it SHALL return the error `provider Elasticsearch client is not configured: set elasticsearch.endpoints or ELASTICSEARCH_ENDPOINTS`
 
 ### Requirement: Kibana-family accessors require an effective Kibana endpoint
-`(*clients.APIClient).GetKibanaClient()`, `GetKibanaOapiClient()`, and `GetSloClient()` SHALL validate that an effective Kibana endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce a Kibana endpoint, each accessor SHALL return an error instead of returning a usable client.
+`(*clients.APIClient).GetKibanaClient()`, `(*clients.APIClient).GetKibanaOapiClient()`, and `(*clients.APIClient).GetSloClient()` SHALL validate that an effective Kibana endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce a Kibana endpoint, each accessor SHALL return an error instead of returning a usable client.
 
 #### Scenario: Missing Kibana endpoint returns actionable error for the legacy Kibana client
 - **GIVEN** a provider client whose effective Kibana endpoint configuration is empty

--- a/openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md
+++ b/openspec/changes/validate-component-client-endpoints/specs/provider-component-client-accessors/spec.md
@@ -1,51 +1,51 @@
 ## ADDED Requirements
 
 ### Requirement: Elasticsearch accessor requires an effective endpoint
-`(*clients.APIClient).GetESClient()` SHALL validate that an effective Elasticsearch endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce an Elasticsearch endpoint, the accessor SHALL return an error instead of returning a usable client.
+`(*clients.APIClient).GetESClient()` SHALL validate that an effective Elasticsearch endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce any non-empty Elasticsearch endpoint values, the accessor SHALL return an error instead of returning a usable client.
 
 #### Scenario: Missing Elasticsearch endpoint returns actionable error
-- **GIVEN** a provider client whose effective Elasticsearch endpoint configuration is empty
+- **GIVEN** a provider client whose effective Elasticsearch endpoint configuration contains no non-empty endpoint values
 - **WHEN** `GetESClient()` is called
 - **THEN** the accessor SHALL return no client
 - **AND** it SHALL return the error `provider Elasticsearch client is not configured: set elasticsearch.endpoints or ELASTICSEARCH_ENDPOINTS`
 
 ### Requirement: Kibana-family accessors require an effective Kibana endpoint
-`(*clients.APIClient).GetKibanaClient()`, `(*clients.APIClient).GetKibanaOapiClient()`, and `(*clients.APIClient).GetSloClient()` SHALL validate that an effective Kibana endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce a Kibana endpoint, each accessor SHALL return an error instead of returning a usable client.
+`(*clients.APIClient).GetKibanaClient()`, `GetKibanaOapiClient()`, and `GetSloClient()` SHALL validate that an effective Kibana endpoint is configured before returning a client. If neither provider configuration nor environment overrides produce any non-empty Kibana endpoint values, each accessor SHALL return an error instead of returning a usable client.
 
 #### Scenario: Missing Kibana endpoint returns actionable error for the legacy Kibana client
-- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **GIVEN** a provider client whose effective Kibana endpoint configuration contains no non-empty endpoint values
 - **WHEN** `GetKibanaClient()` is called
 - **THEN** the accessor SHALL return no client
 - **AND** it SHALL return the error `provider Kibana client is not configured: set kibana.endpoints or KIBANA_ENDPOINT`
 
 #### Scenario: Missing Kibana endpoint returns actionable error for the Kibana OpenAPI client
-- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **GIVEN** a provider client whose effective Kibana endpoint configuration contains no non-empty endpoint values
 - **WHEN** `GetKibanaOapiClient()` is called
 - **THEN** the accessor SHALL return no client
 - **AND** it SHALL return the error `provider Kibana OpenAPI client is not configured: set kibana.endpoints or KIBANA_ENDPOINT`
 
 #### Scenario: Missing Kibana endpoint returns actionable error for the SLO client
-- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **GIVEN** a provider client whose effective Kibana endpoint configuration contains no non-empty endpoint values
 - **WHEN** `GetSloClient()` is called
 - **THEN** the accessor SHALL return no client
 - **AND** it SHALL return the error `provider SLO client is not configured: set kibana.endpoints or KIBANA_ENDPOINT`
 
 #### Scenario: Legacy Kibana accessor does not fall back to localhost when unconfigured
-- **GIVEN** a provider client whose effective Kibana endpoint configuration is empty
+- **GIVEN** a provider client whose effective Kibana endpoint configuration contains no non-empty endpoint values
 - **WHEN** `GetKibanaClient()` is called
 - **THEN** the accessor SHALL fail before a request can target a default localhost endpoint
 
 ### Requirement: Fleet accessor requires an effective Fleet endpoint
-`(*clients.APIClient).GetFleetClient()` SHALL validate that an effective Fleet endpoint is configured before returning a client. The effective Fleet endpoint MAY come from explicit Fleet configuration or from the existing Fleet-from-Kibana endpoint resolution path. If neither resolution path produces a Fleet endpoint, the accessor SHALL return an error instead of returning a usable client.
+`(*clients.APIClient).GetFleetClient()` SHALL validate that an effective Fleet endpoint is configured before returning a client. The effective Fleet endpoint MAY come from explicit Fleet configuration or from the existing Fleet-from-Kibana endpoint resolution path. If neither resolution path produces any non-empty Fleet endpoint value, the accessor SHALL return an error instead of returning a usable client.
 
 #### Scenario: Fleet accessor accepts Kibana-derived endpoint resolution
 - **GIVEN** a provider client whose explicit Fleet endpoint is empty
-- **AND** whose effective Kibana endpoint configuration is present and is the source of the Fleet endpoint
+- **AND** whose effective Kibana endpoint configuration contains at least one non-empty endpoint value and is the source of the Fleet endpoint
 - **WHEN** `GetFleetClient()` is called
 - **THEN** the accessor SHALL return the Fleet client without a missing-endpoint error
 
 #### Scenario: Missing Fleet endpoint returns actionable error
-- **GIVEN** a provider client whose effective Fleet endpoint configuration is empty after explicit Fleet and Kibana-derived resolution are evaluated
+- **GIVEN** a provider client whose effective Fleet endpoint configuration contains no non-empty endpoint values after explicit Fleet and Kibana-derived resolution are evaluated
 - **WHEN** `GetFleetClient()` is called
 - **THEN** the accessor SHALL return no client
 - **AND** it SHALL return the error `provider Fleet client is not configured: set fleet.endpoint or FLEET_ENDPOINT, or configure kibana.endpoints or KIBANA_ENDPOINT for inherited Fleet endpoint resolution`

--- a/openspec/changes/validate-component-client-endpoints/tasks.md
+++ b/openspec/changes/validate-component-client-endpoints/tasks.md
@@ -1,0 +1,17 @@
+## 1. Capture effective endpoint state for accessor validation
+
+- [ ] 1.1 Update `internal/clients/api_client.go` so `APIClient` retains the resolved endpoint values needed to validate Elasticsearch, Kibana, and Fleet accessors after provider configuration and environment overrides are applied.
+- [ ] 1.2 Keep Fleet endpoint validation aligned with the existing Fleet-from-Kibana endpoint resolution path so inherited Kibana endpoints continue to work.
+
+## 2. Enforce accessor-level endpoint checks
+
+- [ ] 2.1 Update `GetESClient()` to reject missing effective Elasticsearch endpoints with the new actionable configuration error.
+- [ ] 2.2 Update `GetKibanaClient()`, `GetKibanaOapiClient()`, and `GetSloClient()` to reject missing effective Kibana endpoints with component-specific actionable errors and without relying on legacy localhost defaults.
+- [ ] 2.3 Update `GetFleetClient()` to reject missing effective Fleet endpoints with the Fleet-specific actionable error while preserving Kibana-derived Fleet endpoint resolution.
+- [ ] 2.4 Keep the new validation limited to endpoint presence only; do not add accessor failures for missing auth settings.
+
+## 3. Add focused regression coverage
+
+- [ ] 3.1 Add unit coverage for accessor behavior when Elasticsearch, Kibana, and Fleet endpoints are missing.
+- [ ] 3.2 Add focused coverage that proves Kibana endpoint validation blocks the legacy localhost fallback and that Fleet access still succeeds when its endpoint is inherited from Kibana.
+


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/355

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add spec and design for validating component client endpoints in provider accessors
> Adds OpenSpec documentation (proposal, design, spec, and tasks) for a new validation behavior that checks endpoint presence when accessing Elasticsearch, Kibana-family, and Fleet clients via `APIClient` accessors.
>
> - The [design doc](https://github.com/elastic/terraform-provider-elasticstack/pull/2238/files#diff-bc54a0501905e72f03828bc2cad811525f1a2a80f637bfc650db1782e8a3bd69) defines goals, decisions, and a migration plan for raising errors at accessor time when no endpoint is configured.
> - The [spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2238/files#diff-bf61dace9e2acbe06d2d28b801ea250036d998a4268e8552ce1e1875aeabbd33) details exact error messages and constrains validation to endpoint presence only.
> - The [tasks doc](https://github.com/elastic/terraform-provider-elasticstack/pull/2238/files#diff-6de6c7d3f33450ecb08c3aa0205f35a6f0fc96b078cb59ca8efd1493ae9078ff) tracks implementation work including endpoint state capture, accessor checks, and regression coverage.
> - No production code is changed in this PR; this is a spec-only change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c523475.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->