### PR TITLE
Skip verification if preflight skips

### DIFF
--- a/openspec/changes/skip-test-validation-on-preflight-skip/.openspec.yaml
+++ b/openspec/changes/skip-test-validation-on-preflight-skip/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/skip-test-validation-on-preflight-skip/design.md
+++ b/openspec/changes/skip-test-validation-on-preflight-skip/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The main CI workflow already has two layers of gating: `preflight` decides whether downstream CI should run at all, and `changes` decides whether acceptance coverage is required for the current diff. Today `test-validation` is declared with `if: always()`, so it still runs when `preflight` disables the rest of the workflow, and the shared validation helper converts that path into a passing result.
+
+That behavior is useful for normal downstream-CI runs where `test-validation` should make a final pass/fail decision even if `changes` or `test` were skipped or failed. It is misleading on the pure preflight-skip path, because the check name implies tests passed even though the workflow intentionally never reached the acceptance-validation stage.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Skip `Test Validation` entirely when `preflight` outputs `should_run=false`.
+- Preserve the existing final-decision behavior for runs where `preflight` allows downstream CI to proceed.
+- Keep openspec-only change handling unchanged once downstream CI is allowed: `test` may be skipped and `Test Validation` may still succeed.
+- Keep the authored workflow source, generated workflow, and validation helper contract aligned.
+
+**Non-Goals:**
+
+- Change the `preflight` decision logic itself.
+- Change the `changes` classifier or what counts as `provider_changes=false`.
+- Change matrix contents, Docker setup, snapshot-failure handling, or branch-protection policy outside the repository.
+
+## Decisions
+
+### 1. Gate the `test-validation` job on both `always()` and `preflightShouldRun`
+
+The workflow will keep `always()` semantics for dependency evaluation, but it will only schedule `test-validation` when `needs.preflight.outputs.should_run == 'true'`.
+
+Why:
+
+- This preserves the existing ability to validate `changes` and `test` outcomes even when one of those jobs is skipped or fails during a real CI run.
+- It avoids emitting a misleading green validation check when `preflight` intentionally disabled the entire downstream workflow.
+- It is the smallest workflow change: the job graph stays the same, but the validation job now reflects the intended lifecycle more accurately.
+
+Alternatives considered:
+
+- Keep the job running and mark the preflight-skip path as neutral inside the script: rejected because the resulting check would still appear as a completed validation job rather than an intentionally skipped one.
+- Remove `always()` entirely: rejected because `test-validation` must still run after failed or skipped upstream jobs once `preflight` has allowed downstream CI.
+
+### 2. Remove the helper's preflight-success branch
+
+Once the job itself no longer runs on the preflight-disabled path, the shared validation helper should no longer describe that state as a passing validation outcome.
+
+Why:
+
+- The helper contract should match the reachable workflow states so unit tests are meaningful.
+- Leaving a dead "preflight skip equals pass" branch behind would preserve stale behavior in tests and future readers' mental models.
+
+Alternatives considered:
+
+- Keep the dead branch for defensive programming: rejected because the workflow already owns that gate, and retaining unreachable success logic makes the contract harder to reason about.
+
+### 3. Keep `auto-approve` behavior unchanged for `ready_for_review`
+
+`auto-approve` should continue to allow the `ready_for_review` path regardless of `test-validation` result, which now includes the validation job being skipped.
+
+Why:
+
+- The current workflow already treats `ready_for_review` as a special preflight-disabled path.
+- Updating only the wording and expectations around that path keeps behavior stable while correcting the meaning of the validation check.
+
+Alternatives considered:
+
+- Make `ready_for_review` wait for `test-validation`: rejected because `preflight` intentionally suppresses the rest of CI on that event.
+
+## Risks / Trade-offs
+
+- **[Risk] A future workflow edit could remove the job-level preflight gate while tests still assume it exists** -> Mitigation: update the helper/unit tests to cover only reachable downstream-CI states and keep the OpenSpec delta explicit about the skip behavior.
+- **[Risk] Consumers expecting a green `Test Validation` check on preflight-disabled runs will now see a skipped check instead** -> Mitigation: limit the behavior change to the preflight-disabled path and keep `auto-approve` explicitly documented as independent from validation success on `ready_for_review`.
+
+## Migration Plan
+
+1. Update the authored workflow template so `test-validation` requires `preflight.outputs.should_run == 'true'` in addition to `always()`.
+2. Remove or rewrite the helper/test cases that currently encode "preflight skip means validation passed."
+3. Regenerate `.github/workflows/test.yml` from the authored source.
+4. Run workflow-source verification to confirm the generated workflow and helper tests remain in sync.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/skip-test-validation-on-preflight-skip/proposal.md
+++ b/openspec/changes/skip-test-validation-on-preflight-skip/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`Test Validation` currently reports success even when the `preflight` gate intentionally skips the entire acceptance workflow. That makes the check look like acceptance coverage passed when no validation job or matrix test actually ran, which is misleading for maintainers and branch-protection consumers.
+
+## What Changes
+
+- Update the CI requirements so `Test Validation` is skipped when `preflight` outputs `should_run=false`.
+- Preserve the existing validation behavior for runs where `preflight` allows downstream CI: openspec-only changes may still skip `test` and pass validation, while provider changes still require a successful `test` job.
+- Align the documented validation helper contract with the new workflow behavior so the preflight-skip path is no longer described as a passing validation result.
+- Regenerate the compiled workflow after the authored template changes so the checked-in workflow artifact stays in sync.
+
+## Capabilities
+
+### New Capabilities
+
+- _(none)_
+
+### Modified Capabilities
+
+- `ci-build-lint-test`: Change `Test Validation` so preflight-disabled workflow runs skip the validation job instead of reporting a successful test result.
+
+## Impact
+
+- **Specs**: `openspec/specs/ci-build-lint-test/spec.md`
+- **Workflow sources**: `.github/workflows-src/test/workflow.yml.tmpl`, `.github/workflows-src/lib/validate-test-result.js`, `.github/workflows-src/lib/validate-test-result.test.mjs`
+- **Generated workflow**: `.github/workflows/test.yml`
+- **Verification**: workflow source generation/tests such as `make workflow-test`

