### PR TITLE
Watcher -> PF

### DIFF
--- a/openspec/changes/harden-elasticsearch-watch-coverage/.openspec.yaml
+++ b/openspec/changes/harden-elasticsearch-watch-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/harden-elasticsearch-watch-coverage/design.md
+++ b/openspec/changes/harden-elasticsearch-watch-coverage/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`elasticstack_elasticsearch_watch` currently has a narrow acceptance suite that covers a basic create/update flow, but it does not exercise import, omitted defaults, or clearing a previously configured `transform`. That gap matters now because the current SDK implementation preserves a stale `transform` value when Elasticsearch no longer returns one, and the Plugin Framework migration should start from behavior that is already covered and correct.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add focused acceptance coverage for import, defaulted `active`, defaulted `throttle_period_in_millis`, and removing `transform`.
+- Fix watch refresh behavior so state stops retaining a stale `transform` after it has been removed remotely or via Terraform.
+- Express the corrected watch behavior in OpenSpec before the migration change builds on it.
+
+**Non-Goals:**
+- Migrating the resource to the Terraform Plugin Framework.
+- Redesigning the watch schema or changing the resource type, import format, or ID format.
+- Expanding test coverage beyond the watch-specific regressions needed to de-risk the upcoming migration.
+
+## Decisions
+
+Clear `transform` from state when the API response omits it.
+The current SDK read path keeps the old value, which makes state diverge from the remote watch after `transform` is removed. The fix should make refresh authoritative so subsequent plans can see and reconcile the drift.
+
+Alternative considered: preserve the old state value when Elasticsearch omits `transform`.
+Rejected because it leaves stale state in place and prevents acceptance tests from proving that a removed transform stays removed.
+
+Add the new acceptance coverage before the Plugin Framework migration.
+The new tests should protect the current behavior boundary first, then travel with the resource during migration.
+
+Alternative considered: fold coverage additions into the migration change.
+Rejected because it would blur whether a regression came from the behavior fix or the framework port.
+
+Keep the change scoped to the existing watch acceptance layout.
+The current `create` and `update` config directories already establish the main watch flow. The new cases should extend that suite with the smallest set of extra configs and checks needed to cover defaults, import, and removal.
+
+## Risks / Trade-offs
+
+- [Risk] Clearing `transform` on refresh could expose previously hidden drift for users whose state already contains a stale value. -> Mitigation: codify the new behavior in the delta spec and cover it with an acceptance test that removes `transform`.
+- [Risk] Adding more acceptance steps can increase runtime and fixture complexity. -> Mitigation: keep the new cases narrowly focused on import, defaults, and transform removal instead of duplicating the existing broad update scenario.
+- [Risk] The migration change could still need to revisit edge cases outside these tests. -> Mitigation: target the cases most likely to break during the SDK-to-PF port and treat this hardening change as a prerequisite for the migration.
+
+## Migration Plan
+
+1. Extend the current watch acceptance suite with import and omitted-default scenarios.
+2. Add a regression test step that removes a previously configured `transform`.
+3. Update watch read behavior so refresh clears `transform` when Elasticsearch no longer returns it.
+4. Validate the watch-specific acceptance suite and use it as the baseline for the Plugin Framework migration.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/harden-elasticsearch-watch-coverage/proposal.md
+++ b/openspec/changes/harden-elasticsearch-watch-coverage/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Elasticsearch watch resource currently lacks acceptance coverage for several migration-sensitive paths, including import, defaulted fields, and clearing an optional `transform`. The current read behavior also preserves a stale `transform` value after it has been removed, so the resource can keep incorrect state and mask regressions.
+
+## What Changes
+
+- Add acceptance coverage for watch import, defaulted `active`, defaulted `throttle_period_in_millis`, and removing a previously configured `transform`.
+- Fix watch refresh behavior so `transform` is cleared from state when it is no longer configured and Elasticsearch no longer returns it.
+- Tighten the watch requirements so default handling, import behavior, and `transform` state synchronization are explicitly specified.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `elasticsearch-watch`: clarify import/default expectations and correct refresh behavior for clearing an optional `transform`
+
+## Impact
+
+- `internal/elasticsearch/watcher/watch.go`
+- `internal/elasticsearch/watcher/watch_test.go`
+- `internal/elasticsearch/watcher/testdata/`
+- `openspec/specs/elasticsearch-watch/spec.md`

