### PR TITLE
Custom lint performance profiling

### DIFF
--- a/openspec/changes/custom-lint-performance/.openspec.yaml
+++ b/openspec/changes/custom-lint-performance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/custom-lint-performance/design.md
+++ b/openspec/changes/custom-lint-performance/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The repository currently ships two custom golangci analyzers through module plugins: `acctestconfigdirlint` and `esclienthelper`. They run in the same repo-wide lint path as other Go linters, so their cost is paid on every local and CI lint invocation.
+
+The current hot spots are different for each analyzer:
+
+- `analysis/acctestconfigdirlintplugin` depends on `inspect.Analyzer`, walks every `*ast.CallExpr` in each package, resolves typed callees, and only then filters to `_test.go` acceptance-test calls. That broad traversal does unnecessary work in mixed packages with large non-test files.
+- `analysis/esclienthelperplugin` is already path-scoped, but it repeats filename checks, function/signature scans, and fact imports while walking in-scope files. The analyzer keeps the right conservative behavior, but it recomputes metadata that is stable for the duration of a pass.
+
+The repository also lacks a dedicated measurement loop for these analyzers. `make lint` is too noisy because it includes setup, formatting, docs generation, and the rest of golangci-lint. To make performance work sustainable, the repo needs a first-class command that isolates custom-linter timing and captures benchmark/profile artifacts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reduce avoidable work in `analysis/acctestconfigdirlintplugin` without changing which code patterns are considered in-scope or which diagnostics are reported.
+- Reduce repeated metadata, signature, and fact lookup work in `analysis/esclienthelperplugin` while preserving its current sink detection and conservative provenance rules.
+- Add a repository-local `lint-perf` workflow that captures isolated custom-linter timings plus CPU, memory, and trace profiles.
+- Add analyzer benchmarks so future changes can compare before/after performance without relying on full aggregate lint wall time.
+
+**Non-Goals:**
+
+- Changing the lint requirements enforced by `acctestconfigdirlint` or `esclienthelper`.
+- Replacing the current conservative provenance model in `esclienthelper` with an SSA-based or whole-program dataflow engine.
+- Introducing external benchmarking dependencies such as `benchstat` as a requirement for the first version of the measurement target.
+- Defining strict runtime budgets that would make lint speed a hard pass/fail contract.
+
+## Decisions
+
+- **Narrow `acctestconfigdirlint` to relevant files before typed call resolution**: Replace the current `inspect.Analyzer`-driven whole-package `CallExpr` preorder with direct iteration over `pass.Files`, early `_test.go` filtering, and a local AST walk for only those files. Keep typed confirmation for `resource.Test` / `resource.ParallelTest`, but move that confirmation behind cheaper file and selector-name guards so non-test files and obviously unrelated calls do not pay for `TypesInfo` lookups.
+
+- **Keep `acctestconfigdirlint` semantics but remove duplicate local work**: Preserve the current inline-literal scope and field-relationship checks, but fold duplicated composite-literal element scans into a single pass and avoid repeated filename position materialization when only the file name is needed.
+
+- **Keep `esclienthelper` in two logical phases but add run-scoped caches**: Preserve the current "export facts first, then inspect sinks" structure so fact availability remains deterministic, but precompute the in-scope file set once per pass and reuse it across both phases. Add caches keyed by `*types.Func` for sink parameter indices, imported return facts, and other stable per-function metadata so repeated sink and provenance checks stop rescanning the same signatures and reimporting the same facts.
+
+- **Refactor `esclienthelper` helpers around resolved callees**: When a sink check or source check already resolves a `*types.Func`, pass that information through helper layers rather than calling `calledFunction` repeatedly for the same expression. Keep the current conservative provenance behavior and existing diagnostic messages intact.
+
+- **Add a single `lint-perf` target for isolated measurement and benchmarks**: The target should build or reuse the repository's custom golangci binary, create a timestamped repo-local output directory, run `esclienthelper` and `acctestconfigdirlint` individually with `--enable-only`, fixed concurrency, and profile flags, then run `go test -bench` for the analyzer packages and capture the outputs in the same report directory. This keeps performance measurement reproducible without conflating it with `make lint`.
+
+- **Benchmark representative analyzer workloads, not only helper functions**: Add benchmarks in the analyzer test packages that execute the analyzers on representative `analysistest` fixtures or equivalent package-scoped workloads. That keeps the benchmarks close to the actual AST/type-analysis cost instead of micro-benchmarking individual helper functions that do not reflect pass-level behavior.
+
+## Risks / Trade-offs
+
+- **[Risk] Early syntactic guards in `acctestconfigdirlint` could accidentally narrow scope too far** -> Mitigation: keep final typed confirmation of the target function and preserve existing analyzer tests for compliant and violating cases.
+- **[Risk] Cached metadata in `esclienthelper` could become stale if scoped incorrectly** -> Mitigation: limit caches to immutable per-pass values such as resolved `*types.Func` metadata and imported facts, and do not cache results that depend on mutable `derivedVars` state.
+- **[Risk] Benchmark results may not reflect full-repo lint cost on their own** -> Mitigation: pair analyzer benchmarks with isolated `golangci-lint` runs from `lint-perf` so both micro and repo-level measurements are available.
+- **[Risk] Performance measurements are noisy across machines and cache states** -> Mitigation: fix concurrency inside `lint-perf`, capture raw profile artifacts, and document that comparisons should be made with warm-cache runs under the same local conditions.
+
+## Migration Plan
+
+1. Add the `makefile-workflows` delta spec for the new `lint-perf` target and the expected measurement artifacts.
+2. Implement the `lint-perf` target so contributors can capture a baseline before changing analyzer internals.
+3. Add benchmark coverage for the custom analyzers under `analysis/`.
+4. Refactor `analysis/acctestconfigdirlintplugin` to narrow traversal to relevant test files and candidate calls while preserving diagnostics.
+5. Refactor `analysis/esclienthelperplugin` to precompute in-scope files and cache stable per-function metadata and facts.
+6. Run targeted analyzer tests and `lint-perf` before/after comparisons to confirm behavior is unchanged and performance improves.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/custom-lint-performance/proposal.md
+++ b/openspec/changes/custom-lint-performance/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The custom analyzers under `analysis/` now run as part of normal repository linting, so avoidable traversal and repeated typed lookups add noticeable cost to every contributor and CI `make lint` / `make check-lint` run. The repository also lacks a repeatable way to isolate those analyzers, capture profiles, and compare benchmark results, which makes performance work harder to validate and maintain.
+
+## What Changes
+
+- Optimize `analysis/acctestconfigdirlintplugin` so it limits work to relevant test files and candidate acceptance-test calls instead of traversing every package call expression before filtering.
+- Optimize `analysis/esclienthelperplugin` so it precomputes in-scope files, reuses resolved function metadata, and caches repeated sink/fact lookups while preserving the current lint contract and diagnostics.
+- Add a dedicated `make lint-perf` target that runs the repository's custom golangci binary in isolated custom-linter mode, captures timing/profile artifacts, and runs analyzer benchmarks for comparison work.
+- Add benchmark and regression coverage for the custom analyzers so contributors can measure performance improvements without relying on full `make lint` wall time.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `makefile-workflows`: add a dedicated make target for isolated custom-linter performance measurement and benchmark capture
+
+## Impact
+
+- **Specs**: delta spec under `openspec/changes/custom-lint-performance/specs/makefile-workflows/spec.md`
+- **Makefile**: new `lint-perf` target and any supporting recipe wiring
+- **Analyzer implementation**: `analysis/acctestconfigdirlintplugin` and `analysis/esclienthelperplugin`
+- **Tests and benchmarks**: analyzer regression coverage plus new benchmark entry points under `analysis/`
+- **Developer workflow**: contributors gain a repository-local way to capture before/after timing and profile artifacts for custom lint rules

