### PR TITLE
Remove legacy kibana clients. 

### DIFF
--- a/openspec/changes/finish-kibana-synthetics-parameter-kbapi/.openspec.yaml
+++ b/openspec/changes/finish-kibana-synthetics-parameter-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/finish-kibana-synthetics-parameter-kbapi/design.md
+++ b/openspec/changes/finish-kibana-synthetics-parameter-kbapi/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`internal/kibana/synthetics/parameter` already uses `synthetics.GetKibanaOAPIClientFromScopedClient` and `kibanaoapi.Client` for create, read, and update. `delete.go` alone still calls `synthetics.GetKibanaClientFromScopedClient` and the legacy `go-kibana-rest` synthetics `Parameter.Delete` API. The canonical spec (`openspec/specs/kibana-synthetics-parameter/spec.md`) still documents that split.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use the generated `kbapi` client (`DeleteParameterWithResponse` on `kibanaoapi.Client`, same type as read/create/update) for delete so all CRUD shares one HTTP stack and response parsing patterns.
+- Keep create/update request construction identical in spirit: build the Go request DTO, `json.Marshal` it, and call `PostParametersWithBodyWithResponse` / `PutParameterWithBodyWithResponse` with `application/json` to work around oapi-codegen oneOf limitations.
+- Preserve post-create and post-update `readState` / `GetParameterWithResponse` behavior and all `share_across_spaces` / `namespaces` mapping rules.
+
+**Non-Goals:**
+
+- Regenerating or editing the OpenAPI spec or `generated/kbapi` beyond what already exists.
+- Replacing manual JSON marshalling with generated `PostParameters` / `PutParameter` helpers until upstream oneOf support is fixed.
+- Migrating other synthetics resources (monitor, private location) off the legacy client.
+
+## Decisions
+
+1. **Delete implementation** — Switch `delete.go` to `GetKibanaOAPIClientFromScopedClient` and invoke `kibanaClient.API.DeleteParameterWithResponse(ctx, resourceID)` (after the same composite-id normalization used elsewhere). **Rationale:** Matches read/create/update, removes the second client factory path, and uses the same base URL and auth as other parameter endpoints. **Alternative considered:** Keep legacy delete “because it already works”; rejected because it blocks client consolidation and duplicates diagnostics behavior.
+
+2. **Error handling** — Mirror `read.go` patterns where applicable: treat transport errors as diagnostics; if the API returns an unexpected status, surface it clearly (consistent with other `WithResponse` usages in this package). **Rationale:** Align delete with the OpenAPI client error model already used for get/post/put.
+
+3. **Spec / notes cleanup** — When syncing to main spec after implementation, update schema notes and REQ-001 / REQ-002 / REQ-005 to describe a single OpenAPI client; add an explicit requirement for the oneOf JSON workaround so it is preserved during future refactors.
+
+## Risks / Trade-offs
+
+- **[Risk] Subtle behavioral difference between legacy delete and `kbapi` delete** (status codes, default space headers) **→ Mitigation:** Acceptance tests for the resource should continue to pass; compare `DeleteParameter` path in generated code to the legacy route; manually verify against a real Kibana if CI stack differs.
+
+- **[Risk] `DeleteParameterWithResponse` returns a body or status we do not handle** **→ Mitigation:** Follow existing resource patterns for `WithResponse` calls; treat 2xx as success; map non-success to diagnostics with response details when the client exposes them.
+
+## Migration Plan
+
+1. Implement delete via `kbapi`; run `make build` and targeted acceptance tests for `TestSyntheticParameterResource` when a stack is available.
+2. Run `make check-openspec` / lint as required by the repo.
+3. After code review, use the OpenSpec sync workflow to merge delta requirements into `openspec/specs/kibana-synthetics-parameter/spec.md` (separate from this proposal folder).
+
+## Open Questions
+
+- None blocking: confirm whether any enterprise Kibana build omits `DeleteParameter` from the bundled OpenAPI (unlikely if GET/POST/PUT are already used from the same client).