--- a/openspec/changes/harden-elasticsearch-watch-coverage/specs/elasticsearch-watch/spec.md
+++ b/openspec/changes/harden-elasticsearch-watch-coverage/specs/elasticsearch-watch/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-### Requirement: Defaulted watch attributes
+### Requirement: Defaulted watch attributes (REQ-028)
 When `active` is omitted from configuration, the resource SHALL behave as if `active` were `true`. When `throttle_period_in_millis` is omitted, the resource SHALL submit the default throttle period and SHALL store the refreshed value in state. When `input`, `condition`, `actions`, or `metadata` are omitted, the resource SHALL use their documented JSON defaults during create and update.
 
 #### Scenario: active omitted from configuration

--- a/openspec/changes/harden-elasticsearch-watch-coverage/specs/elasticsearch-watch/spec.md
+++ b/openspec/changes/harden-elasticsearch-watch-coverage/specs/elasticsearch-watch/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Defaulted watch attributes
+When `active` is omitted from configuration, the resource SHALL behave as if `active` were `true`. When `throttle_period_in_millis` is omitted, the resource SHALL submit the default throttle period and SHALL store the refreshed value in state. When `input`, `condition`, `actions`, or `metadata` are omitted, the resource SHALL use their documented JSON defaults during create and update.
+
+#### Scenario: active omitted from configuration
+- **GIVEN** a watch configuration that omits `active`
+- **WHEN** the resource is created and refreshed
+- **THEN** the `active` attribute in state SHALL be `true`
+
+#### Scenario: throttle period omitted from configuration
+- **GIVEN** a watch configuration that omits `throttle_period_in_millis`
+- **WHEN** the resource is created and refreshed
+- **THEN** the `throttle_period_in_millis` attribute in state SHALL be `5000`
+
+## MODIFIED Requirements
+
+### Requirement: JSON field mapping — read/state (REQ-023–REQ-027)
+On read, the resource SHALL marshal the API response fields `trigger`, `input`, `condition`, `actions`, and `metadata` back into JSON strings and store them in state. When the API response includes a non-nil `transform`, the resource SHALL marshal it to a JSON string and store it in state. When the API response has a nil `transform`, the resource SHALL clear `transform` from state so the Terraform state reflects the remote watch. The resource SHALL store `watch_id` and `active` (from `watch.status.state.active`) directly from the API response. The resource SHALL store `throttle_period_in_millis` from the API response. JSON fields SHALL use `DiffSuppressFunc` (`tfsdkutils.DiffJSONSuppress`) to suppress semantically equivalent JSON diffs.
+
+#### Scenario: transform removed from the remote watch
+- **GIVEN** the watch previously had a `transform` stored in Terraform state
+- **WHEN** read runs and the API response has no `transform` field
+- **THEN** the `transform` attribute SHALL be cleared from state
+
+#### Scenario: active synced from watch status
+- **GIVEN** the watch is deactivated on the cluster
+- **WHEN** read runs
+- **THEN** `active` in state SHALL reflect `watch.status.state.active` from the API response

--- a/openspec/changes/harden-elasticsearch-watch-coverage/tasks.md
+++ b/openspec/changes/harden-elasticsearch-watch-coverage/tasks.md
@@ -1,0 +1,15 @@
+## 1. Acceptance Coverage
+
+- [ ] 1.1 Add watch acceptance coverage for import using the composite `<cluster_uuid>/<watch_id>` identifier
+- [ ] 1.2 Add acceptance coverage for omitted `active` and omitted `throttle_period_in_millis` defaults
+- [ ] 1.3 Add an acceptance step that removes a previously configured `transform` and verifies it stays absent after refresh
+
+## 2. Watch State Synchronization Fix
+
+- [ ] 2.1 Update watch read behavior so a missing API `transform` clears the Terraform state attribute
+- [ ] 2.2 Keep the change scoped to existing watch behavior without altering resource type, ID format, or import format
+
+## 3. Verification
+
+- [ ] 3.1 Validate the OpenSpec change artifacts for `harden-elasticsearch-watch-coverage`
+- [ ] 3.2 Run focused watch tests to confirm the new coverage and `transform` fix behave as specified

