### PR TITLE
Skip acceptance tests for non-provider PRs

### DIFF
--- a/openspec/changes/ci-acceptance-gating/.openspec.yaml
+++ b/openspec/changes/ci-acceptance-gating/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-13

--- a/openspec/changes/ci-acceptance-gating/design.md
+++ b/openspec/changes/ci-acceptance-gating/design.md
@@ -1,0 +1,115 @@
+## Context
+
+The `Build/Lint/Test` workflow in `.github/workflows/test.yml` currently exposes acceptance coverage through the `Matrix Acceptance Test` job only. GitHub branch protection can require those matrix checks, but workflow-level path filtering is not a viable escape hatch for non-provider changes because a skipped workflow leaves required checks pending instead of succeeding.
+
+The workflow already has a `preflight` job that decides whether downstream jobs should execute, and `auto-approve` currently keys off `needs.test.result == 'success'`. That means an intentional acceptance-test skip for `openspec/**`-only changes needs a stable replacement status signal, not just a narrower `if:` on the matrix job.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Skip matrix acceptance tests when a workflow run changes only `openspec/**` paths in the first iteration.
+- Keep the main workflow running so build, lint, and OpenSpec validation behavior remain available for spec-only changes.
+- Publish a single stable validation job that can be used as the required acceptance-related branch-protection check.
+- Preserve existing auto-approve behavior by keying it off the new validation outcome instead of direct matrix-test success.
+
+**Non-Goals:**
+
+- Generalize the first iteration to all non-provider paths outside `openspec/**`.
+- Remove or relax the existing `build` or `lint` jobs.
+- Change the acceptance-test matrix contents, snapshot failure policy, or Docker stack setup.
+- Manage GitHub branch protection entirely from repository code; the workflow will provide the stable check, but maintainers still need to update the ruleset.
+
+## Decisions
+
+### 1. Add a dedicated change-classification job
+
+The workflow will add a small `changes` job after `preflight` that determines whether provider acceptance tests are required for the current diff. In the first iteration, it will emit `provider_changes=false` only when every changed file is under `openspec/`; any other change set will emit `provider_changes=true`.
+
+Why:
+
+- It keeps the workflow itself active, avoiding the required-check deadlock caused by workflow-level path filters.
+- It gives downstream jobs a deterministic, reusable signal instead of duplicating path logic across jobs.
+- It preserves room to widen the non-provider path allowlist later without changing the overall workflow shape.
+
+Alternatives considered:
+
+- Expand `paths-ignore` on the workflow trigger: rejected because required checks stay pending when a workflow is skipped by path filters.
+- Infer non-provider changes inside the matrix `test` job only: rejected because other jobs, including validation and auto-approve, also need the classification result.
+
+### 2. Keep `build` and `lint` independent of the acceptance classifier
+
+Only the matrix acceptance `test` job will be gated by `provider_changes`. `build` and `lint` will continue to follow the existing `preflight` behavior.
+
+Why:
+
+- `lint` already validates OpenSpec structure and remains useful for `openspec/**`-only changes.
+- This keeps the first iteration narrow: save the expensive acceptance matrix without changing the broader CI contract.
+
+Alternatives considered:
+
+- Skip `build` and `lint` for spec-only changes too: rejected because that broadens the scope from acceptance gating into a larger CI redesign.
+
+### 3. Add an always-running `Test Validation` job as the stable required check
+
+The workflow will add a `test-validation` job that runs with `always()` after `preflight`, `changes`, and `test`. It will evaluate workflow outcomes and produce a single final result:
+
+- pass when `preflight` intentionally disables CI execution
+- pass when `provider_changes=false` and the matrix test job is skipped
+- pass when `provider_changes=true` and the matrix test job succeeds
+- fail when `provider_changes=true` and the matrix test job does not succeed
+
+Why:
+
+- GitHub branch protection works reliably with a required job that is present on every run.
+- It collapses per-version matrix behavior into one stable check name for required-check configuration.
+- It makes the skip policy explicit instead of forcing maintainers to reason about matrix-job absence or skipped states.
+
+Alternatives considered:
+
+- Require the matrix checks directly: rejected because the required-check set is unstable for intentionally skipped acceptance runs.
+- Add a second stand-in workflow with inverse path filters: rejected because it recreates the same required-check edge cases and complicates status management across workflows.
+
+### 4. Repoint auto-approve at validation instead of raw test success
+
+`auto-approve` will depend on the new validation outcome, not `needs.test.result == 'success'`.
+
+Why:
+
+- A spec-only pull request should still be able to satisfy the current automation contract when acceptance tests were intentionally not needed.
+- Validation is the new normalized signal for whether the test gate was satisfied.
+
+Alternatives considered:
+
+- Treat `needs.test.result == 'skipped'` as success directly in `auto-approve`: rejected because that spreads skip-policy logic into multiple places instead of using the dedicated validation job.
+
+### 5. Treat branch-protection migration as an operational follow-up
+
+The workflow will expose the stable `Test Validation` check, but repository maintainers must still update GitHub branch protection or rulesets to require that check instead of the matrix acceptance checks.
+
+Why:
+
+- Required-check configuration lives outside the repository.
+- Splitting the workflow change from the ruleset update makes ownership clear and keeps the spec focused on repo-managed behavior while still documenting the operational step.
+
+Alternatives considered:
+
+- Leave branch protection unchanged: rejected because `openspec/**`-only pull requests would still be blocked by existing required matrix checks.
+
+## Risks / Trade-offs
+
+- **[Risk] The first-iteration classifier is intentionally narrow** -> Mitigation: scope the rule to `openspec/**` only for now, and extend it later through the same `changes` job if more non-provider paths should skip acceptance.
+- **[Risk] Validation could hide other CI failures if misconfigured** -> Mitigation: keep `build` and `lint` as separate jobs and recommend retaining them as required checks if they are currently part of the merge gate.
+- **[Risk] Ruleset updates may lag behind workflow rollout** -> Mitigation: document the required-check migration as part of the change and verify the new check name from a live run before removing the matrix checks from protection.
+
+## Migration Plan
+
+1. Add the workflow change-classification and validation logic in `.github/workflows/test.yml`.
+2. Update the `ci-build-lint-test` OpenSpec delta so the canonical workflow requirements match the new job graph and validation semantics.
+3. Trigger a workflow run that publishes the `Build/Lint/Test / Test Validation` check.
+4. Update branch protection or rulesets to require `Test Validation` instead of the per-version `Matrix Acceptance Test (...)` checks.
+5. Verify both an `openspec/**`-only change and a provider-impacting change against the new required-check behavior.
+
+## Open Questions
+
+- None for the first iteration.