--- a/openspec/changes/finish-kibana-synthetics-parameter-kbapi/proposal.md
+++ b/openspec/changes/finish-kibana-synthetics-parameter-kbapi/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`elasticstack_kibana_synthetics_parameter` already uses the generated Kibana OpenAPI (`kbapi`) client for create, read, and update, but delete still goes through the legacy `go-kibana-rest` synthetics client. Splitting traffic across two client stacks increases maintenance cost, diverges from other migrated Kibana entities, and leaves redundant error and connection paths in the resource package.
+
+## What Changes
+
+- Route delete through the same `kbapi` / `kibanaoapi.Client` stack as the other CRUD operations (e.g. `DeleteParameterWithResponse`), removing the legacy client from this resource’s delete path.
+- Remove remaining legacy-specific wiring from `internal/kibana/synthetics/parameter` where it exists only to support delete (and any related comments or spec wording that still refer to “legacy client for delete”).
+- Keep the manual `json.Marshal` + `PostParametersWithBodyWithResponse` / `PutParameterWithBodyWithResponse` pattern for create/update request bodies until oapi-codegen oneOf handling improves (see [oapi-codegen#1620](https://github.com/oapi-codegen/oapi-codegen/issues/1620)).
+- Preserve read-after-write: after successful create and update, state SHALL still be populated from a follow-up `GET` of the parameter by id.
+- Preserve `share_across_spaces` behavior: create-only in the request body, `RequiresReplace` semantics unchanged, and the same `namespaces` ↔ `share_across_spaces` mapping on read.
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `kibana-synthetics-parameter`: Align requirements with a single OpenAPI-based client for all CRUD; document the retained oneOf JSON workaround and unchanged read-after-write and `share_across_spaces` rules.
+
+## Impact
+
+- Primary code: `internal/kibana/synthetics/parameter/delete.go`, possibly `resource.go` or shared helpers if delete-specific branching exists; traceability table in the spec.
+- Generated client: `generated/kbapi` (`DeleteParameterWithResponse` and existing parameter endpoints); no OpenAPI regeneration required unless the team chooses to refresh specs separately.
+- Functional specs: delta under this change for `kibana-synthetics-parameter`; eventual sync to `openspec/specs/kibana-synthetics-parameter/spec.md` after implementation (out of scope for this proposal-only change).

--- a/openspec/changes/finish-kibana-synthetics-parameter-kbapi/specs/kibana-synthetics-parameter/spec.md
+++ b/openspec/changes/finish-kibana-synthetics-parameter-kbapi/specs/kibana-synthetics-parameter/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Synthetics Parameters API (REQ-001)
+
+The resource SHALL manage Synthetics parameters through Kibana's Synthetics Parameters API: create via `POST /api/synthetics/params`, read via `GET /api/synthetics/params/{id}`, update via `PUT /api/synthetics/params/{id}`, and delete via `DELETE /api/synthetics/params/{id}` using the same generated Kibana OpenAPI (`kbapi`) client used for the other operations.
+
+#### Scenario: CRUD uses Synthetics Parameters APIs
+
+- GIVEN a managed Synthetics parameter
+- WHEN create, read, update, or delete runs
+- THEN the provider SHALL use the corresponding Kibana Synthetics Parameters API operation
+
+### Requirement: API and client error surfacing (REQ-002)
+
+The resource SHALL fail with an error diagnostic when it cannot obtain the Kibana OpenAPI client. Transport errors and unexpected API responses for create, read, update, and delete SHALL be surfaced as error diagnostics. On read, a 404 response SHALL cause the resource to be removed from state rather than returning an error.
+
+#### Scenario: Missing Kibana client
+
+- GIVEN the resource cannot obtain a Kibana client from provider configuration
+- WHEN any CRUD operation runs
+- THEN the operation SHALL fail with an error diagnostic
+
+#### Scenario: Read returns 404
+
+- GIVEN a parameter that no longer exists in Kibana
+- WHEN read calls the API and receives a 404 response
+- THEN the provider SHALL remove the resource from state
+
+#### Scenario: Create transport or API error
+
+- GIVEN a create request
+- WHEN the API returns a transport error or an unexpected response
+- THEN the provider SHALL surface an error diagnostic
+
+### Requirement: Provider-level Kibana client by default (REQ-005)
+
+The resource SHALL use the provider's configured Kibana OpenAPI (`kbapi`) client by default for all parameter API operations (create, read, update, and delete). When `kibana_connection` is configured on the resource, the resource SHALL resolve an effective scoped client from that block and SHALL use the scoped Kibana OpenAPI client for all of those operations.
+
+#### Scenario: Standard provider connection
+
+- **WHEN** `kibana_connection` is not configured on the resource
+- **THEN** all parameter API operations SHALL use the provider-level Kibana OpenAPI client
+
+#### Scenario: Scoped Kibana connection
+
+- **WHEN** `kibana_connection` is configured on the resource
+- **THEN** all parameter API operations SHALL use the scoped Kibana OpenAPI client derived from that block
+
+## ADDED Requirements
+
+### Requirement: Create and update request bodies encoded with manual JSON (REQ-011)
+
+For create and update, the resource SHALL serialize the parameter request DTO with `encoding/json` and send it with `Content-Type: application/json` through the generated client's `WithBody` request methods, rather than relying on the generated union request types alone, until oapi-codegen correctly encodes the oneOf request body for this API.
+
+#### Scenario: Create uses marshalled JSON body
+
+- GIVEN a parameter create
+- WHEN the provider issues the POST request
+- THEN the request body SHALL be produced by JSON-marshalling the request DTO and the call SHALL use the OpenAPI client's body-based POST method for parameters
+
+#### Scenario: Update uses marshalled JSON body
+
+- GIVEN a parameter update
+- WHEN the provider issues the PUT request
+- THEN the request body SHALL be produced by JSON-marshalling the request DTO and the call SHALL use the OpenAPI client's body-based PUT method for parameters

--- a/openspec/changes/finish-kibana-synthetics-parameter-kbapi/tasks.md
+++ b/openspec/changes/finish-kibana-synthetics-parameter-kbapi/tasks.md
@@ -1,0 +1,14 @@
+## 1. Delete path migration
+
+- [ ] 1.1 Update `internal/kibana/synthetics/parameter/delete.go` to obtain the client via `GetKibanaOAPIClientFromScopedClient` (same as create/read/update) and call `DeleteParameterWithResponse` with the resolved parameter id (including composite-id parsing already used in delete).
+- [ ] 1.2 Handle delete responses consistently with other `WithResponse` usages in this package (success on expected 2xx; clear diagnostics on failure; no reliance on the legacy `go-kibana-rest` synthetics client for this resource).
+
+## 2. Documentation and spec sync
+
+- [ ] 2.1 Update in-repo references that still imply “legacy client for delete” for this resource (e.g. schema notes in `openspec/specs/kibana-synthetics-parameter/spec.md` Purpose/Schema section, traceability text, and any dev docs that mention the split) when merging this change’s delta into main specs.
+- [ ] 2.2 After implementation, run `make check-openspec` (or `make check-lint` as appropriate) and resolve any validation issues for the change artifacts.
+
+## 3. Verification
+
+- [ ] 3.1 Run `make build` to ensure the provider compiles after the client swap.
+- [ ] 3.2 Run targeted acceptance tests for the synthetics parameter resource (e.g. `TestSyntheticParameterResource`) against a Kibana that exposes the Synthetics Parameters API, confirming create/read/update/delete, import id handling, read-after-write, and `share_across_spaces` behavior are unchanged.

--- a/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/.openspec.yaml
+++ b/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/design.md
+++ b/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/design.md
@@ -1,0 +1,50 @@
+## Context
+
+Today `importObjects` in `internal/kibana/import_saved_objects/create.go` uses `apiClient.GetKibanaClient()` and `kibanaClient.KibanaSavedObject.Import([]byte(file_contents), overwrite, spaceID)`. The generated OpenAPI client in `generated/kbapi` already exposes `PostSavedObjectsImportWithBodyWithResponse`, `PostSavedObjectsImportParams` (including `Overwrite`, `CreateNewCopies`, `CompatibilityMode`), and a typed `PostSavedObjectsImportResponse` with `JSON200` containing `Success`, `SuccessCount`, and loosely typed `errors` / `successResults` as slices of maps. Other Kibana features use `internal/clients/kibanaoapi.Client` and `SpaceAwarePathRequestEditor` for space-prefixed paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Centralize Saved Objects import HTTP details in `kibanaoapi`, calling `client.API.PostSavedObjectsImportWithBodyWithResponse` with the correct `Content-Type` and body.
+- Build `multipart/form-data` from the Terraform `file_contents` string (NDJSON export payload) with a file part named `file` (Kibana import API contract).
+- Map API JSON into the same Terraform state shape as today (including `mapstructure` or equivalent decoding into lists/objects matching the existing schema).
+- Preserve diagnostic behavior: `ignore_import_errors` semantics, warning on partial success, error on total failure, per-error string formatting similar to `importError.String()`.
+- Add optional `create_new_copies` and `compatibility_mode` booleans to the resource schema, passed through `PostSavedObjectsImportParams` when set, and validate mutually exclusive combinations at plan time (`ResourceWithConfigValidators`).
+
+**Non-Goals:**
+
+- Changing read/delete no-op behavior, `id` generation, or the write-only resource model.
+- Implementing the separate “resolve import errors” API flow.
+- Regenerating `kbapi` (spec is already sufficient).
+
+## Decisions
+
+| Decision | Rationale | Alternatives considered |
+|----------|-----------|-------------------------|
+| New helper file `internal/clients/kibanaoapi/saved_objects_import.go` (name may vary slightly but lives in `kibanaoapi`) | Matches existing pattern (`workflows.go`, `security_lists.go`): thin wrapper around `kbapi`, returns diagnostics-friendly results. | Putting multipart + HTTP directly in the resource package — duplicates auth/space handling and is harder to test. |
+| Use `PostSavedObjectsImportWithBodyWithResponse` with a hand-built multipart body | The generated multipart type uses `map[string]interface{}` for `File`, which is awkward for raw NDJSON bytes; `WithBody` accepts any `io.Reader` and content type. | Typed multipart helpers from codegen — not ergonomic for in-memory export strings. |
+| Decode `JSON200` maps into the existing `responseModel` / Terraform attribute types | Keeps computed attribute contract stable; `JSON200` fields are already `map[string]interface{}` for nested structures. | Replacing with strongly typed kbapi structs — would require parallel structs and more mapping work for little gain. |
+| Surface non-200 responses using `JSON400` / status / body | Aligns with REQ-002; kbapi separates `JSON200` and `JSON400`. | Ignoring 400 bodies — loses actionable Kibana error messages. |
+| Config validators for `create_new_copies` vs `overwrite` / `compatibility_mode` | Kibana documents mutual exclusion; fail fast at plan time instead of opaque API errors. | Rely on API-only validation — worse UX and noisy apply failures. |
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Multipart boundary or field name mismatch causes 400 from Kibana | Match Elastic docs: single part `file`; set filename (e.g. `export.ndjson`) on the form file part; integration/acc test covers happy path. |
+| `successCount` is `float32` in codegen vs `int64` in Terraform | Convert with explicit truncation/rounding to int64 consistent with current behavior (counts are integers). |
+| Large `file_contents` strings memory-double with multipart buffer | Accept for now (same as passing `[]byte` to legacy client); document unchanged limitation. |
+
+## Migration Plan
+
+1. Implement `kibanaoapi` helper and unit-test multipart construction if feasible without a live cluster.
+2. Switch resource to OpenAPI client; run `make build` and targeted acceptance test `TestAccResourceImportSavedObjects`.
+3. Add new optional attributes + validators; extend acceptance tests for one conflict scenario with `create_new_copies` or `compatibility_mode` if a stable config exists.
+
+Rollback: revert to legacy `KibanaSavedObject.Import` behind the same resource surface (not desired long-term but mechanically simple).
+
+## Open Questions
+
+- Whether acceptance tests should assert a plan-time error for invalid flag combinations, or only unit-test validators (prefer at least one validator unit test to avoid acc-test flakiness).
+- Exact Kibana version floor for `compatibilityMode` / `createNewCopies` if any; assume same as current provider-supported Kibana unless QA finds otherwise.

--- a/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`elasticstack_kibana_import_saved_objects` still calls the legacy go-kibana-rest client (`KibanaSavedObject.Import`), which diverges from other Kibana resources that use `generated/kbapi` and blocks use of query parameters that the OpenAPI spec already models (`createNewCopies`, `compatibilityMode`). Moving the import path to the generated client keeps the provider on one HTTP stack and unlocks those options without bespoke REST code.
+
+## What Changes
+
+- Add a `kibanaoapi` helper that builds a `multipart/form-data` body from `file_contents`, sets the Saved Objects Import path with space awareness (`SpaceAwarePathRequestEditor`), and calls `PostSavedObjectsImportWithBodyWithResponse` with `PostSavedObjectsImportParams` (overwrite, create-new-copies, compatibility mode).
+- Refactor `internal/kibana/import_saved_objects` create/update to obtain the Kibana OpenAPI client (`GetKibanaOapiClient`) and invoke the helper instead of the legacy SDK import.
+- Preserve existing computed attributes (`success`, `success_count`, `errors`, `success_results`) and the same warning/error diagnostics for partial or failed imports when `ignore_import_errors` is unset or false.
+- Expose optional `create_new_copies` and `compatibility_mode` schema attributes backed by kbapi fields, with plan-time validation mirroring Kibana rules (`create_new_copies` incompatible with `overwrite` and `compatibility_mode`).
+
+## Capabilities
+
+### New Capabilities
+
+_(none — behavior stays within the existing resource spec.)_
+
+### Modified Capabilities
+
+- `kibana-import-saved-objects`: Switch implementation to kbapi + `kibanaoapi`; require multipart upload semantics for `file_contents`; update client-selection requirements; extend create/update triggers and import parameters for `create_new_copies` and `compatibility_mode`; clarify HTTP error surfacing for the OpenAPI response wrapper.
+
+## Impact
+
+- **Code**: `internal/kibana/import_saved_objects` (especially `create.go`, `schema.go`), new file(s) under `internal/clients/kibanaoapi/`, `generated/kbapi` types already present (`PostSavedObjectsImportParams`, `PostSavedObjectsImportResponse`).
+- **Dependencies**: Removes reliance on legacy `KibanaSavedObject.Import` for this resource; no new third-party modules expected (stdlib `mime/multipart`).
+- **Docs / tests**: Resource documentation and acceptance tests should mention new optional arguments once implemented; proposal does not require doc edits in the change folder.

--- a/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/specs/kibana-import-saved-objects/spec.md
+++ b/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/specs/kibana-import-saved-objects/spec.md
@@ -1,0 +1,105 @@
+## MODIFIED Requirements
+
+### Requirement: Kibana Saved Objects Import API (REQ-001)
+
+The resource SHALL import saved objects through the Kibana Saved Objects Import HTTP API (`POST /api/saved_objects/_import`, space-aware when `space_id` is set) as documented in [Kibana saved objects API docs](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-import.html). The provider SHALL send the export NDJSON as `multipart/form-data` with a `file` part whose body is the `file_contents` value. Query parameters on that request SHALL reflect the resource’s `overwrite`, `create_new_copies`, and `compatibility_mode` attributes as defined by the Kibana API.
+
+#### Scenario: Create calls Import API
+
+- **WHEN** create runs with a valid `file_contents` and optional `space_id`
+- **THEN** the provider SHALL issue a multipart Import API request with the file contents and configured query parameters on the correct space-aware path
+
+#### Scenario: Import uses OpenAPI client stack
+
+- **WHEN** create or update runs the import operation with a valid Kibana connection
+- **THEN** the request SHALL be executed through `generated/kbapi` (`PostSavedObjectsImportWithBodyWithResponse`) via an `internal/clients/kibanaoapi` helper, not through the legacy go-kibana-rest `KibanaSavedObject.Import` method
+
+### Requirement: API and client error surfacing (REQ-002)
+
+When the provider cannot obtain the Kibana OpenAPI client, create and update operations SHALL return an error diagnostic. Network errors, non-success HTTP status codes from the Import API, failures to build the multipart request, or failures to parse a successful import JSON body SHALL be surfaced as error diagnostics.
+
+#### Scenario: Missing Kibana client
+
+- **WHEN** create or update runs and the resource cannot obtain a Kibana client from provider configuration
+- **THEN** the operation SHALL fail with an error diagnostic
+
+#### Scenario: Import API call failure
+
+- **WHEN** create or update runs and a network or transport error occurs when calling the Import API
+- **THEN** the provider SHALL surface an error diagnostic
+
+#### Scenario: Import API returns client error response
+
+- **WHEN** create or update runs and the Import API responds with a non-2xx HTTP status or a body that cannot be interpreted as a successful import result
+- **THEN** the provider SHALL surface an error diagnostic with available detail from the response
+
+### Requirement: Effective Kibana client selection (REQ-004)
+
+The resource SHALL use the provider's configured Kibana OpenAPI client by default for create and update. When `kibana_connection` is configured on the resource, the resource SHALL resolve an effective scoped client from that block and SHALL use the scoped Kibana OpenAPI client for create and update.
+
+#### Scenario: Standard provider connection
+
+- **WHEN** `kibana_connection` is not configured on the resource
+- **THEN** all import saved objects API operations SHALL use the provider-level Kibana OpenAPI client
+
+#### Scenario: Scoped Kibana connection
+
+- **WHEN** `kibana_connection` is configured on the resource
+- **THEN** all import saved objects API operations SHALL use the scoped Kibana OpenAPI client derived from that block
+
+### Requirement: Create and update share the same import logic (REQ-005)
+
+Create and update SHALL both invoke the same import logic: reading the plan, calling the Kibana Saved Objects Import API, and writing the result to state. Changing `file_contents`, `overwrite`, `space_id`, `create_new_copies`, or `compatibility_mode` SHALL trigger an in-place update that re-runs the import.
+
+#### Scenario: Update re-imports objects
+
+- **WHEN** update runs for an existing resource whose `file_contents` changed in configuration
+- **THEN** the provider SHALL call the Kibana Saved Objects Import API again with the new file contents
+
+#### Scenario: Update re-imports when import flags change
+
+- **WHEN** update runs for an existing resource whose `overwrite`, `create_new_copies`, or `compatibility_mode` changed in configuration
+- **THEN** the provider SHALL call the Kibana Saved Objects Import API again with the updated parameters
+
+### Requirement: Overwrite flag (REQ-010)
+
+When `overwrite` is `true` and configuration validation permits the combination with other import flags, the resource SHALL send `overwrite: true` on the Kibana Saved Objects Import request so that conflict errors are resolved by overwriting existing saved objects. When `overwrite` is `false` or unset, the provider SHALL omit the overwrite query parameter (Kibana default).
+
+#### Scenario: Overwrite conflicts
+
+- **WHEN** create or update runs with `overwrite = true`, conflicting saved objects exist in Kibana, and `create_new_copies` is not set to `true` in configuration
+- **THEN** the provider SHALL send `overwrite: true` to the Import API, resolving conflicts automatically
+
+## ADDED Requirements
+
+### Requirement: create_new_copies flag (REQ-011)
+
+The resource SHALL expose an optional `create_new_copies` boolean attribute. When set to `true`, the provider SHALL send `createNewCopies=true` on the Import API request. When unset or `false`, the provider SHALL omit the query parameter.
+
+#### Scenario: create_new_copies forwarded to API
+
+- **WHEN** create or update runs with `create_new_copies = true`, a valid export in `file_contents`, and no conflicting `overwrite` or `compatibility_mode` flags in configuration
+- **THEN** the provider SHALL include `createNewCopies=true` on the Import API request
+
+### Requirement: compatibility_mode flag (REQ-012)
+
+The resource SHALL expose an optional `compatibility_mode` boolean attribute. When set to `true`, the provider SHALL send `compatibilityMode=true` on the Import API request. When unset or `false`, the provider SHALL omit the query parameter.
+
+#### Scenario: compatibility_mode forwarded to API
+
+- **WHEN** create or update runs with `compatibility_mode = true`, a valid export in `file_contents`, and `create_new_copies` is not set to `true` in configuration
+- **THEN** the provider SHALL include `compatibilityMode=true` on the Import API request
+
+### Requirement: Mutually exclusive import flags (REQ-013)
+
+The resource SHALL reject, at plan time, the same invalid combinations of `overwrite`, `create_new_copies`, and `compatibility_mode` that the Kibana Saved Objects Import API rejects (`create_new_copies` incompatible with `overwrite` and with `compatibility_mode`).
+
+#### Scenario: create_new_copies conflicts with overwrite
+
+- **WHEN** Terraform validates configuration for a resource with `create_new_copies = true` and `overwrite = true`
+- **THEN** the provider SHALL emit a configuration error diagnostic explaining the conflict
+
+#### Scenario: create_new_copies conflicts with compatibility_mode
+
+- **WHEN** Terraform validates configuration for a resource with `create_new_copies = true` and `compatibility_mode = true`
+- **THEN** the provider SHALL emit a configuration error diagnostic explaining the conflict

--- a/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-import-saved-objects-to-kbapi/tasks.md
@@ -1,0 +1,18 @@
+## 1. `kibanaoapi` Saved Objects import helper
+
+- [ ] 1.1 Add `internal/clients/kibanaoapi` helper(s) that accept `context.Context`, `*Client`, `spaceID`, `fileContents []byte` or `string`, and `*kbapi.PostSavedObjectsImportParams`, build `multipart/form-data` with a `file` part, and call `PostSavedObjectsImportWithBodyWithResponse` with `SpaceAwarePathRequestEditor(spaceID)`.
+- [ ] 1.2 Map `PostSavedObjectsImportResponse` into a result struct suitable for the resource: treat HTTP 2xx with `JSON200` as success payload; for non-2xx or missing `JSON200`, return a clear error including `JSON400` / body snippets when present.
+- [ ] 1.3 Add focused tests (table-driven unit tests where possible) for multipart wire format and/or response classification without requiring a full stack.
+
+## 2. Resource wiring and schema
+
+- [ ] 2.1 Update `internal/kibana/import_saved_objects/create.go` (and shared code paths used by update) to resolve `GetKibanaOapiClient` from the scoped/provider client factory and call the new `kibanaoapi` helper instead of `KibanaSavedObject.Import`.
+- [ ] 2.2 Preserve existing computed attributes and diagnostic rules (`success`, `success_count`, `errors`, `success_results`, `ignore_import_errors` warning vs error split, error string formatting intent).
+- [ ] 2.3 Uncomment and implement `create_new_copies` and `compatibility_mode` in `schema.go` and `modelV0`; wire pointers into `PostSavedObjectsImportParams` only when attributes are true.
+- [ ] 2.4 Enable `ResourceWithConfigValidators` (or equivalent) to enforce mutual exclusion between `create_new_copies` and `overwrite`, and between `create_new_copies` and `compatibility_mode`, matching REQ-013.
+
+## 3. Verification and documentation
+
+- [ ] 3.1 Run `make build` and fix any compile or staticcheck issues from the migration.
+- [ ] 3.2 Run targeted acceptance test `TestAccResourceImportSavedObjects` against a configured stack; extend tests or fixtures if needed to cover at least one of the new flags without breaking existing cases.
+- [ ] 3.3 Update generated resource documentation (`docs/resources/kibana_import_saved_objects.md`) and the canonical spec under `openspec/specs/kibana-import-saved-objects/spec.md` when syncing post-implementation (or as part of apply if your workflow updates docs in the same change).

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/.openspec.yaml
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/design.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Today `internal/kibana/role.go` maps Terraform state to `kbapi.KibanaRole` from `github.com/disaster37/go-kibana-rest/v8/kbapi` and calls `kibana.KibanaRoleManagement.CreateOrUpdate`, `Get`, and `Delete`. The provider already constructs a `kibanaoapi.Client` with `kbapi.ClientWithResponses` for other Kibana resources. The generated spec defines role payloads such as `PutSecurityRoleNameJSONBody`, which mirror the JSON shape Kibana expects for PUT `/api/security/roles/{name}` (cluster, indices with `field_security` as a map of string to string arrays, `remote_indices`, `run_as`, optional `kibana` entries, `metadata`, `description`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Route all role CRUD for `elasticstack_kibana_security_role` (resource and data source) through `KibanaScopedClient.GetKibanaOapiClient()` and new `kibanaoapi` helpers that call `generated/kbapi` `*WithResponse` methods (or equivalent parsing of `Body` when the generator does not attach typed JSON fields).
+- Keep the Terraform schema, version gates, flatten/expand rules, and acceptance test expectations stable unless a true remote/API bug is uncovered.
+- Centralize HTTP semantics (status codes, JSON decode, error bodies) in `kibanaoapi` alongside `errors.go` patterns used by connectors and other helpers.
+
+**Non-Goals:**
+
+- Migrating the resource from the Terraform Plugin SDK to Plugin Framework.
+- Supporting new Kibana role fields not already modeled in Terraform (for example `allow_restricted_indices`, `remote_cluster`) unless they already exist in schema or are required for parity—default is unchanged schema surface.
+- Regenerating or editing `generated/kbapi` sources manually beyond normal project processes.
+
+## Decisions
+
+1. **Helper module location** — Add `internal/clients/kibanaoapi/security_role.go` (name can be `role.go` if consistent with package naming) exposing functions such as `GetSecurityRole`, `PutSecurityRole`, `DeleteSecurityRole` taking `context.Context`, `*Client`, role name, optional `GetSecurityRoleNameParams`, body, and `PutSecurityRoleNameParams`. *Rationale:* Matches `connector.go`, `data_views.go`, keeps `internal/kibana` focused on Terraform mapping.
+
+2. **Typed payloads** — Use `kbapi.PutSecurityRoleNameJSONRequestBody` / the same struct family for read decoding into a local mirror type or the PUT body struct, unmarshalling `GetSecurityRoleNameResponse.Body` when `JSON200` is not generated. *Rationale:* Single shape for read/write mapping; avoids retaining parallel structs from go-kibana-rest.
+
+3. **Create-only semantics** — Map `d.IsNewResource()` to `PutSecurityRoleNameParams.CreateOnly` pointer `true` on create and `false` or nil on update, matching current `CreateOnly` behavior. *Rationale:* Kibana documents `createOnly` as a query parameter on PUT.
+
+4. **Not found on read** — Treat HTTP 404 (and any Kibana-documented empty success the API may return) as “role absent”: for the resource, clear `id`; for the data source, return a clear diagnostic or empty result per existing data source behavior. *Rationale:* Generated responses may not expose `JSON404`; parse `StatusCode()` from `HTTPResponse`.
+
+5. **Version and connection** — Continue using `KibanaScopedClient.ServerVersion(ctx)` (status API via legacy client) for gates until a project-wide decision moves version discovery to kbapi; continue resolving scoped clients via `GetKibanaClientFromSDK` / factory. *Rationale:* Minimizes scope; matches current `role.go`.
+
+6. **Privilege parity** — Before merge, run existing acceptance tests; add a short table-driven unit test that round-trips representative `schema.ResourceData`-like inputs through expand → kbapi struct → flatten (or JSON marshal/unmarshal) for indices, remote_indices, kibana base/feature, and metadata. *Rationale:* Catches ordering or `field_security` map shape regressions without requiring a live cluster for every edge case.
+
+## Risks / Trade-offs
+
+- **[Risk] Subtle JSON shape differences** between go-kibana-rest structs and OpenAPI-generated structs (for example `field_security` map keys, nil slices vs omitted fields) → **Mitigation:** parity tests; compare marshalled JSON for a few fixtures against golden files if needed.
+- **[Risk] GET response decoding** if content-type or status handling differs by Stack version → **Mitigation:** reuse existing `reportUnknownError` patterns; log/debug transport already wraps HTTP.
+- **[Risk] `replaceDeprecatedPrivileges`** not set on GET → **Mitigation:** document default (omit) unless product requires `true` for stable reads; match current behavior (legacy client did not set it).
+
+## Migration Plan
+
+1. Implement `kibanaoapi` helpers and unit-test decoding with mocked `httptest` handlers if feasible.
+2. Switch `internal/kibana/role.go` (and data source) to helpers; run `go test ./internal/kibana/...`.
+3. Run targeted acceptance tests for `TestAccResourceKibanaSecurityRole` and `TestAccDataSourceKibanaSecurityRole` against a suitable Stack (per `dev-docs/high-level/testing.md`).
+4. Remove unused imports / legacy calls from the role code path; verify `make build` and lint.
+
+## Open Questions
+
+- Whether GET should pass `replaceDeprecatedPrivileges=true` for reads to reduce drift on deprecated feature privileges (needs product input; default keep legacy behavior).
+- Exact HTTP codes Kibana returns for “not found” on GET in all supported versions (assume 404).

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `elasticstack_kibana_security_role` resource and data source still depend on `github.com/disaster37/go-kibana-rest` (`KibanaRoleManagement`) while the rest of the provider is standardizing on the generated Kibana OpenAPI client (`generated/kbapi`) plus thin `internal/clients/kibanaoapi` helpers. Migrating removes a duplicate HTTP stack, aligns error handling with other kbapi-backed entities, and makes future OpenAPI regeneration the single source of truth for request/response shapes.
+
+## What Changes
+
+- Add `internal/clients/kibanaoapi` helpers that wrap Kibana Security Role endpoints exposed in `generated/kbapi` (`GetSecurityRoleName`, `PutSecurityRoleName`, `DeleteSecurityRoleName`), including consistent decoding of JSON bodies, HTTP status handling (including not-found on read), and diagnostics on failure.
+- Refactor `internal/kibana/role.go` (and the data source companion if separated) to build requests and interpret responses using `kbapi` types (for example `PutSecurityRoleNameJSONRequestBody`) instead of `kbapi.KibanaRole` from go-kibana-rest, while preserving all Terraform schema semantics.
+- Preserve existing expand/flatten behavior for `elasticsearch`, `kibana`, `metadata`, and JSON `query` diff suppression; preserve version gates for `remote_indices` (≥ 8.10.0) and `description` (≥ 8.15.0).
+- Add or extend verification so Elasticsearch and Kibana privilege mappings remain equivalent to today’s behavior (acceptance tests plus targeted parity checks where practical).
+- Drop the security-role code path’s dependency on `KibanaRoleManagement` for create/read/update/delete once migration is complete (no **BREAKING** Terraform schema or identity changes intended).
+
+## Capabilities
+
+### New Capabilities
+
+- None (all behavior remains under the existing `kibana-security-role` capability).
+
+### Modified Capabilities
+
+- `kibana-security-role`: Update normative requirements so role CRUD is specified in terms of the generated OpenAPI client and `kibanaoapi` helpers instead of `KibanaRoleManagement.*`, including create-only semantics via the `createOnly` query parameter and not-found handling for GET responses.
+
+## Impact
+
+- `internal/kibana/role.go`, related tests under `internal/kibana/`, and any shared helpers used only by this entity.
+- New file(s) under `internal/clients/kibanaoapi/` for role operations.
+- `go.mod` / imports: reduced use of go-kibana-rest for this flow once callers are switched.
+- OpenSpec delta under `openspec/changes/migrate-kibana-security-role-to-kbapi/specs/kibana-security-role/spec.md` for archive-time merge into `openspec/specs/kibana-security-role/spec.md`.

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/specs/kibana-security-role/spec.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/specs/kibana-security-role/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: kibanaoapi security role helpers (REQ-025)
+
+The provider SHALL implement Kibana role management HTTP calls for `elasticstack_kibana_security_role` via functions in `internal/clients/kibanaoapi` that use `generated/kbapi` client methods for put, get, and delete by role name (`PutSecurityRoleNameWithResponse` or `PutSecurityRoleName`, `GetSecurityRoleNameWithResponse` or `GetSecurityRoleName`, `DeleteSecurityRoleNameWithResponse` or `DeleteSecurityRoleName`). Helpers SHALL decode successful JSON GET bodies into the same structural family used for PUT (`PutSecurityRoleNameJSONBody` or equivalent) before returning data to Terraform mapping code. Helpers SHALL map non-success HTTP status codes (other than not-found on read as defined in REQ-012–REQ-014) to Terraform diagnostics including response body context when available.
+
+#### Scenario: Helper surfaces decode errors
+
+- **GIVEN** a GET response whose body is not valid JSON for the role document
+- **WHEN** the helper parses the response
+- **THEN** the provider SHALL return an error diagnostic and SHALL NOT silently treat the role as absent
+
+### Requirement: Privilege mapping parity (REQ-026)
+
+Before this change is considered complete, the provider SHALL demonstrate that Elasticsearch index and remote index privileges, Kibana base and feature privileges, `metadata`, and `description` round-trip equivalently versus the pre-migration behavior for representative configurations covered by tests. At minimum, existing acceptance tests for `elasticstack_kibana_security_role` SHALL pass unchanged against a supported Stack, and unit tests SHALL assert stable JSON or struct equivalence for at least one index entry with `field_security`, one `remote_indices` entry, one `kibana` feature block, and one `kibana` base block.
+
+#### Scenario: Acceptance suite unchanged
+
+- **GIVEN** the existing `internal/kibana` acceptance tests for create, update, remote indices, and description
+- **WHEN** the tests run against a cluster meeting documented version gates
+- **THEN** they SHALL pass without relaxing assertions
+
+## MODIFIED Requirements
+
+### Requirement: Role Management APIs (REQ-001–REQ-003)
+
+The resource SHALL create and update roles using the Kibana Create or update role HTTP API invoked through `internal/clients/kibanaoapi` on top of `generated/kbapi` (`PutSecurityRoleName` for `/api/security/roles/{name}`) ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-put.html)). The resource and data source SHALL read roles using the Kibana Get role HTTP API via the same helper layer (`GetSecurityRoleName`) ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-get.html)). The resource SHALL delete roles using the Kibana Delete role HTTP API via the same helper layer (`DeleteSecurityRoleName`) ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-delete.html)). The resource and data source SHALL NOT call `KibanaRoleManagement.CreateOrUpdate`, `KibanaRoleManagement.Get`, or `KibanaRoleManagement.Delete` for this entity once migration is complete. When a Kibana API call returns an error for create, update, read, or delete (other than role not found on read), the resource SHALL surface the error to Terraform diagnostics.
+
+#### Scenario: API errors surfaced
+
+- GIVEN a failing Kibana API response (other than role not found on read)
+- WHEN the provider processes the response
+- THEN diagnostics SHALL include the API error
+
+### Requirement: Identity (REQ-004)
+
+The resource SHALL expose a computed `id` equal to the role name. After a successful create or update, the resource SHALL set `id` to the configured role `name` (the path parameter used for PUT), which SHALL equal the role name persisted in Kibana after a successful response.
+
+#### Scenario: Computed id after create
+
+- GIVEN a successful create
+- WHEN the provider commits state after write
+- THEN `id` SHALL be set to the role `name` argument
+
+### Requirement: Create and update behavior (REQ-010–REQ-011)
+
+When creating a role, the resource SHALL set the `createOnly` query parameter to `true` on the PUT request to signal new-resource semantics. When updating an existing role, the resource SHALL set `createOnly` to `false` or omit it per Kibana API conventions so the role can be overwritten. When creating or updating a role, the resource SHALL build the API request body from all configured fields (`name`, `kibana`, `elasticsearch`, `metadata`, `description`) using `generated/kbapi` request types and submit it with the Create or update role API. After a successful API response, the resource SHALL set `id` and read the role back to populate state.
+
+#### Scenario: Post-apply read
+
+- GIVEN a successful create or update
+- WHEN the provider refreshes state
+- THEN it SHALL call the Get role API and populate state from the response
+
+### Requirement: Read and refresh (REQ-012–REQ-014)
+
+When refreshing state, the resource and data source SHALL use `id` (or `name` for the data source) as the role name to fetch. If the Get role HTTP response indicates the role does not exist (for example HTTP 404, or the documented empty success response if applicable), the resource SHALL remove itself from state (role not found) and the data source SHALL behave as today for a missing role (diagnostics or empty result per existing implementation). When a role is found, the resource SHALL set `name`, `elasticsearch`, `kibana`, `description`, and `metadata` in state from the decoded API response.
+
+#### Scenario: Role removed in Kibana
+
+- GIVEN refresh runs and the role no longer exists
+- WHEN the Get role API returns a not-found result as defined above
+- THEN the resource SHALL be removed from state
+
+### Requirement: Delete (REQ-015)
+
+When destroying, the resource SHALL use `id` as the role name and delete it via the Kibana Delete role HTTP API implemented through `internal/clients/kibanaoapi` and `generated/kbapi`.
+
+#### Scenario: Destroy
+
+- GIVEN destroy is requested
+- WHEN delete runs
+- THEN the provider SHALL call Delete role for the name stored in `id`

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/tasks.md
@@ -1,0 +1,21 @@
+## 1. kibanaoapi role helpers
+
+- [ ] 1.1 Add `internal/clients/kibanaoapi/security_role.go` with `GetSecurityRole`, `PutSecurityRole`, and `DeleteSecurityRole` (names adjustable) wrapping `kbapi.ClientWithResponses`, decoding GET `Body` into `PutSecurityRoleNameJSONBody` (or shared struct), and handling 404 on read as not found.
+- [ ] 1.2 Reuse `reportUnknownError` / existing error helpers for non-2xx responses; add focused tests with `httptest` for 200, 404, and error body paths where practical.
+
+## 2. Terraform mapping migration
+
+- [ ] 2.1 Replace `kbapi.KibanaRole` / `KibanaRoleManagement` usage in `internal/kibana/role.go` with `kibanaoapi` helpers and `kbapi.PutSecurityRoleNameJSONRequestBody` (and related types); obtain clients via `GetKibanaOapiClient()` from `KibanaScopedClient`.
+- [ ] 2.2 Refactor expand functions to emit `kbapi` OpenAPI structs (including `field_security` as `*map[string][]string` per generated schema), preserving version gates for `remote_indices` and `description`.
+- [ ] 2.3 Refactor flatten functions to read from the decoded OpenAPI response shape while preserving omission rules for empty `cluster` / `run_as` and existing set/list flattening behavior.
+- [ ] 2.4 Update the data source implementation in `internal/kibana` to use the same helper read path; align not-found behavior with REQ-012–REQ-014.
+
+## 3. Parity, tests, and cleanup
+
+- [ ] 3.1 Add unit tests that round-trip representative privilege configurations through expand and flatten (and/or JSON) to lock privilege parity.
+- [ ] 3.2 Run `make build` and `go test ./internal/kibana/...`; run acceptance tests for `TestAccResourceKibanaSecurityRole` and `TestAccDataSourceKibanaSecurityRole` when a Stack is available.
+- [ ] 3.3 Remove unused go-kibana-rest imports from the role code path; verify no regressions in dependent testdata (for example Fleet agent policy restricted user).
+
+## 4. OpenSpec sync
+
+- [ ] 4.1 After implementation, run `make check-openspec` (or `openspec validate`) and archive or sync per project workflow so `openspec/specs/kibana-security-role/spec.md` absorbs the delta.