--- a/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/.openspec.yaml
+++ b/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/design.md
+++ b/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`elasticstack_elasticsearch_watch` is still implemented in `internal/elasticsearch/watcher/watch.go` with the Terraform Plugin SDK, while the provider already serves Plugin Framework resources through the muxed proto6 provider. The watch migration therefore has two moving parts: the watch-specific Elasticsearch client helpers must return framework diagnostics, and the new Framework resource must preserve the existing resource contract, including schema shape, import format, composite IDs, and upgrade compatibility with SDK-managed state.
+
+This change is intentionally separate from the watch hardening change. The migration should build on the corrected watch behavior and stronger acceptance suite rather than mixing framework porting with behavior fixes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reimplement the watch resource with the Terraform Plugin Framework while preserving the existing external resource contract.
+- Convert watch-specific Elasticsearch helper functions to framework diagnostics so the Framework resource can call them directly.
+- Preserve the composite `id`, import ID format, connection override behavior, and watch CRUD semantics.
+- Add upgrade coverage proving a watch created by the last SDK-backed provider release can be managed by the new Framework resource without recreation.
+
+**Non-Goals:**
+- Changing the resource type name, attribute names, defaults, or import format.
+- Redesigning watch behavior beyond the separately tracked hardening fix.
+- Introducing a broad compatibility layer that leaves the watch helper APIs SDK-first after the migration.
+
+## Decisions
+
+Model the migrated resource after existing Elasticsearch Plugin Framework resources.
+The new watch package should follow the repo's standard Framework layout with `resource.go`, `schema.go`, `models.go`, and CRUD files. It should use `providerschema.GetEsFWConnectionBlock()` plus `clients.MaybeNewAPIClientFromFrameworkResource()` so connection override handling matches other Elasticsearch resources.
+
+Alternative considered: keep most logic inside the existing SDK file and adapt it minimally.
+Rejected because it would preserve SDK-specific patterns and make future maintenance inconsistent with the rest of the Framework resources.
+
+Use framework-native diagnostics in `internal/clients/elasticsearch/watch.go`.
+The watch helpers are only used by the watch resource, so converting them to framework diagnostics directly keeps the Framework resource simple and avoids adding conversion glue in each CRUD method.
+
+Alternative considered: leave the helpers SDK-based and convert diagnostics inside the new resource.
+Rejected because it preserves the wrong abstraction boundary and makes the migrated resource responsible for compatibility concerns that belong in the helper layer.
+
+Represent JSON attributes with normalized JSON handling in the Framework schema.
+The SDK resource uses JSON strings plus `DiffSuppressFunc` to avoid semantically meaningless diffs. The Framework resource should preserve that behavior with the repo's normalized JSON string type so existing watch JSON continues to round-trip without perpetual diffs.
+
+Alternative considered: use plain `types.String` attributes for all JSON fields.
+Rejected because it would reintroduce formatting-sensitive diffs and weaken parity with the SDK behavior.
+
+Add an SDK-to-Framework acceptance test pinned to the last SDK-backed release.
+The migration needs an explicit upgrade test that creates the resource with the last published SDK implementation and then refreshes it with the new Framework implementation.
+
+Alternative considered: rely only on regular acceptance tests after the port.
+Rejected because those tests do not prove existing released state upgrades cleanly.
+
+Only add a Framework state upgrader if the upgrade test proves one is necessary.
+The desired outcome is a straight migration with no explicit upgrader. A state upgrader should be introduced only if the new schema or custom JSON types cannot consume SDK-authored state directly.
+
+## Risks / Trade-offs
+
+- [Risk] The Framework JSON type or state model may not deserialize existing SDK state exactly as expected. -> Mitigation: add a `FromSDK` acceptance test first and introduce a minimal state upgrader only if the test demonstrates a compatibility gap.
+- [Risk] Moving the resource from SDK to Framework could accidentally change ID, import, or default behavior. -> Mitigation: preserve the existing acceptance coverage and extend it with explicit upgrade coverage.
+- [Risk] Registering the resource on both sides of the mux would create undefined behavior. -> Mitigation: add the new Framework resource to `provider/plugin_framework.go` and remove the SDK registration from `provider/provider.go` in the same change.
+- [Risk] The helper migration could leave lingering SDK callers or conversions. -> Mitigation: keep the watch helper changes scoped to watch-only call sites and verify no other package still imports the old signatures.
+
+## Migration Plan
+
+1. Convert `internal/clients/elasticsearch/watch.go` to framework diagnostics.
+2. Replace the SDK watch resource implementation with a Framework package that preserves schema, ID, import, and connection behavior.
+3. Register the Framework watch resource and remove the SDK registration from the muxed SDK provider.
+4. Move or adapt watch acceptance coverage into the Framework package layout and add a `FromSDK` upgrade test pinned to `0.14.3`.
+5. Run build and focused watch tests; add a state upgrader only if the upgrade path fails without one.
+
+## Open Questions
+
+- Whether a dedicated Framework state upgrader is needed should be decided by the upgrade test, not assumed up front.

