### PR TITLE
Add changes to enforce correct client usage at compile time

### DIFF
--- a/openspec/changes/typed-elasticsearch-client-resolution/.openspec.yaml
+++ b/openspec/changes/typed-elasticsearch-client-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/typed-elasticsearch-client-resolution/design.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/design.md
@@ -1,0 +1,64 @@
+## Context
+
+After the Kibana/Fleet phase, the provider will already inject a `ProviderClientFactory` and Kibana/Fleet code will resolve typed scoped clients from `kibana_connection`. Elasticsearch will still be the remaining broad-client domain: resources will continue to resolve `*clients.APIClient`, shared sinks in `internal/clients/elasticsearch/` will continue accepting that broad type, and `analysis/esclienthelperplugin` will still enforce correct provenance through expensive static analysis.
+
+This second phase removes that last broad-client path. It extends the factory so Elasticsearch also resolves typed scoped clients from `elasticsearch_connection`, migrates sink boundaries to those typed clients, and then deletes the custom lint rule entirely because the compiler will enforce the same constraint at the API boundary.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend `ProviderClientFactory` so Elasticsearch entities resolve typed Elasticsearch scoped clients rather than broad `*clients.APIClient` values.
+- Change Elasticsearch sink and helper APIs to require typed Elasticsearch scoped clients.
+- Preserve current `elasticsearch_connection` behavior while replacing linter-based provenance checks with compile-time type checking.
+- Remove `analysis/esclienthelperplugin` and its repository wiring entirely once typed sink boundaries are in place.
+
+**Non-Goals:**
+- Revisiting the Kibana/Fleet typed-client design from phase 1 except where the shared factory contract must expand.
+- Changing the `elasticsearch_connection` schema surface or coverage rules.
+- Keeping a reduced version of the current custom provenance lint as a permanent backstop.
+- Redesigning unrelated provider resource behavior beyond client resolution and enforcement.
+
+## Decisions
+
+Extend the existing provider factory rather than introducing a second provider data contract.
+The same `ProviderClientFactory` introduced for Kibana/Fleet should gain typed Elasticsearch resolution methods and become the only provider data contract for all entity families.
+
+Alternative considered: leave the phase 1 factory untouched and inject a separate Elasticsearch resolver.
+Rejected because that would reintroduce multiple provider data types and prolong the mixed model.
+
+Introduce a concrete `ElasticsearchScopedClient` type and make Elasticsearch sinks accept it directly.
+The typed Elasticsearch client should own the Elasticsearch API client plus the existing Elasticsearch-derived helper behavior that resources rely on today, including composite ID generation, cluster identity lookup, version checks, flavor checks, and minimum-version enforcement.
+
+Alternative considered: keep sink signatures broad and rely on resources to resolve the right type before calling them.
+Rejected because compile-time enforcement only becomes real when sink signatures stop accepting the broad client type.
+
+Remove transitional legacy Elasticsearch factory methods after migration.
+Once Elasticsearch resources and sinks use `ElasticsearchScopedClient`, the temporary broad-client resolution methods kept for phase 1 should be removed from the factory contract so there is no supported path back to the old model.
+
+Alternative considered: keep legacy broad-client methods indefinitely for tests or convenience.
+Rejected because that would leave ad-hoc broad-client construction available and weaken the clarity of the new contract.
+
+Delete the custom Elasticsearch provenance analyzer after typed migration completes.
+When no in-scope Elasticsearch sink accepts `*clients.APIClient`, the custom lint no longer provides unique protection and should be removed from the repo, test suite, and lint workflow.
+
+Alternative considered: keep the analyzer for belt-and-suspenders verification.
+Rejected because it duplicates compiler guarantees while continuing to impose maintenance and performance cost.
+
+## Risks / Trade-offs
+
+- [Risk] Elasticsearch resources use more `APIClient` helper behavior than Kibana/Fleet, so the new scoped type may initially miss methods -> Mitigation: define the typed Elasticsearch contract from actual call-site usage and migrate sink packages first.
+- [Risk] Removing the analyzer too early could create an enforcement gap -> Mitigation: delete the analyzer only after all in-scope Elasticsearch sinks and resource call sites no longer accept the broad client type.
+- [Risk] Tests and helper utilities may rely on constructing `*clients.APIClient` directly -> Mitigation: add typed test helpers and update acceptance/unit tests alongside the sink migration.
+- [Risk] The canonical lint capability could drift from implementation during retirement -> Mitigation: explicitly remove the lint requirements in this change and tie deletion to the typed sink migration tasks.
+
+## Migration Plan
+
+1. Extend `ProviderClientFactory` with typed Elasticsearch resolution methods and add `ElasticsearchScopedClient`.
+2. Convert `internal/clients/elasticsearch/` sink and helper packages to accept the typed scoped client.
+3. Migrate Framework and SDK Elasticsearch resources/data sources to resolve typed scoped clients from `elasticsearch_connection`.
+4. Remove the temporary legacy Elasticsearch factory methods introduced in phase 1.
+5. Delete `analysis/esclienthelperplugin`, its tests, `.golangci.yaml` wiring, and associated lint workflow hooks.
+
+## Open Questions
+
+- None. The main dependency is that the Kibana/Fleet-first factory contract has already landed before this change begins.

