### PR TITLE
Enforce go embedded config for Config values

### DIFF
--- a/openspec/changes/restrict-static-inline-acceptance-config/.openspec.yaml
+++ b/openspec/changes/restrict-static-inline-acceptance-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/restrict-static-inline-acceptance-config/design.md
+++ b/openspec/changes/restrict-static-inline-acceptance-config/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The current `acceptance-test-config-directory-lint` capability enforces relationships between `Config`, `ConfigDirectory`, `ExternalProviders`, and `ProtoV6ProviderFactories` inside inline `resource.TestCase` literals. That catches ordinary inline-config drift, but it still treats every `ExternalProviders` step with `Config` as valid regardless of whether the Terraform module is a checked-in fixture or an ad hoc string assembled in Go.
+
+This leaves a narrow but recurring exception path in SDK/backwards-compatibility tests: contributors can hide static Terraform modules in raw string literals, `fmt.Sprintf` heredocs, or helper functions that return HCL. The desired repository pattern is stricter and still mechanical: compatibility steps may continue using `Config`, but only when `Config` references a package-level string variable populated by `//go:embed` from `testdata/.../main.tf`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Extend the existing analyzer so it validates the declaration shape behind `resource.TestStep.Config` for `ExternalProviders` compatibility steps.
+- Allow a single accepted compatibility-step config pattern: `Config` points to a package-level embedded string fixture sourced from `testdata/.../main.tf`.
+- Reject mechanically detectable static inline-config patterns defined in Go, including raw literals, `fmt.Sprintf`, concatenation, and helper-returned Terraform modules.
+- Preserve the existing ordinary-step rule set: current-provider steps continue using `ConfigDirectory: acctest.NamedTestCaseDirectory(...)`.
+- Provide diagnostics that tell contributors to move static Terraform into fixture files and load it through `//go:embed`.
+- Add regression tests and migrate existing compatibility tests that still define static Terraform inside Go before enabling the stricter lint behavior.
+
+**Non-Goals:**
+
+- Following full data flow through arbitrary helper stacks, aliases, or interprocedural value propagation beyond the direct declaration referenced by `Config`.
+- Validating the semantic contents of the Terraform module beyond checking that the config comes from a checked-in embedded fixture.
+- Relaxing the existing rule set to allow new forms of ordinary inline config.
+- Reworking acceptance-test APIs outside the analyzer and the affected compatibility tests.
+
+## Decisions
+
+- **Extend the existing `go/analysis` plugin instead of adding a regex rule**: Pattern matching can catch raw heredocs, but it becomes noisy and incomplete once `Config` values flow through identifiers. The existing analyzer already has typed access to the relevant `resource.TestStep` literals, so adding declaration-aware checks there gives more precise diagnostics with less false-positive risk.
+
+- **Use declaration-aware validation, not full SSA/data-flow**: The analyzer should inspect the `Config` expression shape and, when it is an identifier, resolve that identifier to its declaration. For v1, the accepted declaration shape is a package-level `string` variable with an attached `//go:embed` directive that targets a `testdata/.../main.tf` fixture. This captures the real repository pattern without taking on the maintenance cost of whole-program flow analysis.
+
+- **Treat non-identifier `Config` expressions as invalid for compatibility steps**: Raw string literals, `fmt.Sprintf(...)`, concatenation, selector-based builders, and helper-function calls should all produce diagnostics. The fix is always the same: extract the static module to `testdata/.../main.tf`, embed it at package scope, and reference that variable from `Config`.
+
+- **Require direct package-scope ownership for the embedded fixture variable**: The accepted config source should be declared in the same test package as the acceptance test, not passed through helper layers. That keeps the fixture reference auditable next to the test and avoids analyzer complexity around imported symbols or transitive aliases.
+
+- **Preserve existing `ExternalProviders` semantics while narrowing the source contract**: Compatibility steps still use `ExternalProviders` plus `Config`, and they still must not use `ConfigDirectory` or `ProtoV6ProviderFactories`. This change narrows only where the `Config` string may originate.
+
+- **Migrate existing violations before enabling enforcement**: There are already compatibility tests in the repo that use static Terraform strings in Go. Those tests need conversion to embedded fixtures as part of rollout so the stricter analyzer does not fail immediately on known debt.
+
+## Risks / Trade-offs
+
+- **[Risk] The accepted source shape is stricter than the minimum needed to load equivalent Terraform** -> Mitigation: document the exact approved pattern in the spec and diagnostics so contributors know to use `//go:embed` plus `testdata/.../main.tf` instead of inventing variants.
+
+- **[Risk] Some compatibility tests may currently rely on light parameterization inside helper functions** -> Mitigation: move runtime values into `ConfigVariables` where possible and keep the embedded fixture static.
+
+- **[Risk] A declaration-only check may miss exotic aliasing patterns** -> Mitigation: accept that narrower scope in v1 because it targets the real repository convention and keeps the analyzer predictable. Revisit broader data-flow only if concrete false negatives emerge.
+
+- **[Risk] Tightening the rule may require touching several acceptance tests in one rollout** -> Mitigation: stage the implementation with targeted searches for `ExternalProviders` plus `Config` and convert existing static inline configs before turning the rule on in failing lint paths.
+
+## Migration Plan
+
+1. Update the `acceptance-test-config-directory-lint` delta spec to describe the new compatibility-step config-source restriction and expected diagnostics.
+2. Extend `analysis/acctestconfigdirlintplugin` so `ExternalProviders` steps validate the origin of `Config`.
+3. Add analyzer regression tests for accepted embedded fixture vars and rejected static inline-config patterns.
+4. Convert existing compatibility tests that still define Terraform modules in Go to `testdata/.../main.tf` plus package-level `//go:embed`.
+5. Run targeted analyzer tests and repository lint to verify the stricter rule is enforceable without repository-wide failures.
+
+## Open Questions
+
+- None for the initial change; the v1 contract is intentionally narrow and based on the repository’s preferred fixture pattern.