--- a/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/proposal.md
+++ b/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`elasticstack_elasticsearch_watch` is still implemented with the Terraform Plugin SDK while most new Elasticsearch resources now use the Terraform Plugin Framework. Migrating it safely requires an explicit compatibility contract so the resource keeps the same schema and upgrade behavior while existing SDK-managed state continues to work.
+
+## What Changes
+
+- Reimplement the watch resource with the Terraform Plugin Framework while preserving the existing resource type, schema shape, defaults, import format, and composite `id`.
+- Convert watch-specific Elasticsearch client helpers to return framework diagnostics and support the Plugin Framework resource implementation directly.
+- Add upgrade coverage that creates a watch with the last SDK-backed provider release and verifies the new Plugin Framework resource can manage that state without recreation.
+- Update watch requirements to describe framework-based JSON normalization and SDK-to-Framework state compatibility.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `elasticsearch-watch`: replace SDK-specific implementation requirements with Plugin Framework requirements while preserving external behavior and upgrade compatibility
+
+## Impact
+
+- `internal/clients/elasticsearch/watch.go`
+- `internal/elasticsearch/watcher/`
+- `provider/plugin_framework.go`
+- `provider/provider.go`
+- `openspec/specs/elasticsearch-watch/spec.md`

--- a/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/specs/elasticsearch-watch/spec.md
+++ b/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/specs/elasticsearch-watch/spec.md
@@ -1,6 +1,6 @@
 ## ADDED Requirements
 
-### Requirement: SDK-to-Framework watch state compatibility
+### Requirement: SDK-to-Framework watch state compatibility (REQ-028)
 After the watch resource is migrated to the Terraform Plugin Framework, the resource SHALL continue to manage state created by the last SDK-backed provider release without requiring import, recreation, or changes to the configured resource type. The migrated resource SHALL preserve the existing composite `id` format, `watch_id` semantics, and import identifier format.
 
 #### Scenario: upgrade an SDK-managed watch