--- a/openspec/changes/typed-elasticsearch-client-resolution/proposal.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`elasticsearch_connection` already has behavior protected by custom lint, but that protection is expensive because the compiler still sees provider-default clients, scoped clients, and bypassed clients as the same `*clients.APIClient` type. Once `kibana_connection` is stabilized with a factory-based typed model, Elasticsearch should move to the same compile-time enforcement pattern and remove the custom provenance analyzer entirely.
+
+## What Changes
+
+- Extend the provider client factory to produce typed Elasticsearch scoped clients for SDK and Plugin Framework entities.
+- Change Elasticsearch helper and sink APIs to accept typed Elasticsearch scoped clients instead of the broad `*clients.APIClient`.
+- Update Elasticsearch client-resolution requirements to describe factory-based typed resolution from `elasticsearch_connection`.
+- Remove the custom Elasticsearch client-resolution lint capability and its repository wiring once typed sink boundaries make the misuse unrepresentable at compile time.
+
+## Capabilities
+
+### New Capabilities
+- `provider-elasticsearch-scoped-client-resolution`: provider-level typed Elasticsearch scoped-client requirements for entity-local `elasticsearch_connection` resolution and Elasticsearch sink usage
+
+### Modified Capabilities
+- `provider-client-factory`: extend the phased provider factory contract so Elasticsearch entities also consume typed scoped clients rather than legacy broad-client access
+- `elasticsearch-client-resolution-lint`: retire the custom lint capability after typed Elasticsearch sink boundaries replace provenance analysis
+
+## Impact
+
+- Provider configure paths in `provider/provider.go` and `provider/plugin_framework.go`
+- Shared client construction and config code under `internal/clients/` and `internal/clients/config/`
+- Elasticsearch helper and sink code under `internal/clients/elasticsearch/` and Elasticsearch entity code under `internal/elasticsearch/`
+- `analysis/esclienthelperplugin`, `.golangci.yaml`, and lint-related Makefile wiring
+- OpenSpec requirements for provider factory behavior and Elasticsearch enforcement

--- a/openspec/changes/typed-elasticsearch-client-resolution/specs/elasticsearch-client-resolution-lint/spec.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/specs/elasticsearch-client-resolution-lint/spec.md
@@ -1,0 +1,95 @@
+## REMOVED Requirements
+
+### Requirement: Approved Elasticsearch client sources
+Any `*clients.APIClient` value used at an in-scope sink SHALL originate from `clients.NewAPIClientFromSDKResource(...)`, `clients.MaybeNewAPIClientFromFrameworkResource(...)`, an explicitly allowlisted wrapper, or an interprocedurally inferred wrapper or factory that the analyzer can prove is helper-derived.
+
+#### Scenario: Sink uses approved helper-derived client
+- **GIVEN** an in-scope sink call in code under `internal/elasticsearch/**`
+- **WHEN** the supplied `*clients.APIClient` value comes directly from an approved helper-derived source
+- **THEN** the analyzer SHALL report no diagnostic
+
+**Reason**: Elasticsearch sinks will no longer accept the broad `*clients.APIClient`, so provenance approval by custom lint is replaced by compile-time type safety at the sink boundary.
+
+**Migration**: Resolve a typed Elasticsearch-scoped client from `ProviderClientFactory` and pass that typed client, or a narrower interface derived from it, to Elasticsearch sinks.
+
+### Requirement: No bypass paths at sink usage
+In-scope sink calls SHALL NOT use `*clients.APIClient` values created through direct construction, provider-meta casts, or ad-hoc resolution flows that bypass approved helper-derived sources.
+
+#### Scenario: Sink uses bypassed client source
+- **GIVEN** an in-scope sink call in code under `internal/elasticsearch/**`
+- **WHEN** the supplied `*clients.APIClient` value was obtained through direct construction, provider-meta casting, or another non-helper-derived flow
+- **THEN** the analyzer SHALL emit a diagnostic for that sink usage
+
+**Reason**: Typed Elasticsearch sinks make bypassed broad-client sources uncallable in supported production code, so this prohibition no longer needs a separate linter contract.
+
+**Migration**: Replace broad-client construction or provider-meta casts with factory-based typed Elasticsearch client resolution.
+
+### Requirement: Sink enforcement scope
+The lint rule SHALL validate client origin specifically at sink call sites in code under `internal/elasticsearch/**`: function arguments passed to `internal/clients/elasticsearch` functions with `*clients.APIClient` parameters, and receivers used for method calls on `*clients.APIClient`.
+
+#### Scenario: No sink produces no finding
+- **GIVEN** code under `internal/elasticsearch/**` that does not invoke an in-scope sink
+- **WHEN** the analyzer evaluates that code
+- **THEN** the analyzer SHALL report no issue solely because a `*clients.APIClient` value exists
+
+**Reason**: The shared Elasticsearch sink surface is being redefined to require typed scoped clients instead of broad `*clients.APIClient`, making the old analyzer sink scope obsolete.
+
+**Migration**: Update in-scope Elasticsearch helper and sink signatures to require the typed Elasticsearch-scoped client contract.
+
+### Requirement: Wrapper control and inference
+Wrapper sources SHALL be accepted only when the wrapper is explicitly allowlisted by fully qualified function name or when analyzer-exported provenance facts prove that the wrapper or factory returns a helper-derived `*clients.APIClient`.
+
+#### Scenario: Wrapper policy controls sink compliance
+- **GIVEN** a wrapper or factory function that returns a `*clients.APIClient` later used at an in-scope sink
+- **WHEN** the wrapper is explicitly allowlisted or provenance facts prove its helper-derived return behavior
+- **THEN** the analyzer SHALL allow the sink usage
+
+#### Scenario: Unproven wrapper fails conservatively
+- **GIVEN** a wrapper or factory function that returns a `*clients.APIClient` later used at an in-scope sink
+- **WHEN** neither the allowlist nor provenance facts prove helper-derived behavior
+- **THEN** the analyzer SHALL report the sink usage as non-compliant
+
+**Reason**: Typed sink boundaries eliminate the need for interprocedural wrapper provenance analysis because supported wrappers will traffic in typed Elasticsearch-scoped clients instead of broad `*clients.APIClient`.
+
+**Migration**: Convert wrapper or factory functions to return typed Elasticsearch-scoped clients or narrower typed interfaces and remove analyzer allowlist dependencies.
+
+### Requirement: Type-based conservative analysis
+The lint rule SHALL use type information to identify in-scope sinks and `*clients.APIClient` values, and where provenance cannot be proven it SHALL treat the value as non-derived rather than assuming compliance.
+
+#### Scenario: Uncertain provenance is treated as non-derived
+- **GIVEN** an in-scope sink call whose client origin cannot be proven from type-aware analysis and provenance facts
+- **WHEN** the analyzer evaluates the sink usage
+- **THEN** the analyzer SHALL report a violation instead of assuming the client is approved
+
+**Reason**: The compiler now enforces the supported client type directly, so conservative provenance analysis is no longer the mechanism that protects Elasticsearch sink usage.
+
+**Migration**: Remove analyzer-driven provenance checks and rely on typed Elasticsearch sink signatures plus normal compilation and tests.
+
+### Requirement: Actionable diagnostics
+When the analyzer reports a violation, the diagnostic SHALL state that the sink uses a non-helper-derived client and SHALL point to the approved helper sources.
+
+#### Scenario: Violation message directs remediation
+- **GIVEN** a non-compliant sink usage
+- **WHEN** the analyzer emits a diagnostic
+- **THEN** the diagnostic SHALL identify the non-helper-derived sink usage and reference the approved helper-derived sources
+
+**Reason**: Once the analyzer is removed, remediation is driven by compiler type errors and the provider factory contract rather than custom lint diagnostics.
+
+**Migration**: Follow compile-time errors by resolving typed Elasticsearch clients through `ProviderClientFactory` and passing those typed clients to shared sinks.
+
+### Requirement: Fact-backed lint and regression enforcement
+The analyzer SHALL export and import provenance facts for relevant functions to improve interprocedural detection of helper-derived clients. The rule SHALL be wired into repository lint execution so `make check-lint` fails on violations, and analyzer tests SHALL cover compliant and non-compliant sink usage to prevent regression.
+
+#### Scenario: Fact-proven wrapper remains compliant
+- **GIVEN** a helper-derived wrapper or factory function whose return behavior is captured by exported provenance facts
+- **WHEN** that returned client is passed to an in-scope sink
+- **THEN** the analyzer SHALL report no issue without requiring explicit allowlist configuration
+
+#### Scenario: Lint execution enforces the rule in CI
+- **GIVEN** a committed violation of the client-resolution lint rule
+- **WHEN** repository lint runs through `make check-lint`
+- **THEN** the lint command SHALL fail in local and CI workflows
+
+**Reason**: The repository no longer needs a custom lint and test harness for Elasticsearch client provenance after the sink API is narrowed to typed scoped clients.
+
+**Migration**: Delete `analysis/esclienthelperplugin`, remove its lint wiring, and cover Elasticsearch client-resolution behavior through typed APIs plus normal unit, acceptance, and build checks.