--- a/openspec/changes/custom-lint-performance/specs/makefile-workflows/spec.md
+++ b/openspec/changes/custom-lint-performance/specs/makefile-workflows/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Custom lint performance measurement target
+
+The Makefile SHALL provide a `lint-perf` target that captures isolated performance data for the repository's custom golangci analyzers without relying on aggregate `make lint` wall time. The target SHALL build or reuse the repository-local custom golangci binary, run `esclienthelper` and `acctestconfigdirlint` individually against `./...` with fixed single-run concurrency, and write timing plus CPU, memory, and trace artifacts to a repo-local output directory for each run.
+
+#### Scenario: Isolated custom linter profiles
+
+- **GIVEN** a contributor runs `make lint-perf`
+- **WHEN** the target invokes the custom golangci binary
+- **THEN** `esclienthelper` and `acctestconfigdirlint` SHALL be measured in isolated runs rather than only as part of the full default linter set
+- **AND** each run SHALL emit timing/profile artifacts under a repo-local output directory
+
+#### Scenario: Repository-aligned scope and entrypoint
+
+- **GIVEN** `make lint-perf` measures a custom analyzer
+- **WHEN** it invokes golangci-lint for that analyzer
+- **THEN** it SHALL use the repository's custom golangci binary and the repository-wide package scope `./...`
+- **AND** it SHALL keep concurrency fixed so repeated comparisons use a stable execution mode
+
+### Requirement: Custom analyzer benchmark capture
+
+The `lint-perf` target SHALL also run repository-local Go benchmarks for the custom analyzer packages and capture their outputs alongside the isolated golangci-lint measurements. This benchmark capture SHALL use the analyzer packages under `analysis/` so future optimizer changes can compare targeted analyzer workloads in addition to full-repository isolated runs.
+
+#### Scenario: Analyzer benchmark outputs
+
+- **GIVEN** a contributor runs `make lint-perf`
+- **WHEN** the measurement target completes successfully
+- **THEN** the output directory SHALL contain benchmark output for the custom analyzer packages in addition to the isolated golangci-lint profile artifacts