--- a/openspec/changes/restrict-static-inline-acceptance-config/proposal.md
+++ b/openspec/changes/restrict-static-inline-acceptance-config/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The current acceptance-test config lint rule still treats any `ExternalProviders` step with `Config` as compliant, even when the Terraform module is defined directly in Go as a raw string, a `fmt.Sprintf` heredoc, or a helper that returns static HCL. That leaves a readability and maintainability gap in the exact compatibility-test pattern that recently required a manual cleanup in the watcher acceptance suite.
+
+The repository already prefers checked-in Terraform fixtures for ordinary acceptance steps, and compatibility steps can follow the same fixture discipline without losing the ability to pass `Config` directly to `resource.TestStep`. Tightening this exception now lets the analyzer catch the mechanically detectable class of static inline config that should instead live in `testdata/.../main.tf` and be loaded through package-level `go:embed`.
+
+## What Changes
+
+- Tighten the existing acceptance-test config lint capability so `ExternalProviders` steps no longer accept arbitrary `Config` expressions.
+- Require compatibility-step `Config` values to resolve to package-level string variables populated by `//go:embed` from a checked-in `testdata/.../main.tf` fixture.
+- Reject raw string literals, `fmt.Sprintf` expressions, concatenated strings, and helper-function-returned Terraform modules when used as `Config` for `ExternalProviders` compatibility steps.
+- Keep ordinary current-provider steps on `ConfigDirectory: acctest.NamedTestCaseDirectory(...)`; this change only narrows the compatibility-step exception path.
+- Add analyzer diagnostics and regression coverage for allowed embedded-fixture configs and rejected static inline-config patterns.
+- Migrate existing compatibility tests that still define static Terraform config in Go to the embedded-fixture pattern before enabling the stricter rule.
+
+## Capabilities
+
+### New Capabilities
+- _(none)_
+
+### Modified Capabilities
+- `acceptance-test-config-directory-lint`: compatibility steps that use `ExternalProviders` and `Config` must source that config from package-level embedded `main.tf` fixtures instead of static Terraform strings defined in Go
+
+## Impact
+
+- **Analyzer implementation**: `analysis/acctestconfigdirlintplugin` will need declaration-aware validation for `resource.TestStep.Config` expressions.
+- **Acceptance tests**: SDK/backwards-compatibility tests that currently build static Terraform config in Go will need fixture extraction to `testdata/.../main.tf` plus package-level `//go:embed` variables.
+- **Regression coverage**: analyzer tests will need positive coverage for embedded config vars and negative coverage for raw literals, `fmt.Sprintf`, and helper-returned strings.
+- **Lint workflow**: `make check-lint` will fail on new compatibility-step regressions once the stricter rule is wired in.