--- a/openspec/changes/typed-elasticsearch-client-resolution/specs/provider-client-factory/spec.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/specs/provider-client-factory/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Factory supports phased migration
+After the Elasticsearch typed-client phase is complete, the `ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and typed Elasticsearch scoped-client resolution, and SHALL NOT expose transitional legacy Elasticsearch resolution methods that return the broad `*clients.APIClient`.
+
+#### Scenario: Elasticsearch entity resolves typed client
+- **WHEN** a covered Elasticsearch entity resolves its effective client through the factory
+- **THEN** the factory SHALL return a typed Elasticsearch-scoped client rather than a broad `*clients.APIClient`
+
+#### Scenario: Transitional broad Elasticsearch resolution is removed
+- **WHEN** implementation code attempts to rely on the factory for legacy broad Elasticsearch resolution after this phase
+- **THEN** the provider factory contract SHALL no longer define that transitional path

--- a/openspec/changes/typed-elasticsearch-client-resolution/specs/provider-client-factory/spec.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/specs/provider-client-factory/spec.md
@@ -1,12 +1,12 @@
 ## MODIFIED Requirements
 
 ### Requirement: Factory supports phased migration
-After the Elasticsearch typed-client phase is complete, the `ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and typed Elasticsearch scoped-client resolution, and SHALL NOT expose transitional legacy Elasticsearch resolution methods that return the broad `*clients.APIClient`.
+In this phase, the `ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and typed Elasticsearch scoped-client resolution, and SHALL NOT expose transitional legacy Elasticsearch resolution methods that return the broad `*clients.APIClient`.
 
 #### Scenario: Elasticsearch entity resolves typed client
 - **WHEN** a covered Elasticsearch entity resolves its effective client through the factory
 - **THEN** the factory SHALL return a typed Elasticsearch-scoped client rather than a broad `*clients.APIClient`
 
 #### Scenario: Transitional broad Elasticsearch resolution is removed
-- **WHEN** implementation code attempts to rely on the factory for legacy broad Elasticsearch resolution after this phase
-- **THEN** the provider factory contract SHALL no longer define that transitional path
+- **WHEN** implementation code attempts to rely on the factory for legacy broad Elasticsearch resolution in this phase
+- **THEN** the provider factory contract SHALL not define that transitional path

--- a/openspec/changes/typed-elasticsearch-client-resolution/specs/provider-elasticsearch-scoped-client-resolution/spec.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/specs/provider-elasticsearch-scoped-client-resolution/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Framework Elasticsearch scoped client resolution
+The provider SHALL expose Plugin Framework `elasticsearch_connection` resolution through `ProviderClientFactory` methods that accept an entity-local `elasticsearch_connection` block and return a typed Elasticsearch-scoped client. When the block is not configured, the factory SHALL return a typed client built from provider-level defaults. When the block is configured, the factory SHALL return a typed scoped client rebuilt from that connection for Elasticsearch operations.
+
+#### Scenario: Framework factory falls back to provider defaults
+- **WHEN** a Framework Elasticsearch entity resolves its effective client through the factory and `elasticsearch_connection` is absent
+- **THEN** the factory SHALL return a typed Elasticsearch-scoped client derived from provider configuration
+
+#### Scenario: Framework factory builds a scoped Elasticsearch client
+- **WHEN** a Framework Elasticsearch entity resolves its effective client through the factory and `elasticsearch_connection` is configured
+- **THEN** the factory SHALL return a typed Elasticsearch-scoped client rebuilt from that connection for Elasticsearch operations
+
+### Requirement: SDK Elasticsearch scoped client resolution
+The provider SHALL expose SDK `elasticsearch_connection` resolution through `ProviderClientFactory` methods that accept resource or data source state and return a typed Elasticsearch-scoped client. When the block is not configured, the factory SHALL return a typed client built from provider-level defaults. When the block is configured, the factory SHALL return a typed scoped client rebuilt from that connection for Elasticsearch operations.
+
+#### Scenario: SDK factory falls back to provider defaults
+- **WHEN** an SDK Elasticsearch entity resolves its effective client through the factory and `elasticsearch_connection` is absent
+- **THEN** the factory SHALL return a typed Elasticsearch-scoped client derived from provider configuration
+
+#### Scenario: SDK factory builds a scoped Elasticsearch client
+- **WHEN** an SDK Elasticsearch entity resolves its effective client through the factory and `elasticsearch_connection` is configured
+- **THEN** the factory SHALL return a typed Elasticsearch-scoped client rebuilt from that connection for Elasticsearch operations
+
+### Requirement: Elasticsearch sink type safety
+In-scope shared Elasticsearch helpers and sinks SHALL accept the typed Elasticsearch-scoped client, or narrower interfaces derived from it, instead of accepting the broad `*clients.APIClient`.
+
+#### Scenario: Shared sink requires typed client
+- **WHEN** code under `internal/clients/elasticsearch/**` exposes a sink or helper that consumes provider-resolved Elasticsearch client state
+- **THEN** that sink or helper SHALL require the typed Elasticsearch-scoped client contract rather than `*clients.APIClient`
+
+### Requirement: Elasticsearch scoped client helper behavior
+The typed Elasticsearch-scoped client SHALL expose the Elasticsearch client surface and the Elasticsearch-derived helper behavior needed by covered Elasticsearch entities, including composite ID generation, cluster identity lookup, version checks, flavor checks, and minimum-version enforcement.
+
+#### Scenario: Scoped client supports Elasticsearch helper behavior
+- **WHEN** a covered Elasticsearch entity performs ID generation, cluster identity lookup, version checks, flavor checks, or minimum-version enforcement through the typed scoped client
+- **THEN** the typed scoped client SHALL provide that behavior without requiring access to a broad `*clients.APIClient`

--- a/openspec/changes/typed-elasticsearch-client-resolution/tasks.md
+++ b/openspec/changes/typed-elasticsearch-client-resolution/tasks.md
@@ -1,0 +1,24 @@
+## 1. Elasticsearch Factory And Scoped Client
+
+- [ ] 1.1 Extend `ProviderClientFactory` with typed Elasticsearch resolution methods for SDK and Plugin Framework `elasticsearch_connection`
+- [ ] 1.2 Add `ElasticsearchScopedClient` and unit tests for provider-default versus scoped Elasticsearch resolution behavior
+- [ ] 1.3 Remove the factory's temporary legacy Elasticsearch resolution methods once all Elasticsearch consumers are migrated
+
+## 2. Elasticsearch Sink And Entity Migration
+
+- [ ] 2.1 Update `internal/clients/elasticsearch/` helper and sink packages to accept `ElasticsearchScopedClient` or narrow typed interfaces instead of `*clients.APIClient`
+- [ ] 2.2 Migrate covered Plugin Framework Elasticsearch resources/data sources to store the injected factory and resolve `ElasticsearchScopedClient` from `elasticsearch_connection`
+- [ ] 2.3 Migrate covered SDK Elasticsearch resources/data sources to store the injected factory and resolve `ElasticsearchScopedClient` from `elasticsearch_connection`
+- [ ] 2.4 Update unit and acceptance tests for Elasticsearch helper behavior, version checks, cluster identity, and scoped override handling
+
+## 3. Custom Lint Removal
+
+- [ ] 3.1 Delete `analysis/esclienthelperplugin`, its tests, and any supporting wrapper/export packages
+- [ ] 3.2 Remove `.golangci.yaml`, Makefile, and related lint workflow wiring for the Elasticsearch client-resolution custom analyzer
+- [ ] 3.3 Verify there are no remaining in-scope Elasticsearch sinks or resources that depend on broad `*clients.APIClient` provenance analysis
+
+## 4. Verification
+
+- [ ] 4.1 Run OpenSpec validation for the new change artifacts
+- [ ] 4.2 Run targeted Go tests for updated Elasticsearch client and entity packages plus `make build`
+- [ ] 4.3 Run repository lint after analyzer removal to confirm the new compile-time enforcement model replaces the deleted custom lint task

--- a/openspec/changes/typed-kibana-fleet-client-resolution/.openspec.yaml
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/typed-kibana-fleet-client-resolution/design.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/design.md
@@ -1,0 +1,64 @@
+## Context
+
+Kibana and Fleet entities currently receive the provider's default `*clients.APIClient` through Framework `ProviderData` or SDK `meta`, then optionally rebuild another broad `*clients.APIClient` through `kibana_connection` helpers. That model leaves the provider default client and the correctly scoped client with the same static type, so the compiler cannot force Kibana and Fleet code to resolve a scoped client before reaching Kibana, Kibana OpenAPI, SLO, or Fleet operations.
+
+This matters now because resource-level `kibana_connection` is still being finalized and is directly tied to the multi-cluster Kibana authentication use case tracked in issue [#509](https://github.com/elastic/terraform-provider-elasticstack/issues/509). The next production-ready phase should make Kibana/Fleet behavior correct by construction without waiting for a larger Elasticsearch migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce a provider-injected factory that becomes the stable provider data contract for both Framework and SDK entities.
+- Make Kibana and Fleet code resolve typed scoped clients from `kibana_connection` before calling Kibana, Kibana OpenAPI, SLO, or Fleet sinks.
+- Preserve existing Elasticsearch behavior and lint-backed enforcement during this phase so the change can ship independently.
+- Keep the existing `kibana_connection` schema surface and rollout scope intact while changing the resolution contract under it.
+
+**Non-Goals:**
+- Removing `analysis/esclienthelperplugin` in this phase.
+- Converting Elasticsearch sinks or `elasticsearch_connection` handling to typed scoped clients in this phase.
+- Redesigning provider-level or entity-level connection block fields.
+- Fully deduplicating SDK and Framework decoding paths in `internal/clients/config/`.
+
+## Decisions
+
+Inject a provider client factory for all entities.
+The provider should inject `*clients.ProviderClientFactory` into Framework `ProviderData` and SDK `meta` instead of injecting `*clients.APIClient`. This gives the repository one provider data type during the migration and keeps future scoped-client construction centralized.
+
+Alternative considered: keep injecting `*clients.APIClient` for Elasticsearch entities and use a factory only for Kibana/Fleet entities.
+Rejected because provider configuration has one injected data contract, and splitting it by entity family would create more migration complexity than it removes.
+
+Ship a transitional factory that supports typed Kibana/Fleet resolution and legacy Elasticsearch resolution.
+For this phase, the factory should expose typed Kibana methods that return `*clients.KibanaScopedClient`, while also exposing temporary legacy Elasticsearch resolution methods that preserve current `*clients.APIClient` behavior for unconverted Elasticsearch code paths.
+
+Alternative considered: require phase 1 to convert Kibana/Fleet and Elasticsearch together.
+Rejected because the priority is to finalize `kibana_connection` behavior first, while Elasticsearch already has behavior enforcement through the existing lint rule.
+
+Introduce a concrete `KibanaScopedClient` type with Kibana-derived behavior.
+The typed Kibana/Fleet client should own the Kibana legacy client, Kibana OpenAPI client, SLO client, Fleet client, Kibana auth context helpers, and Kibana-derived version/flavor checks. It should not expose Elasticsearch identity helpers such as `ClusterID()` because scoped `kibana_connection` intentionally avoids reusing provider-level Elasticsearch identity.
+
+Alternative considered: keep passing `*clients.APIClient` to sinks and only move construction behind the factory.
+Rejected because that would still leave sink boundaries too broad for compile-time enforcement.
+
+Move sink boundaries before moving every caller.
+Shared helper and sink packages should accept `*clients.KibanaScopedClient` or narrow interfaces derived from it, and Kibana/Fleet resources should resolve the scoped type before calling those helpers. This keeps the compile-time guarantee at the API boundary instead of relying on call-site conventions.
+
+Alternative considered: migrate resources first and leave helper packages broad.
+Rejected because the compiler only helps once the sink signatures stop accepting the broad client type.
+
+## Risks / Trade-offs
+
+- [Risk] Introducing the factory for all entities while only typing Kibana/Fleet creates a temporary mixed model -> Mitigation: make the factory's legacy Elasticsearch methods explicit and document that they are transitional only for phase 2 removal.
+- [Risk] Kibana/Fleet helper packages currently mix direct client getters with higher-level `APIClient` behaviors -> Mitigation: define the minimum `KibanaScopedClient` surface up front and migrate helper packages to that narrow contract first.
+- [Risk] Version checks could accidentally regress to provider-level Elasticsearch behavior during the refactor -> Mitigation: keep `ServerVersion()`, `ServerFlavor()`, and `EnforceMinVersion()` on `KibanaScopedClient` Kibana-derived by contract.
+- [Risk] Existing tests and helper utilities may assume `*clients.APIClient` -> Mitigation: add targeted unit coverage for factory resolution and scoped client behavior, and adapt helpers that currently unwrap Kibana clients from the broad type.
+
+## Migration Plan
+
+1. Add `ProviderClientFactory` to `internal/clients/` and update provider configure paths to inject it.
+2. Implement typed Kibana/Fleet resolution methods on the factory and add `KibanaScopedClient`.
+3. Convert shared Kibana/Fleet helper and sink packages to accept the typed scoped client.
+4. Migrate covered Kibana and Fleet resources/data sources to resolve `KibanaScopedClient` from `kibana_connection`.
+5. Keep legacy Elasticsearch resolution methods available on the factory until the follow-up Elasticsearch phase replaces them.
+
+## Open Questions
+
+- None. The main design question is sequencing, and this change intentionally fixes that sequence around Kibana/Fleet first.

--- a/openspec/changes/typed-kibana-fleet-client-resolution/proposal.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`kibana_connection` is still being finalized for Kibana and Fleet entities, and the current helper-based `*clients.APIClient` model does not let the compiler enforce that those entities actually rebuild scoped clients from the resource-local override. That leaves the highest-priority new behavior depending on conventions rather than types at the same time that users want reliable multi-cluster Kibana authentication support.
+
+## What Changes
+
+- Introduce a provider-injected client factory that becomes the supported provider data surface for resources and data sources.
+- Add typed Kibana/Fleet scoped-client resolution so Kibana and Fleet code must resolve a scoped client from `kibana_connection` before reaching Kibana, Kibana OpenAPI, SLO, or Fleet sinks.
+- Update `kibana_connection` requirements to describe factory-based, typed scoped-client behavior instead of helper-returned broad `*clients.APIClient` values.
+- Keep Elasticsearch on its current broad-client and lint-enforced path for this phase so Kibana/Fleet enforcement can ship independently.
+
+## Capabilities
+
+### New Capabilities
+- `provider-client-factory`: provider-level factory requirements for injecting typed client resolution into Framework `ProviderData` and SDK `meta`, while supporting phased migration from the current broad API client model
+
+### Modified Capabilities
+- `provider-kibana-connection`: replace helper-returned broad client resolution with factory-based typed Kibana/Fleet scoped client requirements for covered Kibana and Fleet entities
+
+## Impact
+
+- Provider configure paths in `provider/provider.go` and `provider/plugin_framework.go`
+- Shared client construction and config code under `internal/clients/` and `internal/clients/config/`
+- Kibana and Fleet helper and sink code under `internal/kibana/`, `internal/fleet/`, and supporting shared packages
+- Existing `provider-kibana-connection` OpenSpec requirements

--- a/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-client-factory/spec.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-client-factory/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Provider injects a client factory
+The provider SHALL inject a `ProviderClientFactory` into Plugin Framework `ProviderData` and SDK `meta` as the provider-scoped client-resolution surface for resources and data sources.
+
+#### Scenario: Framework configure receives a factory
+- **WHEN** the Plugin Framework provider configures a resource or data source
+- **THEN** the configured provider data SHALL be a `ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
+
+#### Scenario: SDK configure receives a factory
+- **WHEN** the SDK provider configures a resource or data source
+- **THEN** the configured `meta` value SHALL be a `ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
+
+### Requirement: Factory supports phased migration
+During the Kibana/Fleet typed-client phase, the `ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and SHALL also preserve explicit legacy Elasticsearch resolution methods so unconverted Elasticsearch entities continue to behave as they did before the factory migration.
+
+#### Scenario: Kibana entity resolves typed client
+- **WHEN** a Kibana or Fleet entity resolves its effective client through the factory
+- **THEN** the factory SHALL return a typed Kibana-scoped client for Kibana, Kibana OpenAPI, SLO, and Fleet operations
+
+#### Scenario: Elasticsearch entity uses transitional legacy resolution
+- **WHEN** an unconverted Elasticsearch entity resolves its effective client during this phase
+- **THEN** the factory SHALL expose a transitional resolution path that preserves the existing broad-client and lint-enforced Elasticsearch behavior
+
+### Requirement: Kibana scoped client contract
+The typed Kibana-scoped client returned by the factory SHALL expose the Kibana legacy client, Kibana OpenAPI client, SLO client, Fleet client, Kibana auth-context helpers, and Kibana-derived version and flavor checks required by covered Kibana and Fleet entities.
+
+#### Scenario: Scoped client supports Kibana and Fleet operations
+- **WHEN** a covered Kibana or Fleet entity uses a typed Kibana-scoped client
+- **THEN** the client SHALL provide the typed client surfaces needed for Kibana, Kibana OpenAPI, SLO, and Fleet API operations
+
+#### Scenario: Scoped client supports version gating
+- **WHEN** a covered Kibana or Fleet entity performs version or flavor checks through the typed Kibana-scoped client
+- **THEN** the client SHALL provide `ServerVersion()`, `ServerFlavor()`, or equivalent typed behavior needed for those checks

--- a/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-client-factory/spec.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-client-factory/spec.md
@@ -1,18 +1,18 @@
 ## ADDED Requirements
 
 ### Requirement: Provider injects a client factory
-The provider SHALL inject a `ProviderClientFactory` into Plugin Framework `ProviderData` and SDK `meta` as the provider-scoped client-resolution surface for resources and data sources.
+The provider SHALL inject a `*clients.ProviderClientFactory` into Plugin Framework `ProviderData` and SDK `meta` as the provider-scoped client-resolution surface for resources and data sources.
 
 #### Scenario: Framework configure receives a factory
 - **WHEN** the Plugin Framework provider configures a resource or data source
-- **THEN** the configured provider data SHALL be a `ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
+- **THEN** the configured provider data SHALL be a `*clients.ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
 
 #### Scenario: SDK configure receives a factory
 - **WHEN** the SDK provider configures a resource or data source
-- **THEN** the configured `meta` value SHALL be a `ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
+- **THEN** the configured `meta` value SHALL be a `*clients.ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
 
 ### Requirement: Factory supports phased migration
-During the Kibana/Fleet typed-client phase, the `ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and SHALL also preserve explicit legacy Elasticsearch resolution methods so unconverted Elasticsearch entities continue to behave as they did before the factory migration.
+During the Kibana/Fleet typed-client phase, the `*clients.ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and SHALL also preserve explicit legacy Elasticsearch resolution methods so unconverted Elasticsearch entities continue to behave as they did before the factory migration.
 
 #### Scenario: Kibana entity resolves typed client
 - **WHEN** a Kibana or Fleet entity resolves its effective client through the factory

--- a/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-kibana-connection/spec.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-kibana-connection/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Framework scoped Kibana client resolution
+The provider SHALL expose Plugin Framework `kibana_connection` resolution through `ProviderClientFactory` methods that accept an entity-local `kibana_connection` block and return a typed Kibana-scoped client. When the block is not configured, the factory SHALL return a typed client built from provider-level defaults. When the block is configured, the factory SHALL return a typed scoped client whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
+
+#### Scenario: Framework factory falls back to provider defaults
+- **WHEN** a Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
+- **THEN** the factory SHALL return a typed Kibana-scoped client derived from provider configuration
+
+#### Scenario: Framework factory builds a scoped Kibana-derived client
+- **WHEN** a Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
+- **THEN** the factory SHALL return a typed Kibana-scoped client rebuilt from that connection for Kibana, SLO, and Fleet operations
+
+### Requirement: SDK scoped Kibana client resolution
+The provider SHALL expose SDK `kibana_connection` resolution through `ProviderClientFactory` methods that accept resource or data source state and return a typed Kibana-scoped client. When the block is not configured, the factory SHALL return a typed client built from provider-level defaults. When the block is configured, the factory SHALL return a typed scoped client whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
+
+#### Scenario: SDK factory falls back to provider defaults
+- **WHEN** an SDK entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
+- **THEN** the factory SHALL return a typed Kibana-scoped client derived from provider configuration
+
+#### Scenario: SDK factory builds a scoped Kibana-derived client
+- **WHEN** an SDK entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
+- **THEN** the factory SHALL return a typed Kibana-scoped client rebuilt from that connection for Kibana, SLO, and Fleet operations
+
+### Requirement: Scoped client version and identity behavior
+When an entity uses a typed scoped `kibana_connection` client, version, flavor, and other Kibana-derived client checks SHALL resolve against the scoped connection rather than provider-level Elasticsearch identity. The typed Kibana-scoped client SHALL therefore avoid exposing provider-level Elasticsearch identity in a way that can make Kibana or Fleet operations target one cluster while version or identity checks target another.
+
+#### Scenario: Scoped version checks follow the scoped Kibana connection
+- **WHEN** an entity uses `ServerVersion()`, `ServerFlavor()`, or equivalent behavior through a scoped `kibana_connection`
+- **THEN** the result SHALL be derived from the scoped Kibana connection instead of the provider's Elasticsearch connection
+
+#### Scenario: Scoped Kibana client does not expose provider Elasticsearch identity
+- **WHEN** a covered Kibana or Fleet entity uses the typed scoped client returned for `kibana_connection`
+- **THEN** that typed client SHALL NOT require provider-level Elasticsearch identity to perform Kibana or Fleet operations

--- a/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-kibana-connection/spec.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/specs/provider-kibana-connection/spec.md
@@ -1,34 +1,34 @@
 ## MODIFIED Requirements
 
 ### Requirement: Framework scoped Kibana client resolution
-The provider SHALL expose Plugin Framework `kibana_connection` resolution through `ProviderClientFactory` methods that accept an entity-local `kibana_connection` block and return a typed Kibana-scoped client. When the block is not configured, the factory SHALL return a typed client built from provider-level defaults. When the block is configured, the factory SHALL return a typed scoped client whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
+The provider SHALL expose Plugin Framework `kibana_connection` resolution through `*clients.ProviderClientFactory` methods that accept an entity-local `kibana_connection` block and return a `*clients.KibanaScopedClient`. When the block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
 
 #### Scenario: Framework factory falls back to provider defaults
 - **WHEN** a Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
-- **THEN** the factory SHALL return a typed Kibana-scoped client derived from provider configuration
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` derived from provider configuration
 
 #### Scenario: Framework factory builds a scoped Kibana-derived client
 - **WHEN** a Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
-- **THEN** the factory SHALL return a typed Kibana-scoped client rebuilt from that connection for Kibana, SLO, and Fleet operations
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` rebuilt from that connection for Kibana, SLO, and Fleet operations
 
 ### Requirement: SDK scoped Kibana client resolution
-The provider SHALL expose SDK `kibana_connection` resolution through `ProviderClientFactory` methods that accept resource or data source state and return a typed Kibana-scoped client. When the block is not configured, the factory SHALL return a typed client built from provider-level defaults. When the block is configured, the factory SHALL return a typed scoped client whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
+The provider SHALL expose SDK `kibana_connection` resolution through `*clients.ProviderClientFactory` methods that accept resource or data source state and return a `*clients.KibanaScopedClient`. When the block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
 
 #### Scenario: SDK factory falls back to provider defaults
 - **WHEN** an SDK entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
-- **THEN** the factory SHALL return a typed Kibana-scoped client derived from provider configuration
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` derived from provider configuration
 
 #### Scenario: SDK factory builds a scoped Kibana-derived client
 - **WHEN** an SDK entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
-- **THEN** the factory SHALL return a typed Kibana-scoped client rebuilt from that connection for Kibana, SLO, and Fleet operations
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` rebuilt from that connection for Kibana, SLO, and Fleet operations
 
 ### Requirement: Scoped client version and identity behavior
-When an entity uses a typed scoped `kibana_connection` client, version, flavor, and other Kibana-derived client checks SHALL resolve against the scoped connection rather than provider-level Elasticsearch identity. The typed Kibana-scoped client SHALL therefore avoid exposing provider-level Elasticsearch identity in a way that can make Kibana or Fleet operations target one cluster while version or identity checks target another.
+When an entity uses a scoped `*clients.KibanaScopedClient` resolved from `kibana_connection`, version, flavor, and other Kibana-derived client checks SHALL resolve against the scoped connection rather than provider-level Elasticsearch identity. The `*clients.KibanaScopedClient` SHALL therefore avoid exposing provider-level Elasticsearch identity in a way that can make Kibana or Fleet operations target one cluster while version or identity checks target another.
 
 #### Scenario: Scoped version checks follow the scoped Kibana connection
 - **WHEN** an entity uses `ServerVersion()`, `ServerFlavor()`, or equivalent behavior through a scoped `kibana_connection`
 - **THEN** the result SHALL be derived from the scoped Kibana connection instead of the provider's Elasticsearch connection
 
 #### Scenario: Scoped Kibana client does not expose provider Elasticsearch identity
-- **WHEN** a covered Kibana or Fleet entity uses the typed scoped client returned for `kibana_connection`
-- **THEN** that typed client SHALL NOT require provider-level Elasticsearch identity to perform Kibana or Fleet operations
+- **WHEN** a covered Kibana or Fleet entity uses the `*clients.KibanaScopedClient` returned for `kibana_connection`
+- **THEN** that `*clients.KibanaScopedClient` SHALL NOT require provider-level Elasticsearch identity to perform Kibana or Fleet operations

--- a/openspec/changes/typed-kibana-fleet-client-resolution/tasks.md
+++ b/openspec/changes/typed-kibana-fleet-client-resolution/tasks.md
@@ -1,0 +1,23 @@
+## 1. Provider Factory Foundation
+
+- [ ] 1.1 Add `ProviderClientFactory` under `internal/clients/` and update `provider/provider.go` and `provider/plugin_framework.go` to inject it instead of `*clients.APIClient`
+- [ ] 1.2 Implement typed Kibana/Fleet resolution methods plus temporary legacy Elasticsearch resolution methods on the factory
+- [ ] 1.3 Add `KibanaScopedClient` and unit tests covering provider-default and scoped `kibana_connection` resolution for both SDK and Plugin Framework entry points
+
+## 2. Kibana And Fleet Sink Migration
+
+- [ ] 2.1 Update shared Kibana/Fleet helper and sink packages to accept `KibanaScopedClient` or narrow typed interfaces instead of `*clients.APIClient`
+- [ ] 2.2 Refactor helper utilities that currently unwrap Kibana, Kibana OpenAPI, SLO, or Fleet clients from `*clients.APIClient` to use the typed scoped client contract
+- [ ] 2.3 Add or update unit tests for typed Kibana/Fleet sink usage and Kibana-derived version/flavor behavior
+
+## 3. Entity Adoption
+
+- [ ] 3.1 Migrate covered Plugin Framework Kibana and Fleet resources/data sources to store the injected factory and resolve `KibanaScopedClient` from `kibana_connection`
+- [ ] 3.2 Migrate covered SDK Kibana resources/data sources to store the injected factory and resolve `KibanaScopedClient` from `kibana_connection`
+- [ ] 3.3 Update acceptance and regression tests so provider-default and scoped `kibana_connection` behavior are both verified for covered Kibana/Fleet entities
+
+## 4. Verification
+
+- [ ] 4.1 Run OpenSpec validation for the new change artifacts
+- [ ] 4.2 Run targeted Go tests for updated Kibana/Fleet client and entity packages plus `make build`
+- [ ] 4.3 Confirm Elasticsearch entities still work through the factory's temporary legacy path and leave `analysis/esclienthelperplugin` unchanged for the follow-up phase


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/509

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add spec and design documents for typed Elasticsearch and Kibana/Fleet client enforcement at compile time
> - Adds OpenSpec proposals, design docs, and task checklists for two phased migrations: replacing broad `*clients.APIClient` Elasticsearch usage with typed scoped clients via `ProviderClientFactory`, and introducing typed `*clients.KibanaScopedClient` resolution from `kibana_connection`.
> - The typed client approach enforces correct client usage at the type level rather than through a custom lint analyzer, which is marked for removal once migration is complete.
> - Specs define new `ProviderClientFactory` requirements for both Framework and SDK, sink type safety constraints, and helper behaviors (cluster identity, version/flavor checks, min-version enforcement).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66ac7e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->