### PR TITLE
openspec -> npx openspec

### DIFF
--- a/.agents/hooks.json
+++ b/.agents/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": ".agents/hooks/use_npx_openspec.js",
+        "matcher": "Shell"
+      }
+    ]
+  }
+}

--- a/.agents/hooks/use_npx_openspec.js
+++ b/.agents/hooks/use_npx_openspec.js
@@ -3,15 +3,14 @@
 main();
 
 async function main() {
-  const chunks = [];
-
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-
-  const rawInput = Buffer.concat(chunks).toString("utf8");
-
   try {
+    const chunks = [];
+
+    for await (const chunk of process.stdin) {
+      chunks.push(chunk);
+    }
+
+    const rawInput = Buffer.concat(chunks).toString("utf8");
     const payload = rawInput ? JSON.parse(rawInput) : {};
     const toolInput = payload.tool_input ?? {};
     const command = typeof toolInput.command === "string" ? toolInput.command : "";

--- a/.agents/hooks/use_npx_openspec.js
+++ b/.agents/hooks/use_npx_openspec.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+main();
+
+async function main() {
+  const chunks = [];
+
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  const rawInput = Buffer.concat(chunks).toString("utf8");
+
+  try {
+    const payload = rawInput ? JSON.parse(rawInput) : {};
+    const toolInput = payload.tool_input ?? {};
+    const command = typeof toolInput.command === "string" ? toolInput.command : "";
+
+    if (payload.tool_name !== "Shell" || !command) {
+      allow();
+      return;
+    }
+
+    const rewrittenCommand = command.replace(/(^|[;&|()])(\s*)openspec(?=\s|$)/g, "$1$2npx openspec");
+
+    if (rewrittenCommand === command) {
+      allow();
+      return;
+    }
+
+    allow({
+      updated_input: {
+        ...toolInput,
+        command: rewrittenCommand,
+      },
+    });
+  } catch (_error) {
+    allow();
+  }
+}
+
+function allow(extra = {}) {
+  process.stdout.write(
+    JSON.stringify({
+      permission: "allow",
+      ...extra,
+    }),
+  );
+}

--- a/.agents/hooks/use_npx_openspec.js
+++ b/.agents/hooks/use_npx_openspec.js
@@ -1,48 +1,71 @@
 #!/usr/bin/env node
 
-main();
+async function readStdin(stream = process.stdin) {
+  const chunks = [];
 
-async function main() {
-  try {
-    const chunks = [];
-
-    for await (const chunk of process.stdin) {
-      chunks.push(chunk);
-    }
-
-    const rawInput = Buffer.concat(chunks).toString("utf8");
-    const payload = rawInput ? JSON.parse(rawInput) : {};
-    const toolInput = payload.tool_input ?? {};
-    const command = typeof toolInput.command === "string" ? toolInput.command : "";
-
-    if (payload.tool_name !== "Shell" || !command) {
-      allow();
-      return;
-    }
-
-    const rewrittenCommand = command.replace(/(^|[;&|()])(\s*)openspec(?=\s|$)/g, "$1$2npx openspec");
-
-    if (rewrittenCommand === command) {
-      allow();
-      return;
-    }
-
-    allow({
-      updated_input: {
-        ...toolInput,
-        command: rewrittenCommand,
-      },
-    });
-  } catch (_error) {
-    allow();
+  for await (const chunk of stream) {
+    chunks.push(chunk);
   }
+
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function rewriteOpenSpecCommand(command) {
+  if (typeof command !== "string" || command.length === 0) {
+    return command;
+  }
+
+  return command.replace(/(^|[;&|()])(\s*)openspec(?=\s|$)/g, "$1$2npx openspec");
 }
 
 function allow(extra = {}) {
-  process.stdout.write(
-    JSON.stringify({
-      permission: "allow",
-      ...extra,
-    }),
-  );
+  return {
+    permission: "allow",
+    ...extra,
+  };
+}
+
+function buildHookResponse(payload) {
+  const toolInput = payload?.tool_input ?? {};
+  const command = typeof toolInput.command === "string" ? toolInput.command : "";
+
+  if (payload?.tool_name !== "Shell" || !command) {
+    return allow();
+  }
+
+  const rewrittenCommand = rewriteOpenSpecCommand(command);
+
+  if (rewrittenCommand === command) {
+    return allow();
+  }
+
+  return allow({
+    updated_input: {
+      ...toolInput,
+      command: rewrittenCommand,
+    },
+  });
+}
+
+async function main({ input = process.stdin, output = process.stdout } = {}) {
+  try {
+    const rawInput = await readStdin(input);
+    const payload = rawInput ? JSON.parse(rawInput) : {};
+
+    output.write(JSON.stringify(buildHookResponse(payload)));
+  } catch (_error) {
+    output.write(JSON.stringify(allow()));
+  }
+}
+
+module.exports = {
+  allow,
+  buildHookResponse,
+  main,
+  readStdin,
+  rewriteOpenSpecCommand,
+};
+
+if (require.main === module) {
+  void main();
 }

--- a/.agents/hooks/use_npx_openspec.test.js
+++ b/.agents/hooks/use_npx_openspec.test.js
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const hookPath = path.resolve(__dirname, 'use_npx_openspec.js');
+
+const require = createRequire(import.meta.url);
+const { buildHookResponse, rewriteOpenSpecCommand } = require('./use_npx_openspec.js');
+
+test('rewriteOpenSpecCommand rewrites a plain openspec invocation', () => {
+  assert.equal(rewriteOpenSpecCommand('openspec validate'), 'npx openspec validate');
+});
+
+test('rewriteOpenSpecCommand rewrites openspec after common shell separators', () => {
+  assert.equal(
+    rewriteOpenSpecCommand('make setup && openspec validate ; ( openspec check )'),
+    'make setup && npx openspec validate ; ( npx openspec check )'
+  );
+});
+
+test('rewriteOpenSpecCommand leaves non-command mentions unchanged', () => {
+  assert.equal(rewriteOpenSpecCommand('echo openspec && printf "%s" openspec'), 'echo openspec && printf "%s" openspec');
+});
+
+test('buildHookResponse allows non-shell payloads unchanged', () => {
+  assert.deepEqual(
+    buildHookResponse({
+      tool_name: 'ReadFile',
+      tool_input: {
+        path: 'openspec/specs/example.md',
+      },
+    }),
+    {
+      permission: 'allow',
+    }
+  );
+});
+
+test('buildHookResponse preserves other shell inputs when rewriting', () => {
+  assert.deepEqual(
+    buildHookResponse({
+      tool_name: 'Shell',
+      tool_input: {
+        command: 'openspec validate',
+        working_directory: '/tmp/example',
+        description: 'Validate change',
+      },
+    }),
+    {
+      permission: 'allow',
+      updated_input: {
+        command: 'npx openspec validate',
+        working_directory: '/tmp/example',
+        description: 'Validate change',
+      },
+    }
+  );
+});
+
+test('buildHookResponse allows shell payloads without a command', () => {
+  assert.deepEqual(
+    buildHookResponse({
+      tool_name: 'Shell',
+      tool_input: {
+        working_directory: '/tmp/example',
+      },
+    }),
+    {
+      permission: 'allow',
+    }
+  );
+});
+
+test('hook CLI rewrites stdin payloads end-to-end', () => {
+  const result = spawnSync(process.execPath, [hookPath], {
+    input: JSON.stringify({
+      tool_name: 'Shell',
+      tool_input: {
+        command: 'openspec validate',
+        working_directory: '/tmp/example',
+      },
+    }),
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+  assert.deepEqual(JSON.parse(result.stdout), {
+    permission: 'allow',
+    updated_input: {
+      command: 'npx openspec validate',
+      working_directory: '/tmp/example',
+    },
+  });
+});
+
+test('hook CLI falls back to allow on invalid JSON', () => {
+  const result = spawnSync(process.execPath, [hookPath], {
+    input: '{not valid json',
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+  assert.deepEqual(JSON.parse(result.stdout), {
+    permission: 'allow',
+  });
+});


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add agent hook to rewrite `openspec` shell commands to `npx openspec`
- Adds a `preToolUse` agent hook in [hooks.json](.agents/hooks.json) that intercepts Shell tool inputs and rewrites standalone `openspec` invocations to `npx openspec`.
- The rewrite logic in [use_npx_openspec.js](.agents/hooks/use_npx_openspec.js) uses a regex to match `openspec` only at command positions (start of input or after `;`, `&`, `|`, `(`, `)`) to avoid rewriting non-command occurrences.
- The hook reads a JSON payload from stdin and emits an `allow` response, optionally with `updated_input` when a rewrite occurs; falls back to a plain `allow` on invalid input.
- Tests in [use_npx_openspec.test.js](.agents/hooks/use_npx_openspec.test.js) cover rewrite cases, passthrough cases, and end-to-end CLI behavior.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4eef781.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->