### PR TITLE
Use litellm for schema-coverage

### DIFF
--- a/openspec/changes/schema-coverage-rotation-claude-proxy/.openspec.yaml
+++ b/openspec/changes/schema-coverage-rotation-claude-proxy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/schema-coverage-rotation-claude-proxy/design.md
+++ b/openspec/changes/schema-coverage-rotation-claude-proxy/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The `schema-coverage-rotation` workflow is already structured around deterministic issue-slot gating, repo-memory bookkeeping, repository-local Go commands, and safe outputs that create and assign actionable issues. Today the workflow still uses the `copilot` engine directly.
+
+This proposal is intentionally narrow: it changes only the schema-coverage worker's model-execution path. Unlike the `openspec-verify-label` migration, this workflow should switch engines outright to `claude`, and it should route Claude traffic through the Anthropic-compatible LiteLLM endpoint at `https://elastic.litellm-prod.ai/` using `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY`.
+
+The workflow also runs repository-local commands such as `make setup` and `go run ./scripts/schema-coverage-rotation ...`. Under GH AW, the Claude engine has a shorter default per-tool timeout than Copilot, so the migration should make the execution budget explicit instead of relying on engine defaults.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Move the `schema-coverage-rotation` worker to `engine.id: claude`.
+- Route Claude requests through the Elastic LiteLLM Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL`.
+- Source `ANTHROPIC_API_KEY` from a GitHub Actions secret-backed expression.
+- Extend the workflow firewall contract to allow `elastic.litellm-prod.ai`.
+- Preserve the workflow's existing issue-slot gating, repo-memory flow, issue creation rules, and `assign-to-agent` behavior.
+- Set an explicit Claude-compatible tool timeout for the workflow's repository-local commands.
+
+**Non-Goals:**
+- Changing how entities are selected, analyzed, or recorded in repo-memory.
+- Changing the issue content rubric or the `acceptance-test-improver` assignment flow.
+- Migrating other GH AW workflows in the same change.
+- Introducing a separate custom Claude model pin unless the repository later decides it needs one.
+
+## Decisions
+
+### 1. Switch the workflow engine to Claude and route it with Anthropic-compatible env vars
+
+The workflow should move from `engine.id: copilot` to `engine.id: claude` and configure:
+
+- `engine.env.ANTHROPIC_BASE_URL: https://elastic.litellm-prod.ai/`
+- `engine.env.ANTHROPIC_API_KEY` sourced from a GitHub Actions secret expression
+
+Why:
+- The requested migration explicitly says to use Claude as the engine.
+- GH AW documents `ANTHROPIC_BASE_URL` as the supported path for routing Claude through a custom Anthropic-compatible endpoint.
+- Secret-backed `ANTHROPIC_API_KEY` keeps provider auth out of the repository while making the operational requirement explicit.
+
+Alternatives considered:
+- Keep the workflow on Copilot and use the same BYOK pattern as `openspec-verify-label`: rejected because this workflow request explicitly switches to Claude.
+- Use a broader engine endpoint override without `ANTHROPIC_BASE_URL`: rejected because the request specifically names the Anthropic env var path and GH AW treats it as a first-class routing mechanism.
+
+### 2. Set an explicit Claude tool timeout
+
+The workflow should set `tools.timeout: 300` so repository-local commands have a stable per-tool-call budget after the engine switch.
+
+Why:
+- Claude's GH AW default per-tool timeout is shorter than Copilot's effective behavior.
+- The workflow runs `make setup` and `go run` commands that may exceed Claude's default 60-second budget.
+- Encoding the timeout in the workflow contract makes the migration behavior explicit and testable.
+
+Alternative considered:
+- Rely on Claude defaults: rejected because the workflow already depends on longer-running repository-local commands and would become more brittle after the engine switch.
+
+### 3. Extend the existing firewall contract without broadening it further
+
+The workflow should add `elastic.litellm-prod.ai` to `network.allowed` while keeping the existing `defaults`, `node`, and `go` entries.
+
+Why:
+- The workflow already declares an explicit AWF allowlist.
+- Claude traffic routed through LiteLLM will fail unless the proxy host is permitted.
+- Adding only the required host preserves the current least-privilege posture.
+
+Alternative considered:
+- Use a broader or implicit network allowance: rejected because it weakens auditability and expands access beyond what this migration needs.
+
+### 4. Keep downstream issue-assignment behavior unchanged
+
+This change should affect only the schema-coverage analysis worker. The safe output that assigns newly created issues to `acceptance-test-improver` can remain unchanged.
+
+Why:
+- The user request is limited to the rotation workflow engine path.
+- The assignment target is a separate automation decision and does not need to move in lockstep with the rotation worker.
+
+Alternative considered:
+- Switch `assign-to-agent` to a different engine in the same change: rejected because it adds an unrelated behavioral change and complicates rollout.
+
+## Risks / Trade-offs
+
+- [LiteLLM endpoint availability becomes part of schema-coverage rotation reliability] -> Mitigation: make the dependency explicit in workflow frontmatter and specs, then validate on a representative run before rollout.
+- [The workflow gains a new provider-auth prerequisite in `ANTHROPIC_API_KEY`] -> Mitigation: require the key to be secret-backed and document it in the workflow contract.
+- [Claude may behave differently from Copilot when following the schema-coverage skill] -> Mitigation: keep the prompt, gating, and safe outputs stable and validate with a representative workflow execution.
+- [The workflow engine and the downstream assignment agent will differ] -> Mitigation: document that the change is intentionally scoped to the rotation worker only.
+
+## Migration Plan
+
+1. Update `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` to switch to `engine.id: claude`, set `ANTHROPIC_BASE_URL`, source `ANTHROPIC_API_KEY` from secrets, add `tools.timeout: 300`, and allow `elastic.litellm-prod.ai`.
+2. Regenerate `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml`.
+3. Update workflow generation tests and sync the canonical schema-coverage OpenSpec requirements with the approved engine and firewall contract.
+4. Validate the change and run or inspect a representative schema-coverage rotation workflow execution using the Claude + LiteLLM configuration.
+
+## Open Questions
+
+- None for the requested proposal. If the repository later wants a pinned Claude model rather than the engine default, that can be handled as an implementation detail or a follow-up requirements change.