--- a/openspec/changes/ci-acceptance-gating/proposal.md
+++ b/openspec/changes/ci-acceptance-gating/proposal.md
@@ -4,6 +4,7 @@ The main CI workflow exposes required acceptance checks as per-version matrix jo
 
 ## What Changes
 
+- Define the proposed CI behavior in OpenSpec change artifacts first; the workflow YAML implementation remains a follow-up task before the change can be considered implemented.
 - Update the `ci-build-lint-test` workflow requirements so matrix acceptance tests run only when the current change set includes provider-impacting files; in the first iteration, changes limited to `openspec/**` SHALL be treated as non-provider changes.
 - Add a dedicated workflow validation job that always reports a final test status: it passes when acceptance tests are intentionally skipped for non-provider changes, and it fails when provider changes require acceptance coverage but the matrix test job does not succeed.
 - Change the auto-approve gate to depend on the validation job result instead of raw matrix test success so spec-only pull requests can still satisfy the existing automation contract.
@@ -22,5 +23,5 @@ The main CI workflow exposes required acceptance checks as per-version matrix jo
 ## Impact
 
 - **Specs**: `openspec/specs/ci-build-lint-test/spec.md`
-- **Workflow logic**: `.github/workflows/test.yml` needs a change-classification step, conditional matrix-test execution, a `Test Validation` job, and updated auto-approve gating.
+- **Workflow logic**: `.github/workflows/test.yml` is unchanged in this proposal-only change set and still needs a follow-up implementation change for the change-classification step, conditional matrix-test execution, `Test Validation`, and updated auto-approve gating.
 - **Repository operations**: GitHub branch protection or rulesets must be updated to require the stable validation check instead of individual matrix acceptance checks.