--- a/openspec/changes/migrate-kibana-slo-to-kbapi/.openspec.yaml
+++ b/openspec/changes/migrate-kibana-slo-to-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-kibana-slo-to-kbapi/design.md
+++ b/openspec/changes/migrate-kibana-slo-to-kbapi/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The `elasticstack_kibana_slo` resource today issues SLO HTTP calls through a dedicated OpenAPI client under `generated/slo`, wired from `internal/clients/kibana_scoped_client.go` and `internal/clients/api_client.go` via `GetSloClient()` / `buildSloClient()` and `SetSloAuthContext()` (context-based credential injection tailored to that client). Domain types on the wire (`SloWithSummaryResponse`, `CreateSloRequest`, `UpdateSloRequest`, indicator unions, `GroupBy`, `Settings`, etc.) are imported from `generated/slo` in `internal/models/slo.go` and throughout `internal/kibana/slo`.
+
+The repository already generates a unified Kibana client in `generated/kbapi` (`kibana.gen.go`) with SLO operations and models such as `SLOsSloWithSummaryResponse`, `SLOsCreateSloRequest`, `SLOsUpdateSloRequest`, `FindSlosOp`, `GetSloOp`, `CreateSloOp`, `UpdateSloOp`, `DeleteSloOp`, plus `SLOsGroupBy` (string vs string-array union). Other Kibana entities use thin wrappers in `internal/clients/kibanaoapi` around `*kbapi.ClientWithResponses`, `SpaceAwarePathRequestEditor`, and consistent HTTP status handling.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `internal/clients/kibanaoapi` helpers for SLO **find** (paginated search via `FindSlosOpWithResponse` or equivalent), **get**, **create**, **update**, and **delete**, mirroring patterns in `alerting_rule.go` / `connector.go` (typed responses, `SpaceAwarePathRequestEditor`, `kbn-xsrf` header where required by the generated client, clear diagnostics on unknown status codes).
+- Retarget `internal/clients/kibana/slo.go` to obtain `*kibanaoapi.Client` from `KibanaScopedClient.GetKibanaOapiClient()` (or the same factory path other PF resources use) and delegate to those helpers instead of `slo.SloAPI` + `SetSloAuthContext`.
+- Replace all `github.com/elastic/terraform-provider-elasticstack/generated/slo` imports in `internal/models/slo.go` and `internal/kibana/slo/**` with `generated/kbapi` types, including discriminated indicator unions and `SLOsGroupBy` encode/decode aligned with REQ-023.
+- Remove the `generated/slo` client surface from the provider wiring (`GetSloClient`, `SetSloAuthContext`, `buildSloClient`, `APIClient.slo` field, factory tests that only exist for the legacy client) once nothing references it.
+- Preserve **exact** user-visible behavior for version gates and wire formats: REQ-014 (`group_by` ≥ 8.10.0), REQ-015 (multi `group_by` ≥ 8.14.0), REQ-016 (`prevent_initial_backfill` ≥ 8.15.0), REQ-017 (`data_view_id` ≥ 8.15.0), and REQ-023 (`group_by` string vs JSON array by version). Version resolution and scoped `kibana_connection` behavior stay as today (REQ-007, scoped-client scenarios).
+
+**Non-Goals:**
+
+- Terraform schema changes, attribute renames, or new SLO indicator types.
+- Regenerating or editing the standalone SLO OpenAPI spec under `generated/slo` unless required purely to delete the tree; primary work is **consumer** migration to `kbapi`.
+- Broader refactors of unrelated Kibana resources or the Plugin SDK.
+
+## Decisions
+
+1. **Single transport: `kbapi.ClientWithResponses` via `kibanaoapi.Client`** — SLO CRUD and find use the same HTTP stack, TLS, debug transport, and auth as other `kibanaoapi` consumers (`transport` round-tripper in `kibanaoapi.NewClient`). **Rationale:** Eliminates parallel auth (`SetSloAuthContext`) and duplicate base URLs. **Alternative considered:** keep `generated/slo` for SLO only — rejected per consolidation goal.
+
+2. **Rename-aligned types, not parallel DTOs** — `models.Slo` and `tfModel` indicator helpers use `kbapi` structs (`SLOsSloWithSummaryResponse`, `SLOsSloWithSummaryResponse_Indicator`, etc.) directly. **Rationale:** One set of generated types; compile-time coverage. **Alternative considered:** adapter structs mapping slo→kbapi — rejected as extra maintenance.
+
+3. **Indicator conversion layer** — Keep a focused conversion from read/response indicator unions to create/update indicator unions (today `responseIndicatorToCreateSloRequestIndicator` in `internal/clients/kibana/slo.go`); reimplement against `SLOsSloWithSummaryResponse_Indicator` → `SLOsCreateSloRequest_Indicator` / `SLOsUpdateSloRequest_Indicator` using kbapi `As*` / `From*` helpers where available, with explicit switches for parity. **Rationale:** API asymmetry between GET and PUT/POST bodies remains; behavior must match current implementation.
+
+4. **`group_by` mapping** — Reimplement `transformGroupBy` / `transformGroupByFromResponse` using `SLOsGroupBy` (union of string vs `[]string`) with the same version-driven rules as today (`supportsGroupByList` / stack version flags passed from the resource). **Rationale:** REQ-023 is normative; only the backing type changes.
+
+5. **Find helper scope** — Implement `FindSlos` (or similar) in `kibanaoapi` with parameters sufficient to locate an SLO by id within a space (e.g. KQL / filter supported by the API). The current resource read path may continue to use **get-by-id** only; find is for consistency with the requested helper surface and for tests or future diagnostics. **Rationale:** Matches user-requested API surface without forcing a read-path change unless beneficial.
+
+6. **Legacy client removal order** — Migrate call sites and types first, then delete `GetSloClient` / `buildSloClient` / tests, then Makefile `generate-slo-client` / `generated/slo` references in a final cleanup sub-task if no other package imports `generated/slo`. **Rationale:** Keeps intermediate builds green.
+
+## Risks / Trade-offs
+
+- **[Risk] Union / JSON shape drift between `generated/slo` and `kbapi`** — Field names or nested types may differ. **Mitigation:** Compare structs side-by-side for each indicator; add unit tests with golden JSON fixtures from existing tests; run acceptance tests for `elasticstack_kibana_slo`.
+
+- **[Risk] Subtle plan noise** — Nil vs empty slices on `tags` / `group_by` after decode. **Mitigation:** Reuse existing normalization in `internal/kibana/slo/models.go` read paths; do not change schema defaults.
+
+- **[Risk] Auth regression** — SLO previously used context-injected credentials. **Mitigation:** Rely on `kibanaoapi` transport already used by other resources for the same `kibana_connection`; extend factory tests if a gap appears.
+
+- **[Risk] Version gate bypass** — If refactor accidentally skips pre-flight checks. **Mitigation:** Leave version checks in `internal/kibana/slo` create/update/read; add a regression test that mocks low version and expects diagnostics before HTTP (where feasible).
+
+## Migration Plan
+
+1. Implement `internal/clients/kibanaoapi/slo.go` (name may vary) with get/create/update/delete/find, using `SpaceAwarePathRequestEditor(spaceID)` and response classification (200 vs 404 vs error bodies).
+2. Replace `generated/slo` types in `internal/models/slo.go` and all `internal/kibana/slo` files and tests; fix compile errors indicator-by-indicator.
+3. Switch `internal/clients/kibana/slo.go` to call helpers with `*kibanaoapi.Client`; update `responseIndicatorToCreateSloRequestIndicator` and `group_by` transforms for kbapi types.
+4. Update resource create/read/update/delete to resolve `GetKibanaOapiClient()` instead of any SLO-specific client accessor.
+5. Remove dead `generated/slo` wiring from `api_client.go`, `provider_client_factory.go`, `kibana_scoped_client.go`, and associated tests; adjust Makefile/spec references if the SLO generator becomes unused.
+6. Run `make build`, unit tests for `internal/clients/kibana` and `internal/kibana/slo`, and targeted acceptance `TestAccResourceKibanaSlo` (or current SLO acc test name).
+
+## Open Questions
+
+- Whether `FindSlos` needs to be invoked from production code in the first iteration, or only implemented and unit-tested for parity (read currently uses get-by-id).
+- Exact `FindSlosOp` query parameter for filtering by SLO id — confirm against `kbapi` parameter names during implementation.
+- Whether any **other** package still imports `generated/slo` after SLO migration; if yes, either migrate those callers or defer deleting `generate-slo-client` until a follow-up change.

--- a/openspec/changes/migrate-kibana-slo-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-slo-to-kbapi/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `elasticstack_kibana_slo` resource still depends on a separately generated SLO OpenAPI client under `generated/slo`, while the rest of the Kibana surface is consolidating on the shared `generated/kbapi` client and `internal/clients/kibanaoapi` helpers. Maintaining two generators and client stacks for the same Kibana SLO HTTP API increases drift risk, complicates authentication and transport wiring, and blocks removal of the legacy `generated/slo` tree.
+
+## What Changes
+
+- Introduce `kibanaoapi` helper functions for Kibana SLO operations: find (list/search), get (single SLO with summary), create, update, and delete, built on `generated/kbapi` request/response types and consistent with existing `kibanaoapi` patterns (typed errors, diagnostics, `kbn-xsrf` where required).
+- Replace imports of `github.com/elastic/terraform-provider-elasticstack/generated/slo` in `internal/kibana/slo` and `internal/models/slo.go` with the equivalent SLO models from `generated/kbapi` (including discriminated unions for indicators and `group_by` wire encoding).
+- Migrate `internal/clients/kibana/slo.go` to call the new helpers using the shared `kibanaoapi.Client` (backed by `kbapi.ClientWithResponses`) instead of `slo.SloAPI` from `generated/slo`.
+- Remove or stop building the legacy `generated/slo` client for SLO once all references are gone (follow-up cleanup as part of the same change where feasible).
+- Preserve existing Terraform-visible behavior and **all** documented version gates for `prevent_initial_backfill`, `data_view_id`, `group_by`, and multi-value `group_by` (no relaxation of minimum stack versions or schema semantics).
+
+## Capabilities
+
+### New Capabilities
+
+- _(none)_
+
+### Modified Capabilities
+
+- `kibana-slo`: Add normative implementation requirements that SLO HTTP traffic uses the shared `kbapi` client via `kibanaoapi` helpers, without altering user-facing resource behavior or version-gated attributes.
+
+## Impact
+
+- **New / updated Go**: `internal/clients/kibanaoapi/slo.go` (or similarly named) for find/get/create/update/delete helpers; refactors in `internal/clients/kibana/slo.go`, `internal/models/slo.go`, and `internal/kibana/slo/*` model wiring and tests.
+- **Client factory / scoped client**: `internal/clients/kibana_scoped_client.go`, `internal/clients/provider_client_factory.go`, and `internal/clients/api_client.go` — remove or replace `GetSloClient` / `buildSloClient` paths that bind `generated/slo`; align SLO auth with whatever mechanism `kbapi` + `kibanaoapi` use for other resources (may subsume `SetSloAuthContext` or reimplement equivalent credential injection).
+- **Generated code**: Prefer `generated/kbapi` types for SLO; deprecate `generated/slo` for provider use.
+- **Specs**: Delta under `openspec/changes/migrate-kibana-slo-to-kbapi/specs/kibana-slo/spec.md` documenting the implementation contract; canonical `openspec/specs/kibana-slo/spec.md` unchanged until archive/sync.
+- **Tests**: `internal/clients/kibana/slo_test.go` and `internal/kibana/slo/*_test.go` updated for new types and client entry points.