--- a/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/specs/elasticsearch-watch/spec.md
+++ b/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/specs/elasticsearch-watch/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: SDK-to-Framework watch state compatibility
+After the watch resource is migrated to the Terraform Plugin Framework, the resource SHALL continue to manage state created by the last SDK-backed provider release without requiring import, recreation, or changes to the configured resource type. The migrated resource SHALL preserve the existing composite `id` format, `watch_id` semantics, and import identifier format.
+
+#### Scenario: upgrade an SDK-managed watch
+- **GIVEN** a watch created by the last SDK-backed release of the provider
+- **WHEN** Terraform refreshes and plans the resource with the Plugin Framework implementation
+- **THEN** the resource SHALL keep the same `id` and `watch_id` without forcing replacement
+
+## MODIFIED Requirements
+
+### Requirement: Import (REQ-007–REQ-008)
+The resource SHALL support import by storing the provided `id` value in state when the import identifier is in the format `<cluster_uuid>/<watch_id>`. For import and all subsequent read/delete operations, the resource SHALL require the `id` to be in the format `<cluster_uuid>/<watch_id>` and SHALL return an error diagnostic when the format is invalid.
+
+#### Scenario: Import with valid composite id
+- **GIVEN** an `id` in the format `<cluster_uuid>/<watch_id>`
+- **WHEN** import completes
+- **THEN** the `id` SHALL be stored in state for subsequent operations
+
+#### Scenario: Invalid id format
+- **GIVEN** a stored or imported `id` that does not contain exactly one `/`
+- **WHEN** read or delete runs
+- **THEN** the resource SHALL return an error diagnostic with "Wrong resource ID"
+
+### Requirement: JSON field mapping — read/state (REQ-023–REQ-027)
+On read, the resource SHALL marshal the API response fields `trigger`, `input`, `condition`, `actions`, and `metadata` back into normalized JSON strings and store them in state. When the API response includes a non-nil `transform`, the resource SHALL marshal it to a normalized JSON string and store it in state. When the API response has a nil `transform`, the resource SHALL clear `transform` from state so the Terraform state reflects the remote watch. The resource SHALL store `watch_id` and `active` (from `watch.status.state.active`) directly from the API response. The resource SHALL store `throttle_period_in_millis` from the API response. JSON fields SHALL normalize semantically equivalent JSON so formatting-only changes do not create perpetual diffs.
+
+#### Scenario: transform removed from the remote watch
+- **GIVEN** the watch previously had a `transform` stored in Terraform state
+- **WHEN** read runs and the API response has no `transform` field
+- **THEN** the `transform` attribute SHALL be cleared from state
+
+#### Scenario: active synced from watch status
+- **GIVEN** the watch is deactivated on the cluster
+- **WHEN** read runs
+- **THEN** `active` in state SHALL reflect `watch.status.state.active` from the API response

--- a/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/tasks.md
+++ b/openspec/changes/migrate-elasticsearch-watch-to-plugin-framework/tasks.md
@@ -1,0 +1,21 @@
+## 1. Watch Helper Migration
+
+- [ ] 1.1 Convert `internal/clients/elasticsearch/watch.go` to return Terraform Plugin Framework diagnostics
+- [ ] 1.2 Update watch callers so the migrated resource can use the helper layer directly without SDK diagnostic conversion glue
+
+## 2. Plugin Framework Resource Implementation
+
+- [ ] 2.1 Replace the SDK watch resource implementation with a Plugin Framework package layout that preserves schema, defaults, IDs, import behavior, and connection overrides
+- [ ] 2.2 Register the Plugin Framework watch resource in `provider/plugin_framework.go` and remove the SDK registration from `provider/provider.go`
+- [ ] 2.3 Preserve semantically equivalent JSON handling for watch JSON string attributes in the new Framework schema and read/write paths
+
+## 3. Upgrade And Acceptance Coverage
+
+- [ ] 3.1 Move or adapt the watch acceptance suite to the migrated resource package
+- [ ] 3.2 Add a `FromSDK` acceptance test pinned to provider version `0.14.3`
+- [ ] 3.3 Add a Framework state upgrader only if the SDK-to-Framework upgrade test proves one is required
+
+## 4. Verification
+
+- [ ] 4.1 Validate the OpenSpec change artifacts for `migrate-elasticsearch-watch-to-plugin-framework`
+- [ ] 4.2 Run build plus focused watch tests, including the SDK-to-Framework upgrade path


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/353

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenSpec changesets for migrating Elasticsearch watch resource to Plugin Framework
> - Adds design, proposal, spec, and task documents for migrating the Elasticsearch watch resource from the Terraform Plugin SDK to Plugin Framework, preserving schema, composite IDs, and import behavior.
> - Adds a parallel changeset to harden acceptance coverage for the watch resource, covering import, default field handling (`active`, `throttle_period_in_millis`), and `transform` removal.
> - Specifies a state synchronization fix to clear stale `transform` from state when the API omits it on read.
> - Defines requirements for strict import format (`<cluster_uuid>/<watch_id>`) with an error on invalid IDs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b6eeca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->