--- a/openspec/changes/skip-test-validation-on-preflight-skip/specs/ci-build-lint-test/spec.md
+++ b/openspec/changes/skip-test-validation-on-preflight-skip/specs/ci-build-lint-test/spec.md
@@ -1,0 +1,67 @@
+## MODIFIED Requirements
+
+### Requirement: Test validation job (REQ-034–REQ-036)
+
+The workflow SHALL publish a `Test Validation` job that evaluates the change-classification output and the matrix acceptance job result whenever the preflight gate permits downstream CI execution. When the preflight gate outputs `should_run=false`, the `Test Validation` job SHALL be intentionally skipped.
+
+When the preflight gate allows downstream execution, the `Test Validation` job SHALL succeed when any of the following is true:
+
+* The change-classification job reports `provider_changes=false` and the matrix acceptance `test` job is intentionally skipped
+* The change-classification job reports `provider_changes=false` and the matrix acceptance `test` job completes successfully
+* The change-classification job reports `provider_changes=true` and the matrix acceptance `test` job completes successfully
+
+When the preflight gate allows downstream execution, the `Test Validation` job SHALL fail if either of the following is true:
+
+* The change-classification job reports `provider_changes=true` and the matrix acceptance `test` job does not complete successfully
+* The change-classification job reports `provider_changes=false` and the matrix acceptance `test` job still runs but does not complete successfully
+
+The validation job SHALL provide a stable required-check target for workflow runs where the preflight gate allows downstream execution, so GitHub branch protection or rulesets can require one normalized acceptance signal instead of per-version matrix checks.
+
+#### Scenario: OpenSpec-only pull request
+
+- **GIVEN** a pull request whose changed files are all under `openspec/`
+- **AND** the preflight gate outputs `should_run=true`
+- **WHEN** the workflow reaches `Test Validation`
+- **THEN** the matrix acceptance `test` job SHALL be treated as intentionally skipped
+- **AND** `Test Validation` SHALL succeed
+
+#### Scenario: Preflight-disabled workflow run
+
+- **GIVEN** a workflow run where the preflight gate outputs `should_run=false`
+- **WHEN** downstream jobs evaluate their execution conditions
+- **THEN** the `Test Validation` job SHALL be skipped
+
+#### Scenario: Provider change with failing acceptance coverage
+
+- **GIVEN** a workflow run with `provider_changes=true`
+- **AND** the preflight gate outputs `should_run=true`
+- **AND** the matrix acceptance `test` job does not complete successfully
+- **WHEN** `Test Validation` evaluates the workflow state
+- **THEN** `Test Validation` SHALL fail
+
+### Requirement: Auto-approve job (REQ-018–REQ-021)
+
+The `auto-approve` job SHALL depend on the `Test Validation` job and SHALL only run on `pull_request` events. For non-`ready_for_review` events, `auto-approve` SHALL require `Test Validation` to succeed before it runs. For `ready_for_review` events, `auto-approve` SHALL be eligible to run regardless of `Test Validation`'s result, because the preflight gate intentionally skips the downstream CI path on that event. The `auto-approve` job SHALL execute `go run ./scripts/auto-approve`; approval policy and gate behavior are defined in [`openspec/specs/ci-pr-auto-approve/spec.md`](../ci-pr-auto-approve/spec.md). The `auto-approve` job SHALL request `contents: read` and `pull-requests: write` permissions.
+
+#### Scenario: Auto-approve after satisfied validation
+
+- **GIVEN** a pull request workflow and successful `Test Validation`
+- **WHEN** auto-approve runs
+- **THEN** it SHALL invoke `go run ./scripts/auto-approve` with the specified permissions
+
+#### Scenario: Ready-for-review bypasses validation result
+
+- **GIVEN** a `pull_request` workflow with action `ready_for_review`
+- **WHEN** `auto-approve` evaluates its execution conditions
+- **THEN** it SHALL remain eligible to run regardless of whether `Test Validation` succeeded or was skipped
+
+### Requirement: Ready-for-review behavior (REQ-030)
+
+On `ready_for_review` `pull_request` events, the workflow SHALL keep the preflight gate behavior that prevents the `build`, `lint`, change-classification, matrix acceptance `test`, and `Test Validation` jobs from running. `auto-approve` SHALL remain eligible to run on that path.
+
+#### Scenario: Ready for review event
+
+- **GIVEN** a `pull_request` with action `ready_for_review`
+- **WHEN** the workflow runs
+- **THEN** `build`, `lint`, change-classification, matrix acceptance `test`, and `Test Validation` SHALL be skipped by the preflight gate
+- **AND** auto-approve SHALL be eligible to run