--- a/openspec/changes/migrate-kibana-slo-to-kbapi/specs/kibana-slo/spec.md
+++ b/openspec/changes/migrate-kibana-slo-to-kbapi/specs/kibana-slo/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: SLO HTTP via shared kbapi client (REQ-031)
+
+The `elasticstack_kibana_slo` implementation SHALL perform Find SLOs (search/list), Get SLO, Create SLO, Update SLO, and Delete SLO HTTP calls using the generated OpenAPI Kibana package `github.com/elastic/terraform-provider-elasticstack/generated/kbapi` and helper functions under `internal/clients/kibanaoapi` colocated with other Kibana entity helpers. The implementation SHALL NOT use `github.com/elastic/terraform-provider-elasticstack/generated/slo` types or `slo.SloAPI` for those operations after this migration.
+
+#### Scenario: Reads and mutations use kbapi transport
+
+- **WHEN** the provider performs create, read, update, or delete for `elasticstack_kibana_slo`
+- **THEN** each corresponding Kibana SLO HTTP request SHALL be executed through the configured `kibanaoapi.Client` (`kbapi.ClientWithResponses`) for the effective Kibana connection (provider default or `kibana_connection` scoped client)
+
+#### Scenario: Legacy generated/slo client not used for SLO
+
+- **WHEN** the provider issues any SLO HTTP request for this resource
+- **THEN** the code path SHALL NOT depend on `GetSloClient`, `buildSloClient`, or `SetSloAuthContext` for authentication or transport
+
+### Requirement: kbapi SLO models replace generated/slo in domain layer (REQ-032)
+
+`internal/models/slo.go` and all SLO Terraform model and indicator mapping code under `internal/kibana/slo` SHALL use kbapi SLO request and response types (including `SLOsSloWithSummaryResponse`, `SLOsSloWithSummaryResponse_Indicator`, `SLOsCreateSloRequest`, `SLOsUpdateSloRequest`, `SLOsGroupBy`, `SLOsSettings`, and related indicator structs) instead of types from `generated/slo`. Indicator mapping SHALL preserve the same logical JSON payloads as the pre-migration implementation for each indicator variant.
+
+#### Scenario: Model compile-time binding to kbapi
+
+- **WHEN** a developer builds the provider after the migration
+- **THEN** `internal/models/slo.go` and `internal/kibana/slo` SHALL not import `generated/slo`
+
+### Requirement: kibanaoapi SLO helper surface (REQ-033)
+
+The provider SHALL expose focused `kibanaoapi` functions (or methods on `*kibanaoapi.Client`) for at minimum: **Get** SLO by space and id, **Create** SLO, **Update** SLO, **Delete** SLO, and **Find** SLOs (paginated search using the kbapi `FindSlos` operation). Helpers SHALL apply space-aware path editing consistent with other `kibanaoapi` modules and SHALL map HTTP status codes to Terraform diagnostics in line with existing patterns (including treating get-by-id not found as absence where the resource layer expects it).
+
+#### Scenario: Find helper is available for search operations
+
+- **WHEN** code requests a paginated SLO search within a space via the new helper
+- **THEN** the helper SHALL call the kbapi find-SLOs operation with `SpaceAwarePathRequestEditor` for that space and return typed results or diagnostics on failure
+
+### Requirement: Version gates and group_by wire format unchanged (REQ-034)
+
+After migration, the resource SHALL continue to satisfy existing compatibility and mapping requirements **without weakening minimum stack versions or error messages**: REQ-014 (`group_by` when non-empty), REQ-015 (multiple `group_by` elements), REQ-016 (`settings.prevent_initial_backfill` when set to a known value), REQ-017 (non-empty `data_view_id` on indicators), REQ-023 (`group_by` JSON string vs array encoding by stack version), and REQ-007 (version must be obtainable before create/update). Version evaluation SHALL use the same effective scoped Kibana client and version source as today.
+
+#### Scenario: Multi group_by still blocked below 8.14
+
+- **WHEN** the resolved stack version is below 8.14.0 and the user configures more than one `group_by` element
+- **THEN** the provider SHALL return an unsupported-version error diagnostic and SHALL NOT successfully persist an SLO that violates REQ-015
+
+#### Scenario: prevent_initial_backfill still gated below 8.15
+
+- **WHEN** the resolved stack version is below 8.15.0 and `settings.prevent_initial_backfill` is set to a known value
+- **THEN** the provider SHALL return an unsupported-version error diagnostic consistent with REQ-016
+
+#### Scenario: data_view_id still gated below 8.15
+
+- **WHEN** the resolved stack version is below 8.15.0 and any indicator has a non-empty `data_view_id`
+- **THEN** the provider SHALL return an unsupported-version error diagnostic consistent with REQ-017
+
+#### Scenario: group_by wire encoding by version
+
+- **WHEN** the stack version is in [8.10.0, 8.14.0) and a single-element `group_by` is sent on create or update
+- **THEN** the JSON body SHALL encode `group_by` as a single string as required by REQ-023
+
+- **WHEN** the stack version is at least 8.14.0 and multiple `group_by` elements are sent
+- **THEN** the JSON body SHALL encode `group_by` as a JSON array of strings as required by REQ-023

--- a/openspec/changes/migrate-kibana-slo-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-slo-to-kbapi/tasks.md
@@ -1,0 +1,24 @@
+## 1. `kibanaoapi` SLO helpers
+
+- [ ] 1.1 Add `internal/clients/kibanaoapi/slo.go` implementing Get SLO (`GetSloOpWithResponse`), Create (`CreateSloOpWithResponse`), Update (`UpdateSloOpWithResponse`), Delete (`DeleteSloOpWithResponse`), and Find (`FindSlosOpWithResponse`) using `SpaceAwarePathRequestEditor(spaceID)` and the same error/status patterns as `alerting_rule.go` (including `kbn-xsrf` if required by generated signatures).
+- [ ] 1.2 Ensure get-by-id returns `(nil, nil)` diagnostics on HTTP 404 where the existing `internal/clients/kibana/slo.go` contract expects “not found”.
+- [ ] 1.3 Add unit tests for the helper layer (mocked `*http.Client` or response fixtures) covering at least one success path and one non-2xx path per operation where practical.
+
+## 2. Types and model migration (`generated/slo` → `generated/kbapi`)
+
+- [ ] 2.1 Replace `generated/slo` imports in `internal/models/slo.go` with `generated/kbapi` equivalents (`SLOsSloWithSummaryResponse`, `SLOsSloWithSummaryResponse_Indicator`, `SLOsTimeWindow`, `SLOsObjective`, `SLOsBudgetingMethod`, `SLOsSettings`, etc.).
+- [ ] 2.2 Update `internal/kibana/slo/models.go`, all `models_*_indicator.go` files, tests, and `group_by` / settings mapping to use kbapi types end-to-end; fix indicator union construction to use kbapi `From*` / `As*` helpers or explicit switches matching current JSON.
+- [ ] 2.3 Reimplement `group_by` request/response transforms using `SLOsGroupBy` while preserving REQ-023 behavior driven by existing version flags (`supportsGroupByList` / stack version from resource).
+
+## 3. Client wiring and legacy removal
+
+- [ ] 3.1 Refactor `internal/clients/kibana/slo.go` to resolve `*kibanaoapi.Client` via `KibanaScopedClient.GetKibanaOapiClient()` (or equivalent factory path) and call the new helpers; reimplement `responseIndicatorToCreateSloRequestIndicator` (and any update-body builder) against kbapi indicator unions.
+- [ ] 3.2 Update `internal/kibana/slo/create.go`, `read.go`, `update.go`, and `delete.go` to use the refactored client entry points only (no `GetSloClient` / `SetSloAuthContext`).
+- [ ] 3.3 Remove `GetSloClient`, `SetSloAuthContext`, `buildSloClient`, and `APIClient`/factory fields that exist solely for `generated/slo`; update `internal/clients/provider_client_factory_test.go` and related tests to cover `kibanaoapi` paths instead.
+- [ ] 3.4 Confirm no remaining `generated/slo` imports in the provider; remove or narrow Makefile `generate-slo-client` / `generated/slo` targets per repo policy if nothing else consumes that client.
+
+## 4. Verification
+
+- [ ] 4.1 Run `make build` and fix compile or staticcheck issues.
+- [ ] 4.2 Run unit tests for `internal/clients/kibana`, `internal/clients/kibanaoapi`, and `internal/kibana/slo`.
+- [ ] 4.3 Run targeted acceptance tests for `elasticstack_kibana_slo` against a configured stack, including cases that exercise `group_by`, multiple `group_by`, `prevent_initial_backfill`, and `data_view_id` where the stack version supports them.

--- a/openspec/changes/migrate-kibana-spaces-to-kbapi/.openspec.yaml
+++ b/openspec/changes/migrate-kibana-spaces-to-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-kibana-spaces-to-kbapi/design.md
+++ b/openspec/changes/migrate-kibana-spaces-to-kbapi/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Today, `internal/kibana/space.go` and `internal/kibana/spaces/read.go` obtain a `*kbapi.Client` from the provider factory and call `KibanaSpaces.List|Get|Create|Update|Delete` from `github.com/disaster37/go-kibana-rest/v8/kbapi`. That client uses hand-written REST helpers with loosely typed JSON unmarshalling into `kbapi.KibanaSpace`. The repository already ships a large generated OpenAPI client under `generated/kbapi` plus thin wrappers in `internal/clients/kibanaoapi` (for example `data_views_spaces.go`, `alerting_rule.go`) that call `client.API.*WithResponse`, normalize status codes, and return structured errors for Terraform diagnostics.
+
+The Kibana OpenAPI schema for Spaces may currently expose list/get responses as `additionalProperties`/generic maps or incomplete structs, which is why `transform_schema.go` must be extended before regeneration so space entities decode into Go structs that cover the same fields as legacy `KibanaSpace`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Route all Spaces CRUD and list operations for `elasticstack_kibana_space` and `elasticstack_kibana_spaces` through `generated/kbapi` using `kibanaoapi` helpers consistent with other migrated entities.
+- After regeneration, use strongly typed kbapi models for space payloads whose JSON tags align with legacy `KibanaSpace` (`id`, `name`, `description`, `disabledFeatures`, `initials`, `color`, `imageUrl`, `solution`, `_reserved` when present) so Terraform attribute mapping stays equivalent.
+- Preserve `solution` minimum version checks (8.16.0) on create/update when `solution` is non-empty, using the same server version resolution path as today (`client.ServerVersion` on the effective connection wrapper), independent of whether HTTP is issued via resty or oapi-codegen transport.
+- Preserve composite `id` parsing, import passthrough, not-found read behavior, post-upsert read refresh, omitting optional unset fields on write, and omitting `image_url` from read mapping.
+
+**Non-Goals:**
+
+- Changing Terraform schema, attribute names, or validation rules for either entity.
+- Migrating the SDK space resource to Plugin Framework (out of scope).
+- Removing or altering `libs/go-kibana-rest` for unrelated consumers.
+
+## Decisions
+
+1. **Transform + regenerate instead of ad-hoc structs** — Prefer fixing the OpenAPI-derived schema in `transform_schema.go` (similar to `fixGetSpacesParams` and other transformers) so `oapi-codegen` emits dedicated types for space list/item responses. **Rationale:** Keeps a single source of truth and avoids parallel hand-maintained DTOs. **Alternative considered:** private structs with `json.Unmarshal` into `map[string]any` — rejected for weaker compile-time guarantees and drift risk.
+
+2. **`kibanaoapi` facade for Spaces** — Add a focused module (e.g. `spaces.go`) exposing functions or methods on `*kibanaoapi.Client` that wrap the specific `kbapi` operations (GET `/api/spaces/space`, GET `/api/spaces/space/{id}`, POST, PUT, DELETE) and map HTTP failures to Terraform-friendly errors, mirroring patterns in `alerting_rule.go` / `data_views.go`. **Rationale:** Keeps resource/data source code thin and centralizes status handling. **Alternative considered:** calling `client.API` directly from `internal/kibana` — rejected to avoid duplicating HTTP semantics.
+
+3. **SDK resource keeps `GetKibanaClientFromSDK` until a broader factory migration** — Only replace the `KibanaSpaces` call sites with code that builds or reuses `*kibanaoapi.Client` from the same effective `kibana_connection` / provider defaults as other PF entities. **Rationale:** Minimizes churn outside Spaces; align with how other resources obtain the oapi client from the factory if a helper already exists, or add a narrow factory method documented in tasks.
+
+4. **PF data source** — Replace `apiClient.GetKibanaClient()` + `KibanaSpaces.List` with the same `kibanaoapi` list helper used by the design, mapping typed results into the existing `spaces` model. **Rationale:** One implementation of list semantics and error handling.
+
+## Risks / Trade-offs
+
+- **[Risk] OpenAPI schema mismatch** — Kibana’s published OAS may not describe every field the legacy client returned. **Mitigation:** Compare generated structs against `libs/go-kibana-rest/kbapi/api.kibana_spaces.go` struct; extend transforms or use merge-patch overlays in `transform_schema.go` until fields match; add unit tests with fixture JSON from both default and custom spaces.
+
+- **[Risk] Subtle state diffs** — Differences in nil vs empty slice or omitted JSON fields could cause plan noise. **Mitigation:** Map through explicit normalization functions shared by resource read and data source; mirror existing `Set` / `ListValueFrom` behavior.
+
+- **[Risk] `solution` gating regression** — If the kbapi path skips version lookup, older clusters could error differently. **Mitigation:** Keep the explicit version guard in `resourceSpaceUpsert` before any mutating kbapi call; add a scenario-style unit test if feasible.
+
+## Migration Plan
+
+1. Land schema transforms and regenerate `generated/kbapi` in the developer environment (`make` targets under `generated/kbapi/` per repo docs).
+2. Implement `kibanaoapi` spaces helpers and unit tests with mocked `*http.Client` or golden responses if the repo pattern supports it.
+3. Switch `internal/kibana/space.go` and `internal/kibana/spaces` to the helpers; run `make build` and targeted acceptance tests for space + spaces data source.
+4. No user migration steps — state format unchanged.
+
+## Open Questions
+
+- The exact factory helper used elsewhere to obtain `*kibanaoapi.Client` from `kibana_connection` for SDK resources should be confirmed during implementation (search `kibanaoapi.New` / factory patterns); if none exists for SDK, add a small bridge without widening scope beyond Spaces.

--- a/openspec/changes/migrate-kibana-spaces-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-spaces-to-kbapi/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `elasticstack_kibana_space` resource and `elasticstack_kibana_spaces` data source still call Kibana through the legacy `go-kibana-rest` `KibanaSpaces` client, while the rest of the provider is standardizing on the generated OpenAPI client (`generated/kbapi`) plus `internal/clients/kibanaoapi` helpers. Moving these entities reduces duplicate HTTP stacks, improves type safety, and aligns Spaces with the same client patterns as other Kibana resources.
+
+## What Changes
+
+- Extend `generated/kbapi/transform_schema.go` so regenerated OpenAPI models for space responses decode the same JSON surface as legacy `kbapi.KibanaSpace` (field names and optionality), enabling strongly typed request/response structs without losing fields today mapped into Terraform state.
+- Regenerate `generated/kbapi` (transform + `oapi-codegen`) so the kbapi package includes the adjusted space schemas.
+- Add `internal/clients/kibanaoapi` helpers for list/get/create/update/delete spaces that wrap the kbapi client, handle HTTP status and errors consistently with other kibanaoapi modules, and return data suitable for the SDK resource and PF data source.
+- Migrate `elasticstack_kibana_space` (SDK in `internal/kibana/space.go`) and `elasticstack_kibana_spaces` (PF under `internal/kibana/spaces`) to use those helpers instead of `kibanaClient.KibanaSpaces.*`, while preserving:
+  - `solution` minimum version gating (8.16.0) before create/update when `solution` is set,
+  - composite `id` handling, import, destroy, post-upsert read refresh, and `image_url` not being populated from read,
+  - diagnostics and state values equivalent to current behavior for the same Kibana responses.
+
+## Capabilities
+
+### New Capabilities
+
+_(None — behavior stays under existing capabilities.)_
+
+### Modified Capabilities
+
+- `kibana-space`: Document that Spaces HTTP traffic is satisfied via `generated/kbapi` + `kibanaoapi`, and that typed models MUST remain compatible with the legacy `KibanaSpace` JSON shape for state mapping; existing user-facing requirements (including `solution` gating) remain.
+- `kibana-spaces`: Update connection/client wording and list implementation expectations to match kbapi + `kibanaoapi` while keeping list semantics and field mapping unchanged.
+
+## Impact
+
+- `generated/kbapi/transform_schema.go`, regenerated files under `generated/kbapi/`, and the kbapi Makefile-driven codegen pipeline.
+- New or updated Go in `internal/clients/kibanaoapi/` (e.g. `spaces.go`).
+- `internal/kibana/space.go` and `internal/kibana/spaces/` (read path and client acquisition).
+- Tests that assert on client types or mocks may need updates; acceptance tests should remain valid if responses are unchanged.

