### PR TITLE
Proposal to clean up scoped client resolution

### DIFF
--- a/openspec/changes/cleanup-scoped-client-resolution/.openspec.yaml
+++ b/openspec/changes/cleanup-scoped-client-resolution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/cleanup-scoped-client-resolution/design.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The provider already injects `*clients.ProviderClientFactory` into Framework `ProviderData` and SDK `meta`, and most entities now resolve either `*clients.KibanaScopedClient` or `*clients.ElasticsearchScopedClient` from that factory. The remaining gaps are concentrated in `internal/clients/api_client.go`, where a broad `APIClient` still owns duplicated helper behavior and legacy bridge helpers, and in `internal/apm/agent_configuration`, which still converts provider data back into a broad client.
+
+This cleanup spans production code, tests, exported compatibility surfaces, and synced OpenSpec specs. The main constraint is that the factory still needs an internal provider-default client representation to bootstrap typed scoped clients, even after the broad client stops being part of the supported contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove remaining production reliance on broad `APIClient` resolution.
+- Make typed factory/scoped-client resolution the only supported provider client contract.
+- Shrink `internal/clients` so Kibana- and Elasticsearch-specific helper behavior lives on the corresponding scoped clients.
+- Capture the remaining requirement changes in OpenSpec so implementation and specs converge again.
+
+**Non-Goals:**
+- Rework provider configuration parsing or connection schema shape.
+- Expand the rollout to new resources beyond the existing cleanup target.
+- Fully redesign `xpprovider`; this change only narrows or replaces the parts that expose the broad client.
+- Eliminate every internal bootstrap helper immediately if a small private helper remains useful during the refactor.
+
+## Decisions
+
+### Decision: Migrate APM agent configuration directly to typed Kibana client resolution
+
+`internal/apm/agent_configuration` only needs Kibana OpenAPI access. It will stop storing `*clients.APIClient` and instead resolve a typed Kibana client from `ProviderClientFactory`, then call `GetKibanaOapiClient()` on that typed client.
+
+This keeps the resource aligned with the same typed contract already used elsewhere and removes the last known Framework production use of `ConvertProviderData`.
+
+Alternatives considered:
+- Keep using `ConvertProviderData` and accept one broad-client exception. Rejected because it preserves the exact bridge this cleanup is meant to remove.
+- Introduce a new APM-specific provider data adapter. Rejected because it adds another special case instead of converging on the factory pattern.
+
+### Decision: Keep a private provider-default bootstrap client, but remove it from the supported API surface
+
+The factory still needs a provider-default object that contains the clients and configuration necessary to construct typed scoped clients. The broad client type can remain as a private implementation detail inside `internal/clients`, while exported accessors and bridge helpers are removed.
+
+This allows the factory to keep reusing internal construction logic without advertising a public escape hatch back to the broad client.
+
+Alternatives considered:
+- Delete the broad client struct entirely in the same change. Rejected because the factory and acceptance bootstrap still need a shared internal assembly point.
+- Keep `GetDefaultClient()` exported for internal convenience. Rejected because it contradicts the typed factory contract and invites new broad-client call sites.
+
+### Decision: Move duplicated helper behavior to the owning scoped client and update tests accordingly
+
+Elasticsearch-derived behavior such as `GetESClient`, cluster identity, version/flavor lookup, and minimum-version enforcement belongs on `ElasticsearchScopedClient`. Kibana-derived behavior such as `GetKibanaOapiClient`, `GetFleetClient`, SLO auth context, and Kibana version/flavor checks belongs on `KibanaScopedClient`.
+
+Tests and acceptance helpers will be updated to construct scoped clients directly rather than reaching those helpers through `NewAcceptanceTestingClient()`.
+
+Alternatives considered:
+- Leave duplicated methods on both the private broad client and the scoped clients. Rejected because that keeps behavior split across two contracts and weakens compile-time enforcement.
+- Replace all test helpers with ad hoc client construction in each package. Rejected because the repo already benefits from shared acceptance bootstrap helpers.
+
+### Decision: Treat `xpprovider` broad-client export removal as an explicit compatibility change
+
+`xpprovider` currently aliases `clients.APIClient`, so privatizing the type changes the exported surface. The change proposal will treat this as a breaking compatibility edge and require the implementation to either expose typed replacements or intentionally narrow the public API.
+
+Alternatives considered:
+- Preserve the alias indefinitely. Rejected because it blocks the cleanup goal of making `APIClient` private.
+- Defer `xpprovider` until a later cleanup. Rejected because it leaves the most visible external leak of the broad client in place.
+
+## Risks / Trade-offs
+
+- `xpprovider` consumers may rely on `APIClient` today -> Mitigation: call out the break in the proposal, replace it with typed factory/scoped surfaces where possible, and verify downstream compile failures early.
+- Acceptance test churn may be larger than production code churn -> Mitigation: centralize replacement helpers first, then migrate package tests mechanically.
+- Private bootstrap logic may still temporarily resemble the old broad client -> Mitigation: remove exported access paths in the same change, then trim remaining private-only methods once no callers require them.
+- Some synced specs still reference deleted helper names -> Mitigation: include delta specs in this change and update canonical specs when the change is applied and archived.
+
+## Migration Plan
+
+1. Move `internal/apm/agent_configuration` onto factory-resolved typed Kibana client usage.
+2. Remove production bridge helpers and `GetDefaultClient()` from the supported factory surface.
+3. Privatize the broad client type and delete duplicated exported helper behavior that scoped clients now own.
+4. Update `xpprovider`, tests, and acceptance helpers to consume typed surfaces.
+5. Sync OpenSpec capability deltas and canonical specs, then validate with the repo's spec checks.
+
+Rollback is low risk because this is a source-level refactor: reverting the change restores the previous bridges and export surface.
+
+## Open Questions
+
+- Whether `xpprovider` should expose the factory directly, expose typed scoped constructors, or deliberately drop the client-construction surface altogether.
+- Whether any internal test-only helpers still need a small private bootstrap wrapper after `NewAcceptanceTestingClient()` stops being the default path.