--- a/openspec/changes/skip-test-validation-on-preflight-skip/tasks.md
+++ b/openspec/changes/skip-test-validation-on-preflight-skip/tasks.md
@@ -1,0 +1,14 @@
+## 1. Update workflow gating
+
+- [ ] 1.1 Update `.github/workflows-src/test/workflow.yml.tmpl` so `test-validation` runs only when `preflight.outputs.should_run == 'true'` while preserving `always()` behavior for upstream `changes` and `test` results.
+- [ ] 1.2 Confirm `auto-approve` still behaves correctly for `ready_for_review` runs when `test-validation` is skipped.
+
+## 2. Align validation helper behavior
+
+- [ ] 2.1 Update `.github/workflows-src/lib/validate-test-result.js` so it only models reachable post-preflight validation states.
+- [ ] 2.2 Update `.github/workflows-src/lib/validate-test-result.test.mjs` to remove or rewrite cases that treat preflight-disabled runs as a passed validation result.
+
+## 3. Regenerate and verify
+
+- [ ] 3.1 Regenerate `.github/workflows/test.yml` from the authored workflow sources.
+- [ ] 3.2 Run the workflow-focused verification commands, including `make workflow-test`, and address any failures caused by the change.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Skip `test-validation` job when preflight `should_run` is false
- Adds a spec, design, and proposal for gating the `test-validation` CI job on the preflight gate's `should_run` output, so it is skipped rather than producing a misleading result on preflight-disabled runs.
- Removes the preflight-success branch from the validation helper, keeping only reachable states.
- Preserves auto-approve behavior for `ready_for_review` events, which bypass validation entirely.
- Behavioral Change: `test-validation` now reports skipped instead of a passing/failing result when preflight is not run.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f49e197.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->