### PR TITLE
feat(kibana-security-role): migrate elasticstack_kibana_security_role to kbapi

### DIFF
--- a/docs/resources/kibana_security_role.md
+++ b/docs/resources/kibana_security_role.md
@@ -187,7 +187,7 @@ Optional:
 
 Optional:
 
-- `except` (Set of String) List of the fields to which the grants will not be applied.
+- `except` (Set of String) List of the fields to which the grants will not be allowed.
 - `grant` (Set of String) List of the fields to grant the access to.
 
 

--- a/docs/resources/kibana_security_role.md
+++ b/docs/resources/kibana_security_role.md
@@ -187,7 +187,7 @@ Optional:
 
 Optional:
 
-- `except` (Set of String) List of the fields to which the grants will not be allowed.
+- `except` (Set of String) List of the fields to which the grants will not be applied.
 - `grant` (Set of String) List of the fields to grant the access to.
 
 

--- a/internal/clients/kibanaoapi/security_role.go
+++ b/internal/clients/kibanaoapi/security_role.go
@@ -50,8 +50,8 @@ type SecurityRoleESRemoteIndex struct {
 // SecurityRoleES holds the elasticsearch section of a Kibana role.
 type SecurityRoleES struct {
 	Cluster       *[]string                    `json:"cluster,omitempty"`
-	Indices       *[]SecurityRoleESIndex        `json:"indices,omitempty"`
-	RemoteIndices *[]SecurityRoleESRemoteIndex  `json:"remote_indices,omitempty"`
+	Indices       *[]SecurityRoleESIndex       `json:"indices,omitempty"`
+	RemoteIndices *[]SecurityRoleESRemoteIndex `json:"remote_indices,omitempty"`
 	RunAs         *[]string                    `json:"run_as,omitempty"`
 }
 

--- a/internal/clients/kibanaoapi/security_role.go
+++ b/internal/clients/kibanaoapi/security_role.go
@@ -1,0 +1,178 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibanaoapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
+	sdkdiag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+// SecurityRoleESIndex represents an index entry in the elasticsearch.indices section of a Kibana role.
+type SecurityRoleESIndex struct {
+	AllowRestrictedIndices *bool                `json:"allow_restricted_indices,omitempty"`
+	FieldSecurity          *map[string][]string `json:"field_security,omitempty"`
+	Names                  []string             `json:"names"`
+	Privileges             []string             `json:"privileges"`
+	Query                  *string              `json:"query,omitempty"`
+}
+
+// SecurityRoleESRemoteIndex represents an entry in the elasticsearch.remote_indices section of a Kibana role.
+type SecurityRoleESRemoteIndex struct {
+	AllowRestrictedIndices *bool                `json:"allow_restricted_indices,omitempty"`
+	Clusters               []string             `json:"clusters"`
+	FieldSecurity          *map[string][]string `json:"field_security,omitempty"`
+	Names                  []string             `json:"names"`
+	Privileges             []string             `json:"privileges"`
+	Query                  *string              `json:"query,omitempty"`
+}
+
+// SecurityRoleES holds the elasticsearch section of a Kibana role.
+type SecurityRoleES struct {
+	Cluster       *[]string                    `json:"cluster,omitempty"`
+	Indices       *[]SecurityRoleESIndex        `json:"indices,omitempty"`
+	RemoteIndices *[]SecurityRoleESRemoteIndex  `json:"remote_indices,omitempty"`
+	RunAs         *[]string                    `json:"run_as,omitempty"`
+}
+
+// SecurityRoleKibana holds one entry from the kibana section of a Kibana role.
+// Base is kept as json.RawMessage to handle both []string and null gracefully,
+// since the generated kbapi union type cannot unmarshal from the Kibana API response.
+type SecurityRoleKibana struct {
+	Base    json.RawMessage      `json:"base,omitempty"`
+	Feature *map[string][]string `json:"feature,omitempty"`
+	Spaces  *[]string            `json:"spaces,omitempty"`
+}
+
+// SecurityRole is a decodable representation of a Kibana role as returned by GET
+// /api/security/role/{name}. It mirrors the PUT request body shape but uses
+// named exported struct types and json.RawMessage for the kibana.base field.
+type SecurityRole struct {
+	Description   *string              `json:"description,omitempty"`
+	Elasticsearch SecurityRoleES       `json:"elasticsearch"`
+	Kibana        []SecurityRoleKibana `json:"kibana,omitempty"`
+	Metadata      *map[string]any      `json:"metadata,omitempty"`
+}
+
+// SecurityRolePutBody is the request body for creating or updating a Kibana role.
+// It uses plain Go types for all fields (no kbapi union structs) so that JSON
+// marshaling produces the correct wire format.
+type SecurityRolePutBody struct {
+	Description   *string              `json:"description,omitempty"`
+	Elasticsearch SecurityRoleES       `json:"elasticsearch"`
+	Kibana        []SecurityRoleKibana `json:"kibana,omitempty"`
+	Metadata      *map[string]any      `json:"metadata,omitempty"`
+}
+
+// GetSecurityRole retrieves a Kibana security role by name.
+// Returns (nil, nil) when the role is not found (HTTP 404).
+// Returns (nil, diags) on error.
+func GetSecurityRole(ctx context.Context, client *Client, name string) (*SecurityRole, sdkdiag.Diagnostics) {
+	params := &kbapi.GetSecurityRoleNameParams{}
+	resp, err := client.API.GetSecurityRoleNameWithResponse(ctx, name, params)
+	if err != nil {
+		return nil, sdkdiag.Diagnostics{
+			sdkdiag.Diagnostic{
+				Severity: sdkdiag.Error,
+				Summary:  "Failed to read Kibana security role",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		var role SecurityRole
+		if err := json.Unmarshal(resp.Body, &role); err != nil {
+			return nil, sdkdiag.Diagnostics{
+				sdkdiag.Diagnostic{
+					Severity: sdkdiag.Error,
+					Summary:  "Failed to parse Kibana security role response",
+					Detail:   fmt.Sprintf("JSON decode error: %s. Body: %s", err.Error(), string(resp.Body)),
+				},
+			}
+		}
+		return &role, nil
+	case http.StatusNotFound:
+		return nil, nil
+	default:
+		return nil, reportUnknownErrorSDK(resp.StatusCode(), resp.Body)
+	}
+}
+
+// PutSecurityRole creates or updates a Kibana security role using the supplied body.
+// It uses the WithBody variant so that the kbapi union type for kibana.base is bypassed
+// and the body is sent as-is.
+func PutSecurityRole(ctx context.Context, client *Client, name string, params kbapi.PutSecurityRoleNameParams, body SecurityRolePutBody) sdkdiag.Diagnostics {
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return sdkdiag.Diagnostics{
+			sdkdiag.Diagnostic{
+				Severity: sdkdiag.Error,
+				Summary:  "Failed to serialize Kibana security role",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	resp, err := client.API.PutSecurityRoleNameWithBodyWithResponse(ctx, name, &params, "application/json", bytes.NewReader(bodyBytes))
+	if err != nil {
+		return sdkdiag.Diagnostics{
+			sdkdiag.Diagnostic{
+				Severity: sdkdiag.Error,
+				Summary:  "Failed to write Kibana security role",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	default:
+		return reportUnknownErrorSDK(resp.StatusCode(), resp.Body)
+	}
+}
+
+// DeleteSecurityRole deletes a Kibana security role by name.
+func DeleteSecurityRole(ctx context.Context, client *Client, name string) sdkdiag.Diagnostics {
+	resp, err := client.API.DeleteSecurityRoleNameWithResponse(ctx, name)
+	if err != nil {
+		return sdkdiag.Diagnostics{
+			sdkdiag.Diagnostic{
+				Severity: sdkdiag.Error,
+				Summary:  "Failed to delete Kibana security role",
+				Detail:   err.Error(),
+			},
+		}
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return nil
+	default:
+		return reportUnknownErrorSDK(resp.StatusCode(), resp.Body)
+	}
+}

--- a/internal/clients/kibanaoapi/security_role_test.go
+++ b/internal/clients/kibanaoapi/security_role_test.go
@@ -146,11 +146,10 @@ func TestPutSecurityRole_200(t *testing.T) {
 
 func TestPutSecurityRole_WithBase_SerializesCorrectly(t *testing.T) {
 	var capturedBody []byte
+	var captureErr error
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		var err error
-		capturedBody, err = io.ReadAll(r.Body)
-		require.NoError(t, err)
+		capturedBody, captureErr = io.ReadAll(r.Body)
 		rw.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -171,6 +170,7 @@ func TestPutSecurityRole_WithBase_SerializesCorrectly(t *testing.T) {
 	params := kbapi.PutSecurityRoleNameParams{}
 	diags := kibanaoapi.PutSecurityRole(t.Context(), oapiClient, "test-role", params, body)
 	assert.Nil(t, diags)
+	require.NoError(t, captureErr)
 
 	// Verify kibana.base is correctly serialized in the request body
 	var sent map[string]any

--- a/internal/clients/kibanaoapi/security_role_test.go
+++ b/internal/clients/kibanaoapi/security_role_test.go
@@ -62,7 +62,7 @@ func TestGetSecurityRole_200(t *testing.T) {
 		},
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Set("Content-Type", "application/json")
 		rw.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(rw).Encode(roleBody)
@@ -79,7 +79,7 @@ func TestGetSecurityRole_200(t *testing.T) {
 }
 
 func TestGetSecurityRole_404(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -92,7 +92,7 @@ func TestGetSecurityRole_404(t *testing.T) {
 }
 
 func TestGetSecurityRole_InvalidJSON(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Set("Content-Type", "application/json")
 		rw.WriteHeader(http.StatusOK)
 		_, _ = rw.Write([]byte("not-valid-json"))
@@ -108,7 +108,7 @@ func TestGetSecurityRole_InvalidJSON(t *testing.T) {
 }
 
 func TestGetSecurityRole_500(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		_, _ = rw.Write([]byte(`{"error":"internal server error"}`))
 	}))
@@ -123,7 +123,7 @@ func TestGetSecurityRole_500(t *testing.T) {
 }
 
 func TestPutSecurityRole_200(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -184,7 +184,7 @@ func TestPutSecurityRole_WithBase_SerializesCorrectly(t *testing.T) {
 }
 
 func TestPutSecurityRole_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusBadRequest)
 		_, _ = rw.Write([]byte(`{"error":"bad request"}`))
 	}))
@@ -201,7 +201,7 @@ func TestPutSecurityRole_Error(t *testing.T) {
 }
 
 func TestDeleteSecurityRole_200(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -212,7 +212,7 @@ func TestDeleteSecurityRole_200(t *testing.T) {
 }
 
 func TestDeleteSecurityRole_404(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -223,7 +223,7 @@ func TestDeleteSecurityRole_404(t *testing.T) {
 }
 
 func TestDeleteSecurityRole_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		_, _ = rw.Write([]byte(`{"error":"internal error"}`))
 	}))

--- a/internal/clients/kibanaoapi/security_role_test.go
+++ b/internal/clients/kibanaoapi/security_role_test.go
@@ -19,6 +19,7 @@ package kibanaoapi_test
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -147,8 +148,9 @@ func TestPutSecurityRole_WithBase_SerializesCorrectly(t *testing.T) {
 	var capturedBody []byte
 
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		capturedBody = make([]byte, r.ContentLength)
-		_, _ = r.Body.Read(capturedBody)
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
 		rw.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/internal/clients/kibanaoapi/security_role_test.go
+++ b/internal/clients/kibanaoapi/security_role_test.go
@@ -1,0 +1,236 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibanaoapi_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	kibanaoapi "github.com/elastic/terraform-provider-elasticstack/internal/clients/kibanaoapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestKibanaOapiClient(t *testing.T, server *httptest.Server) *kibanaoapi.Client {
+	t.Helper()
+	t.Setenv("ELASTICSEARCH_URL", server.URL)
+	t.Setenv("KIBANA_ENDPOINT", server.URL)
+
+	apiClient, err := clients.NewAcceptanceTestingClient()
+	require.NoError(t, err)
+
+	oapiClient, err := apiClient.GetKibanaOapiClient()
+	require.NoError(t, err)
+	return oapiClient
+}
+
+func TestGetSecurityRole_200(t *testing.T) {
+	roleBody := map[string]any{
+		"elasticsearch": map[string]any{
+			"cluster": []string{"monitor"},
+			"indices": []any{
+				map[string]any{
+					"names":      []string{"logs-*"},
+					"privileges": []string{"read"},
+				},
+			},
+		},
+		"kibana": []any{
+			map[string]any{
+				"base":   []string{"all"},
+				"spaces": []string{"default"},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(rw).Encode(roleBody)
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	role, diags := kibanaoapi.GetSecurityRole(t.Context(), oapiClient, "test-role")
+
+	require.Nil(t, diags)
+	require.NotNil(t, role)
+	require.NotNil(t, role.Elasticsearch.Cluster)
+	assert.Equal(t, []string{"monitor"}, *role.Elasticsearch.Cluster)
+}
+
+func TestGetSecurityRole_404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	role, diags := kibanaoapi.GetSecurityRole(t.Context(), oapiClient, "missing-role")
+
+	assert.Nil(t, diags)
+	assert.Nil(t, role)
+}
+
+func TestGetSecurityRole_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte("not-valid-json"))
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	role, diags := kibanaoapi.GetSecurityRole(t.Context(), oapiClient, "test-role")
+
+	assert.NotNil(t, diags)
+	assert.True(t, diags.HasError())
+	assert.Nil(t, role)
+}
+
+func TestGetSecurityRole_500(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	role, diags := kibanaoapi.GetSecurityRole(t.Context(), oapiClient, "test-role")
+
+	assert.NotNil(t, diags)
+	assert.True(t, diags.HasError())
+	assert.Nil(t, role)
+}
+
+func TestPutSecurityRole_200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+
+	createOnly := true
+	params := kbapi.PutSecurityRoleNameParams{CreateOnly: &createOnly}
+	cluster := []string{"monitor"}
+	body := kibanaoapi.SecurityRolePutBody{
+		Elasticsearch: kibanaoapi.SecurityRoleES{
+			Cluster: &cluster,
+		},
+	}
+
+	diags := kibanaoapi.PutSecurityRole(t.Context(), oapiClient, "test-role", params, body)
+	assert.Nil(t, diags)
+}
+
+func TestPutSecurityRole_WithBase_SerializesCorrectly(t *testing.T) {
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		capturedBody = make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(capturedBody)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+
+	spaces := []string{"default"}
+	body := kibanaoapi.SecurityRolePutBody{
+		Kibana: []kibanaoapi.SecurityRoleKibana{
+			{
+				Base:   json.RawMessage(`["all"]`),
+				Spaces: &spaces,
+			},
+		},
+		Elasticsearch: kibanaoapi.SecurityRoleES{},
+	}
+
+	params := kbapi.PutSecurityRoleNameParams{}
+	diags := kibanaoapi.PutSecurityRole(t.Context(), oapiClient, "test-role", params, body)
+	assert.Nil(t, diags)
+
+	// Verify kibana.base is correctly serialized in the request body
+	var sent map[string]any
+	require.NoError(t, json.Unmarshal(capturedBody, &sent))
+	kibanaArr, ok := sent["kibana"].([]any)
+	require.True(t, ok)
+	require.Len(t, kibanaArr, 1)
+	kibanaEntry := kibanaArr[0].(map[string]any)
+	base, ok := kibanaEntry["base"].([]any)
+	require.True(t, ok)
+	require.Len(t, base, 1)
+	assert.Equal(t, "all", base[0])
+}
+
+func TestPutSecurityRole_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusBadRequest)
+		_, _ = rw.Write([]byte(`{"error":"bad request"}`))
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+
+	params := kbapi.PutSecurityRoleNameParams{}
+	body := kibanaoapi.SecurityRolePutBody{}
+
+	diags := kibanaoapi.PutSecurityRole(t.Context(), oapiClient, "test-role", params, body)
+	assert.NotNil(t, diags)
+	assert.True(t, diags.HasError())
+}
+
+func TestDeleteSecurityRole_200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	diags := kibanaoapi.DeleteSecurityRole(t.Context(), oapiClient, "test-role")
+	assert.Nil(t, diags)
+}
+
+func TestDeleteSecurityRole_404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	diags := kibanaoapi.DeleteSecurityRole(t.Context(), oapiClient, "missing-role")
+	assert.Nil(t, diags)
+}
+
+func TestDeleteSecurityRole_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusInternalServerError)
+		_, _ = rw.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer server.Close()
+
+	oapiClient := newTestKibanaOapiClient(t, server)
+	diags := kibanaoapi.DeleteSecurityRole(t.Context(), oapiClient, "test-role")
+	assert.NotNil(t, diags)
+	assert.True(t, diags.HasError())
+}