--- a/openspec/changes/custom-lint-performance/tasks.md
+++ b/openspec/changes/custom-lint-performance/tasks.md
@@ -1,0 +1,27 @@
+## 1. Define the performance-measurement contract
+
+- [ ] 1.1 Add the `makefile-workflows` delta spec describing the `lint-perf` target, isolated custom-linter measurement scope, profile outputs, and analyzer benchmark capture.
+
+## 2. Add repository-local measurement tooling
+
+- [ ] 2.1 Add a `lint-perf` target to `Makefile` that builds or reuses the repository's custom golangci binary, runs `esclienthelper` and `acctestconfigdirlint` individually against `./...`, fixes concurrency for repeatable comparisons, and writes timing plus CPU, memory, and trace artifacts to a repo-local output directory.
+- [ ] 2.2 Add benchmark entry points under `analysis/` for the custom analyzers so `lint-perf` can capture targeted analyzer benchmark output alongside the isolated golangci-lint runs.
+- [ ] 2.3 Ensure the target prints or documents where the per-run artifacts are written so contributors can compare before/after optimization runs.
+
+## 3. Optimize `acctestconfigdirlint`
+
+- [ ] 3.1 Refactor `analysis/acctestconfigdirlintplugin/analyzer.go` to iterate `pass.Files`, skip non-`*_test.go` files before AST walking, and inspect only candidate acceptance-test calls rather than traversing every package call expression through `inspect.Analyzer`.
+- [ ] 3.2 Preserve the current typed confirmation and diagnostics for `resource.Test` / `resource.ParallelTest` inline `resource.TestCase` handling while removing duplicate local work such as repeated composite-literal element scans and unnecessary filename position materialization.
+- [ ] 3.3 Add or update analyzer tests and benchmarks so current compliant and violating cases remain unchanged while the narrowed traversal path is exercised.
+
+## 4. Optimize `esclienthelper`
+
+- [ ] 4.1 Refactor `analysis/esclienthelperplugin/analyzer.go` to precompute the in-scope non-test Elasticsearch files once per pass and reuse that scoped file list across the fact-export and sink-check phases.
+- [ ] 4.2 Add run-scoped caches for stable per-function metadata such as Elasticsearch sink parameter indices and imported client-return facts so repeated sink checks stop rescanning the same signatures and reimporting the same facts.
+- [ ] 4.3 Refactor sink and provenance helpers to reuse resolved callees where practical while preserving the current conservative provenance model and diagnostics.
+- [ ] 4.4 Add or update analyzer tests and benchmarks so current compliant and violating sink behaviors remain unchanged while the cached path is exercised.
+
+## 5. Validate behavior and performance
+
+- [ ] 5.1 Capture before/after isolated measurements for both custom analyzers with `make lint-perf` and inspect the generated timing/profile artifacts to confirm the expected hot paths shrink.
+- [ ] 5.2 Run targeted analyzer tests and the relevant repository lint checks to confirm the optimizations do not change the enforced lint behavior.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design spec and tasks for custom lint performance profiling
Adds a set of spec-driven planning documents for optimizing custom linter performance and introducing a `lint-perf` Makefile target.

- [proposal.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2246/files#diff-a3614bd7d4e2ad0e2428d7d6dbaac9b13fcc830f75c24a28f4a07015df58fb89) describes the motivation and planned changes for improving `acctestconfigdirlint` and `esclienthelper` analyzer performance
- [design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2246/files#diff-ae6672e2d62074b92ddea659371e061374e04b540b516711a5b2c511d6c56ffd) covers decisions, risks, migration plan, and open questions
- [spec.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2246/files#diff-6d53c370f15035609e28d30d9737ded7ca382f9dc2413b20c3119d857a6e4342) defines requirements for the new `lint-perf` target, which runs isolated benchmark and profiling artifact capture
- [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2246/files#diff-d3c431aabca42432f5b0d5c14a7a541003c87b62e3832db5138fded980db91d1) breaks down implementation steps across measurement contract, tooling, optimization, and validation

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f983a76.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->