--- a/openspec/changes/ci-acceptance-gating/proposal.md
+++ b/openspec/changes/ci-acceptance-gating/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The main CI workflow exposes required acceptance checks as per-version matrix jobs. That makes branch protection awkward for non-provider pull requests, because skipping the workflow with path filters leaves required checks pending while requiring every matrix leg blocks `openspec/**`-only changes that do not need provider acceptance coverage.
+
+## What Changes
+
+- Update the `ci-build-lint-test` workflow requirements so matrix acceptance tests run only when the current change set includes provider-impacting files; in the first iteration, changes limited to `openspec/**` SHALL be treated as non-provider changes.
+- Add a dedicated workflow validation job that always reports a final test status: it passes when acceptance tests are intentionally skipped for non-provider changes, and it fails when provider changes require acceptance coverage but the matrix test job does not succeed.
+- Change the auto-approve gate to depend on the validation job result instead of raw matrix test success so spec-only pull requests can still satisfy the existing automation contract.
+- Document the GitHub branch-protection follow-up to require the stable validation check instead of the per-version matrix acceptance checks.
+
+## Capabilities
+
+### New Capabilities
+
+- _(none)_
+
+### Modified Capabilities
+
+- `ci-build-lint-test`: Add diff-aware acceptance-test gating and a stable validation job for required-check integration.
+
+## Impact
+
+- **Specs**: `openspec/specs/ci-build-lint-test/spec.md`
+- **Workflow logic**: `.github/workflows/test.yml` needs a change-classification step, conditional matrix-test execution, a `Test Validation` job, and updated auto-approve gating.
+- **Repository operations**: GitHub branch protection or rulesets must be updated to require the stable validation check instead of individual matrix acceptance checks.

--- a/openspec/changes/ci-acceptance-gating/specs/ci-build-lint-test/spec.md
+++ b/openspec/changes/ci-acceptance-gating/specs/ci-build-lint-test/spec.md
@@ -2,19 +2,21 @@
 
 ### Requirement: Change classification gate (REQ-032–REQ-033)
 
-The workflow SHALL evaluate whether matrix acceptance tests are required for the current change set via a dedicated change-classification job. In the first iteration, the classifier SHALL set `provider_changes=false` only when every changed file for the workflow run is under `openspec/`; any change set containing a path outside `openspec/` SHALL set `provider_changes=true`.
+The workflow SHALL evaluate whether matrix acceptance tests are required for the current change set via a dedicated change-classification job, but only when the preflight gate permits downstream CI execution by outputting `should_run=true`. When the preflight gate outputs `should_run=false`, the change-classification job SHALL be intentionally skipped. In the first iteration, when the classifier runs, it SHALL set `provider_changes=false` only when every changed file for the workflow run is under `openspec/`; any change set containing a path outside `openspec/` SHALL set `provider_changes=true`.
 
-The change-classification job SHALL expose its result as a workflow output that downstream jobs can consume when deciding whether acceptance coverage is required.
+When the change-classification job runs, it SHALL expose its result as a workflow output that downstream jobs can consume when deciding whether acceptance coverage is required.
 
 #### Scenario: OpenSpec-only change set
 
 - **GIVEN** a workflow run whose changed files are all under `openspec/`
+- **AND** the preflight gate outputs `should_run=true`
 - **WHEN** the change-classification job evaluates the diff
 - **THEN** it SHALL report `provider_changes=false`
 
 #### Scenario: Provider-impacting change set
 
 - **GIVEN** a workflow run whose changed files include at least one path outside `openspec/`
+- **AND** the preflight gate outputs `should_run=true`
 - **WHEN** the change-classification job evaluates the diff
 - **THEN** it SHALL report `provider_changes=true`
 
@@ -25,10 +27,15 @@ The workflow SHALL publish a `Test Validation` job that always reports a final a
 The `Test Validation` job SHALL succeed when any of the following is true:
 
 * The preflight gate intentionally disables downstream CI execution
-* The change-classification job reports `provider_changes=false`
+* The change-classification job reports `provider_changes=false` and the matrix acceptance `test` job is intentionally skipped
 * The matrix acceptance `test` job completes successfully
 
-The `Test Validation` job SHALL fail when `provider_changes=true` and the matrix acceptance `test` job does not complete successfully. The validation job SHALL provide a stable required-check target that can be used by GitHub branch protection or rulesets instead of the per-version matrix acceptance checks.
+When the preflight gate allows downstream execution, the `Test Validation` job SHALL fail if either of the following is true:
+
+* The change-classification job reports `provider_changes=true` and the matrix acceptance `test` job does not complete successfully
+* The change-classification job reports `provider_changes=false` and the matrix acceptance `test` job still runs but does not complete successfully
+
+The validation job SHALL provide a stable required-check target that can be used by GitHub branch protection or rulesets instead of the per-version matrix acceptance checks.
 
 #### Scenario: OpenSpec-only pull request
 

