### PR TITLE
Proposal to remove config drift due to watcher secret redaction

### DIFF
--- a/openspec/changes/preserve-redacted-watch-actions/.openspec.yaml
+++ b/openspec/changes/preserve-redacted-watch-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/preserve-redacted-watch-actions/design.md
+++ b/openspec/changes/preserve-redacted-watch-actions/design.md
@@ -1,0 +1,83 @@
+## Context
+
+`elasticstack_elasticsearch_watch` currently treats `actions` like any other normalized JSON blob: create/update unmarshals the configured JSON into the Put Watch request, and read marshals the Get Watch response back into state. That breaks for action secrets because Watcher may return nested placeholders such as `::es_redacted::` instead of the original password value.
+
+The immediate failure happens after a successful create or update. The resource performs a read-after-write, stores the redacted placeholder in `actions`, and later reuses that state-derived JSON when another update touches an unrelated field. Elasticsearch rejects the placeholder as an invalid password value, so ordinary watch updates fail.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve last-known action secret values in Terraform state when Watcher read responses redact those values.
+- Keep refresh authoritative for non-secret action fields so real drift outside redacted leaves still appears in state.
+- Scope the fix to the watch resource without introducing a provider-wide JSON comparison type.
+- Add focused regression coverage for the redacted-actions update path.
+
+**Non-Goals:**
+
+- Introduce a new generic custom Terraform type for redaction-aware JSON equality.
+- Change the `actions` schema shape or split secret values into separate Terraform attributes.
+- Recover original secret values during import or any first read where Terraform has no prior concrete `actions` value to preserve.
+- Broaden the change to `trigger`, `input`, `condition`, `metadata`, or other resources unless they show the same concrete failure mode.
+
+## Decisions
+
+### 1. Preserve redacted leaves during read instead of changing `actions` type semantics
+
+The implementation will keep `actions` as a normalized JSON string and adjust watch read/state mapping so redacted leaves from the API are replaced with the corresponding prior value from plan/state before final state is written.
+
+Why:
+
+- The bug is caused by read-time state replacement, so fixing read-time behavior addresses the root cause directly.
+- Preserving the prior concrete secret keeps future password changes visible to Terraform, because state continues to hold the last applied value instead of a wildcard placeholder.
+- The provider already uses resource-specific preservation patterns when APIs omit or redact sensitive values, so this approach matches existing practice better than introducing new type semantics.
+
+Alternatives considered:
+
+- Add a custom `actions` type with redaction-aware `StringSemanticEquals`: rejected as the primary fix because treating `::es_redacted::` as semantically equal to any configured string can hide legitimate secret rotations.
+- Preserve the entire prior `actions` document whenever any redaction appears: rejected because it would hide unrelated drift in non-secret action fields that the API still returns accurately.
+
+### 2. Merge only matching paths where the API returns a redaction sentinel
+
+The read helper will decode both the API `actions` document and the prior Terraform `actions` value, walk them recursively, and replace only string leaves equal to the Watcher redaction sentinel with the prior value at the same path when one exists.
+
+Why:
+
+- Path-level replacement keeps the API authoritative everywhere except at the exact redacted leaf.
+- Restricting preservation to matching paths avoids copying stale values into unrelated branches when the action structure changes.
+- A recursive merge helper is straightforward to unit test without involving Terraform framework internals.
+
+Alternatives considered:
+
+- Compare the full JSON blobs semantically and keep state unchanged when they are "close enough": rejected because the resource still needs a concrete merged document to write back into state.
+- Special-case only known password field names: rejected because the issue is defined by API redaction behavior, not by a stable field-name allowlist.
+
+### 3. Keep imports and first reads explicit about their limitation
+
+When Terraform has no prior concrete `actions` value, the resource will store the API response as returned, even if it contains redacted placeholders.
+
+Why:
+
+- There is no trustworthy prior secret value to restore on import or the first refresh after state loss.
+- Making this limitation explicit keeps the design honest and avoids inventing hidden storage just for this fix.
+
+Alternatives considered:
+
+- Introduce private-state secret storage for actions: rejected as out of scope for this bug fix because it adds a broader state-management pattern and migration burden.
+
+## Risks / Trade-offs
+
+- **[Risk] Out-of-band cluster changes to redacted action secrets will not appear in Terraform state once a prior concrete value is being preserved** -> Mitigation: limit preservation to redacted leaves only and document that imported/first-read resources without prior values cannot recover the original secret.
+- **[Risk] Merge logic could accidentally preserve stale values when action structure changes significantly** -> Mitigation: only reuse a prior value when the API path is redacted and a corresponding prior path exists; otherwise keep the API value.
+- **[Risk] Acceptance coverage may be harder if Watcher redaction behavior varies by stack version or action shape** -> Mitigation: add deterministic unit coverage for the merge helper and keep the acceptance case narrowly focused on a known redacted auth path.
+
+## Migration Plan
+
+1. Add a watch-local helper that merges API `actions` JSON with prior Terraform `actions` JSON, preserving only redacted string leaves.
+2. Update watch read/state mapping to use that merged document before writing `actions` into state.
+3. Add unit coverage for nested redaction-preservation behavior and extend watch acceptance coverage for unrelated updates after redacted action secrets are present.
+4. Validate the OpenSpec change and use the new tests as the implementation guardrail.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/preserve-redacted-watch-actions/proposal.md
+++ b/openspec/changes/preserve-redacted-watch-actions/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The Elasticsearch watch resource currently writes redacted Watcher action secrets such as `::es_redacted::` into Terraform state during read-after-write and refresh. That causes later updates that do not touch `actions` to resend the redacted placeholder back to Elasticsearch, which fails with a parse error and prevents normal watch maintenance.
+
+## What Changes
+
+- Preserve previously known `actions` values when the Watcher Get API returns redacted string leaves inside the actions JSON.
+- Keep non-redacted action fields authoritative from the API so normal refresh behavior still applies.
+- Add focused test coverage for watches whose actions include redacted secrets and are later updated through unrelated fields.
+- Clarify the watch requirements so refresh behavior for redacted action secrets is explicitly specified.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `elasticsearch-watch`: refine read/state synchronization for `actions` when the Watcher API redacts nested secret values
+
+## Impact
+
+- `internal/elasticsearch/watcher/watch/models.go`
+- `internal/elasticsearch/watcher/watch/read.go`
+- `internal/elasticsearch/watcher/watch/acc_test.go`
+- `internal/elasticsearch/watcher/watch/testdata/`
+- `openspec/specs/elasticsearch-watch/spec.md`