--- a/openspec/changes/migrate-kibana-spaces-to-kbapi/specs/kibana-space/spec.md
+++ b/openspec/changes/migrate-kibana-spaces-to-kbapi/specs/kibana-space/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Kibana OpenAPI client for Spaces (REQ-018)
+
+The `elasticstack_kibana_space` implementation SHALL perform Create Space, Get Space, Update Space, and Delete Space HTTP calls using the generated OpenAPI Kibana client package (`generated/kbapi`) and helper functions colocated under `internal/clients/kibanaoapi` for Spaces. The implementation SHALL NOT use the legacy `go-kibana-rest` `KibanaSpaces` API methods for those operations after this migration.
+
+#### Scenario: Mutations use kbapi transport
+
+- **GIVEN** a create, update, read, or delete operation for the resource
+- **WHEN** the provider issues the corresponding Kibana Spaces HTTP request
+- **THEN** the request SHALL be executed through the kbapi client configured for the effective Kibana connection (provider default or `kibana_connection` scoped client)
+
+### Requirement: Typed space models aligned with legacy KibanaSpace (REQ-019)
+
+The kbapi types used to decode and encode space request and response JSON SHALL include the same logical fields as `github.com/disaster37/go-kibana-rest/v8/kbapi.KibanaSpace` for provider purposes: `id`, `name`, `description`, `disabledFeatures`, `initials`, `color`, `imageUrl`, `solution`, and `_reserved` when returned by Kibana. Schema adjustments needed to achieve this SHALL be implemented in `generated/kbapi/transform_schema.go` followed by regeneration of `generated/kbapi`.
+
+#### Scenario: Read maps equivalent Terraform attributes
+
+- **GIVEN** a successful Get Space response identical to one handled by the pre-migration implementation
+- **WHEN** read populates Terraform state from the typed kbapi response
+- **THEN** the values stored for `space_id`, `name`, `description`, `disabled_features`, `initials`, `color`, and `solution` SHALL match the values the legacy client mapping would have produced for that JSON payload
+
+### Requirement: solution version gate uses effective connection (REQ-020)
+
+When the `solution` argument is set to a non-empty value, the resource SHALL evaluate the minimum Kibana/Stack version using the same effective Kibana connection as the kbapi Spaces calls before performing create or update, and SHALL fail with diagnostics when the version is below 8.16.0 as specified in existing requirements.
+
+#### Scenario: Version check precedes kbapi mutation
+
+- **GIVEN** `solution` is set and the resolved server version is below 8.16.0
+- **WHEN** create or update runs
+- **THEN** the resource SHALL return an error diagnostic without issuing a successful mutating Spaces API call that would persist an unsupported `solution`