--- a/openspec/changes/ci-acceptance-gating/specs/ci-build-lint-test/spec.md
+++ b/openspec/changes/ci-acceptance-gating/specs/ci-build-lint-test/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Change classification gate (REQ-032–REQ-033)
+
+The workflow SHALL evaluate whether matrix acceptance tests are required for the current change set via a dedicated change-classification job. In the first iteration, the classifier SHALL set `provider_changes=false` only when every changed file for the workflow run is under `openspec/`; any change set containing a path outside `openspec/` SHALL set `provider_changes=true`.
+
+The change-classification job SHALL expose its result as a workflow output that downstream jobs can consume when deciding whether acceptance coverage is required.
+
+#### Scenario: OpenSpec-only change set
+
+- **GIVEN** a workflow run whose changed files are all under `openspec/`
+- **WHEN** the change-classification job evaluates the diff
+- **THEN** it SHALL report `provider_changes=false`
+
+#### Scenario: Provider-impacting change set
+
+- **GIVEN** a workflow run whose changed files include at least one path outside `openspec/`
+- **WHEN** the change-classification job evaluates the diff
+- **THEN** it SHALL report `provider_changes=true`
+
+### Requirement: Test validation job (REQ-034–REQ-036)
+
+The workflow SHALL publish a `Test Validation` job that always reports a final acceptance-gate result for the workflow run. The validation job SHALL evaluate the preflight output, the change-classification output, and the matrix acceptance job result.
+
+The `Test Validation` job SHALL succeed when any of the following is true:
+
+* The preflight gate intentionally disables downstream CI execution
+* The change-classification job reports `provider_changes=false`
+* The matrix acceptance `test` job completes successfully
+
+The `Test Validation` job SHALL fail when `provider_changes=true` and the matrix acceptance `test` job does not complete successfully. The validation job SHALL provide a stable required-check target that can be used by GitHub branch protection or rulesets instead of the per-version matrix acceptance checks.
+
+#### Scenario: OpenSpec-only pull request
+
+- **GIVEN** a pull request whose changed files are all under `openspec/`
+- **WHEN** the workflow reaches `Test Validation`
+- **THEN** the matrix acceptance `test` job SHALL be treated as intentionally skipped
+- **AND** `Test Validation` SHALL succeed
+
+#### Scenario: Provider change with failing acceptance coverage
+
+- **GIVEN** a workflow run with `provider_changes=true`
+- **AND** the matrix acceptance `test` job does not complete successfully
+- **WHEN** `Test Validation` evaluates the workflow state
+- **THEN** `Test Validation` SHALL fail
+
+## MODIFIED Requirements
+
+### Requirement: Acceptance test job structure (REQ-009–REQ-014)
+
+The matrix acceptance test job SHALL depend on successful completion of the `build` job and the change-classification job. The acceptance test job SHALL run with a non-fail-fast matrix covering configured stack versions and included version-specific overrides. The acceptance test job SHALL configure required environment variables for Elastic credentials and experimental provider behavior. The acceptance test job SHALL execute only when the preflight gate outputs `should_run=true` and the change-classification job reports `provider_changes=true`.
+
+For each matrix entry, the job SHALL free disk space, set up Go and Terraform, run `make vendor`, start the stack via Docker Compose, and wait for Elasticsearch and Kibana readiness. Fleet setup and forced synthetics installation SHALL run only for configured version subsets. Acceptance tests SHALL run via `make testacc`, with snapshot versions allowed to fail (`continue-on-error`) while non-snapshot versions remain blocking.
+
+#### Scenario: Provider change runs stack and tests
+
+- **GIVEN** a matrix version and runner
+- **AND** the preflight gate allows execution
+- **AND** the change-classification job reports `provider_changes=true`
+- **WHEN** the test job executes
+- **THEN** the stack SHALL be provisioned, readiness waits SHALL pass, and `make testacc` SHALL run with the documented policy for snapshots
+
+#### Scenario: OpenSpec-only change skips matrix acceptance
+
+- **GIVEN** a workflow run whose changed files are all under `openspec/`
+- **WHEN** the acceptance test job evaluates its execution conditions
+- **THEN** the matrix acceptance `test` job SHALL be skipped
+
+### Requirement: Auto-approve job (REQ-018–REQ-021)
+
+The `auto-approve` job SHALL depend on successful completion of the `Test Validation` job, except on `ready_for_review` events where it SHALL run without that dependency. The `auto-approve` job SHALL only run on `pull_request` events. The `auto-approve` job SHALL execute `go run ./scripts/auto-approve`; approval policy and gate behavior are defined in [`openspec/specs/ci-pr-auto-approve/spec.md`](../ci-pr-auto-approve/spec.md). The `auto-approve` job SHALL request `contents: read` and `pull-requests: write` permissions.
+
+#### Scenario: Auto-approve after satisfied validation
+
+- **GIVEN** a pull request workflow and successful `Test Validation`
+- **WHEN** auto-approve runs
+- **THEN** it SHALL invoke `go run ./scripts/auto-approve` with the specified permissions
+
+### Requirement: Ready-for-review behavior (REQ-030)
+
+On `ready_for_review` `pull_request` events, the workflow SHALL keep the preflight gate behavior that prevents the `build`, `lint`, change-classification, and matrix acceptance `test` jobs from running. The `Test Validation` job SHALL succeed based on the intentional preflight skip, and `auto-approve` SHALL remain eligible to run.
+
+#### Scenario: Ready for review event
+
+- **GIVEN** a `pull_request` with action `ready_for_review`
+- **WHEN** the workflow runs
+- **THEN** `build`, `lint`, change-classification, and matrix acceptance `test` SHALL be skipped by the preflight gate
+- **AND** `Test Validation` SHALL succeed
+- **AND** auto-approve SHALL be eligible to run