--- a/openspec/changes/schema-coverage-rotation-claude-proxy/proposal.md
+++ b/openspec/changes/schema-coverage-rotation-claude-proxy/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `schema-coverage-rotation` workflow currently runs on the GitHub-hosted Copilot engine. The repository wants this workflow to follow the same LiteLLM routing direction as other GH AW migrations, but with the worker itself using the `claude` engine through an Anthropic-compatible proxy at `https://elastic.litellm-prod.ai/`.
+
+## What Changes
+
+- Update the `schema-coverage-rotation` workflow contract so the rotation worker uses `engine.id: claude`.
+- Route Claude API traffic through the Elastic LiteLLM Anthropic-compatible endpoint via `ANTHROPIC_BASE_URL` and a secret-backed `ANTHROPIC_API_KEY`.
+- Extend the workflow's AWF network policy to allow the LiteLLM host in addition to the existing bootstrap ecosystems.
+- Require an explicit tool timeout suitable for the Claude engine so repository-local schema analysis commands are not constrained by Claude's shorter default tool-call budget.
+- Preserve the existing issue-slot gating, repo-memory flow, issue creation rules, and downstream `assign-to-agent` behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-schema-coverage-rotation-engine`: Define the schema-coverage rotation workflow's Claude engine, Anthropic proxy configuration, and explicit Claude execution budget.
+
+### Modified Capabilities
+
+- `ci-schema-coverage-rotation-toolchain`: Extend the workflow network requirements so the existing bootstrap/toolchain contract also allows the LiteLLM proxy host needed by the Claude engine.
+
+## Impact
+
+- Authored workflow source under `.github/workflows-src/schema-coverage-rotation/`
+- Generated workflow artifacts under `.github/workflows/schema-coverage-rotation.*`
+- GH AW engine authentication and network policy for the schema-coverage worker
+- Workflow generation tests under `.github/workflows-src/lib/`
+- OpenSpec requirements for `ci-schema-coverage-rotation-engine` and `ci-schema-coverage-rotation-toolchain`

--- a/openspec/changes/schema-coverage-rotation-claude-proxy/specs/ci-schema-coverage-rotation-engine/spec.md
+++ b/openspec/changes/schema-coverage-rotation-claude-proxy/specs/ci-schema-coverage-rotation-engine/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Schema-coverage rotation uses the Claude engine through the Anthropic-compatible proxy
+The `schema-coverage-rotation` workflow SHALL set `engine.id` to `claude` and SHALL route Claude traffic through `ANTHROPIC_BASE_URL` set to `https://elastic.litellm-prod.ai/`. Any configured `ANTHROPIC_API_KEY` value SHALL be sourced from a GitHub Actions secret-backed expression rather than from a checked-in literal.
+
+#### Scenario: Authored workflow selects Claude
+- **WHEN** maintainers inspect the authored `schema-coverage-rotation` workflow source
+- **THEN** `engine.id` SHALL be `claude`
+
+#### Scenario: Claude traffic is routed through the Elastic LiteLLM endpoint
+- **WHEN** maintainers inspect the workflow engine environment
+- **THEN** `ANTHROPIC_BASE_URL` SHALL be `https://elastic.litellm-prod.ai/`
+
+#### Scenario: Anthropic authentication is secret-backed
+- **WHEN** maintainers inspect the authored workflow source
+- **THEN** any configured `ANTHROPIC_API_KEY` value SHALL come from a GitHub Actions secret expression rather than a literal API key value committed to the repository
+
+### Requirement: Schema-coverage rotation sets an explicit Claude execution budget
+The `schema-coverage-rotation` workflow SHALL set an explicit per-tool execution timeout of 300 seconds so the repository-local bootstrap and schema-analysis commands are not constrained by the Claude engine's shorter default tool-call timeout.
+
+#### Scenario: Workflow frontmatter defines the Claude tool timeout
+- **WHEN** maintainers inspect the schema-coverage rotation workflow frontmatter
+- **THEN** `tools.timeout` SHALL be `300`