--- a/openspec/changes/preserve-redacted-watch-actions/specs/elasticsearch-watch/spec.md
+++ b/openspec/changes/preserve-redacted-watch-actions/specs/elasticsearch-watch/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Read (REQ-014–REQ-016)
 
-On read, the resource SHALL parse `id` using `clients.ResourceIDFromStr` to extract the watch identifier. The resource SHALL call the Get Watch API with the extracted watch identifier. When the Get Watch API returns 404, the resource SHALL remove itself from state (set id to `""`). When the API returns a successful response, the resource SHALL decode the JSON response and update state from the response, except that `actions` SHALL preserve previously known values at nested paths where the API returns a redacted string sentinel and prior Terraform state has a corresponding concrete value.
+On read, the resource SHALL parse `id` using the framework resource's composite ID format to extract the watch identifier. The resource SHALL call the Get Watch API with the extracted watch identifier. When the Get Watch API returns 404, the resource SHALL remove itself from state (set id to `""`). When the API returns a successful response, the resource SHALL decode the JSON response and update state from the response, except that `actions` SHALL preserve previously known values at nested paths where the API returns a redacted string sentinel and prior Terraform state has a corresponding concrete value.
 
 #### Scenario: Watch not found on refresh
 

--- a/openspec/changes/preserve-redacted-watch-actions/specs/elasticsearch-watch/spec.md
+++ b/openspec/changes/preserve-redacted-watch-actions/specs/elasticsearch-watch/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Read (REQ-014–REQ-016)
+
+On read, the resource SHALL parse `id` using `clients.ResourceIDFromStr` to extract the watch identifier. The resource SHALL call the Get Watch API with the extracted watch identifier. When the Get Watch API returns 404, the resource SHALL remove itself from state (set id to `""`). When the API returns a successful response, the resource SHALL decode the JSON response and update state from the response, except that `actions` SHALL preserve previously known values at nested paths where the API returns a redacted string sentinel and prior Terraform state has a corresponding concrete value.
+
+#### Scenario: Watch not found on refresh
+
+- GIVEN the watch no longer exists on the cluster
+- WHEN read runs
+- THEN the resource SHALL be removed from state without an error
+
+#### Scenario: Redacted action secret during refresh
+
+- GIVEN the prior Terraform state contains a concrete `actions` value for a nested action secret
+- WHEN read runs and the Get Watch API returns the same action path with a redacted string sentinel
+- THEN the resource SHALL preserve the prior concrete value at that path while updating the rest of state from the API response
+
+### Requirement: JSON field mapping — read/state (REQ-023–REQ-027)
+
+On read, the resource SHALL marshal the API response fields `trigger`, `input`, `condition`, and `metadata` back into normalized JSON strings and store them in state. For `actions`, the resource SHALL marshal the API response into a normalized JSON string, but when the API response contains a redacted string sentinel at a nested path and prior Terraform state has a concrete value at the same path, the resource SHALL preserve the prior concrete value at that path in the final stored JSON. When no prior concrete value exists for a redacted `actions` path, the resource SHALL store the API value as returned. When the API response includes a non-nil `transform`, the resource SHALL marshal it to a normalized JSON string and store it in state. When the API response has a nil `transform`, the resource SHALL clear `transform` from state so the Terraform state reflects the remote watch. The resource SHALL store `watch_id` and `active` (from `watch.status.state.active`) directly from the API response. The resource SHALL store `throttle_period_in_millis` from the API response. JSON fields SHALL normalize semantically equivalent JSON so formatting-only changes do not create perpetual diffs.
+
+#### Scenario: transform removed from the remote watch
+
+- **GIVEN** the watch previously had a `transform` stored in Terraform state
+- **WHEN** read runs and the API response has no `transform` field
+- **THEN** the `transform` attribute SHALL be cleared from state
+
+#### Scenario: active synced from watch status
+
+- **GIVEN** the watch is deactivated on the cluster
+- **WHEN** read runs
+- **THEN** `active` in state SHALL reflect `watch.status.state.active` from the API response
+
+#### Scenario: redacted action secret preserved from prior state
+
+- **GIVEN** the watch previously stored an `actions` JSON document with a concrete nested secret value
+- **WHEN** read runs and the API response returns `::es_redacted::` for that nested action path
+- **THEN** the final `actions` value in state SHALL keep the prior concrete secret for that path
+- **AND** non-redacted action fields from the API response SHALL still be reflected in state
+
+#### Scenario: imported watch with redacted action secret
+
+- **GIVEN** Terraform has no prior concrete value for a redacted nested `actions` path
+- **WHEN** read runs and the API response returns `::es_redacted::` for that path
+- **THEN** the `actions` value in state SHALL store the redacted API value for that path