--- a/openspec/changes/cleanup-scoped-client-resolution/proposal.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The typed Kibana/Fleet and Elasticsearch client-resolution changes are archived, but the codebase still keeps a legacy broad `APIClient` path alive for one Framework resource, several bridge helpers, and test/export surfaces. Finishing that cleanup now will bring the implementation back in line with the scoped-client design, reduce duplicate client behavior, and remove ambiguity about which client contract resources are allowed to use.
+
+## What Changes
+
+- Migrate the remaining Framework holdout, `elasticstack_apm_agent_configuration`, from provider data conversion through a broad `APIClient` to factory-resolved typed scoped clients.
+- Remove legacy broad-client bridge helpers from `internal/clients` once no production call sites remain, including `ConvertProviderData`, `MaybeNewAPIClientFromFrameworkResource`, `MaybeNewKibanaAPIClientFromFrameworkResource`, `NewAPIClientFromSDKResource`, and `NewKibanaAPIClientFromSDKResource`.
+- Remove broad-client behavior from `APIClient` where the same behavior is already provided by `KibanaScopedClient` or `ElasticsearchScopedClient`.
+- **BREAKING** Stop exporting `clients.APIClient` as a supported public surface; keep exported client-resolution APIs focused on `ProviderClientFactory`, `KibanaScopedClient`, and `ElasticsearchScopedClient`.
+- Update acceptance helpers, tests, and synced OpenSpec specs so they reference scoped-client resolution rather than the removed broad-client helpers.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `provider-client-factory`: remove the remaining broad-client bridge from the factory contract and make the typed factory/scoped-client surface the only supported provider injection path.
+- `provider-kibana-connection`: ensure Framework resources that need Kibana-derived operations consume factory-resolved typed Kibana scoped clients rather than broad `APIClient` adapters.
+- `provider-elasticsearch-scoped-client-resolution`: finish the cleanup by removing overlapping Elasticsearch helper behavior from the broad client surface once scoped clients fully own it.
+- `apm-agent-configuration`: update the resource contract to acquire its Kibana OpenAPI client through typed scoped-client resolution instead of the broad provider API client.
+
+## Impact
+
+- Affected code is concentrated in `internal/clients`, `internal/apm/agent_configuration`, `xpprovider`, acceptance test helpers, and tests/mocks that still construct or depend on `APIClient`.
+- This change narrows the provider's supported client-resolution API surface and may require compatibility decisions for external `xpprovider` consumers.
+- Synced OpenSpec requirements under `openspec/specs/` will need cleanup so they stop naming helper paths that are being removed.

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/apm-agent-configuration/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/apm-agent-configuration/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Kibana client usage (REQ-005)
+The resource SHALL obtain its Kibana OpenAPI client through typed scoped-client resolution from the provider-configured `*clients.ProviderClientFactory`. The resource SHALL use `GetKibanaOapiClient()` on the resolved `*clients.KibanaScopedClient` for all API operations. The resource SHALL use the Elastic API version `2023-10-31` in all API requests.
+
+#### Scenario: Resource resolves typed Kibana client from provider defaults
+- **WHEN** the resource is configured without an entity-local Kibana override
+- **THEN** it SHALL resolve a `*clients.KibanaScopedClient` from the provider client factory and use that typed client for Kibana API operations
+
+#### Scenario: Kibana client acquisition failure
+- **WHEN** the provider cannot provide a typed Kibana client or Kibana OpenAPI client
+- **THEN** Terraform diagnostics SHALL include an "Unable to get Kibana client" error

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/provider-client-factory/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/provider-client-factory/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Provider injects a client factory
+The provider SHALL inject a `*clients.ProviderClientFactory` into Plugin Framework `ProviderData` and SDK `meta` as the provider-scoped client-resolution surface for resources and data sources. Covered consumers SHALL resolve typed scoped clients through factory methods rather than converting provider data or meta back into a broad `*clients.APIClient`.
+
+#### Scenario: Framework configure receives a factory
+- **WHEN** the Plugin Framework provider configures a resource or data source
+- **THEN** the configured provider data SHALL be a `*clients.ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
+
+#### Scenario: Framework consumer resolves typed client from factory
+- **WHEN** a covered Framework resource or data source needs Elasticsearch- or Kibana-derived operations
+- **THEN** it SHALL obtain a typed scoped client from `*clients.ProviderClientFactory` instead of converting provider data into a broad `*clients.APIClient`
+
+#### Scenario: SDK configure receives a factory
+- **WHEN** the SDK provider configures a resource or data source
+- **THEN** the configured `meta` value SHALL be a `*clients.ProviderClientFactory` rather than a ready-to-use broad `*clients.APIClient`
+
+### Requirement: Factory supports phased migration
+In this phase, the `ProviderClientFactory` SHALL provide typed Kibana/Fleet scoped-client resolution and typed Elasticsearch scoped-client resolution, and SHALL NOT expose a supported bridge back to the broad `*clients.APIClient`.
+
+#### Scenario: Kibana entity resolves typed client
+- **WHEN** a Kibana, Fleet, or other covered Kibana-derived entity resolves its effective client through the factory
+- **THEN** the factory SHALL return a typed Kibana-scoped client for Kibana, Kibana OpenAPI, SLO, and Fleet operations
+
+#### Scenario: Elasticsearch entity resolves typed client
+- **WHEN** a covered Elasticsearch entity resolves its effective client through the factory
+- **THEN** the factory SHALL return a typed Elasticsearch-scoped client rather than a broad `*clients.APIClient`
+
+#### Scenario: Broad-client bridge is not part of the factory contract
+- **WHEN** implementation code attempts to rely on the factory for a supported broad-client escape hatch
+- **THEN** the provider factory contract SHALL not define that path

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/provider-elasticsearch-scoped-client-resolution/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/provider-elasticsearch-scoped-client-resolution/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Elasticsearch scoped client helper behavior
+The typed Elasticsearch-scoped client SHALL expose the Elasticsearch client surface and the Elasticsearch-derived helper behavior needed by covered Elasticsearch entities, including composite ID generation, cluster identity lookup, version checks, flavor checks, and minimum-version enforcement. Those behaviors SHALL be available through `*clients.ElasticsearchScopedClient` without requiring a supported broad `*clients.APIClient` Elasticsearch helper surface.
+
+#### Scenario: Scoped client supports Elasticsearch helper behavior
+- **WHEN** a covered Elasticsearch entity performs ID generation, cluster identity lookup, version checks, flavor checks, or minimum-version enforcement through the typed scoped client
+- **THEN** the typed scoped client SHALL provide that behavior without requiring access to a broad `*clients.APIClient`
+
+#### Scenario: Broad client is not required for Elasticsearch helper behavior
+- **WHEN** in-scope Elasticsearch helper behavior has been migrated to `*clients.ElasticsearchScopedClient`
+- **THEN** implementation code SHALL not need a supported broad `*clients.APIClient` contract to perform those Elasticsearch-specific operations

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/provider-kibana-connection/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/provider-kibana-connection/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Framework scoped Kibana client resolution
+The provider SHALL expose Plugin Framework Kibana-derived client resolution through `*clients.ProviderClientFactory` methods that return a `*clients.KibanaScopedClient`. When an entity-local `kibana_connection` block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`. Covered Framework resources that need Kibana-derived operations SHALL consume that typed scoped client rather than a broad `*clients.APIClient` adapter.
+
+#### Scenario: Framework factory falls back to provider defaults
+- **WHEN** a covered Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` derived from provider configuration
+
+#### Scenario: Framework factory builds a scoped Kibana-derived client
+- **WHEN** a covered Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is configured
+- **THEN** the factory SHALL return a `*clients.KibanaScopedClient` rebuilt from that connection for Kibana, SLO, and Fleet operations
+
+#### Scenario: Framework entity does not downcast to a broad client
+- **WHEN** a covered Framework entity performs Kibana-derived operations
+- **THEN** it SHALL use the typed `*clients.KibanaScopedClient` contract rather than converting provider data into a broad `*clients.APIClient`

--- a/openspec/changes/cleanup-scoped-client-resolution/tasks.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/tasks.md
@@ -1,0 +1,19 @@
+## 1. Migrate the remaining production holdout
+
+- [ ] 1.1 Update `internal/apm/agent_configuration` to configure from `ConvertProviderDataToFactory` and store a typed Kibana scoped client instead of `*clients.APIClient`.
+- [ ] 1.2 Switch APM create/read/update/delete operations to obtain the Kibana OpenAPI client from the typed scoped client and remove the remaining `ConvertProviderData` production dependency.
+
+## 2. Remove legacy broad-client bridges
+
+- [ ] 2.1 Delete legacy provider-data and resource-scoped broad-client helpers from `internal/clients/api_client.go`, including `ConvertProviderData`, `MaybeNewAPIClientFromFrameworkResource`, `MaybeNewKibanaAPIClientFromFrameworkResource`, `NewAPIClientFromSDKResource`, `NewKibanaAPIClientFromSDKResource`, and `extractDefaultClientFromMeta`.
+- [ ] 2.2 Remove the supported factory bridge back to the broad client from `internal/clients/provider_client_factory.go` while preserving private bootstrap logic needed to construct typed scoped clients.
+
+## 3. Privatize the broad client and update compatibility surfaces
+
+- [ ] 3.1 Make the broad client type private within `internal/clients` and remove duplicated exported Elasticsearch- and Kibana-specific helper behavior now owned by scoped clients.
+- [ ] 3.2 Update `xpprovider`, acceptance helpers, and tests/mocks to stop exporting or depending on `clients.APIClient` and to construct typed scoped clients directly.
+
+## 4. Sync specs and verify the cleanup
+
+- [ ] 4.1 Update canonical OpenSpec specs under `openspec/specs/` to remove references to deleted broad-client helper paths and to reflect the typed scoped-client contract.
+- [ ] 4.2 Run targeted tests, `make build`, and OpenSpec validation/checks needed to confirm the cleanup compiles and the synced requirements stay consistent.


### PR DESCRIPTION
## Summary
- add a new OpenSpec change for cleaning up the remaining broad `APIClient` usage after the typed scoped-client migrations
- capture the design decisions for migrating APM, removing factory bridge helpers, and tightening exported client surfaces
- define implementation tasks and delta specs for the affected provider client-resolution capabilities

## Test plan
- [x] `npx openspec status --change \"cleanup-scoped-client-resolution\"`
- [ ] Implementation tests not run (proposal-only change)

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenSpec proposal to replace broad `APIClient` usage with typed scoped clients
> - Adds a design proposal and task checklist for migrating from broad `APIClient` usage to typed scoped clients resolved through a `ProviderClientFactory`.
> - The `ProviderClientFactory` becomes the single resolution point for scoped clients; direct downcasting to a broad `APIClient` is prohibited.
> - APM agent configuration is updated to resolve a typed Kibana scoped client via `GetKibanaOapiClient` (API version `2023-10-31`) and emit an error on acquisition failure.
> - `ElasticsearchScopedClient` gains Elasticsearch helper behavior (ID generation, cluster identity, version checks) without depending on a broad client.
> - Risk: legacy broad-client bridges are slated for deletion, which is a breaking change for any consumers relying on those exports.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6be2d4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->