--- a/openspec/changes/schema-coverage-rotation-claude-proxy/specs/ci-schema-coverage-rotation-toolchain/spec.md
+++ b/openspec/changes/schema-coverage-rotation-claude-proxy/specs/ci-schema-coverage-rotation-toolchain/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+
+### Requirement: Schema-coverage rotation allows repository bootstrap ecosystems
+The `schema-coverage-rotation` workflow SHALL declare an AWF network policy that allows the repository bootstrap path to use the default allowlist plus the Node and Go ecosystems, and SHALL allow `elastic.litellm-prod.ai` for the Claude engine's Anthropic-compatible proxy access.
+
+#### Scenario: Workflow frontmatter allows required ecosystems
+- **WHEN** maintainers inspect the schema-coverage rotation workflow frontmatter
+- **THEN** `network.allowed` SHALL include `defaults`
+- **AND** `network.allowed` SHALL include `node`
+- **AND** `network.allowed` SHALL include `go`
+- **AND** `network.allowed` SHALL include `elastic.litellm-prod.ai`

--- a/openspec/changes/schema-coverage-rotation-claude-proxy/tasks.md
+++ b/openspec/changes/schema-coverage-rotation-claude-proxy/tasks.md
@@ -1,0 +1,16 @@
+## 1. Update the schema-coverage rotation workflow contract
+
+- [ ] 1.1 Update `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` so the workflow switches from `engine.id: copilot` to `engine.id: claude` and configures `ANTHROPIC_BASE_URL` for `https://elastic.litellm-prod.ai/`.
+- [ ] 1.2 Ensure any configured `ANTHROPIC_API_KEY` value is sourced from a GitHub Actions secret-backed expression, add `tools.timeout: 300`, and extend `network.allowed` with `elastic.litellm-prod.ai`.
+- [ ] 1.3 Regenerate `.github/workflows/schema-coverage-rotation.md` and `.github/workflows/schema-coverage-rotation.lock.yml` from the authored workflow source without changing unrelated workflow behavior.
+
+## 2. Align tests and requirements
+
+- [ ] 2.1 Update workflow generation tests under `.github/workflows-src/lib/` to assert the Claude engine, Anthropic proxy environment, explicit tool timeout, and LiteLLM host allowlist.
+- [ ] 2.2 Sync the canonical `ci-schema-coverage-rotation-engine` and `ci-schema-coverage-rotation-toolchain` specs with the approved workflow contract from this change.
+
+## 3. Validate the migration
+
+- [ ] 3.1 Validate the OpenSpec artifacts with `npx openspec validate schema-coverage-rotation-claude-proxy --type change` or an equivalent repository OpenSpec check.
+- [ ] 3.2 Run workflow generation and the relevant workflow tests (for example `make workflow-generate` and `make workflow-test`) to confirm the authored and generated artifacts stay in sync.
+- [ ] 3.3 Run or inspect a representative `schema-coverage-rotation` workflow execution that uses the Claude + LiteLLM configuration to confirm the worker reaches `https://elastic.litellm-prod.ai/` successfully.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Migrate schema-coverage-rotation workflow to Claude via litellm proxy
- Switches the `schema-coverage-rotation` workflow engine from Copilot to Claude, routing through `https://elastic.litellm-prod.ai/` via `ANTHROPIC_BASE_URL` with a secret-backed `ANTHROPIC_API_KEY`.
- Sets `tools.timeout: 300` and extends the AWF network allowlist to include `elastic.litellm-prod.ai`.
- Adds OpenSpec specs, design doc, and task checklist to validate the migration; existing gating and issue assignment behavior is unchanged.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ecbadd1.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->