--- a/openspec/changes/preserve-redacted-watch-actions/tasks.md
+++ b/openspec/changes/preserve-redacted-watch-actions/tasks.md
@@ -1,0 +1,17 @@
+## 1. Watch read-state preservation
+
+- [ ] 1.1 Add a watch-local helper that recursively merges API `actions` JSON with prior Terraform `actions` JSON, preserving only redacted string leaves when a prior concrete value exists at the same path
+- [ ] 1.2 Update watch read/state mapping so refreshed `actions` uses the merged JSON while all other watch fields keep their existing read behavior
+- [ ] 1.3 Keep imported or first-read watches without prior concrete `actions` values on the raw API response path for redacted leaves
+
+## 2. Regression coverage
+
+- [ ] 2.1 Add unit tests for the redacted-actions merge helper, including nested objects, arrays, mismatched paths, and no-prior-value cases
+- [ ] 2.2 Extend watch acceptance coverage with a scenario where actions contain a redacted secret and an unrelated update still succeeds
+- [ ] 2.3 Verify non-redacted action fields from the API continue to refresh into state when redacted leaves are being preserved
+
+## 3. Spec and verification
+
+- [ ] 3.1 Align the watch implementation with the new read/state preservation requirements for redacted `actions`
+- [ ] 3.2 Validate the OpenSpec change artifacts for `preserve-redacted-watch-actions`
+- [ ] 3.3 Run focused watch tests that exercise the new preservation behavior and address any failures


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/353

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add design proposal for preserving redacted Watcher action secrets in Terraform state
> - Adds a proposal, design doc, spec, and task checklist under `openspec/changes/preserve-redacted-watch-actions/` to address config drift caused by the Elasticsearch Watcher API returning redacted sentinel values for action secrets.
> - The proposed approach preserves previously known concrete values at redacted string leaves in Terraform state during read/state mapping, while keeping all non-secret fields authoritative from the API.
> - Includes scenarios covering not-found, redacted preservation, transform removal, active sync, and import behavior in the [spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2294/files#diff-2969a63d8dd8c2b699959a22de44740d172ed712eb6bbd6b3ddf70ce45f25a58).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a70328.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->