--- a/openspec/changes/migrate-kibana-spaces-to-kbapi/specs/kibana-spaces/spec.md
+++ b/openspec/changes/migrate-kibana-spaces-to-kbapi/specs/kibana-spaces/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Kibana OpenAPI client for listing spaces (REQ-006)
+
+The `elasticstack_kibana_spaces` implementation SHALL retrieve spaces using the generated OpenAPI Kibana client (`generated/kbapi`) and `internal/clients/kibanaoapi` list-spaces helpers. The implementation SHALL NOT call the legacy `go-kibana-rest` `KibanaSpaces.List` method after this migration.
+
+#### Scenario: Read uses kbapi list transport
+
+- **GIVEN** the data source read runs successfully
+- **WHEN** the provider fetches all spaces from Kibana
+- **THEN** the HTTP call SHALL be executed through the kbapi client configured for the effective Kibana connection
+
+### Requirement: Typed list items aligned with legacy KibanaSpace (REQ-007)
+
+The kbapi types used for each entry in the Get All Spaces response SHALL decode the same logical fields as `github.com/disaster37/go-kibana-rest/v8/kbapi.KibanaSpace` for provider mapping (`id`, `name`, `description`, `disabledFeatures`, `initials`, `color`, `imageUrl`, `solution`, and `_reserved` when returned by Kibana), produced after `generated/kbapi/transform_schema.go` updates and regeneration.
+
+#### Scenario: Nested spaces attributes unchanged for a fixed API payload
+
+- **GIVEN** a list response payload identical to one handled before the migration
+- **WHEN** read completes
+- **THEN** each nested `spaces` entry SHALL carry the same Terraform-visible values for `id`, `name`, `description`, `disabled_features`, `initials`, `color`, `image_url`, and `solution` as the pre-migration mapping
+
+## MODIFIED Requirements
+
+### Requirement: List Spaces API (REQ-001)
+
+The data source SHALL use the Kibana Get All Spaces API to retrieve all spaces ([docs](https://www.elastic.co/guide/en/kibana/master/spaces-api-get-all.html)) via the generated OpenAPI kbapi client and `internal/clients/kibanaoapi` helpers. When the API returns an error, the data source SHALL surface the error to Terraform diagnostics and SHALL NOT write any state.
+
+#### Scenario: API call on read
+
+- **GIVEN** the data source is referenced in configuration
+- **WHEN** Terraform refreshes state
+- **THEN** the provider SHALL call the Kibana Get All Spaces API through kbapi to retrieve the full list of spaces
+
+#### Scenario: API error surfaces to diagnostics
+
+- **GIVEN** the Kibana API returns an error
+- **WHEN** read runs
+- **THEN** the error SHALL appear in Terraform diagnostics and no state SHALL be written
+
+### Requirement: Connection (REQ-003)
+
+The data source SHALL use the provider's configured Kibana connection resolved to the generated OpenAPI Kibana client (`generated/kbapi`) and `internal/clients/kibanaoapi` spaces helpers by default. When `kibana_connection` is configured on the data source, the data source SHALL resolve an effective scoped client from that block and SHALL use that scoped client for the Get All Spaces API call.
+
+#### Scenario: Provider-level Kibana client
+
+- **WHEN** `kibana_connection` is not configured on the data source
+- **THEN** the provider-level Kibana connection mapped to kbapi SHALL be used
+
+#### Scenario: Scoped Kibana connection
+
+- **WHEN** `kibana_connection` is configured on the data source
+- **THEN** the scoped Kibana client derived from that block SHALL be used for kbapi Spaces list calls

--- a/openspec/changes/migrate-kibana-spaces-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-spaces-to-kbapi/tasks.md
@@ -1,0 +1,22 @@
+## 1. OpenAPI schema and codegen
+
+- [ ] 1.1 Identify current kbapi types and operations for `/api/spaces/space` (list, get by id, create, update, delete) and compare JSON fields to legacy `kbapi.KibanaSpace` in `libs/go-kibana-rest/kbapi/api.kibana_spaces.go`.
+- [ ] 1.2 Extend `generated/kbapi/transform_schema.go` so space list and space detail responses generate strongly typed models matching the legacy `KibanaSpace` shape (including `disabledFeatures`, `imageUrl`, `solution`, `_reserved` as applicable).
+- [ ] 1.3 Regenerate `generated/kbapi` using the subdirectory workflow (`generated/kbapi` Makefile: transform + `oapi-codegen`) and ensure the repo builds (`make build`).
+
+## 2. kibanaoapi helpers
+
+- [ ] 2.1 Add `internal/clients/kibanaoapi` Spaces helpers (e.g. new `spaces.go`) wrapping the kbapi `WithResponse` methods for list, get, create, update, and delete, including consistent non-success status handling aligned with existing kibanaoapi modules.
+- [ ] 2.2 Expose a path for both the SDK resource and PF data source to obtain a `*kibanaoapi.Client` (or equivalent) from the same effective `kibana_connection` resolution used elsewhere, adding a factory/helper only if missing.
+
+## 3. Terraform entities
+
+- [ ] 3.1 Migrate `internal/kibana/space.go` to call the new helpers for create, update, read, and delete; remove direct `KibanaSpaces` usage while preserving composite id handling, import behavior, post-upsert read refresh, optional-field omission on write, read mapping (including not setting `image_url` from API), and diagnostics text where appropriate.
+- [ ] 3.2 Preserve `solution` minimum version gating (`>= 8.16.0`) before create/update when `solution` is non-empty, using server version from the same effective connection as the kbapi calls.
+- [ ] 3.3 Migrate `internal/kibana/spaces` (Plugin Framework data source `read.go` and any shared wiring) to list spaces via the helpers instead of `GetKibanaClient().KibanaSpaces.List`, preserving `spaces` nested attribute mapping and `id = "spaces"` behavior.
+
+## 4. Verification
+
+- [ ] 4.1 Update or add unit tests for transforms, helpers, or mapping if the repository pattern supports them; otherwise rely on compile-time checks and targeted acceptance tests.
+- [ ] 4.2 Run targeted acceptance tests for `elasticstack_kibana_space` and `elasticstack_kibana_spaces` when a stack is available; at minimum run `make build` and relevant `go test` packages.
+- [ ] 4.3 Run `make check-openspec` or `./node_modules/.bin/openspec validate --all` after syncing expectations to ensure delta specs validate.

--- a/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/.openspec.yaml
+++ b/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/design.md
+++ b/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Today `internal/kibana/synthetics/monitor` calls `kibanaClient.KibanaSynthetics.Monitor.{Add,Get,Update,Delete}` on `github.com/disaster37/go-kibana-rest/v8`, using types from `github.com/disaster37/go-kibana-rest/v8/kbapi` (`SyntheticsMonitor`, `SyntheticsMonitorConfig`, `HTTPMonitorFields`, `JsonObject`, `APIError`, etc.). Mapping between Terraform models and those structs lives largely in `schema.go` (~1000+ lines) with table-driven tests in `schema_test.go`.
+
+The repository already ships `generated/kbapi` (oapi-codegen) including `/api/synthetics/monitors` operations and rich models (`SyntheticsHttpMonitorFields`, `SyntheticsBrowserMonitorFields`, …). `internal/clients/kibanaoapi.Client` wraps `*kbapi.ClientWithResponses` and is the established pattern for newer resources (streams, dashboards, alerting, …).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Route all synthetics monitor **HTTP** CRUD through `kibanaoapi` helpers built on `ClientWithResponses` (`PostSyntheticMonitorsWithResponse`, `GetSyntheticMonitorWithResponse`, `PutSyntheticMonitorWithResponse`, `DeleteSyntheticMonitorWithResponse` or equivalent).
+- Preserve every requirement in `openspec/specs/kibana-synthetics-monitor/spec.md` that affects Terraform users: schema shape, validation, composite ID, import, labels version gate, read mapping quirks, error semantics for 404 on read, and delete error surfacing.
+- Centralize space header / base URL handling in `kibanaoapi` the same way as other resources (reuse request editor patterns from existing files).
+- Map legacy `kbapi.JsonObject` fields to/from `json.RawMessage` or concrete generated pointer fields without changing normalized JSON string behavior in state.
+
+**Non-Goals:**
+
+- Changing the Terraform schema, attribute names, or import ID format.
+- Migrating other synthetics resources (`private_location`, `parameter`, …) in the same change.
+- Regenerating the OpenAPI bundle (unless a gap is found; assume current `generated/kbapi` is sufficient).
+- Rewriting acceptance tests to new fixtures unless behavior forces it (prefer keeping `testdata` HCL).
+
+## Decisions
+
+1. **`kibanaoapi` owns HTTP + status decoding**  
+   Rationale: Matches streams/dashboards; keeps `monitor` package focused on Terraform ↔ domain mapping. Helpers accept `context.Context`, space id, monitor id (where applicable), typed or raw bodies, and return typed structs plus `diag.Diagnostics` using `internal/diagutil` patterns.
+
+2. **Generated union bodies (`PostSyntheticMonitorsJSONBody`, `PutSyntheticMonitorJSONBody`)**  
+   The generated types wrap `json.RawMessage`. Decision: implement small constructors in `kibanaoapi` that accept the appropriate concrete generated struct (e.g. HTTP/TCP/ICMP/browser monitor + shared config) and marshal into the union field Kibana expects, mirroring the JSON shape the legacy client produced.  
+   *Alternatives considered:* (a) keep an internal “wire DTO” struct tagged for JSON and bypass generated body types — rejected as second schema to maintain; (b) raw `json.Marshal` from `map[string]any` — rejected as losing compile-time checks.
+
+3. **404 handling**  
+   Map `GetSyntheticMonitorWithResponse` non-success responses to the same behavior as today (`errors.As` into legacy `APIError` with code 404). Use `kibanaoapi`/`diagutil` shared helpers for HTTP status if they exist; otherwise add a minimal status classifier in the new monitor helper file.
+
+4. **Version / labels gate**  
+   Keep `enforceVersionConstraints` on `*clients.KibanaScopedClient` as today to avoid scope creep; only the monitor HTTP path switches to OpenAPI.
+
+5. **Incremental replacement**  
+   Replace legacy types end-to-end in `monitor` in one PR series (not half-migrated public types). Internal package-private aliases are acceptable short-term inside `kibanaoapi` only.
+
+## Risks / Trade-offs
+
+- **[Risk] JSON shape drift** between legacy structs and generated models → **Mitigation:** golden JSON tests for one monitor per type (create/update body) and compare to captured legacy payloads or Kibana docs; run full acc tests.
+- **[Risk] Opaque union marshal bugs** → **Mitigation:** isolate marshal in unit-tested `kibanaoapi` functions; fail fast with clear diagnostics on marshal error.
+- **[Risk] Large diff in `schema.go`** → **Mitigation:** consider extracting `api_model_http.go`-style files only if it clarifies review; default to minimal file moves to reduce merge pain.
+- **[Trade-off] Two client stacks** (`ScopedClient` for version, `kibanaoapi` for HTTP) until a later consolidation.
+
+## Migration Plan
+
+1. Land `kibanaoapi` monitor helpers + unit tests (no resource wiring).
+2. Switch `create`/`read`/`update`/`delete` to helpers; fix compile in `schema.go` mappers.
+3. Rewrite `schema_test.go` tables for new types; run `go test ./internal/kibana/synthetics/monitor/...`.
+4. Run acceptance tests for all `TestAcc*` monitor tests against a versioned stack (including labels tests on ≥ 8.16).
+5. Remove unused legacy imports from `monitor` package; optionally add a `go mod` tidy follow-up if nothing else uses legacy kbapi synthetics types.
+
+Rollback: revert the branch; no state migration required.
+
+## Open Questions
+
+- Whether `GetSyntheticMonitor` response typing is fully adequate in `generated/kbapi` for all nested fields the resource reads, or whether some fields still arrive as raw JSON needing custom unmarshaling.
+- Exact Kibana `kbn-xsrf` / space header requirements for these endpoints relative to other `kibanaoapi` calls (validate against `client.go` transport).

--- a/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `elasticstack_kibana_synthetics_monitor` resource still depends on the legacy `go-kibana-rest` client and hand-maintained `kbapi` structs for monitor payloads, while the rest of the provider is standardizing on the OpenAPI-generated `generated/kbapi` client with thin `kibanaoapi` wrappers. Migrating removes duplicate type definitions, aligns error handling with other Kibana resources, and reduces drift between provider models and Kibana’s published OpenAPI schema.
+
+## What Changes
+
+- Add `internal/clients/kibanaoapi` helpers for synthetics monitor **create**, **read**, **update**, and **delete** using `generated/kbapi` (`PostSyntheticMonitors`, `GetSyntheticMonitor`, `PutSyntheticMonitor`, `DeleteSyntheticMonitor`) with space-aware request editors consistent with other `kibanaoapi` resources.
+- Replace all uses of `github.com/disaster37/go-kibana-rest/v8/kbapi` **monitor request/response types** inside `internal/kibana/synthetics/monitor` (including `schema.go`, CRUD, and tests) with generated `kbapi` types and/or small internal DTOs where unions require explicit JSON handling.
+- Keep **practitioner-visible behavior** unchanged: Plugin Framework schema, validators (exactly-one type, at-least-one location, enums), composite `id`, import format, `labels` version gating (≥ 8.16.0), read-side preservation rules (`locations`, `http.check`/`http.response`, null `params`), private-location mapping, and diagnostics text where the canonical spec requires it.
+- Retain use of `*clients.KibanaScopedClient` where needed for **non-monitor** concerns already wired through it (for example `enforceVersionConstraints` / stack version checks), unless a follow-up change consolidates version discovery on the OpenAPI path.
+- This change is **not** a Terraform schema or import-format **BREAKING** change; it is an internal client migration with a large code touch surface.
+
+## Capabilities
+
+### New Capabilities
+
+- (none — behavior stays under the existing monitor capability)
+
+### Modified Capabilities
+
+- `kibana-synthetics-monitor`: Document that synthetics monitor HTTP traffic is implemented via `generated/kbapi` and `kibanaoapi` helpers; clarify write-path wording that today references legacy Go type names; add an implementation placement requirement for the new client layer.
+
+## Impact
+
+- **Primary**: `internal/kibana/synthetics/monitor` (`schema.go`, `create.go`, `read.go`, `update.go`, `delete.go`, `resource.go`, `schema_test.go`, `acc_test.go`, extensive `testdata/`).
+- **New**: `internal/clients/kibanaoapi` (new file(s) for monitor operations, following patterns in `streams.go`, `dashboards.go`, etc.).
+- **Shared**: `internal/kibana/synthetics/api_client.go` (may gain or reuse `GetKibanaOAPIClient` for monitor CRUD only; avoid widening scope to unrelated synthetics resources).
+- **Tests**: Acceptance tests in `acc_test.go` must be re-run against a live stack; `schema_test.go` must be rewritten around generated types or public mapper tests.
+- **External**: Removes monitor-specific dependency on legacy `kbapi` structs from `go-kibana-rest` for this resource (module cleanup may be deferred until no other package imports those types).
+- **Risk**: Generated request bodies use `json.RawMessage` unions (`PostSyntheticMonitorsJSONBody`, `PutSyntheticMonitorJSONBody`); helpers must marshal discriminator + payload correctly or Kibana will reject requests.

--- a/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/specs/kibana-synthetics-monitor/spec.md
+++ b/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/specs/kibana-synthetics-monitor/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: Provider configuration and Kibana client (REQ-003)
+
+On create, read, update, and delete, if the provider did not supply a usable API client, the resource SHALL return an "Unconfigured Client" error diagnostic and SHALL NOT proceed to the Kibana API. The resource SHALL use the provider-configured Kibana client by default. When `kibana_connection` is configured on the resource, the resource SHALL resolve an effective scoped client from that block and SHALL use the scoped Kibana client for all operations.
+
+For synthetics monitor HTTP operations (create, read, update, delete against Kibana’s `/api/synthetics/monitors` endpoints), the resource SHALL use the OpenAPI-generated Kibana client in `generated/kbapi`, invoked through monitor-specific helper functions in `internal/clients/kibanaoapi`, rather than the legacy `go-kibana-rest` synthetics monitor client. Ancillary operations that are not synthetics monitor HTTP calls (for example, server version checks required for `labels` compatibility) MAY continue to use `*clients.KibanaScopedClient` as they do today.
+
+#### Scenario: Unconfigured provider
+
+- GIVEN the resource has no provider-supplied API client
+- WHEN any CRUD operation runs
+- THEN the operation SHALL fail with an "Unconfigured Client" error diagnostic
+
+#### Scenario: Provider client used by default
+
+- GIVEN `kibana_connection` is not configured on the resource
+- WHEN any CRUD operation runs
+- THEN the resource SHALL use the provider-configured Kibana client
+
+#### Scenario: Scoped Kibana connection
+
+- GIVEN `kibana_connection` is configured on the resource
+- WHEN any CRUD operation runs
+- THEN the resource SHALL use the scoped Kibana client derived from that block
+
+#### Scenario: Synthetics monitor HTTP uses OpenAPI client path
+
+- GIVEN a fully configured provider and a synthetics monitor CRUD operation
+- WHEN the provider issues the synthetics monitor HTTP request
+- THEN the request SHALL be executed via `generated/kbapi` through `internal/clients/kibanaoapi` monitor helpers and SHALL NOT use `go-kibana-rest` synthetics monitor methods for that HTTP request
+
+### Requirement: Write path — type-specific API request fields (REQ-022)
+
+On create and update, the provider SHALL build the API request from the one configured type block. The HTTP type SHALL send `url`, `ssl` config, `max_redirects`, `mode`, `ipv4`, `ipv6`, `username`, `password`, `proxy_header`, `proxy_url`, `response`, and `check`. The TCP type SHALL send `host`, `check_send`, `check_receive`, `proxy_url`, `proxy_use_local_resolver`, and `ssl` config. The ICMP type SHALL send `host` and `wait` (as a string). The browser type SHALL send `inline_script`, `screenshots`, `synthetics_args`, `ignore_https_errors`, and `playwright_options`. If the configured type block is absent (none of the four), the provider SHALL fail with an "Unsupported monitor type config" error diagnostic.
+
+#### Scenario: HTTP fields sent to API
+
+- GIVEN a configuration with an `http` block
+- WHEN create or update runs
+- THEN the provider SHALL build an HTTP-type synthetics monitor request payload including the configured `url` and optional HTTP-specific fields that conform to Kibana’s synthetics HTTP monitor schema
+
+### Requirement: Write path — common config fields (REQ-023)
+
+On create and update, the provider SHALL send common monitor configuration fields: `name`, `schedule`, `locations` (as managed location strings), `private_locations` (as label strings), `enabled`, `tags`, `labels`, `alert`, `service_name` (as `apm_service_name`), `timeout`, `namespace`, `params`, and `retest_on_failure`. When `labels` is null or unknown, the provider SHALL send an empty map rather than null.
+
+#### Scenario: Common fields in create request
+
+- GIVEN a monitor config with `name`, `schedule`, `locations`, and `tags`
+- WHEN create runs
+- THEN the API request SHALL include `name`, `schedule`, `locations`, and `tags` matching the plan values
+
+## ADDED Requirements
+
+### Requirement: OpenAPI-backed implementation placement (REQ-024)
+
+The implementation SHALL define synthetics monitor HTTP client operations in `internal/clients/kibanaoapi` (for example `synthetics_monitor.go`), using types and clients from `github.com/elastic/terraform-provider-elasticstack/generated/kbapi`. The package `internal/kibana/synthetics/monitor` SHALL call those helpers for CRUD and SHALL NOT import `github.com/disaster37/go-kibana-rest/v8/kbapi` for monitor request or response modeling after this migration is complete.
+
+#### Scenario: Code ownership
+
+- GIVEN a maintainer searches for synthetics monitor HTTP calls
+- WHEN they inspect the implementation
+- THEN monitor HTTP calls SHALL be routed through `internal/clients/kibanaoapi` and SHALL rely on `generated/kbapi` for wire types

--- a/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-synthetics-monitor-to-kbapi/tasks.md
@@ -1,0 +1,28 @@
+## 1. Discovery and kbapi surface
+
+- [ ] 1.1 Inventory generated operations and types for `PostSyntheticMonitors`, `GetSyntheticMonitor`, `PutSyntheticMonitor`, `DeleteSyntheticMonitor`, including union body handling and JSON response structs.
+- [ ] 1.2 Compare legacy `go-kibana-rest/v8/kbapi` monitor JSON (from current `toKibanaAPIRequest` / tests) with a sample marshal of generated request types for http/tcp/icmp/browser to confirm field names and discriminators.
+
+## 2. `kibanaoapi` monitor helpers
+
+- [ ] 2.1 Add `internal/clients/kibanaoapi/synthetics_monitor.go` (name may vary) with `CreateMonitor`, `GetMonitor`, `UpdateMonitor`, `DeleteMonitor` functions using `Client.API` / `ClientWithResponses`, space request editors, and consistent error diagnostics.
+- [ ] 2.2 Implement constructors or marshal helpers for `PostSyntheticMonitorsJSONBody` / `PutSyntheticMonitorJSONBody` unions from concrete generated monitor + config structs.
+- [ ] 2.3 Add unit tests for marshal helpers and status handling (at minimum 404 vs error for get).
+
+## 3. Replace legacy client in resource
+
+- [ ] 3.1 Update `create.go`, `read.go`, `update.go`, `delete.go` to obtain `*kibanaoapi.Client` via `synthetics.GetKibanaOAPIClientFromScopedClient` (or equivalent) and call new helpers instead of `kibanaClient.KibanaSynthetics.Monitor.*`.
+- [ ] 3.2 Refactor `schema.go` (and any satellite files) to remove `github.com/disaster37/go-kibana-rest/v8/kbapi` monitor types from public mapping functions; use `generated/kbapi` types or small internal structs.
+- [ ] 3.3 Preserve `enforceVersionConstraints`, composite ID logic, import passthrough, and all plan modifiers / validators unchanged unless a compile error forces an equivalent refactor.
+
+## 4. Tests and verification
+
+- [ ] 4.1 Rewrite `schema_test.go` fixtures to use generated types or test-only wire helpers; keep scenario coverage for all four monitor kinds, SSL branches, alerts, and private locations where present today.
+- [ ] 4.2 Run `go test ./internal/kibana/synthetics/monitor/...` and fix regressions.
+- [ ] 4.3 Run monitor acceptance tests in `acc_test.go` (HTTP/TCP/ICMP/browser, non-default space, labels) against a stack meeting version assumptions; update skips only if OpenAPI behavior documents a new minimum version.
+- [ ] 4.4 Run `make build` and `make check-openspec` (or `make check-lint` if that is the project gate for OpenSpec).
+
+## 5. Cleanup
+
+- [ ] 5.1 Remove unused legacy imports from `internal/kibana/synthetics/monitor`; verify no remaining references to legacy `kbapi` monitor types in that tree.
+- [ ] 5.2 If no other package uses legacy synthetics monitor kbapi types, consider a follow-up change to trim `go-kibana-rest` usage (optional, separate task if scope bleeds).

--- a/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/.openspec.yaml
+++ b/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/design.md
+++ b/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Today `elasticstack_kibana_synthetics_private_location` uses `synthetics.GetKibanaClientFromScopedClient` and `kibanaClient.KibanaSynthetics.PrivateLocation.{Create,Get,Delete}` from `go-kibana-rest`, with Terraform models converting to `kbapi.PrivateLocationConfig` / `kbapi.PrivateLocation` (`internal/kibana/synthetics/privatelocation/schema.go`). Other Synthetics surfaces already use `GetKibanaOAPIClientFromScopedClient` and `internal/clients/kibanaoapi` helpers. The generated Kibana client already exposes `PostPrivateLocationWithResponse`, `GetPrivateLocationWithResponse`, and `DeletePrivateLocationWithResponse` plus `PostPrivateLocationJSONBody` and `SyntheticsGetPrivateLocation` in `generated/kbapi/kibana.gen.go`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement private location CRUD through `kibanaoapi` + `generated/kbapi`, including correct space-prefixed paths for non-default spaces (same effective URLs as today).
+- Remove `go-kibana-rest` kbapi private location types from this resource’s model mapping path.
+- Keep `space_id` 9.4.0-SNAPSHOT gating, composite import ids, `ImportStatePassthroughID`, all `RequiresReplace` plan modifiers, Update-as-error behavior, and `kibana_connection` behavior unchanged from a practitioner perspective.
+- Prove mapping fidelity for `SyntheticsGetPrivateLocation` (including JSON fields not modeled as first-class struct fields but preserved via `AdditionalProperties`, such as `tags` if the OpenAPI model omits them).
+
+**Non-Goals:**
+
+- Regenerating or editing the upstream Kibana OpenAPI spec in this change.
+- Supporting in-place updates or new Terraform attributes.
+- Migrating other `go-kibana-rest` Synthetics code paths beyond this resource.
+
+## Decisions
+
+1. **`kibanaoapi` helper module** — Add functions such as `CreatePrivateLocation`, `GetPrivateLocation`, and `DeletePrivateLocation` (exact names follow repo conventions) that accept `context.Context`, `*kibanaoapi.Client`, effective `spaceID`, location id / body, and return typed results plus `diag.Diagnostics`. Centralize the `kbapi.RequestEditorFn` that rewrites `req.URL.Path` to prefix `/s/<space_id>` when the effective space is not default, matching patterns used elsewhere for space-scoped Kibana routes.
+
+2. **Typed read model vs loose create response** — `GetPrivateLocation` parses JSON200 into `kbapi.SyntheticsGetPrivateLocation`. `PostPrivateLocation` currently exposes `JSON200` as `*map[string]interface{}` in generated code. **Decision:** After a successful POST, normalize the created object by unmarshaling the raw `Body` (or re-encoding the map) into `kbapi.SyntheticsGetPrivateLocation` so create and read share one mapping function to Terraform state. If unmarshaling fails, return a clear diagnostic (do not silently drop fields).
+
+3. **404 handling** — Use HTTP status from `*WithResponse` results (`StatusCode() == 404` on success path with nil JSON, or documented generator behavior) rather than `go-kibana-rest`’s `kbapi.APIError`. Align with other PF resources that use generated clients.
+
+4. **Geo numeric types** — OpenAPI uses `float32` in nested geo structs where Terraform uses `float64`. **Decision:** Convert explicitly at boundaries; document acceptable precision limits (float32) so behavior matches API, not introduce new validation beyond existing schema.
+
+5. **Tags on read** — If `tags` appear only under `AdditionalProperties` on `SyntheticsGetPrivateLocation`, extract them in the mapper with a small, tested helper rather than fork-generating the OpenAPI model.
+
+## Risks / Trade-offs
+
+- **[Risk] Generated POST typing is weak (`map[string]interface{}`)** → **Mitigation:** Always normalize through `SyntheticsGetPrivateLocation` + shared mapper; add unit tests for JSON fixtures.
+
+- **[Risk] OpenAPI model incomplete vs real Kibana JSON** → **Mitigation:** Rely on custom `UnmarshalJSON` / `AdditionalProperties` on `SyntheticsGetPrivateLocation`; acceptance tests plus focused unit tests on tags/geo.
+
+- **[Risk] Space path regression** → **Mitigation:** Reuse the same `RequestEditorFn` approach as other space-aware `kbapi` calls; keep existing acceptance tests for default and non-default space.
+
+## Migration Plan
+
+1. Land `kibanaoapi` helpers and unit-tested mappers.
+2. Switch `privatelocation` create/read/delete to the OpenAPI client; remove legacy imports from that package.
+3. Run `make build`, unit tests for the package, and targeted acceptance tests (`TestSyntheticPrivateLocationResource` and related) on a stack that satisfies test version gates.
+
+## Open Questions
+
+- None blocking proposal: confirm during implementation whether create responses are always JSON-compatible with `SyntheticsGetPrivateLocation` on supported stack versions; if not, extend the normalizer with a narrow fallback for `id`/`label` only and fail closed for inconsistent payloads.

--- a/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The private location resource is one of the remaining Synthetics entities that still depends on `go-kibana-rest` / `kbapi.PrivateLocation*` types for CRUD. Moving it to the generated OpenAPI client (`generated/kbapi` via `kibanaoapi`) aligns it with other migrated Kibana resources, reduces dual-client drift, and makes wire types and responses traceable to the published Kibana OpenAPI spec.
+
+## What Changes
+
+- Add focused `kibanaoapi` helpers for Synthetics private locations (create, get, delete) that call `kbapi.ClientWithResponses` and apply the same space-scoped URL behavior the legacy client used for non-default spaces.
+- Refactor `internal/kibana/synthetics/privatelocation` so schema/model mapping and CRUD use `generated/kbapi` request/response models instead of `github.com/disaster37/go-kibana-rest/v8/kbapi` private location structs.
+- Preserve existing `space_id` version gating (`MinVersionSpaceID` / `requiresSpaceIDMinVersion`), composite import id handling, `RequiresReplace` / no in-place update semantics, and `kibana_connection` scoping.
+- Add validation (unit tests and/or targeted checks) that private location payloads round-trip through the generated read model (`SyntheticsGetPrivateLocation`), including fields that may deserialize into `AdditionalProperties` when the OpenAPI struct is incomplete (notably `tags` if absent from first-class fields).
+
+## Capabilities
+
+### New Capabilities
+
+_None — normative behavior stays under the existing `kibana-synthetics-private-location` capability; this change updates how the provider satisfies those requirements._
+
+### Modified Capabilities
+
+- `kibana-synthetics-private-location`: Replace legacy-client obligations with OpenAPI/`kbapi` obligations for private location CRUD while keeping observable Terraform behavior (import id format, replacement rules, 404 handling, `space_id` gating, connection scoping).
+
+## Impact
+
+- **Code:** `internal/kibana/synthetics/privatelocation` (`schema.go`, `create.go`, `read.go`, `delete.go`, tests), new or extended helpers under `internal/clients/kibanaoapi/`, and `internal/kibana/synthetics/api_client.go` usage patterns (switch from `GetKibanaClient` to `GetKibanaOAPIClient` for this resource).
+- **Dependencies:** Less use of `go-kibana-rest` types in this package; continued use of `github.com/elastic/terraform-provider-elasticstack/generated/kbapi` types.
+- **Specs:** Delta updates under `openspec/specs/kibana-synthetics-private-location` when the change is archived or synced; acceptance tests remain the regression surface for end-to-end behavior.

--- a/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/specs/kibana-synthetics-private-location/spec.md
+++ b/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/specs/kibana-synthetics-private-location/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Synthetics Private Locations API (REQ-001)
+
+The resource SHALL manage private locations through Kibana's Synthetics Private Locations HTTP API using the generated OpenAPI client (`generated/kbapi`) invoked via provider `kibanaoapi` helpers. Create SHALL use the POST private locations endpoint, read SHALL use GET by id, and delete SHALL use DELETE by id. The provider SHALL pass the effective Kibana space derived from `space_id` (per REQ-010) and from composite import identifiers (per REQ-004) into these operations so that requests use the correct space-scoped API paths.
+
+#### Scenario: CRUD uses Private Locations API
+
+- **WHEN** create, read, or delete runs for a managed Synthetics private location
+- **THEN** the provider SHALL use the corresponding Synthetics Private Location OpenAPI operation with the effective space from `space_id` and import resolution rules
+
+### Requirement: API and client error surfacing (REQ-002)
+
+The resource SHALL fail with an error diagnostic when it cannot obtain the Kibana OpenAPI client (`kibanaoapi` / `generated/kbapi`) required for private location operations. Transport errors and unexpected HTTP status codes or unusable response bodies for create, read, and delete SHALL be surfaced as error diagnostics. On read, an HTTP 404 response SHALL cause the resource to be removed from state rather than returning an error.
+
+#### Scenario: Missing Kibana client
+
+- **GIVEN** the resource cannot obtain the scoped Kibana OpenAPI client from provider configuration
+- **WHEN** any CRUD operation runs
+- **THEN** the operation SHALL fail with an error diagnostic
+
+#### Scenario: Read returns 404
+
+- **GIVEN** a private location that no longer exists in Kibana
+- **WHEN** read calls the API and receives a 404 response
+- **THEN** the provider SHALL remove the resource from state
+
+#### Scenario: Create API error
+
+- **GIVEN** a create request
+- **WHEN** the API returns a transport error or unexpected response
+- **THEN** the provider SHALL surface an error diagnostic
+
+### Requirement: Provider-level default Kibana legacy client with optional scoped override (REQ-005)
+
+The resource SHALL use the provider's configured Kibana OpenAPI client by default for create, read, and delete. When `kibana_connection` is configured on the resource, the resource SHALL resolve an effective scoped client from that block and SHALL use the scoped Kibana OpenAPI client for create, read, and delete.
+
+#### Scenario: Standard provider connection
+
+- **WHEN** `kibana_connection` is not configured on the resource
+- **THEN** all private location API operations SHALL use the provider-level Kibana OpenAPI client
+
+#### Scenario: Scoped Kibana connection
+
+- **WHEN** `kibana_connection` is configured on the resource
+- **THEN** all private location API operations SHALL use the scoped Kibana OpenAPI client derived from that block
+
+## ADDED Requirements
+
+### Requirement: Generated private location model mapping (REQ-012)
+
+The resource SHALL map API responses onto Terraform state using `kbapi.SyntheticsGetPrivateLocation` as the canonical decoded representation for successful GET responses and for normalized POST success payloads. The mapping layer SHALL populate `id`, `label`, `agent_policy_id`, optional `tags`, and optional `geo` without silent loss of API-returned values, including values deserialized into `AdditionalProperties` when they are not first-class fields on the generated struct. The implementation SHALL include automated tests (for example JSON fixture tests or table-driven mapper tests) that assert round-trip fidelity for representative payloads.
+
+#### Scenario: Tags round-trip when present in API JSON
+
+- **GIVEN** a GET (or normalized POST) JSON body that includes a `tags` array for the private location
+- **WHEN** the provider maps the body into state
+- **THEN** the Terraform `tags` attribute SHALL match the API values
+
+#### Scenario: Geo round-trip
+
+- **GIVEN** a GET JSON body that includes `geo` coordinates
+- **WHEN** the provider maps the body into state
+- **THEN** the Terraform `geo` object SHALL reflect the API `lat` and `lon` values within float32 precision

--- a/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-synthetics-private-location-to-kbapi/tasks.md
@@ -1,0 +1,28 @@
+## 1. `kibanaoapi` private location helpers
+
+- [ ] 1.1 Add a new source file under `internal/clients/kibanaoapi/` implementing `CreatePrivateLocation`, `GetPrivateLocation`, and `DeletePrivateLocation` (or equivalent names consistent with sibling helpers) using `client.API.PostPrivateLocationWithResponse`, `GetPrivateLocationWithResponse`, and `DeletePrivateLocationWithResponse`.
+- [ ] 1.2 Apply a shared `kbapi.RequestEditorFn` that prefixes `/s/<space_id>` to the request path when the effective Kibana space is non-default (and treats `default` like the default space), matching existing legacy URL behavior.
+- [ ] 1.3 Map HTTP failures to `diag.Diagnostics` using patterns from nearby `kibanaoapi` packages (status code, body snippet); treat GET 404 as a sentinel the resource layer can convert to state removal.
+
+## 2. Wire model and schema away from `go-kibana-rest`
+
+- [ ] 2.1 Replace `kbapi.PrivateLocationConfig`, `kbapi.PrivateLocation`, and `kbapi.SyntheticGeoConfig` usages in `internal/kibana/synthetics/privatelocation/schema.go` with `kbapi.PostPrivateLocationJSONBody` / `kbapi.SyntheticsGetPrivateLocation` (and nested geo structs) or small local DTOs that convert cleanly at the boundary.
+- [ ] 2.2 Implement a single `privateLocationFromAPI(loc kbapi.SyntheticsGetPrivateLocation, spaceID string, kibanaConnection types.List) tfModelV0` (or equivalent) that reads `AdditionalProperties["tags"]` when needed.
+- [ ] 2.3 Implement `privateLocationToCreateBody(m tfModelV0) kbapi.PostPrivateLocationJSONRequestBody` including optional `Tags` as `*[]string` and optional `Geo` with explicit float32 conversion.
+
+## 3. CRUD migration
+
+- [ ] 3.1 Update `create.go` to call `synthetics.GetKibanaOAPIClientFromScopedClient`, enforce existing `requiresSpaceIDMinVersion` + `EnforceMinVersion` logic unchanged, invoke the new helper, and set state from the normalized `SyntheticsGetPrivateLocation`.
+- [ ] 3.2 Update `read.go` to use the OpenAPI client and helpers; preserve composite id parsing, `effectiveSpaceID`, 404 → `RemoveResource`, and version gating diagnostics.
+- [ ] 3.3 Update `delete.go` similarly; preserve composite id handling and version gating.
+- [ ] 3.4 Remove unused legacy client imports from the `privatelocation` package and ensure `resource.go` / `Update` messaging still matches REQ-006.
+
+## 4. Tests and validation
+
+- [ ] 4.1 Add unit tests for JSON → `SyntheticsGetPrivateLocation` → Terraform model mapping, including a fixture with `tags` and `geo` (and, if applicable, `AdditionalProperties` for tags).
+- [ ] 4.2 Add a focused test that POST success `Body` normalization into `SyntheticsGetPrivateLocation` succeeds for a representative create response payload.
+- [ ] 4.3 Run `make build` and `go test` for affected packages; run `TestSyntheticPrivateLocationResource` (and import / non-default space variants) against a stack meeting existing version gates documented in `dev-docs/high-level/testing.md`.
+
+## 5. Spec hygiene
+
+- [ ] 5.1 After implementation, run `make check-openspec` (or `openspec validate` as prescribed by repo docs) and resolve any validation issues for this change directory.

--- a/openspec/changes/remove-deprecated-kibana-clients/.openspec.yaml
+++ b/openspec/changes/remove-deprecated-kibana-clients/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/remove-deprecated-kibana-clients/design.md
+++ b/openspec/changes/remove-deprecated-kibana-clients/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Today the repository still ships a second Kibana OpenAPI client under `generated/slo` (produced by `make generate-slo-client` from `generated/slo-spec.yml`) and patches `github.com/disaster37/go-kibana-rest/v8` through a local `replace` into `libs/go-kibana-rest`. Multiple OpenSpec changes are migrating individual resources to `generated/kbapi` and `internal/clients/kibanaoapi`. This change is **migration plan item 9**: once those consumers are gone, delete the legacy trees and module wiring so only the consolidated kbapi stack remains.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Eliminate `generated/slo` from the repository (sources, generator inputs used only for that tree, and Makefile/CI hooks).
+- Eliminate `github.com/disaster37/go-kibana-rest/v8` from `go.mod` and eliminate the `libs/go-kibana-rest` fork directory when it exists solely for the replace directive.
+- Prove absence of deprecated imports and update contributor-facing docs that still mention the old paths.
+
+**Non-Goals:**
+
+- Migrating any remaining resource logic to kbapi (that belongs in the earlier per-entity migration changes).
+- Changing Terraform schema or runtime behavior of resources except as required to compile after dependency removal (there should be no such need if preconditions are met).
+- Replacing `go-kibana-rest` with a different third-party Kibana client; the single supported path is `generated/kbapi`.
+
+## Decisions
+
+1. **Strict sequencing** — Implementation runs only after the kbapi migrations that still reference `generated/slo` or `go-kibana-rest` are merged on the target branch. **Rationale:** Avoids a broken intermediate state. **Alternative:** delete packages first — rejected as it would not compile.
+
+2. **Delete generator inputs with the package** — Remove `generated/slo-spec.yml` if the Makefile is the only consumer, so contributors are not tempted to revive the old generator. **Rationale:** Single source of truth for SLO shapes lives in the kbapi OpenAPI pipeline. **Alternative:** keep the YAML archived — rejected unless legal/product needs require retaining it (not assumed here).
+
+3. **`generate-clients` becomes kbapi-only** — After removal, `generate-clients` SHALL depend only on `gen` (or equivalent documented aggregate that does not reference `generated/slo`). **Rationale:** Preserves a familiar “regenerate everything” entrypoint without resurrecting the SLO split.
+
+4. **Module cleanup** — Remove both `require` and `replace` for `go-kibana-rest`, delete `libs/go-kibana-rest`, then `go mod tidy`. **Rationale:** A dangling replace or empty directory confuses Renovate and new contributors.
+
+## Risks / Trade-offs
+
+- **[Risk] Preconditions not actually met** — A hidden import in tests or tools could reappear on rebase. **Mitigation:** Mandatory `rg` / `go list`/compile gate in tasks; run full `go test ./...` and `make build`.
+
+- **[Risk] CI or release scripts invoke `generate-slo-client`** — Removing the target breaks jobs. **Mitigation:** Grep workflows and `Makefile` callers in tasks; update or delete those steps.
+
+- **[Risk] External forks depend on `libs/go-kibana-rest` in this repo** — Unlikely for the provider module, but if discovered, document fork removal in proposal Impact. **Mitigation:** Confirm no submodule or cross-module reference before deleting the directory.
+
+## Migration Plan
+
+1. Merge all prerequisite kbapi migration changes; confirm default branch has zero imports of deprecated paths.
+2. Apply this change: delete trees, edit Makefile and `go.mod`, refresh docs, verify build and tests.
+3. Rollback: revert the single cleanup commit (or branch) if a missed import is found post-merge; no runtime feature flag is involved.
+
+## Open Questions
+
+- Whether `generated/slo-spec.yml` must be retained for compliance or historical comparison; default assumption is **delete** if unused outside the removed Makefile target.

--- a/openspec/changes/remove-deprecated-kibana-clients/proposal.md
+++ b/openspec/changes/remove-deprecated-kibana-clients/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The provider still carries two deprecated Kibana HTTP stacks (`github.com/disaster37/go-kibana-rest/v8` via the vendored `libs/go-kibana-rest` fork and the standalone OpenAPI package under `generated/slo`). Those duplicates complicate auth, transport, regeneration, and dependency hygiene. They should be removed only as a **final cleanup** once every in-repo consumer has moved to `generated/kbapi` and `internal/clients/kibanaoapi`, so this change is explicitly sequenced **after** the outstanding kbapi migration changes land.
+
+## What Changes
+
+- Delete the `generated/slo` Go package and remove **all** imports of `github.com/elastic/terraform-provider-elasticstack/generated/slo` from provider and test code.
+- Remove Makefile targets, Docker/OpenAPI generator wiring, and any repository inputs used **only** to produce `generated/slo` (including `generate-slo-client`, `generated/slo-spec.yml` if nothing else references it, and `generate-clients` chaining into that path).
+- Remove `github.com/disaster37/go-kibana-rest/v8` from the root module: drop the `require` entry, delete the `replace github.com/disaster37/go-kibana-rest/v8 => ./libs/go-kibana-rest` directive, remove the `libs/go-kibana-rest` tree when it exists only to satisfy that replace, and run `go mod tidy` so the module graph is clean.
+- Search the tree (including workflows, scripts, and contributor docs that describe deprecated paths) and confirm **no** remaining references to the deprecated import paths or generators; align high-level dev docs that still list deprecated clients.
+- **BREAKING** for contributors who relied on `make generate-slo-client` or direct use of `libs/go-kibana-rest`: those workflows are removed; Kibana client work uses `generated/kbapi` / `make gen` (and related documented targets) only.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-go-module-kibana-clients`: Normative requirements that the root Go module and source tree exclude deprecated Kibana client packages (`github.com/disaster37/go-kibana-rest/v8`, `github.com/elastic/terraform-provider-elasticstack/generated/slo`) and the vendored fork directory once migrations are complete.
+
+### Modified Capabilities
+
+- `makefile-workflows`: Remove standalone SLO OpenAPI generation (`generate-slo-client`) and redefine `generate-clients` so it no longer depends on or produces `generated/slo`; update the delta to remove the old requirement and add a consolidated codegen requirement.
+
+## Impact
+
+- **Preconditions:** This change **MUST NOT** start until prior migration changes have merged so that no package imports `generated/slo` or `github.com/disaster37/go-kibana-rest/v8`. Concretely, that includes (at minimum) the OpenSpec-tracked kbapi migrations such as `migrate-kibana-slo-to-kbapi`, `migrate-kibana-spaces-to-kbapi`, `migrate-kibana-security-role-to-kbapi`, `migrate-kibana-synthetics-monitor-to-kbapi`, `migrate-kibana-synthetics-private-location-to-kbapi`, and `migrate-kibana-import-saved-objects-to-kbapi`, plus any other in-flight changes still touching those import paths. If a straggling reference remains, complete or supersede that work before applying this cleanup.
+- **Build / codegen:** Root `Makefile`, possible CI references to `generate-slo-client`, `go.mod` / `go.sum`, directory `libs/go-kibana-rest`, directory `generated/slo`, and `generated/slo-spec.yml` when unused elsewhere.
+- **Documentation:** `dev-docs/high-level/generated-clients.md`, `dev-docs/high-level/coding-standards.md`, and any other docs or comments that mention the deprecated clients or Makefile targets.
+- **Verification:** `go test ./...`, `make build`, and repository-wide search (for example `rg`) for forbidden import paths; `openspec validate` after spec deltas are written.

--- a/openspec/changes/remove-deprecated-kibana-clients/specs/makefile-workflows/spec.md
+++ b/openspec/changes/remove-deprecated-kibana-clients/specs/makefile-workflows/spec.md
@@ -1,0 +1,23 @@
+## REMOVED Requirements
+
+### Requirement: SLO client generation (REQ-064–REQ-065)
+
+**Reason:** Kibana SLO and other migrated surfaces use the shared OpenAPI client under `generated/kbapi`; maintaining a separate `generated/slo` generator and Docker-based pipeline is obsolete once all consumers are migrated.
+
+**Migration:** Complete and merge the kbapi migration changes that remove `generated/slo` and `go-kibana-rest` imports; regenerate Kibana clients via the `gen` / `generated/kbapi` workflow documented for the provider. Use `make generate-clients` only after it has been retargeted to kbapi-only codegen per the ADDED requirement below.
+
+## ADDED Requirements
+
+### Requirement: Consolidated Kibana client codegen (`generate-clients`)
+
+The `generate-clients` target SHALL run the repository’s general Kibana/OpenAPI codegen path (`gen`) and SHALL NOT invoke a separate OpenAPI generation step that writes under `generated/slo`. The Makefile SHALL NOT define a `generate-slo-client` target.
+
+#### Scenario: generate-clients does not produce generated/slo
+
+- **WHEN** `make generate-clients` completes successfully on a clean checkout after this change
+- **THEN** the recipe SHALL NOT run OpenAPI generation dedicated to a `generated/slo` package path
+
+#### Scenario: Deprecated SLO generator target absent
+
+- **WHEN** a contributor inspects the root Makefile for SLO-specific client generation
+- **THEN** there SHALL be no `generate-slo-client` phony target or equivalent recipe that populated `generated/slo`

--- a/openspec/changes/remove-deprecated-kibana-clients/specs/provider-go-module-kibana-clients/spec.md
+++ b/openspec/changes/remove-deprecated-kibana-clients/specs/provider-go-module-kibana-clients/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: No standalone generated SLO client in the module graph
+
+The provider’s Go packages SHALL NOT import `github.com/elastic/terraform-provider-elasticstack/generated/slo`. The repository SHALL NOT ship a `generated/slo` Go module tree as part of the build after this change.
+
+#### Scenario: Source tree free of generated/slo imports
+
+- **WHEN** static analysis or `go test`/`go build` runs across `./...` at the repository root
+- **THEN** no package SHALL import the `generated/slo` module path
+
+### Requirement: No go-kibana-rest module dependency
+
+The root `go.mod` SHALL NOT contain a `require` directive for `github.com/disaster37/go-kibana-rest/v8` and SHALL NOT contain a `replace` directive mapping that module path to `./libs/go-kibana-rest` (or any other local path). After removal, `go mod tidy` SHALL leave no requirement edge to that module for the provider.
+
+#### Scenario: Module file excludes legacy client
+
+- **WHEN** a reviewer opens the root `go.mod` after this change
+- **THEN** neither `github.com/disaster37/go-kibana-rest/v8` nor a `replace` stanza for it SHALL appear
+
+### Requirement: Vendored go-kibana-rest fork removed
+
+The directory `libs/go-kibana-rest` SHALL NOT remain in the repository when its sole purpose was to satisfy the removed `replace` directive for `github.com/disaster37/go-kibana-rest/v8`.
+
+#### Scenario: Fork directory absent
+
+- **WHEN** the change is applied and the branch builds successfully
+- **THEN** the path `libs/go-kibana-rest` SHALL not exist in the tree (unless a separate, explicitly scoped follow-up documents a different use — out of scope for this change; default is deletion)
+
+### Requirement: No legacy Kibana REST import paths in provider code
+
+No first-party Go source under the provider module (for example `internal/`, `generated/kbapi` consumers, tools owned by this repo) SHALL import `github.com/disaster37/go-kibana-rest/v8` or subpackages such as `github.com/disaster37/go-kibana-rest/v8/kbapi`.
+
+#### Scenario: Repository search shows no deprecated imports
+
+- **WHEN** a maintainer searches the repository for `disaster37/go-kibana-rest` and `terraform-provider-elasticstack/generated/slo`
+- **THEN** no matches SHALL appear in first-party Go sources, the root `Makefile`, or GitHub Actions workflow definitions under `.github/workflows/`

--- a/openspec/changes/remove-deprecated-kibana-clients/tasks.md
+++ b/openspec/changes/remove-deprecated-kibana-clients/tasks.md
@@ -1,0 +1,22 @@
+## 1. Preconditions and inventory
+
+- [ ] 1.1 Confirm on the integration branch that all kbapi migration changes that touch `generated/slo` or `github.com/disaster37/go-kibana-rest/v8` are merged (or explicitly superseded) so this cleanup can compile.
+- [ ] 1.2 Run `rg 'generated/slo|disaster37/go-kibana-rest'` from the repository root; resolve any hits outside `openspec/changes/**/archive/**` and historical change folders before proceeding.
+
+## 2. Remove generated/slo and its generator
+
+- [ ] 2.1 Delete the `generated/slo` directory and remove `generate-slo-client` from the root `Makefile`; retarget `generate-clients` to invoke only `gen` (or the documented kbapi aggregate) with no dependency on a SLO-only generator.
+- [ ] 2.2 Delete `generated/slo-spec.yml` if nothing else references it after Makefile removal; otherwise document the exception in the change implementation notes.
+- [ ] 2.3 Search `.github/workflows`, scripts, and `contributing.md` / other automation for `generate-slo-client` or `generated/slo` and update or remove those references.
+
+## 3. Remove go-kibana-rest module wiring
+
+- [ ] 3.1 Remove the `require` and `replace` entries for `github.com/disaster37/go-kibana-rest/v8` from root `go.mod`; run `go mod tidy` and commit the resulting `go.sum` updates as part of the implementation PR (not this proposal PR).
+- [ ] 3.2 Delete `libs/go-kibana-rest` when it exists only as the fork for that replace; confirm no other module or tooling path depends on it.
+
+## 4. Documentation and verification
+
+- [ ] 4.1 Update `dev-docs/high-level/generated-clients.md` and `dev-docs/high-level/coding-standards.md` (and any other contributor docs found in 1.2) so they no longer instruct use of `generated/slo` or `libs/go-kibana-rest`.
+- [ ] 4.2 Run `make build` and `go test ./...` at minimum; fix any compile or test drift from removed packages.
+- [ ] 4.3 Re-run forbidden-path search from 1.2; ensure only benign matches remain (for example archived OpenSpec text if allowed by policy).
+- [ ] 4.4 Run `openspec validate` for this change after implementation (or `make check-openspec` per repo workflow) so delta specs and tasks stay coherent.

--- a/openspec/changes/remove-legacy-kibana-client-wiring/.openspec.yaml
+++ b/openspec/changes/remove-legacy-kibana-client-wiring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/remove-legacy-kibana-client-wiring/design.md
+++ b/openspec/changes/remove-legacy-kibana-client-wiring/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`internal/clients/kibana_scoped_client.go` and `internal/clients/api_client.go` still depend on `*kibana.Client` from `go-kibana-rest` for `KibanaStatus.Get()` when Elasticsearch is not configured (`APIClient`) and for all `KibanaScopedClient` version and flavor checks. The generated Kibana client already exposes `/api/status` as `GetStatus` / `GetStatusWithResponse` (`generated/kbapi`), and `internal/clients/kibanaoapi` is the established wrapper layer for auth, errors, and typed calls. Many resources still call `GetKibanaClient()` for CRUD; this change is intentionally sequenced **after** those migrations so wiring can drop the legacy pointer without leaving dead imports or broken packages.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Single HTTP stack for Kibana status reads used by `ServerVersion` / `ServerFlavor` on `KibanaScopedClient` and the Kibana-only branches of `APIClient`.
+- Remove `*kibana.Client` fields and `GetKibanaClient()` from `APIClient` and `KibanaScopedClient` once no in-repo production code requires them.
+- Delete `internal/kibana/synthetics/api_client.go` legacy accessors when no callers remain.
+- Keep user-visible behavior for version constraints and serverless detection aligned with today (same version string source, same empty flavor when `build_flavor` is absent).
+
+**Non-Goals:**
+
+- Migrating individual resources in this change (covered by separate OpenSpec changes per entity).
+- Changing Elasticsearch-backed `APIClient.ServerVersion` / `ServerFlavor` when an Elasticsearch client is configured (existing split behavior remains).
+- Removing `libs/go-kibana-rest` from the repository entirely unless the module has zero references after wiring and resource migrations (may remain for examples or transitional tooling per repo policy).
+
+## Decisions
+
+1. **Status implementation path** — Implement a small helper in `internal/clients/kibanaoapi` (for example `GetKibanaStatus` or parse helpers used by `clients` package) that calls `ClientWithResponses.GetStatusWithResponse`, maps HTTP errors to Terraform diagnostics consistent with other `kibanaoapi` helpers, and unmarshals `version.number` and optional `version.build_flavor` from the response body. **Rationale:** Keeps raw OpenAPI usage out of duplicated logic and matches other resources. **Alternative considered:** Call `kbapi` directly from `kibana_scoped_client.go`; rejected to avoid scattering HTTP policy.
+
+2. **Handling weakly typed `GetStatus` JSON** — The generator may surface `JSON200` as an opaque union. **Decision:** Unmarshal from `GetStatusResponse.Body` (or documented JSON200 path) into a minimal local DTO `{ Version struct { Number string; BuildFlavor *string } }` with `encoding/json` rather than relying on legacy `map[string]any`. **Rationale:** Stable parsing and explicit fields; easier tests. **Alternative:** Keep map-based parsing for parity with legacy; acceptable if generator makes typed decode impractical.
+
+3. **Context threading** — Pass `context.Context` into status helpers (update `ServerVersion` / `ServerFlavor` on `KibanaScopedClient` to use ctx on the wire path where today `_ context.Context` is ignored for legacy). **Rationale:** Correct cancellation and tracing for acceptance tests and long applies.
+
+4. **Synthetics helpers** — Remove `GetKibanaClient` / `GetKibanaClientFromScopedClient` only after the last synthetics (and any other) package stops importing them; consolidate callers on `GetKibanaOAPIClientFromScopedClient` or resource-local `kibanaoapi` usage.
+
+## Risks / Trade-offs
+
+- **[Risk] Subtle JSON or status-code differences** between legacy `KibanaStatus.Get()` and generated `/api/status` → **Mitigation:** Golden or fixture tests for status JSON; run targeted acceptance tests for version-gated resources (synthetics, spaces, etc.).
+- **[Risk] Build breaks if prerequisite migrations slip** → **Mitigation:** Gate this change behind a checklist in `tasks.md`; CI compile catches stragglers.
+- **[Risk] Duplicate status calls** if both `ServerVersion` and `ServerFlavor` fetch full status sequentially → **Mitigation:** Optional small cache on `KibanaScopedClient` for a single apply step (only if profiling shows pain; default is clarity over micro-optimization).
+
+## Migration Plan
+
+1. Complete all resource-level migrations that still require `GetKibanaClient()` for Kibana CRUD (tracked by their respective OpenSpec changes).
+2. Land status helper on `kibanaoapi` and switch `KibanaScopedClient` / `APIClient` Kibana-only paths.
+3. Remove legacy client construction from `buildKibanaClient` / factory / `APIClient` struct; fix compile errors by updating remaining call sites (should be none if step 1 is done).
+4. Delete `internal/kibana/synthetics/api_client.go` if reduced to legacy-only functions; keep `GetKibanaOAPIClient*` in a remaining file if still needed.
+5. Run `make build` and targeted acceptance tests per `dev-docs/high-level/testing.md`.
+6. If `go list` shows no `go-kibana-rest` imports, trim `go.mod` / `replace` in a final task or follow-up change per scope.
+
+## Open Questions
+
+- Whether `GetStatusParams` (for example `getStatusSummary`) needs to be set for serverless or large payloads; default to generator defaults unless product requires a flag.
+- Whether any SDK-only code paths still need a bare `*kibana.Client` for non-status operations after migrations; if yes, those resources block step 3.

--- a/openspec/changes/remove-legacy-kibana-client-wiring/proposal.md
+++ b/openspec/changes/remove-legacy-kibana-client-wiring/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+After per-resource migrations off `github.com/disaster37/go-kibana-rest` (`libs/go-kibana-rest`), the provider still constructs and threads a legacy `*kibana.Client` through `*clients.APIClient`, `*clients.KibanaScopedClient`, and small helper packages solely to read Kibana status (version and flavor) and to satisfy historical `GetKibanaClient()` call sites. That duplicates HTTP stacks, keeps the forked module in the dependency graph, and blocks fully retiring the legacy client. This change finishes the wiring layer by using `generated/kbapi` status calls for the same facts and removing the legacy surface from shared provider types.
+
+**Prerequisite:** This work MUST land only after the outstanding Kibana resource and data source migrations that still call `GetKibanaClient()` / `synthetics.GetKibanaClientFromScopedClient` (or otherwise depend on the legacy client for CRUD) are complete. Attempting it earlier would break compilation or runtime behavior for unmigrated entities.
+
+## What Changes
+
+- Replace `KibanaScopedClient.ServerVersion` / `ServerFlavor` (and any equivalent paths in `APIClient` that read Kibana-only status via `kibClient.KibanaStatus.Get()`) with calls through the existing OpenAPI stack (`generated/kbapi` `GetStatus` / `GetStatusWithResponse`, typically via `internal/clients/kibanaoapi` helpers) using the same scoped credentials and base URL as today’s `kibanaoapi` client.
+- Remove the legacy `*kibana.Client` field and `GetKibanaClient()` from `*clients.KibanaScopedClient` and `*clients.APIClient`, and stop building `kibana.NewClient` in provider wiring once nothing in-tree requires it for status or CRUD.
+- Remove helper surfaces that exist only to obtain the legacy client from a scoped client, including `internal/kibana/synthetics/api_client.go` (`GetKibanaClient`, `GetKibanaClientFromScopedClient`) **after** all call sites are migrated to `GetKibanaOapiClient` / `GetKibanaOAPIClientFromScopedClient` (or direct `kibanaoapi` usage).
+- Update `ProviderClientFactory` / acceptance test helpers / any tests that assumed a legacy Kibana client was always present on `APIClient` or `KibanaScopedClient`.
+- Optional follow-on (same change if trivial, otherwise noted in tasks): trim `go.mod` / `replace` directives for `go-kibana-rest` if no remaining imports exist anywhere in the module (including tests and `libs/go-kibana-rest` vendoring policy per repo conventions).
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `provider-kibana-connection`: Update the Framework/SDK scoped-client requirements so the factory-built `*clients.KibanaScopedClient` no longer includes or rebuilds a legacy Kibana REST client; clarify that version and flavor checks remain scoped to the effective Kibana connection but are satisfied via the OpenAPI client path.
+- `provider-client-factory`: Update the typed Kibana-scoped client contract so it no longer lists a legacy Kibana client as a required surface; keep OpenAPI, SLO, Fleet, auth helpers, and version/flavor behavior required for covered entities.
+
+## Impact
+
+- **Code:** `internal/clients/kibana_scoped_client.go`, `internal/clients/api_client.go`, `internal/clients/provider_client_factory.go` (and related constructors), tests under `internal/clients/`, `internal/kibana/synthetics/api_client.go` (delete when unused), any remaining `GetKibanaClient()` usages across `internal/kibana/**`, `internal/fleet/**`, and SDK resources.
+- **Dependencies:** Reduced or eliminated direct use of `github.com/disaster37/go-kibana-rest/v8` from provider wiring; `generated/kbapi` becomes the single HTTP path for Kibana `/api/status` in these flows.
+- **Risk:** Status JSON parsing may differ from the legacy client’s `map[string]any` shape; implementation must preserve current semantics for `version.number` and `version.build_flavor` (including absent `build_flavor` on older Kibanas) and preserve scoped-connection behavior required by existing specs.

--- a/openspec/changes/remove-legacy-kibana-client-wiring/specs/provider-client-factory/spec.md
+++ b/openspec/changes/remove-legacy-kibana-client-wiring/specs/provider-client-factory/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Factory supports phased migration
+During the Kibana/Fleet typed-client phase, the `*clients.ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and SHALL also preserve explicit legacy Elasticsearch resolution methods so unconverted Elasticsearch entities continue to behave as they did before the factory migration.
+
+#### Scenario: Kibana entity resolves typed client
+- **WHEN** a Kibana or Fleet entity resolves its effective client through the factory
+- **THEN** the factory SHALL return a typed Kibana-scoped client whose surfaces include the Kibana OpenAPI client, SLO client, and Fleet client for their respective operations
+
+#### Scenario: Elasticsearch entity uses transitional legacy resolution
+- **WHEN** an unconverted Elasticsearch entity resolves its effective client during this phase
+- **THEN** the factory SHALL expose a transitional resolution path that preserves the existing broad-client and lint-enforced Elasticsearch behavior
+
+### Requirement: Kibana scoped client contract
+The typed Kibana-scoped client returned by the factory SHALL expose the Kibana OpenAPI client, SLO client, Fleet client, Kibana auth-context helpers, and Kibana-derived version and flavor checks required by covered Kibana and Fleet entities. The typed Kibana-scoped client SHALL NOT expose `github.com/disaster37/go-kibana-rest` as part of the provider wiring contract once all dependent Kibana and Fleet resources have completed their per-entity migrations off the legacy client.
+
+#### Scenario: Scoped client supports Kibana and Fleet operations
+- **WHEN** a covered Kibana or Fleet entity uses a typed Kibana-scoped client
+- **THEN** the client SHALL provide the typed client surfaces needed for Kibana HTTP workloads through the OpenAPI client, plus SLO and Fleet API operations as applicable
+
+#### Scenario: Scoped client supports version gating
+- **WHEN** a covered Kibana or Fleet entity performs version or flavor checks through the typed Kibana-scoped client
+- **THEN** the client SHALL provide `ServerVersion()`, `ServerFlavor()`, or equivalent typed behavior needed for those checks

--- a/openspec/changes/remove-legacy-kibana-client-wiring/specs/provider-kibana-connection/spec.md
+++ b/openspec/changes/remove-legacy-kibana-client-wiring/specs/provider-kibana-connection/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Framework scoped Kibana client resolution
+The provider SHALL expose Plugin Framework `kibana_connection` resolution through `*clients.ProviderClientFactory` methods that accept an entity-local `kibana_connection` block and return a `*clients.KibanaScopedClient`. When the block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
+
+#### Scenario: Framework factory falls back to provider defaults
+- **WHEN** a Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` derived from provider configuration
+
+#### Scenario: Framework factory builds a scoped Kibana-derived client
+- **WHEN** a Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` rebuilt from that connection for Kibana HTTP operations via the OpenAPI client, SLO, and Fleet operations
+
+### Requirement: SDK scoped Kibana client resolution
+The provider SHALL expose SDK `kibana_connection` resolution through `*clients.ProviderClientFactory` methods that accept resource or data source state and return a `*clients.KibanaScopedClient`. When the block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`.
+
+#### Scenario: SDK factory falls back to provider defaults
+- **WHEN** an SDK entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` derived from provider configuration
+
+#### Scenario: SDK factory builds a scoped Kibana-derived client
+- **WHEN** an SDK entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` rebuilt from that connection for Kibana HTTP operations via the OpenAPI client, SLO, and Fleet operations
+
+## ADDED Requirements
+
+### Requirement: Scoped Kibana status reads use OpenAPI client
+For `*clients.KibanaScopedClient`, implementations that need the Kibana server version number or build flavor SHALL obtain them from the Kibana `/api/status` response using the generated OpenAPI Kibana client (`generated/kbapi`) for the same effective scoped Kibana connection (via `internal/clients/kibanaoapi` or equivalent provider-internal wiring). The provider SHALL NOT depend on `github.com/disaster37/go-kibana-rest` for this status read after this change is complete. When `version.build_flavor` is absent (older Kibana releases), the flavor result SHALL be an empty string, matching prior behavior for traditional deployments.
+
+#### Scenario: Scoped version uses OpenAPI status
+- **WHEN** a covered entity uses `ServerVersion()` on a `*clients.KibanaScopedClient` resolved from `kibana_connection` or provider defaults
+- **THEN** the version SHALL be derived from `version.number` in the `/api/status` payload retrieved through the OpenAPI client for that scoped connection
+
+#### Scenario: Scoped flavor uses OpenAPI status
+- **WHEN** a covered entity uses `ServerFlavor()` on a `*clients.KibanaScopedClient` resolved from `kibana_connection` or provider defaults
+- **THEN** the flavor SHALL be derived from `version.build_flavor` when present in that same `/api/status` payload and SHALL otherwise be an empty string

--- a/openspec/changes/remove-legacy-kibana-client-wiring/tasks.md
+++ b/openspec/changes/remove-legacy-kibana-client-wiring/tasks.md
@@ -1,0 +1,28 @@
+## 1. Preconditions (blocking)
+
+- [ ] 1.1 Confirm every Kibana/Fleet resource and data source that still imports `github.com/disaster37/go-kibana-rest` or calls `(*clients.KibanaScopedClient).GetKibanaClient()` / `synthetics.GetKibanaClientFromScopedClient` for CRUD has merged its kbapi migration (tracked OpenSpec changes such as `migrate-kibana-*-to-kbapi`, `finish-kibana-synthetics-parameter-kbapi`, and related items on the migration plan).
+- [ ] 1.2 Run `go list` / `rg 'disaster37/go-kibana-rest'` on `internal/` and fix any remaining stragglers before deleting wiring; this change MUST NOT merge while production packages still require the legacy client.
+
+## 2. Status and version wiring
+
+- [ ] 2.1 Add `internal/clients/kibanaoapi` helper(s) that call `generated/kbapi` `GetStatusWithResponse` (or equivalent) with the same HTTP client and request editors as other helpers, returning parsed `version.number` and optional `version.build_flavor` plus consistent error diagnostics on non-2xx or decode failures.
+- [ ] 2.2 Refactor `(*KibanaScopedClient).ServerVersion` and `ServerFlavor` in `internal/clients/kibana_scoped_client.go` to use the helper from 2.1 with `GetKibanaOapiClient()`, remove `GetKibanaClient()` and the legacy `kibana` field from the struct, and adjust `kibanaScopedClientFromAPIClient` accordingly.
+- [ ] 2.3 Refactor `(*APIClient).versionFromKibana` and `flavorFromKibana` in `internal/clients/api_client.go` to use the same helper path (via `kibanaoapi` on the API client’s OpenAPI client) instead of `GetKibanaClient().KibanaStatus.Get()`.
+
+## 3. Remove legacy client from shared types
+
+- [ ] 3.1 Remove `kibana` / legacy-related fields, `GetKibanaClient()`, and `buildKibanaClient` usage from `APIClient` construction paths (`NewAPIClientFromFramework`, SDK constructor, `NewAcceptanceTestingClient`, etc.) once no callers need them; retain debug transport behavior on the HTTP client shared with `kibanaoapi` where applicable.
+- [ ] 3.2 Update `internal/clients/provider_client_factory.go` (and any scoped rebuild helpers) so scoped clients are built without instantiating `kibana.NewClient`.
+- [ ] 3.3 Fix all compile breaks: replace remaining `GetKibanaClient()` usages in tests and resources with `GetKibanaOapiClient()` + `kibanaoapi` helpers or entity-specific kbapi paths.
+
+## 4. Delete legacy-only helper surfaces
+
+- [ ] 4.1 Remove `GetKibanaClient` and `GetKibanaClientFromScopedClient` from `internal/kibana/synthetics/api_client.go` when zero references remain; if the file only contains OpenAPI helpers afterward, consider inlining `GetKibanaOAPIClient*` next to call sites or keeping a slim `api_client.go` without `go-kibana-rest` imports.
+- [ ] 4.2 Search for other packages whose sole purpose is re-exporting the legacy client from scoped wiring; delete or fold into `kibanaoapi` helpers.
+
+## 5. Verification and cleanup
+
+- [ ] 5.1 Update or add unit tests for status parsing and for `ServerVersion` / `ServerFlavor` on `KibanaScopedClient` (including missing `build_flavor` and serverless flavor behavior).
+- [ ] 5.2 Run `make build` and targeted acceptance tests for version-gated Kibana resources per `dev-docs/high-level/testing.md`.
+- [ ] 5.3 Run `make check-openspec` (or `openspec validate` for this change) and address any spec or schema issues.
+- [ ] 5.4 If the module has no remaining `go-kibana-rest` imports, remove the dependency from `go.mod` / tidy; otherwise document the residual owners in `design.md` open questions and leave a follow-up task.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec planning documents for removing legacy Kibana clients
Adds a set of OpenSpec design, proposal, task, and specification documents that plan the full removal of legacy Kibana clients (`go-kibana-rest` and `generated/slo`) from the provider.

- Documents cover migrating each affected resource (SLO, Spaces, Security Role, Synthetics Monitor, Private Location, Parameters, Saved Objects Import) from `go-kibana-rest` to the generated `kbapi` client via `internal/clients/kibanaoapi` helpers.
- Specifies removal of the `generated/slo` package, the `go-kibana-rest` dependency, its `replace` directive, and the vendored fork directory.
- Defines provider client factory requirements for routing Kibana status (version/flavor) reads through the OpenAPI client instead of `go-kibana-rest`.
- Adds Makefile/workflow specs consolidating Kibana client code generation to the general OpenAPI path, removing the separate SLO generator target.
- No production code is changed in this PR; all files are planning and specification documents under `openspec/changes/`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25680b4.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->