--- a/openspec/changes/ci-acceptance-gating/tasks.md
+++ b/openspec/changes/ci-acceptance-gating/tasks.md
@@ -1,4 +1,4 @@
-## 1. Workflow changes
+## 1. Workflow implementation follow-up
 
 - [ ] 1.1 Add a change-classification job to `.github/workflows/test.yml` that reports `provider_changes=false` only when the workflow diff is limited to `openspec/**`.
 - [ ] 1.2 Update the matrix acceptance `test` job to depend on the change classifier and run only when both preflight allows execution and `provider_changes=true`.

--- a/openspec/changes/ci-acceptance-gating/tasks.md
+++ b/openspec/changes/ci-acceptance-gating/tasks.md
@@ -1,0 +1,16 @@
+## 1. Workflow changes
+
+- [ ] 1.1 Add a change-classification job to `.github/workflows/test.yml` that reports `provider_changes=false` only when the workflow diff is limited to `openspec/**`.
+- [ ] 1.2 Update the matrix acceptance `test` job to depend on the change classifier and run only when both preflight allows execution and `provider_changes=true`.
+- [ ] 1.3 Add the `Test Validation` job and repoint `auto-approve` so the workflow exposes a stable acceptance-related required check.
+
+## 2. OpenSpec sync
+
+- [ ] 2.1 Sync the delta in `openspec/changes/ci-acceptance-gating/specs/ci-build-lint-test/spec.md` into `openspec/specs/ci-build-lint-test/spec.md` or archive the change once the workflow implementation matches the proposed behavior.
+- [ ] 2.2 Confirm the canonical CI spec consistently describes the new change-classification, validation, auto-approve, and ready-for-review behavior.
+
+## 3. Verification and rollout
+
+- [ ] 3.1 Validate the change artifacts with `npx openspec validate ci-acceptance-gating --type change` or an equivalent project OpenSpec validation command.
+- [ ] 3.2 Verify that an `openspec/**`-only change skips the matrix acceptance job while `Test Validation` succeeds, and that a provider-impacting change fails `Test Validation` when required acceptance coverage does not succeed.
+- [ ] 3.3 Update GitHub branch protection or rulesets to require `Build/Lint/Test / Test Validation` instead of the per-version `Matrix Acceptance Test (...)` checks after confirming the new check name from a live run.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add CI acceptance gating to skip acceptance tests for non-provider PRs
- Introduces a change-classification job that detects whether a PR contains provider-impacting changes and outputs a `provider_changes` flag
- Gates the acceptance test matrix on both preflight and `provider_changes`, so PRs touching only OpenSpec artifacts skip acceptance tests entirely
- Adds an always-running `Test Validation` job to serve as a stable required check for branch protection, replacing direct dependencies on the acceptance matrix
- Updates auto-approve to depend on `Test Validation` instead of the acceptance test jobs
- Documents the design, proposal, and specs in [openspec/changes/ci-acceptance-gating/](https://github.com/elastic/terraform-provider-elasticstack/pull/2243/files#diff-3c361c82c06b189c521e710591f4520e8e9debb5fb8afa0f5806ba9acb60ff3d)

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9471c79.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->