--- a/openspec/changes/restrict-static-inline-acceptance-config/specs/acceptance-test-config-directory-lint/spec.md
+++ b/openspec/changes/restrict-static-inline-acceptance-config/specs/acceptance-test-config-directory-lint/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Inline config is restricted to external-provider compatibility steps
+Any in-scope `resource.TestStep` that sets `Config` SHALL also set `ExternalProviders`. Inline `Config` SHALL NOT be accepted as the ordinary fixture mechanism for in-scope acceptance steps, which use `ProtoV6ProviderFactories` and directory-backed fixtures instead. When an `ExternalProviders` step uses `Config`, that `Config` value SHALL satisfy the embedded-fixture source rules defined for external-provider compatibility steps.
+
+#### Scenario: Ordinary inline config is rejected
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `Config` and does not set `ExternalProviders`
+- **THEN** the analyzer SHALL emit a diagnostic requiring directory-backed fixtures
+
+#### Scenario: External-provider compatibility step may use embedded config
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets both `ExternalProviders` and `Config`, and `Config` resolves to an allowed embedded fixture variable
+- **THEN** the analyzer SHALL report no diagnostic for using `Config`
+
+### Requirement: External-provider compatibility steps stay on inline config
+Any in-scope `resource.TestStep` that sets `ExternalProviders` SHALL use `Config`, SHALL NOT use `ConfigDirectory`, and SHALL NOT set `ProtoV6ProviderFactories`. For these compatibility steps, `Config` SHALL resolve to a package-level `string` variable populated by a `//go:embed` directive whose embedded fixture path points to `testdata/.../main.tf`. The analyzer SHALL reject raw string literals, formatted strings, concatenated strings, helper-function-returned strings, and identifiers that do not resolve to that embedded-fixture declaration shape.
+
+#### Scenario: External-provider compatibility step mixes config sources
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `ExternalProviders` together with `ConfigDirectory`
+- **THEN** the analyzer SHALL emit a diagnostic requiring `Config` instead of `ConfigDirectory`
+
+#### Scenario: External-provider compatibility step omits inline config
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `ExternalProviders` and omits `Config`
+- **THEN** the analyzer SHALL emit a diagnostic requiring `Config`
+
+#### Scenario: External-provider compatibility step also sets ProtoV6 provider factories
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets both `ExternalProviders` and `ProtoV6ProviderFactories`
+- **THEN** the analyzer SHALL emit a diagnostic requiring the step to use only `ExternalProviders` for backwards-compatibility wiring
+
+#### Scenario: External-provider compatibility step uses an embedded fixture variable
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `ExternalProviders` and `Config` references a package-level `string` variable populated by `//go:embed testdata/.../main.tf`
+- **THEN** the analyzer SHALL report no diagnostic for the config source
+
+#### Scenario: External-provider compatibility step uses a raw Terraform string
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `ExternalProviders` and `Config` to a raw string literal, a formatted string expression, or a concatenated string expression
+- **THEN** the analyzer SHALL emit a diagnostic requiring the config to come from a package-level embedded `main.tf` fixture variable
+
+#### Scenario: External-provider compatibility step uses a helper-returned Terraform string
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `ExternalProviders` and `Config` to a helper call that returns Terraform text
+- **THEN** the analyzer SHALL emit a diagnostic requiring the config to come from a package-level embedded `main.tf` fixture variable
+
+#### Scenario: External-provider compatibility step uses a non-embedded string variable
+- **GIVEN** an in-scope acceptance `resource.TestStep`
+- **WHEN** the step sets `ExternalProviders` and `Config` references a string variable that is not populated by `//go:embed testdata/.../main.tf`
+- **THEN** the analyzer SHALL emit a diagnostic requiring the config to come from a package-level embedded `main.tf` fixture variable
+
+### Requirement: Field-relationship diagnostics are actionable
+When the lint rule reports a violation, the diagnostic SHALL identify the invalid `resource.TestCase` or `resource.TestStep` field relationship or invalid compatibility-step config source and SHALL direct contributors toward the accepted shape for that step.
+
+#### Scenario: Diagnostic explains the accepted replacement
+- **GIVEN** a non-compliant in-scope acceptance `resource.TestStep`
+- **WHEN** the analyzer emits a diagnostic
+- **THEN** the diagnostic SHALL tell the contributor whether to move `ProtoV6ProviderFactories` onto the step, switch to `ConfigDirectory: acctest.NamedTestCaseDirectory(...)`, keep the step as an `ExternalProviders` plus `Config` compatibility case, or move static Terraform into `testdata/.../main.tf` and load it through package-level `//go:embed`
+
+### Requirement: Repository lint enforces the rule
+The analyzer SHALL be wired into repository lint execution so `make check-lint` fails on violations, and regression tests SHALL cover compliant and non-compliant step shapes for both config sourcing and provider wiring, including accepted embedded compatibility fixtures and rejected static Terraform strings defined in Go.
+
+#### Scenario: Lint fails on a new violation
+- **GIVEN** a committed in-scope acceptance step that violates the config-directory lint rule
+- **WHEN** repository lint runs through `make check-lint`
+- **THEN** the lint command SHALL fail in local and CI workflows
+
+#### Scenario: Regression tests protect the accepted shapes
+- **GIVEN** analyzer regression coverage for directory-backed ordinary steps, step-level `ProtoV6ProviderFactories`, external-provider compatibility steps that use embedded fixture variables, and rejected static Terraform strings defined in Go
+- **WHEN** the analyzer implementation changes later
+- **THEN** the regression suite SHALL continue to distinguish compliant and non-compliant step shapes as specified