--- a/internal/kibana/role.go
+++ b/internal/kibana/role.go
@@ -155,7 +155,7 @@ func ResourceRole() *schema.Resource {
 												},
 											},
 											"except": {
-												Description: "List of the fields to which the grants will not be allowed.",
+												Description: "List of the fields to which the grants will not be applied.",
 												Type:        schema.TypeSet,
 												Optional:    true,
 												Elem: &schema.Schema{
@@ -386,10 +386,12 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	if err := d.Set("kibana", flattenKibanaRoleKibanaData(role.Kibana)); err != nil {
 		return diag.FromErr(err)
 	}
+	description := ""
 	if role.Description != nil {
-		if err := d.Set("description", *role.Description); err != nil {
-			return diag.FromErr(err)
-		}
+		description = *role.Description
+	}
+	if err := d.Set("description", description); err != nil {
+		return diag.FromErr(err)
 	}
 	if role.Metadata != nil {
 		metadata, err := json.Marshal(*role.Metadata)

--- a/internal/kibana/role.go
+++ b/internal/kibana/role.go
@@ -25,8 +25,9 @@ import (
 
 	_ "embed"
 
-	"github.com/disaster37/go-kibana-rest/v8/kbapi"
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	kibanaoapi "github.com/elastic/terraform-provider-elasticstack/internal/clients/kibanaoapi"
 	providerSchema "github.com/elastic/terraform-provider-elasticstack/internal/schema"
 	"github.com/elastic/terraform-provider-elasticstack/internal/tfsdkutils"
 	"github.com/hashicorp/go-version"
@@ -154,7 +155,7 @@ func ResourceRole() *schema.Resource {
 												},
 											},
 											"except": {
-												Description: "List of the fields to which the grants will not be applied.",
+												Description: "List of the fields to which the grants will not be allowed.",
 												Type:        schema.TypeSet,
 												Optional:    true,
 												Elem: &schema.Schema{
@@ -297,52 +298,56 @@ func resourceRoleUpsert(ctx context.Context, d *schema.ResourceData, meta any) d
 		return diags
 	}
 
-	kibana, err := client.GetKibanaClient()
+	oapiClient, err := client.GetKibanaOapiClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	kibanaRole := kbapi.KibanaRole{
-		Name:          d.Get("name").(string),
-		Kibana:        []kbapi.KibanaRoleKibana{},
-		Elasticsearch: &kbapi.KibanaRoleElasticsearch{},
-		CreateOnly:    d.IsNewResource(),
-	}
+
+	roleName := d.Get("name").(string)
+
+	body := kibanaoapi.SecurityRolePutBody{}
 
 	if v, ok := d.GetOk("kibana"); ok {
-		kibanaRole.Kibana, diags = expandKibanaRoleKibana(v)
-		if diags != nil {
-			return diags
+		kibanaPrivs, ds := expandKibanaRoleKibana(v)
+		if ds != nil {
+			return ds
 		}
+		body.Kibana = kibanaPrivs
 	}
 
 	if v, ok := d.GetOk("elasticsearch"); ok {
-		kibanaRole.Elasticsearch, diags = expandKibanaRoleElasticsearch(v, serverVersion)
-		if diags != nil {
-			return diags
+		ds := expandKibanaRoleElasticsearchInto(v, serverVersion, &body.Elasticsearch)
+		if ds != nil {
+			return ds
 		}
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
-		kibanaRole.Metadata, diags = expandKibanaRoleMetadata(v)
-		if diags != nil {
-			return diags
+		metadata, ds := expandKibanaRoleMetadata(v)
+		if ds != nil {
+			return ds
 		}
+		body.Metadata = &metadata
 	}
 
 	if v, ok := d.GetOk("description"); ok {
 		if serverVersion.LessThan(minSupportedDescriptionVersion) {
 			return diag.FromErr(fmt.Errorf("'description' is supported only for Kibana v%s and above", minSupportedDescriptionVersion.String()))
 		}
-
-		kibanaRole.Description = v.(string)
+		desc := v.(string)
+		body.Description = &desc
 	}
 
-	roleManageResponse, err := kibana.KibanaRoleManagement.CreateOrUpdate(&kibanaRole)
-	if err != nil {
-		return diag.FromErr(err)
+	createOnly := d.IsNewResource()
+	params := kbapi.PutSecurityRoleNameParams{
+		CreateOnly: &createOnly,
 	}
 
-	d.SetId(roleManageResponse.Name)
+	if ds := kibanaoapi.PutSecurityRole(ctx, oapiClient, roleName, params, body); ds != nil {
+		return ds
+	}
+
+	d.SetId(roleName)
 	return resourceRoleRead(ctx, d, meta)
 }
 
@@ -356,37 +361,38 @@ func resourceRoleRead(_ context.Context, d *schema.ResourceData, meta any) diag.
 		return diags
 	}
 
-	name := d.Id()
-
-	kibana, err := client.GetKibanaClient()
+	oapiClient, err := client.GetKibanaOapiClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	role, err := kibana.KibanaRoleManagement.Get(name)
-	if role == nil && err == nil {
+	name := d.Id()
+
+	role, ds := kibanaoapi.GetSecurityRole(context.Background(), oapiClient, name)
+	if ds != nil {
+		return ds
+	}
+	if role == nil {
 		d.SetId("")
 		return diags
 	}
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
-	// set the fields
-	if err := d.Set("name", role.Name); err != nil {
+	if err := d.Set("name", name); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("elasticsearch", flattenKibanaRoleElasticsearchData(role.Elasticsearch)); err != nil {
+	if err := d.Set("elasticsearch", flattenKibanaRoleElasticsearchData(role)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("kibana", flattenKibanaRoleKibanaData(&role.Kibana)); err != nil {
+	if err := d.Set("kibana", flattenKibanaRoleKibanaData(role.Kibana)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("description", role.Description); err != nil {
-		return diag.FromErr(err)
+	if role.Description != nil {
+		if err := d.Set("description", *role.Description); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	if role.Metadata != nil {
-		metadata, err := json.Marshal(role.Metadata)
+		metadata, err := json.Marshal(*role.Metadata)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -406,16 +412,16 @@ func resourceRoleDelete(_ context.Context, d *schema.ResourceData, meta any) dia
 	if diags.HasError() {
 		return diags
 	}
-	resourceID := d.Id()
 
-	kibana, err := client.GetKibanaClient()
+	oapiClient, err := client.GetKibanaOapiClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	err = kibana.KibanaRoleManagement.Delete(resourceID)
-	if err != nil {
-		return diag.FromErr(err)
+	resourceID := d.Id()
+
+	if ds := kibanaoapi.DeleteSecurityRole(context.Background(), oapiClient, resourceID); ds != nil {
+		return ds
 	}
 
 	d.SetId("")
@@ -432,211 +438,232 @@ func expandKibanaRoleMetadata(v any) (map[string]any, diag.Diagnostics) {
 	return metadata, nil
 }
 
-func expandKibanaRoleElasticsearch(v any, serverVersion *version.Version) (*kbapi.KibanaRoleElasticsearch, diag.Diagnostics) {
-	elasticConfig := &kbapi.KibanaRoleElasticsearch{}
-	var diags diag.Diagnostics
-
+// expandKibanaRoleElasticsearchInto expands the elasticsearch block from Terraform
+// state into a SecurityRoleES struct, modifying es in place.
+func expandKibanaRoleElasticsearchInto(v any, serverVersion *version.Version, es *kibanaoapi.SecurityRoleES) diag.Diagnostics {
 	if definedElasticConfigs := v.(*schema.Set); definedElasticConfigs.Len() > 0 {
 		userElasticConfig := definedElasticConfigs.List()[0].(map[string]any)
+
 		if v, ok := userElasticConfig["cluster"]; ok {
 			definedCluster := v.(*schema.Set)
-			cls := make([]string, definedCluster.Len())
-			for i, cl := range definedCluster.List() {
-				cls[i] = cl.(string)
-			}
-			elasticConfig.Cluster = cls
-
-			if v, ok := userElasticConfig["indices"]; ok {
-				definedIndices := v.(*schema.Set)
-				indices := make([]kbapi.KibanaRoleElasticsearchIndice, definedIndices.Len())
-				for i, idx := range definedIndices.List() {
-					index := idx.(map[string]any)
-
-					definedNames := index["names"].(*schema.Set)
-					names := make([]string, definedNames.Len())
-					for i, name := range definedNames.List() {
-						names[i] = name.(string)
-					}
-					definedPrivileges := index["privileges"].(*schema.Set)
-					privileges := make([]string, definedPrivileges.Len())
-					for i, pr := range definedPrivileges.List() {
-						privileges[i] = pr.(string)
-					}
-
-					newIndex := kbapi.KibanaRoleElasticsearchIndice{
-						Names:      names,
-						Privileges: privileges,
-					}
-
-					if query := index["query"].(string); query != "" {
-						newIndex.Query = &query
-					}
-					if fieldSec := index["field_security"].([]any); len(fieldSec) > 0 {
-						fieldSecurity := map[string]any{}
-						// there must be only 1 entry
-						definedFieldSec := fieldSec[0].(map[string]any)
-
-						// grants
-						if gr := definedFieldSec["grant"].(*schema.Set); gr != nil {
-							grants := make([]string, gr.Len())
-							for i, grant := range gr.List() {
-								grants[i] = grant.(string)
-							}
-							fieldSecurity["grant"] = grants
-						}
-						// except
-						if exp := definedFieldSec["except"].(*schema.Set); exp != nil {
-							excepts := make([]string, exp.Len())
-							for i, except := range exp.List() {
-								excepts[i] = except.(string)
-							}
-							fieldSecurity["except"] = excepts
-						}
-						newIndex.FieldSecurity = fieldSecurity
-					}
-
-					indices[i] = newIndex
+			if definedCluster.Len() > 0 {
+				cls := make([]string, definedCluster.Len())
+				for i, cl := range definedCluster.List() {
+					cls[i] = cl.(string)
 				}
-				elasticConfig.Indices = indices
+				es.Cluster = &cls
 			}
+		}
 
-			if v, ok := userElasticConfig["remote_indices"]; ok {
-				definedRemoteIndices := v.(*schema.Set)
-				if definedRemoteIndices.Len() > 0 {
-					if serverVersion.LessThan(minSupportedRemoteIndicesVersion) {
-						return nil, diag.FromErr(fmt.Errorf("'remote_indices' is supported only for Kibana v%s and above", minSupportedRemoteIndicesVersion.String()))
-					}
+		if v, ok := userElasticConfig["indices"]; ok {
+			definedIndices := v.(*schema.Set)
+			if definedIndices.Len() > 0 {
+				indices, diags := expandIndices(definedIndices)
+				if diags != nil {
+					return diags
 				}
-				remoteIndices := make([]kbapi.KibanaRoleElasticsearchRemoteIndice, definedRemoteIndices.Len())
-				for i, idx := range definedRemoteIndices.List() {
-					index := idx.(map[string]any)
-
-					definedNames := index["names"].(*schema.Set)
-					names := make([]string, definedNames.Len())
-					for i, name := range definedNames.List() {
-						names[i] = name.(string)
-					}
-					definedClusters := index["clusters"].(*schema.Set)
-					clusters := make([]string, definedClusters.Len())
-					for i, cluster := range definedClusters.List() {
-						clusters[i] = cluster.(string)
-					}
-					definedPrivileges := index["privileges"].(*schema.Set)
-					privileges := make([]string, definedPrivileges.Len())
-					for i, pr := range definedPrivileges.List() {
-						privileges[i] = pr.(string)
-					}
-
-					newRemoteIndex := kbapi.KibanaRoleElasticsearchRemoteIndice{
-						Names:      names,
-						Clusters:   clusters,
-						Privileges: privileges,
-					}
-
-					if query := index["query"].(string); query != "" {
-						newRemoteIndex.Query = &query
-					}
-					if fieldSec := index["field_security"].([]any); len(fieldSec) > 0 {
-						fieldSecurity := map[string]any{}
-						// there must be only 1 entry
-						definedFieldSec := fieldSec[0].(map[string]any)
-
-						// grants
-						if gr := definedFieldSec["grant"].(*schema.Set); gr != nil {
-							grants := make([]string, gr.Len())
-							for i, grant := range gr.List() {
-								grants[i] = grant.(string)
-							}
-							fieldSecurity["grant"] = grants
-						}
-						// except
-						if exp := definedFieldSec["except"].(*schema.Set); exp != nil {
-							excepts := make([]string, exp.Len())
-							for i, except := range exp.List() {
-								excepts[i] = except.(string)
-							}
-							fieldSecurity["except"] = excepts
-						}
-						newRemoteIndex.FieldSecurity = fieldSecurity
-					}
-
-					remoteIndices[i] = newRemoteIndex
-				}
-				elasticConfig.RemoteIndices = remoteIndices
+				es.Indices = &indices
 			}
+		}
 
-			if v, ok := userElasticConfig["run_as"]; ok {
-				definedRuns := v.(*schema.Set)
+		if v, ok := userElasticConfig["remote_indices"]; ok {
+			definedRemoteIndices := v.(*schema.Set)
+			if definedRemoteIndices.Len() > 0 {
+				if serverVersion.LessThan(minSupportedRemoteIndicesVersion) {
+					return diag.FromErr(fmt.Errorf("'remote_indices' is supported only for Kibana v%s and above", minSupportedRemoteIndicesVersion.String()))
+				}
+
+				remoteIndices, diags := expandRemoteIndices(definedRemoteIndices)
+				if diags != nil {
+					return diags
+				}
+				es.RemoteIndices = &remoteIndices
+			}
+		}
+
+		if v, ok := userElasticConfig["run_as"]; ok {
+			definedRuns := v.(*schema.Set)
+			if definedRuns.Len() > 0 {
 				runs := make([]string, definedRuns.Len())
 				for i, run := range definedRuns.List() {
 					runs[i] = run.(string)
 				}
-				elasticConfig.RunAs = runs
+				es.RunAs = &runs
 			}
 		}
 	}
-	return elasticConfig, diags
+	return nil
 }
 
-func expandKibanaRoleKibana(v any) ([]kbapi.KibanaRoleKibana, diag.Diagnostics) {
-	kibanaConfigs := []kbapi.KibanaRoleKibana{}
+func expandIndices(definedIndices *schema.Set) ([]kibanaoapi.SecurityRoleESIndex, diag.Diagnostics) {
+	indices := make([]kibanaoapi.SecurityRoleESIndex, definedIndices.Len())
+	for i, idx := range definedIndices.List() {
+		index := idx.(map[string]any)
+
+		definedNames := index["names"].(*schema.Set)
+		names := make([]string, definedNames.Len())
+		for j, name := range definedNames.List() {
+			names[j] = name.(string)
+		}
+		definedPrivileges := index["privileges"].(*schema.Set)
+		privileges := make([]string, definedPrivileges.Len())
+		for j, pr := range definedPrivileges.List() {
+			privileges[j] = pr.(string)
+		}
+
+		entry := kibanaoapi.SecurityRoleESIndex{
+			Names:      names,
+			Privileges: privileges,
+		}
+
+		if query := index["query"].(string); query != "" {
+			entry.Query = &query
+		}
+		if fieldSec := index["field_security"].([]any); len(fieldSec) > 0 {
+			fieldSecurity := expandFieldSecurity(fieldSec[0].(map[string]any))
+			if len(fieldSecurity) > 0 {
+				entry.FieldSecurity = &fieldSecurity
+			}
+		}
+
+		indices[i] = entry
+	}
+	return indices, nil
+}
+
+func expandRemoteIndices(definedRemoteIndices *schema.Set) ([]kibanaoapi.SecurityRoleESRemoteIndex, diag.Diagnostics) {
+	remoteIndices := make([]kibanaoapi.SecurityRoleESRemoteIndex, definedRemoteIndices.Len())
+	for i, idx := range definedRemoteIndices.List() {
+		index := idx.(map[string]any)
+
+		definedNames := index["names"].(*schema.Set)
+		names := make([]string, definedNames.Len())
+		for j, name := range definedNames.List() {
+			names[j] = name.(string)
+		}
+		definedClusters := index["clusters"].(*schema.Set)
+		clusters := make([]string, definedClusters.Len())
+		for j, cluster := range definedClusters.List() {
+			clusters[j] = cluster.(string)
+		}
+		definedPrivileges := index["privileges"].(*schema.Set)
+		privileges := make([]string, definedPrivileges.Len())
+		for j, pr := range definedPrivileges.List() {
+			privileges[j] = pr.(string)
+		}
+
+		entry := kibanaoapi.SecurityRoleESRemoteIndex{
+			Names:      names,
+			Clusters:   clusters,
+			Privileges: privileges,
+		}
+
+		if query := index["query"].(string); query != "" {
+			entry.Query = &query
+		}
+		if fieldSec := index["field_security"].([]any); len(fieldSec) > 0 {
+			fieldSecurity := expandFieldSecurity(fieldSec[0].(map[string]any))
+			if len(fieldSecurity) > 0 {
+				entry.FieldSecurity = &fieldSecurity
+			}
+		}
+
+		remoteIndices[i] = entry
+	}
+	return remoteIndices, nil
+}
+
+func expandFieldSecurity(definedFieldSec map[string]any) map[string][]string {
+	fieldSecurity := map[string][]string{}
+	if gr := definedFieldSec["grant"].(*schema.Set); gr != nil && gr.Len() > 0 {
+		grants := make([]string, gr.Len())
+		for i, grant := range gr.List() {
+			grants[i] = grant.(string)
+		}
+		fieldSecurity["grant"] = grants
+	}
+	if exp := definedFieldSec["except"].(*schema.Set); exp != nil && exp.Len() > 0 {
+		excepts := make([]string, exp.Len())
+		for i, except := range exp.List() {
+			excepts[i] = except.(string)
+		}
+		fieldSecurity["except"] = excepts
+	}
+	return fieldSecurity
+}
+
+func expandKibanaRoleKibana(v any) ([]kibanaoapi.SecurityRoleKibana, diag.Diagnostics) {
 	definedKibanaConfigs := v.(*schema.Set)
+	entries := make([]kibanaoapi.SecurityRoleKibana, 0, definedKibanaConfigs.Len())
 
 	for _, item := range definedKibanaConfigs.List() {
 		each := item.(map[string]any)
-		config := kbapi.KibanaRoleKibana{
-			Base:    []string{},
-			Feature: map[string][]string{},
-		}
+		entry := kibanaoapi.SecurityRoleKibana{}
 
 		if basePrivileges, ok := each["base"].(*schema.Set); ok && basePrivileges.Len() > 0 {
-			if _features, ok := each["feature"].(*schema.Set); ok && _features.Len() > 0 {
+			if features, ok := each["feature"].(*schema.Set); ok && features.Len() > 0 {
 				return nil, diag.Errorf("Only one of the `feature` or `base` privileges allowed!")
 			}
-			config.Base = make([]string, basePrivileges.Len())
+			base := make([]string, basePrivileges.Len())
 			for i, name := range basePrivileges.List() {
-				config.Base[i] = name.(string)
+				base[i] = name.(string)
 			}
+			baseJSON, err := json.Marshal(base)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+			entry.Base = json.RawMessage(baseJSON)
 		} else if kibanaFeatures, ok := each["feature"].(*schema.Set); ok && kibanaFeatures.Len() > 0 {
+			featureMap := map[string][]string{}
 			for _, item := range kibanaFeatures.List() {
 				featureData := item.(map[string]any)
 				featurePrivileges := featureData["privileges"].(*schema.Set)
-				_features := make([]string, featurePrivileges.Len())
+				privs := make([]string, featurePrivileges.Len())
 				for i, f := range featurePrivileges.List() {
-					_features[i] = f.(string)
+					privs[i] = f.(string)
 				}
-				config.Feature[featureData["name"].(string)] = _features
+				featureMap[featureData["name"].(string)] = privs
 			}
+			entry.Feature = &featureMap
 		} else {
 			return nil, diag.Errorf("Either on of the `feature` or `base` privileges must be set for kibana role!")
 		}
 
 		if roleSpaces, ok := each["spaces"].(*schema.Set); ok && roleSpaces.Len() > 0 {
-			config.Spaces = make([]string, roleSpaces.Len())
+			spaces := make([]string, roleSpaces.Len())
 			for i, name := range roleSpaces.List() {
-				config.Spaces[i] = name.(string)
+				spaces[i] = name.(string)
 			}
+			entry.Spaces = &spaces
 		}
-		kibanaConfigs = append(kibanaConfigs, config)
+		entries = append(entries, entry)
 	}
-	return kibanaConfigs, nil
+
+	return entries, nil
 }
 
-func flattenKibanaRoleIndicesData(indices []kbapi.KibanaRoleElasticsearchIndice) []any {
-	oindx := make([]any, len(indices))
+func flattenKibanaRoleIndicesData(indices *[]kibanaoapi.SecurityRoleESIndex) []any {
+	if indices == nil {
+		return []any{}
+	}
+	oindx := make([]any, len(*indices))
 
-	for i, index := range indices {
+	for i, index := range *indices {
 		oi := make(map[string]any)
 		oi["names"] = index.Names
 		oi["privileges"] = index.Privileges
-		oi["query"] = index.Query
+		if index.Query != nil {
+			oi["query"] = *index.Query
+		} else {
+			oi["query"] = ""
+		}
 
 		if index.FieldSecurity != nil {
 			fsec := make(map[string]any)
-			if grantV, ok := index.FieldSecurity["grant"]; ok {
+			if grantV, ok := (*index.FieldSecurity)["grant"]; ok {
 				fsec["grant"] = grantV
 			}
-			if exceptV, ok := index.FieldSecurity["except"]; ok {
+			if exceptV, ok := (*index.FieldSecurity)["except"]; ok {
 				fsec["except"] = exceptV
 			}
 			oi["field_security"] = []any{fsec}
@@ -646,22 +673,29 @@ func flattenKibanaRoleIndicesData(indices []kbapi.KibanaRoleElasticsearchIndice)
 	return oindx
 }
 
-func flattenKibanaRoleRemoteIndicesData(indices []kbapi.KibanaRoleElasticsearchRemoteIndice) []any {
-	oindx := make([]any, len(indices))
+func flattenKibanaRoleRemoteIndicesData(indices *[]kibanaoapi.SecurityRoleESRemoteIndex) []any {
+	if indices == nil {
+		return []any{}
+	}
+	oindx := make([]any, len(*indices))
 
-	for i, index := range indices {
+	for i, index := range *indices {
 		oi := make(map[string]any)
 		oi["clusters"] = index.Clusters
 		oi["names"] = index.Names
 		oi["privileges"] = index.Privileges
-		oi["query"] = index.Query
+		if index.Query != nil {
+			oi["query"] = *index.Query
+		} else {
+			oi["query"] = ""
+		}
 
 		if index.FieldSecurity != nil {
 			fsec := make(map[string]any)
-			if grantV, ok := index.FieldSecurity["grant"]; ok {
+			if grantV, ok := (*index.FieldSecurity)["grant"]; ok {
 				fsec["grant"] = grantV
 			}
-			if exceptV, ok := index.FieldSecurity["except"]; ok {
+			if exceptV, ok := (*index.FieldSecurity)["except"]; ok {
 				fsec["except"] = exceptV
 			}
 			oi["field_security"] = []any{fsec}
@@ -671,49 +705,66 @@ func flattenKibanaRoleRemoteIndicesData(indices []kbapi.KibanaRoleElasticsearchR
 	return oindx
 }
 
-func flattenKibanaRoleElasticsearchData(elastic *kbapi.KibanaRoleElasticsearch) []any {
-	if elastic != nil {
-		result := make(map[string]any)
-		if len(elastic.Cluster) > 0 {
-			result["cluster"] = elastic.Cluster
-		}
-		result["indices"] = flattenKibanaRoleIndicesData(elastic.Indices)
-		result["remote_indices"] = flattenKibanaRoleRemoteIndicesData(elastic.RemoteIndices)
-		if len(elastic.RunAs) > 0 {
-			result["run_as"] = elastic.RunAs
-		}
-		return []any{result}
+func flattenKibanaRoleElasticsearchData(role *kibanaoapi.SecurityRole) []any {
+	result := make(map[string]any)
+	es := role.Elasticsearch
+
+	if es.Cluster != nil && len(*es.Cluster) > 0 {
+		result["cluster"] = *es.Cluster
 	}
-	return make([]any, 0)
+	result["indices"] = flattenKibanaRoleIndicesData(es.Indices)
+	result["remote_indices"] = flattenKibanaRoleRemoteIndicesData(es.RemoteIndices)
+	if es.RunAs != nil && len(*es.RunAs) > 0 {
+		result["run_as"] = *es.RunAs
+	}
+	return []any{result}
 }
 
-func flattenKibanaRoleKibanaFeatureData(features map[string][]string) []any {
-	if features != nil {
-		result := make([]any, len(features))
-		i := 0
-		for k, v := range features {
-			m := make(map[string]any)
-			m["name"] = k
-			m["privileges"] = v
-			result[i] = m
-			i++
-		}
-		return result
+func flattenKibanaRoleKibanaFeatureData(features *map[string][]string) []any {
+	if features == nil {
+		return []any{}
 	}
-	return make([]any, 0)
+	result := make([]any, len(*features))
+	i := 0
+	for k, v := range *features {
+		m := make(map[string]any)
+		m["name"] = k
+		m["privileges"] = v
+		result[i] = m
+		i++
+	}
+	return result
 }
 
-func flattenKibanaRoleKibanaData(kibanaConfigs *[]kbapi.KibanaRoleKibana) []any {
-	if kibanaConfigs != nil {
-		result := make([]any, len(*kibanaConfigs))
-		for i, index := range *kibanaConfigs {
-			nk := make(map[string]any)
-			nk["base"] = index.Base
-			nk["feature"] = flattenKibanaRoleKibanaFeatureData(index.Feature)
-			nk["spaces"] = index.Spaces
-			result[i] = nk
-		}
-		return result
+func flattenKibanaRoleKibanaData(kibanaConfigs []kibanaoapi.SecurityRoleKibana) []any {
+	if kibanaConfigs == nil {
+		return []any{}
 	}
-	return make([]any, 0)
+
+	result := make([]any, len(kibanaConfigs))
+	for i, config := range kibanaConfigs {
+		nk := make(map[string]any)
+
+		// base is stored as json.RawMessage - decode to []string
+		if len(config.Base) > 0 {
+			var base []string
+			if err := json.Unmarshal(config.Base, &base); err == nil && len(base) > 0 {
+				nk["base"] = base
+			}
+		}
+		if _, ok := nk["base"]; !ok {
+			nk["base"] = []string{}
+		}
+
+		nk["feature"] = flattenKibanaRoleKibanaFeatureData(config.Feature)
+
+		if config.Spaces != nil {
+			nk["spaces"] = *config.Spaces
+		} else {
+			nk["spaces"] = []string{}
+		}
+
+		result[i] = nk
+	}
+	return result
 }

--- a/internal/kibana/role.go
+++ b/internal/kibana/role.go
@@ -351,7 +351,7 @@ func resourceRoleUpsert(ctx context.Context, d *schema.ResourceData, meta any) d
 	return resourceRoleRead(ctx, d, meta)
 }
 
-func resourceRoleRead(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	factory, diags := clients.ConvertMetaToFactory(meta)
 	if diags.HasError() {
 		return diags
@@ -368,7 +368,7 @@ func resourceRoleRead(_ context.Context, d *schema.ResourceData, meta any) diag.
 
 	name := d.Id()
 
-	role, ds := kibanaoapi.GetSecurityRole(context.Background(), oapiClient, name)
+	role, ds := kibanaoapi.GetSecurityRole(ctx, oapiClient, name)
 	if ds != nil {
 		return ds
 	}
@@ -403,7 +403,7 @@ func resourceRoleRead(_ context.Context, d *schema.ResourceData, meta any) diag.
 	return diags
 }
 
-func resourceRoleDelete(_ context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func resourceRoleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	factory, diags := clients.ConvertMetaToFactory(meta)
 	if diags.HasError() {
 		return diags
@@ -420,7 +420,7 @@ func resourceRoleDelete(_ context.Context, d *schema.ResourceData, meta any) dia
 
 	resourceID := d.Id()
 
-	if ds := kibanaoapi.DeleteSecurityRole(context.Background(), oapiClient, resourceID); ds != nil {
+	if ds := kibanaoapi.DeleteSecurityRole(ctx, oapiClient, resourceID); ds != nil {
 		return ds
 	}
 
@@ -458,10 +458,7 @@ func expandKibanaRoleElasticsearchInto(v any, serverVersion *version.Version, es
 		if v, ok := userElasticConfig["indices"]; ok {
 			definedIndices := v.(*schema.Set)
 			if definedIndices.Len() > 0 {
-				indices, diags := expandIndices(definedIndices)
-				if diags != nil {
-					return diags
-				}
+				indices := expandIndices(definedIndices)
 				es.Indices = &indices
 			}
 		}
@@ -473,10 +470,7 @@ func expandKibanaRoleElasticsearchInto(v any, serverVersion *version.Version, es
 					return diag.FromErr(fmt.Errorf("'remote_indices' is supported only for Kibana v%s and above", minSupportedRemoteIndicesVersion.String()))
 				}
 
-				remoteIndices, diags := expandRemoteIndices(definedRemoteIndices)
-				if diags != nil {
-					return diags
-				}
+				remoteIndices := expandRemoteIndices(definedRemoteIndices)
 				es.RemoteIndices = &remoteIndices
 			}
 		}
@@ -495,7 +489,7 @@ func expandKibanaRoleElasticsearchInto(v any, serverVersion *version.Version, es
 	return nil
 }
 
-func expandIndices(definedIndices *schema.Set) ([]kibanaoapi.SecurityRoleESIndex, diag.Diagnostics) {
+func expandIndices(definedIndices *schema.Set) []kibanaoapi.SecurityRoleESIndex {
 	indices := make([]kibanaoapi.SecurityRoleESIndex, definedIndices.Len())
 	for i, idx := range definedIndices.List() {
 		index := idx.(map[string]any)
@@ -528,10 +522,10 @@ func expandIndices(definedIndices *schema.Set) ([]kibanaoapi.SecurityRoleESIndex
 
 		indices[i] = entry
 	}
-	return indices, nil
+	return indices
 }
 
-func expandRemoteIndices(definedRemoteIndices *schema.Set) ([]kibanaoapi.SecurityRoleESRemoteIndex, diag.Diagnostics) {
+func expandRemoteIndices(definedRemoteIndices *schema.Set) []kibanaoapi.SecurityRoleESRemoteIndex {
 	remoteIndices := make([]kibanaoapi.SecurityRoleESRemoteIndex, definedRemoteIndices.Len())
 	for i, idx := range definedRemoteIndices.List() {
 		index := idx.(map[string]any)
@@ -570,7 +564,7 @@ func expandRemoteIndices(definedRemoteIndices *schema.Set) ([]kibanaoapi.Securit
 
 		remoteIndices[i] = entry
 	}
-	return remoteIndices, nil
+	return remoteIndices
 }
 
 func expandFieldSecurity(definedFieldSec map[string]any) map[string][]string {

--- a/internal/kibana/role_test.go
+++ b/internal/kibana/role_test.go
@@ -18,12 +18,14 @@
 package kibana_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest/checks"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	kibanaoapi "github.com/elastic/terraform-provider-elasticstack/internal/clients/kibanaoapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/versionutils"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -124,7 +126,12 @@ func TestAccResourceKibanaSecurityRole(t *testing.T) {
 }
 
 func checkResourceSecurityRoleDestroy(s *terraform.State) error {
-	client, err := clients.NewAcceptanceTestingClient()
+	apiClient, err := clients.NewAcceptanceTestingClient()
+	if err != nil {
+		return err
+	}
+
+	oapiClient, err := apiClient.GetKibanaOapiClient()
 	if err != nil {
 		return err
 	}
@@ -135,12 +142,8 @@ func checkResourceSecurityRoleDestroy(s *terraform.State) error {
 		}
 		compID := rs.Primary.ID
 
-		kibanaClient, err := client.GetKibanaClient()
-		if err != nil {
-			return err
-		}
-		res, err := kibanaClient.KibanaRoleManagement.Get(compID)
-		if err != nil || res != nil {
+		role, diags := kibanaoapi.GetSecurityRole(context.Background(), oapiClient, compID)
+		if diags.HasError() || role != nil {
 			return fmt.Errorf("Role (%s) still exists", compID)
 		}
 	}

--- a/internal/kibana/role_unit_test.go
+++ b/internal/kibana/role_unit_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func strPtr(s string) *string { return &s }
-
 // expandESForTest calls expandKibanaRoleElasticsearchInto and returns the SecurityRoleES for testing.
 func expandESForTest(t *testing.T, esSet *schema.Set, ver *version.Version) kibanaoapi.SecurityRoleES {
 	t.Helper()
@@ -63,15 +61,15 @@ func TestRoleIndexFieldSecurityRoundTrip(t *testing.T) {
 		Schema: map[string]*schema.Schema{},
 	}), []any{indexEntry})
 
-	indices, diags := expandIndices(indexSet)
-	require.Nil(t, diags)
+	indices := expandIndices(indexSet)
 	require.Len(t, indices, 1)
 
 	idx := indices[0]
 	require.NotNil(t, idx.FieldSecurity)
 	assert.ElementsMatch(t, []string{"field1", "field2"}, (*idx.FieldSecurity)["grant"])
 	assert.ElementsMatch(t, []string{"secret"}, (*idx.FieldSecurity)["except"])
-	assert.Equal(t, strPtr(`{"match_all":{}}`), idx.Query)
+	require.NotNil(t, idx.Query)
+	assert.Equal(t, `{"match_all":{}}`, *idx.Query)
 
 	// Round-trip through JSON into SecurityRoleESIndex
 	idxJSON, err := json.Marshal(indices)
@@ -86,7 +84,7 @@ func TestRoleIndexFieldSecurityRoundTrip(t *testing.T) {
 	flatIdx := flatResult[0].(map[string]any)
 	assert.ElementsMatch(t, []string{"logs-*"}, flatIdx["names"])
 	assert.ElementsMatch(t, []string{"read", "write"}, flatIdx["privileges"])
-	assert.Equal(t, `{"match_all":{}}`, flatIdx["query"])
+	assert.JSONEq(t, `{"match_all":{}}`, flatIdx["query"].(string))
 
 	fsec := flatIdx["field_security"].([]any)[0].(map[string]any)
 	assert.ElementsMatch(t, []string{"field1", "field2"}, fsec["grant"])
@@ -116,8 +114,7 @@ func TestRoleRemoteIndicesRoundTrip(t *testing.T) {
 
 	remoteSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{remoteEntry})
 
-	remoteIndices, diags := expandRemoteIndices(remoteSet)
-	require.Nil(t, diags)
+	remoteIndices := expandRemoteIndices(remoteSet)
 	require.Len(t, remoteIndices, 1)
 
 	ri := remoteIndices[0]

--- a/internal/kibana/role_unit_test.go
+++ b/internal/kibana/role_unit_test.go
@@ -1,0 +1,267 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"encoding/json"
+	"testing"
+
+	kibanaoapi "github.com/elastic/terraform-provider-elasticstack/internal/clients/kibanaoapi"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string { return &s }
+
+// expandESForTest calls expandKibanaRoleElasticsearchInto and returns the SecurityRoleES for testing.
+func expandESForTest(t *testing.T, esSet *schema.Set, ver *version.Version) kibanaoapi.SecurityRoleES {
+	t.Helper()
+	var es kibanaoapi.SecurityRoleES
+	diags := expandKibanaRoleElasticsearchInto(esSet, ver, &es)
+	require.Nil(t, diags)
+	return es
+}
+
+func TestRoleIndexFieldSecurityRoundTrip(t *testing.T) {
+	grantSet := schema.NewSet(schema.HashString, []any{"field1", "field2"})
+	exceptSet := schema.NewSet(schema.HashString, []any{"secret"})
+	namesSet := schema.NewSet(schema.HashString, []any{"logs-*"})
+	privsSet := schema.NewSet(schema.HashString, []any{"read", "write"})
+
+	fieldSecList := []any{
+		map[string]any{
+			"grant":  grantSet,
+			"except": exceptSet,
+		},
+	}
+
+	indexEntry := map[string]any{
+		"names":          namesSet,
+		"privileges":     privsSet,
+		"query":          `{"match_all":{}}`,
+		"field_security": fieldSecList,
+	}
+
+	indexSet := schema.NewSet(schema.HashResource(&schema.Resource{
+		Schema: map[string]*schema.Schema{},
+	}), []any{indexEntry})
+
+	indices, diags := expandIndices(indexSet)
+	require.Nil(t, diags)
+	require.Len(t, indices, 1)
+
+	idx := indices[0]
+	require.NotNil(t, idx.FieldSecurity)
+	assert.ElementsMatch(t, []string{"field1", "field2"}, (*idx.FieldSecurity)["grant"])
+	assert.ElementsMatch(t, []string{"secret"}, (*idx.FieldSecurity)["except"])
+	assert.Equal(t, strPtr(`{"match_all":{}}`), idx.Query)
+
+	// Round-trip through JSON into SecurityRoleESIndex
+	idxJSON, err := json.Marshal(indices)
+	require.NoError(t, err)
+
+	var decoded []kibanaoapi.SecurityRoleESIndex
+	require.NoError(t, json.Unmarshal(idxJSON, &decoded))
+
+	flatResult := flattenKibanaRoleIndicesData(&decoded)
+	require.Len(t, flatResult, 1)
+
+	flatIdx := flatResult[0].(map[string]any)
+	assert.ElementsMatch(t, []string{"logs-*"}, flatIdx["names"])
+	assert.ElementsMatch(t, []string{"read", "write"}, flatIdx["privileges"])
+	assert.Equal(t, `{"match_all":{}}`, flatIdx["query"])
+
+	fsec := flatIdx["field_security"].([]any)[0].(map[string]any)
+	assert.ElementsMatch(t, []string{"field1", "field2"}, fsec["grant"])
+	assert.ElementsMatch(t, []string{"secret"}, fsec["except"])
+}
+
+func TestRoleRemoteIndicesRoundTrip(t *testing.T) {
+	namesSet := schema.NewSet(schema.HashString, []any{"sample"})
+	clustersSet := schema.NewSet(schema.HashString, []any{"test-cluster"})
+	privsSet := schema.NewSet(schema.HashString, []any{"create", "read", "write"})
+	grantSet := schema.NewSet(schema.HashString, []any{"sample"})
+
+	fieldSecList := []any{
+		map[string]any{
+			"grant":  grantSet,
+			"except": schema.NewSet(schema.HashString, []any{}),
+		},
+	}
+
+	remoteEntry := map[string]any{
+		"names":          namesSet,
+		"clusters":       clustersSet,
+		"privileges":     privsSet,
+		"query":          "",
+		"field_security": fieldSecList,
+	}
+
+	remoteSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{remoteEntry})
+
+	remoteIndices, diags := expandRemoteIndices(remoteSet)
+	require.Nil(t, diags)
+	require.Len(t, remoteIndices, 1)
+
+	ri := remoteIndices[0]
+	assert.ElementsMatch(t, []string{"sample"}, ri.Names)
+	assert.ElementsMatch(t, []string{"test-cluster"}, ri.Clusters)
+	assert.ElementsMatch(t, []string{"create", "read", "write"}, ri.Privileges)
+	require.NotNil(t, ri.FieldSecurity)
+	assert.ElementsMatch(t, []string{"sample"}, (*ri.FieldSecurity)["grant"])
+
+	// Round-trip through JSON
+	riJSON, err := json.Marshal(remoteIndices)
+	require.NoError(t, err)
+
+	var decoded []kibanaoapi.SecurityRoleESRemoteIndex
+	require.NoError(t, json.Unmarshal(riJSON, &decoded))
+
+	flatResult := flattenKibanaRoleRemoteIndicesData(&decoded)
+	require.Len(t, flatResult, 1)
+
+	flatRI := flatResult[0].(map[string]any)
+	assert.ElementsMatch(t, []string{"sample"}, flatRI["names"])
+	assert.ElementsMatch(t, []string{"test-cluster"}, flatRI["clusters"])
+	assert.ElementsMatch(t, []string{"create", "read", "write"}, flatRI["privileges"])
+
+	fsec := flatRI["field_security"].([]any)[0].(map[string]any)
+	assert.ElementsMatch(t, []string{"sample"}, fsec["grant"])
+}
+
+func TestRoleKibanaBaseRoundTrip(t *testing.T) {
+	spacesSet := schema.NewSet(schema.HashString, []any{"default"})
+	baseSet := schema.NewSet(schema.HashString, []any{"all"})
+
+	kibanaEntry := map[string]any{
+		"base":    baseSet,
+		"feature": schema.NewSet(schema.HashString, []any{}),
+		"spaces":  spacesSet,
+	}
+
+	kibanaSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{kibanaEntry})
+
+	kibanaPrivs, diags := expandKibanaRoleKibana(kibanaSet)
+	require.Nil(t, diags)
+	require.Len(t, kibanaPrivs, 1)
+
+	// Verify base is correctly encoded as JSON array
+	var base []string
+	require.NoError(t, json.Unmarshal(kibanaPrivs[0].Base, &base))
+	assert.ElementsMatch(t, []string{"all"}, base)
+
+	// Round-trip flatten
+	flatResult := flattenKibanaRoleKibanaData(kibanaPrivs)
+	require.Len(t, flatResult, 1)
+
+	flat := flatResult[0].(map[string]any)
+	assert.ElementsMatch(t, []string{"all"}, flat["base"])
+	assert.ElementsMatch(t, []string{"default"}, flat["spaces"])
+}
+
+func TestRoleKibanaFeatureRoundTrip(t *testing.T) {
+	spacesSet := schema.NewSet(schema.HashString, []any{"default"})
+
+	featurePrivsSet := schema.NewSet(schema.HashString, []any{"minimal_read", "url_create"})
+	featureEntry := map[string]any{
+		"name":       "discover",
+		"privileges": featurePrivsSet,
+	}
+	featureSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{featureEntry})
+
+	kibanaEntry := map[string]any{
+		"base":    schema.NewSet(schema.HashString, []any{}),
+		"feature": featureSet,
+		"spaces":  spacesSet,
+	}
+
+	kibanaSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{kibanaEntry})
+
+	kibanaPrivs, diags := expandKibanaRoleKibana(kibanaSet)
+	require.Nil(t, diags)
+	require.Len(t, kibanaPrivs, 1)
+
+	// Feature map should have "discover"
+	require.NotNil(t, kibanaPrivs[0].Feature)
+	featurePrivs, ok := (*kibanaPrivs[0].Feature)["discover"]
+	require.True(t, ok)
+	assert.ElementsMatch(t, []string{"minimal_read", "url_create"}, featurePrivs)
+
+	// Flatten
+	flatResult := flattenKibanaRoleKibanaData(kibanaPrivs)
+	require.Len(t, flatResult, 1)
+
+	flat := flatResult[0].(map[string]any)
+	assert.Empty(t, flat["base"])
+
+	featureFlat := flattenKibanaRoleKibanaFeatureData(kibanaPrivs[0].Feature)
+	assert.Len(t, featureFlat, 1)
+	featureMap := featureFlat[0].(map[string]any)
+	assert.Equal(t, "discover", featureMap["name"])
+	assert.ElementsMatch(t, []string{"minimal_read", "url_create"}, featureMap["privileges"])
+}
+
+func TestRoleMetadataRoundTrip(t *testing.T) {
+	metaJSON := `{"team":"ops","env":"prod"}`
+
+	metadata, diags := expandKibanaRoleMetadata(metaJSON)
+	require.Nil(t, diags)
+	require.NotNil(t, metadata)
+	assert.Equal(t, "ops", metadata["team"])
+
+	// Simulate what flatten does: marshal back
+	out, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	var roundTripped map[string]any
+	require.NoError(t, json.Unmarshal(out, &roundTripped))
+	assert.Equal(t, "ops", roundTripped["team"])
+	assert.Equal(t, "prod", roundTripped["env"])
+}
+
+func TestExpandESConfig_EmptyClusterAndRunAs(t *testing.T) {
+	// Verify that empty cluster and run_as are omitted (not set as non-nil pointers)
+	clusterSet := schema.NewSet(schema.HashString, []any{})
+	runAsSet := schema.NewSet(schema.HashString, []any{})
+	namesSet := schema.NewSet(schema.HashString, []any{"my-index"})
+	privsSet := schema.NewSet(schema.HashString, []any{"read"})
+
+	indexEntry := map[string]any{
+		"names":          namesSet,
+		"privileges":     privsSet,
+		"query":          "",
+		"field_security": []any{},
+	}
+	indexSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{indexEntry})
+
+	esMap := map[string]any{
+		"cluster":        clusterSet,
+		"indices":        indexSet,
+		"remote_indices": schema.NewSet(schema.HashString, []any{}),
+		"run_as":         runAsSet,
+	}
+	esSet := schema.NewSet(schema.HashResource(&schema.Resource{Schema: map[string]*schema.Schema{}}), []any{esMap})
+
+	ver := version.Must(version.NewVersion("9.0.0"))
+	es := expandESForTest(t, esSet, ver)
+
+	assert.Nil(t, es.Cluster, "empty cluster should be nil")
+	assert.Nil(t, es.RunAs, "empty run_as should be nil")
+	assert.NotNil(t, es.Indices)
+}

--- a/internal/kibana/role_unit_test.go
+++ b/internal/kibana/role_unit_test.go
@@ -69,7 +69,7 @@ func TestRoleIndexFieldSecurityRoundTrip(t *testing.T) {
 	assert.ElementsMatch(t, []string{"field1", "field2"}, (*idx.FieldSecurity)["grant"])
 	assert.ElementsMatch(t, []string{"secret"}, (*idx.FieldSecurity)["except"])
 	require.NotNil(t, idx.Query)
-	assert.Equal(t, `{"match_all":{}}`, *idx.Query)
+	assert.JSONEq(t, `{"match_all":{}}`, *idx.Query)
 
 	// Round-trip through JSON into SecurityRoleESIndex
 	idxJSON, err := json.Marshal(indices)

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/proposal.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/proposal.md
@@ -5,7 +5,8 @@ The `elasticstack_kibana_security_role` resource and data source still depend on
 ## What Changes
 
 - Add `internal/clients/kibanaoapi` helpers that wrap Kibana Security Role endpoints exposed in `generated/kbapi` (`GetSecurityRoleName`, `PutSecurityRoleName`, `DeleteSecurityRoleName`), including consistent decoding of JSON bodies, HTTP status handling (including not-found on read), and diagnostics on failure.
-- Refactor `internal/kibana/role.go` (and the data source companion if separated) to build requests and interpret responses using `kbapi` types (for example `PutSecurityRoleNameJSONRequestBody`) instead of `kbapi.KibanaRole` from go-kibana-rest, while preserving all Terraform schema semantics.
+- Refactor `internal/kibana/role.go` to build requests and interpret responses using `kbapi` types (for example `PutSecurityRoleNameJSONRequestBody`) instead of `kbapi.KibanaRole` from go-kibana-rest, while preserving all Terraform schema semantics.
+- Update the data source in `internal/kibana/role_data_source.go`: `dataSourceSecurityRoleRead` delegates to `resourceRoleRead` in `role.go`, so the data source implicitly transitions to `kibanaoapi.GetSecurityRole` for HTTP-level reads. Not-found behavior on the data source (HTTP 404 from Kibana) is handled inside `resourceRoleRead`, which removes the resource from state; the data source caller receives an empty result or diagnostic per existing behavior. No data source schema changes are required.
 - Preserve existing expand/flatten behavior for `elasticsearch`, `kibana`, `metadata`, and JSON `query` diff suppression; preserve version gates for `remote_indices` (≥ 8.10.0) and `description` (≥ 8.15.0).
 - Add or extend verification so Elasticsearch and Kibana privilege mappings remain equivalent to today’s behavior (acceptance tests plus targeted parity checks where practical).
 - Drop the security-role code path’s dependency on `KibanaRoleManagement` for create/read/update/delete once migration is complete (no **BREAKING** Terraform schema or identity changes intended).
@@ -23,6 +24,7 @@ The `elasticstack_kibana_security_role` resource and data source still depend on
 ## Impact
 
 - `internal/kibana/role.go`, related tests under `internal/kibana/`, and any shared helpers used only by this entity.
+- `internal/kibana/role_data_source.go`: no direct code changes required (the data source delegates read to `resourceRoleRead` in `role.go`), but the data source's runtime behavior is affected — it transitions from go-kibana-rest to `kibanaoapi.GetSecurityRole` through that delegation.
 - New file(s) under `internal/clients/kibanaoapi/` for role operations.
 - `go.mod` / imports: reduced use of go-kibana-rest for this flow once callers are switched.
 - OpenSpec delta under `openspec/changes/migrate-kibana-security-role-to-kbapi/specs/kibana-security-role/spec.md` for archive-time merge into `openspec/specs/kibana-security-role/spec.md`.

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/tasks.md
@@ -1,20 +1,20 @@
 ## 1. kibanaoapi role helpers
 
-- [ ] 1.1 Add `internal/clients/kibanaoapi/security_role.go` with `GetSecurityRole`, `PutSecurityRole`, and `DeleteSecurityRole` (names adjustable) wrapping `kbapi.ClientWithResponses`, decoding GET `Body` into `PutSecurityRoleNameJSONBody` (or shared struct), and handling 404 on read as not found.
-- [ ] 1.2 Reuse `reportUnknownError` / existing error helpers for non-2xx responses; add focused tests with `httptest` for 200, 404, and error body paths where practical.
+- [x] 1.1 Add `internal/clients/kibanaoapi/security_role.go` with `GetSecurityRole`, `PutSecurityRole`, and `DeleteSecurityRole` (names adjustable) wrapping `kbapi.ClientWithResponses`, decoding GET `Body` into `PutSecurityRoleNameJSONBody` (or shared struct), and handling 404 on read as not found.
+- [x] 1.2 Reuse `reportUnknownError` / existing error helpers for non-2xx responses; add focused tests with `httptest` for 200, 404, and error body paths where practical.
 
 ## 2. Terraform mapping migration
 
-- [ ] 2.1 Replace `kbapi.KibanaRole` / `KibanaRoleManagement` usage in `internal/kibana/role.go` with `kibanaoapi` helpers and `kbapi.PutSecurityRoleNameJSONRequestBody` (and related types); obtain clients via `GetKibanaOapiClient()` from `KibanaScopedClient`.
-- [ ] 2.2 Refactor expand functions to emit `kbapi` OpenAPI structs (including `field_security` as `*map[string][]string` per generated schema), preserving version gates for `remote_indices` and `description`.
-- [ ] 2.3 Refactor flatten functions to read from the decoded OpenAPI response shape while preserving omission rules for empty `cluster` / `run_as` and existing set/list flattening behavior.
-- [ ] 2.4 Update the data source implementation in `internal/kibana` to use the same helper read path; align not-found behavior with REQ-012–REQ-014.
+- [x] 2.1 Replace `kbapi.KibanaRole` / `KibanaRoleManagement` usage in `internal/kibana/role.go` with `kibanaoapi` helpers and `kbapi.PutSecurityRoleNameJSONRequestBody` (and related types); obtain clients via `GetKibanaOapiClient()` from `KibanaScopedClient`.
+- [x] 2.2 Refactor expand functions to emit `kbapi` OpenAPI structs (including `field_security` as `*map[string][]string` per generated schema), preserving version gates for `remote_indices` and `description`.
+- [x] 2.3 Refactor flatten functions to read from the decoded OpenAPI response shape while preserving omission rules for empty `cluster` / `run_as` and existing set/list flattening behavior.
+- [x] 2.4 Update the data source implementation in `internal/kibana` to use the same helper read path; align not-found behavior with REQ-012–REQ-014.
 
 ## 3. Parity, tests, and cleanup
 
-- [ ] 3.1 Add unit tests that round-trip representative privilege configurations through expand and flatten (and/or JSON) to lock privilege parity.
-- [ ] 3.2 Run `make build` and `go test ./internal/kibana/...`; run acceptance tests for `TestAccResourceKibanaSecurityRole` and `TestAccDataSourceKibanaSecurityRole` when a Stack is available.
-- [ ] 3.3 Remove unused go-kibana-rest imports from the role code path; verify no regressions in dependent testdata (for example Fleet agent policy restricted user).
+- [x] 3.1 Add unit tests that round-trip representative privilege configurations through expand and flatten (and/or JSON) to lock privilege parity.
+- [x] 3.2 Run `make build` and `go test ./internal/kibana/...`; run acceptance tests for `TestAccResourceKibanaSecurityRole` and `TestAccDataSourceKibanaSecurityRole` when a Stack is available.
+- [x] 3.3 Remove unused go-kibana-rest imports from the role code path; verify no regressions in dependent testdata (for example Fleet agent policy restricted user).
 
 ## 4. OpenSpec sync
 

--- a/openspec/changes/migrate-kibana-security-role-to-kbapi/tasks.md
+++ b/openspec/changes/migrate-kibana-security-role-to-kbapi/tasks.md
@@ -18,4 +18,4 @@
 
 ## 4. OpenSpec sync
 
-- [ ] 4.1 After implementation, run `make check-openspec` (or `openspec validate`) and archive or sync per project workflow so `openspec/specs/kibana-security-role/spec.md` absorbs the delta.
+- [x] 4.1 After implementation, run `make check-openspec` (or `openspec validate`) and archive or sync per project workflow so `openspec/specs/kibana-security-role/spec.md` absorbs the delta.

--- a/openspec/specs/kibana-security-role/spec.md
+++ b/openspec/specs/kibana-security-role/spec.md
@@ -97,7 +97,7 @@ data "elasticstack_kibana_security_role" "example" {
 
 ### Requirement: Role Management APIs (REQ-001–REQ-003)
 
-The resource SHALL use the Kibana Create or update role API (`KibanaRoleManagement.CreateOrUpdate`) to create and update roles ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-put.html)). The resource and data source SHALL use the Kibana Get role API (`KibanaRoleManagement.Get`) to read roles ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-get.html)). The resource SHALL use the Kibana Delete role API (`KibanaRoleManagement.Delete`) to delete roles ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-delete.html)). When a Kibana API call returns an error for create, update, read, or delete (other than role not found on read), the resource SHALL surface the error to Terraform diagnostics.
+The resource SHALL create and update roles using the Kibana Create or update role HTTP API invoked through `internal/clients/kibanaoapi` on top of `generated/kbapi` (`PutSecurityRoleName` for `/api/security/roles/{name}`) ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-put.html)). The resource and data source SHALL read roles using the Kibana Get role HTTP API via the same helper layer (`GetSecurityRoleName`) ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-get.html)). The resource SHALL delete roles using the Kibana Delete role HTTP API via the same helper layer (`DeleteSecurityRoleName`) ([docs](https://www.elastic.co/guide/en/kibana/current/role-management-specific-api-delete.html)). The resource and data source SHALL NOT call `KibanaRoleManagement.CreateOrUpdate`, `KibanaRoleManagement.Get`, or `KibanaRoleManagement.Delete` for this entity once migration is complete. When a Kibana API call returns an error for create, update, read, or delete (other than role not found on read), the resource SHALL surface the error to Terraform diagnostics.
 
 #### Scenario: API errors surfaced
 
@@ -107,13 +107,13 @@ The resource SHALL use the Kibana Create or update role API (`KibanaRoleManageme
 
 ### Requirement: Identity (REQ-004)
 
-The resource SHALL expose a computed `id` equal to the role name. After a successful create or update, the resource SHALL set `id` from the name returned in the `CreateOrUpdate` API response.
+The resource SHALL expose a computed `id` equal to the role name. After a successful create or update, the resource SHALL set `id` to the configured role `name` (the path parameter used for PUT), which SHALL equal the role name persisted in Kibana after a successful response.
 
 #### Scenario: Computed id after create
 
 - GIVEN a successful create
-- WHEN the API returns the role name
-- THEN `id` SHALL be set to that role name
+- WHEN the provider commits state after write
+- THEN `id` SHALL be set to the role `name` argument
 
 ### Requirement: Import (REQ-005)
 
@@ -171,7 +171,7 @@ When `elasticsearch.remote_indices` is configured with one or more entries, the 
 
 ### Requirement: Create and update behavior (REQ-010–REQ-011)
 
-When creating a role, the resource SHALL set `CreateOnly: true` on the API request to signal new-resource semantics. When creating or updating a role, the resource SHALL build the API request body from all configured fields (`name`, `kibana`, `elasticsearch`, `metadata`, `description`) and submit it with the Create or update role API. After a successful API response, the resource SHALL set `id` and read the role back to populate state.
+When creating a role, the resource SHALL set the `createOnly` query parameter to `true` on the PUT request to signal new-resource semantics. When updating an existing role, the resource SHALL set `createOnly` to `false` or omit it per Kibana API conventions so the role can be overwritten. When creating or updating a role, the resource SHALL build the API request body from all configured fields (`name`, `kibana`, `elasticsearch`, `metadata`, `description`) using `generated/kbapi` request types and submit it with the Create or update role API. After a successful API response, the resource SHALL set `id` and read the role back to populate state.
 
 #### Scenario: Post-apply read
 
@@ -181,17 +181,17 @@ When creating a role, the resource SHALL set `CreateOnly: true` on the API reque
 
 ### Requirement: Read and refresh (REQ-012–REQ-014)
 
-When refreshing state, the resource and data source SHALL use `id` (or `name` for the data source) as the role name to fetch. If the Kibana Get role API returns `nil` with no error, the resource SHALL remove itself from state (role not found). When a role is found, the resource SHALL set `name`, `elasticsearch`, `kibana`, `description`, and `metadata` in state from the API response.
+When refreshing state, the resource and data source SHALL use `id` (or `name` for the data source) as the role name to fetch. If the Get role HTTP response indicates the role does not exist (for example HTTP 404, or the documented empty success response if applicable), the resource SHALL remove itself from state (role not found) and the data source SHALL behave as today for a missing role (diagnostics or empty result per existing implementation). When a role is found, the resource SHALL set `name`, `elasticsearch`, `kibana`, `description`, and `metadata` in state from the decoded API response.
 
 #### Scenario: Role removed in Kibana
 
 - GIVEN refresh runs and the role no longer exists
-- WHEN the Get role API returns nil with no error
+- WHEN the Get role API returns a not-found result as defined above
 - THEN the resource SHALL be removed from state
 
 ### Requirement: Delete (REQ-015)
 
-When destroying, the resource SHALL use `id` as the role name and delete it via the Kibana Delete role API.
+When destroying, the resource SHALL use `id` as the role name and delete it via the Kibana Delete role HTTP API implemented through `internal/clients/kibanaoapi` and `generated/kbapi`.
 
 #### Scenario: Destroy
 
@@ -258,3 +258,23 @@ When the API response contains `kibana` privilege entries, the resource SHALL fl
 - GIVEN the API returns kibana privilege entries
 - WHEN read populates state
 - THEN each entry SHALL appear as a `kibana` block with `base`, `feature`, and `spaces`
+
+### Requirement: kibanaoapi security role helpers (REQ-025)
+
+The provider SHALL implement Kibana role management HTTP calls for `elasticstack_kibana_security_role` via functions in `internal/clients/kibanaoapi` that use `generated/kbapi` client methods for put, get, and delete by role name (`PutSecurityRoleNameWithResponse` or `PutSecurityRoleName`, `GetSecurityRoleNameWithResponse` or `GetSecurityRoleName`, `DeleteSecurityRoleNameWithResponse` or `DeleteSecurityRoleName`). Helpers SHALL decode successful JSON GET bodies into the same structural family used for PUT (`PutSecurityRoleNameJSONBody` or equivalent) before returning data to Terraform mapping code. Helpers SHALL map non-success HTTP status codes (other than not-found on read as defined in REQ-012–REQ-014) to Terraform diagnostics including response body context when available.
+
+#### Scenario: Helper surfaces decode errors
+
+- **GIVEN** a GET response whose body is not valid JSON for the role document
+- **WHEN** the helper parses the response
+- **THEN** the provider SHALL return an error diagnostic and SHALL NOT silently treat the role as absent
+
+### Requirement: Privilege mapping parity (REQ-026)
+
+Before this change is considered complete, the provider SHALL demonstrate that Elasticsearch index and remote index privileges, Kibana base and feature privileges, `metadata`, and `description` round-trip equivalently versus the pre-migration behavior for representative configurations covered by tests. At minimum, existing acceptance tests for `elasticstack_kibana_security_role` SHALL pass unchanged against a supported Stack, and unit tests SHALL assert stable JSON or struct equivalence for at least one index entry with `field_security`, one `remote_indices` entry, one `kibana` feature block, and one `kibana` base block.
+
+#### Scenario: Acceptance suite unchanged
+
+- **GIVEN** the existing `internal/kibana` acceptance tests for create, update, remote indices, and description
+- **WHEN** the tests run against a cluster meeting documented version gates
+- **THEN** they SHALL pass without relaxing assertions


### PR DESCRIPTION
## Summary

- Migrates `elasticstack_kibana_security_role` resource and data source from the legacy `go-kibana-rest` `KibanaRoleManagement` client to the generated `kbapi` client via new `internal/clients/kibanaoapi` helpers
- Adds `GetSecurityRole`, `PutSecurityRole`, and `DeleteSecurityRole` helpers in `internal/clients/kibanaoapi/security_role.go` using plain Go structs (bypassing the kbapi union type for `kibana.base`) for correct JSON serialization
- Preserves all Terraform schema semantics: version gates for `remote_indices` (≥8.10.0) and `description` (≥8.15.0), `createOnly` semantics, empty `cluster`/`run_as` omission, and `field_security` as `map[string][]string`
- Adds parity unit tests round-tripping index field_security, remote_indices, kibana base, kibana feature, metadata, and empty cluster/run_as
- Adds httptest-backed unit tests for all three helper functions (200, 404, invalid JSON, error body paths)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/kibana/ ./internal/clients/kibanaoapi/...` (non-acceptance) passes
- [x] `openspec validate migrate-kibana-security-role-to-kbapi` passes
- [x] `golangci-lint run ./internal/kibana/ ./internal/clients/kibanaoapi/` - 0 issues
- [ ] Acceptance tests `TestAccResourceKibanaSecurityRole` and `TestAccDataSourceKibanaSecurityRole` - require live Stack (CI)

## OpenSpec change

`migrate-kibana-security-role-to-kbapi` — implements REQ-001–REQ-003, REQ-004, REQ-010–REQ-015, REQ-025, REQ-026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `elasticstack_kibana_security_role` CRUD operations to generated kbapi client
> - Replaces `go-kibana-rest` with the generated `kbapi` client for all role CRUD operations via new helpers in [`internal/clients/kibanaoapi/security_role.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2300/files#diff-69cc011910668b744b239e3edbf08d19ebdd6e3a45617486161327e2abbeab17).
> - Adds `GetSecurityRole`, `PutSecurityRole`, and `DeleteSecurityRole` helpers that handle 404-as-missing, `createOnly` semantics, and surface errors as Terraform diagnostics.
> - Refactors expand/flatten utilities in [`internal/kibana/role.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2300/files#diff-094daeab810cf6d5ed5bc0444da4f59b456ee6f698a99d4f4d31228ebb5f1b96) to use the new `SecurityRole*` structs, including correct handling of `kibana.base` as `json.RawMessage` to support both `[]string` and `null` API responses.
> - Adds unit tests in [`internal/kibana/role_unit_test.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2300/files#diff-6de729b1f6ec78545d2686c51969217fa73178b520ca4b61f4059eb5044e2ff9) and API-level tests in [`internal/clients/kibanaoapi/security_role_test.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2300/files#diff-b8258f12b37780ba45e09eb6d4fff6011504787c27927a08f5a52e21d9737d63) covering round-trip and error scenarios.
> - Behavioral Change: resource ID is now set directly to the configured role name rather than derived from the create response.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 768839b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->