--- a/openspec/changes/restrict-static-inline-acceptance-config/tasks.md
+++ b/openspec/changes/restrict-static-inline-acceptance-config/tasks.md
@@ -1,0 +1,22 @@
+## 1. Extend analyzer behavior
+
+- [ ] 1.1 Update `analysis/acctestconfigdirlintplugin` so `ExternalProviders` steps validate the shape of their `Config` expression instead of accepting any `Config`.
+- [ ] 1.2 Resolve identifier-based `Config` expressions to their declarations and accept only package-level `string` variables populated by `//go:embed` from `testdata/.../main.tf`.
+- [ ] 1.3 Emit actionable diagnostics for rejected compatibility-step config sources, including raw string literals, `fmt.Sprintf` expressions, concatenated strings, helper-returned strings, and non-embedded variables.
+
+## 2. Migrate existing compatibility tests
+
+- [ ] 2.1 Identify existing `ExternalProviders` compatibility steps that still define static Terraform config inside Go.
+- [ ] 2.2 Extract each static compatibility fixture to `testdata/.../main.tf` and load it through package-level `//go:embed` variables.
+- [ ] 2.3 Replace helper- or literal-based compatibility-step `Config` usage with embedded fixture vars and move runtime values into `ConfigVariables` where needed.
+
+## 3. Add regression coverage
+
+- [ ] 3.1 Add analyzer tests for accepted compatibility steps whose `Config` references package-level embedded fixture variables.
+- [ ] 3.2 Add analyzer tests for rejected compatibility steps that use raw string literals, formatted strings, helper-returned strings, and non-embedded variables for `Config`.
+- [ ] 3.3 Preserve or extend existing analyzer tests covering ordinary directory-backed steps and provider-wiring rules so the stricter compatibility check does not regress current behavior.
+
+## 4. Validate rollout
+
+- [ ] 4.1 Run targeted analyzer tests for `analysis/acctestconfigdirlintplugin`.
+- [ ] 4.2 Run repository lint to confirm the stricter rule passes after compatibility-test migrations.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec design and proposal to enforce go:embed config in acceptance-test compatibility steps
- Adds an OpenSpec change entry, design doc, proposal, requirements spec, and task checklist under `openspec/changes/restrict-static-inline-acceptance-config/`.
- The design extends the acceptance-test config analyzer to reject raw or constructed inline `Config` strings in `ExternalProviders` compatibility steps, requiring package-level `go:embed`-backed `testdata/.../main.tf` variables instead.
- The spec defines scenarios for enforcing embedded fixtures, rejecting inline strings, and surfacing actionable lint diagnostics.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dec994.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->