### PR TITLE
Tighten local connection requirements

### DIFF
--- a/openspec/changes/cleanup-scoped-client-resolution/design.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/design.md
@@ -2,18 +2,20 @@
 
 The provider already injects `*clients.ProviderClientFactory` into Framework `ProviderData` and SDK `meta`, and most entities now resolve either `*clients.KibanaScopedClient` or `*clients.ElasticsearchScopedClient` from that factory. The remaining gaps are concentrated in `internal/clients/api_client.go`, where a broad `APIClient` still owns duplicated helper behavior and legacy bridge helpers, and in `internal/apm/agent_configuration`, which still converts provider data back into a broad client.
 
-This cleanup spans production code, tests, exported compatibility surfaces, and synced OpenSpec specs. The main constraint is that the factory still needs an internal provider-default client representation to bootstrap typed scoped clients, even after the broad client stops being part of the supported contract.
+This cleanup spans production code, tests, exported compatibility surfaces, shared entity-local connection schema helpers, and synced OpenSpec specs. The main constraint is that the factory still needs an internal provider-default client representation to bootstrap typed scoped clients, even after the broad client stops being part of the supported contract.
 
 ## Goals / Non-Goals
 
 **Goals:**
+- Add `kibana_connection` to `elasticstack_apm_agent_configuration` without inventing a resource-specific connection schema.
+- Make the connection-schema fixtures follow the real provider registry instead of partial naming heuristics, so future entities cannot be omitted silently.
 - Remove remaining production reliance on broad `APIClient` resolution.
 - Make typed factory/scoped-client resolution the only supported provider client contract.
 - Shrink `internal/clients` so Kibana- and Elasticsearch-specific helper behavior lives on the corresponding scoped clients.
 - Capture the remaining requirement changes in OpenSpec so implementation and specs converge again.
 
 **Non-Goals:**
-- Rework provider configuration parsing or connection schema shape.
+- Rework provider-level configuration parsing or invent a new APM-specific connection schema shape.
 - Expand the rollout to new resources beyond the existing cleanup target.
 - Fully redesign `xpprovider`; this change only narrows or replaces the parts that expose the broad client.
 - Eliminate every internal bootstrap helper immediately if a small private helper remains useful during the refactor.
@@ -22,13 +24,26 @@ This cleanup spans production code, tests, exported compatibility surfaces, and 
 
 ### Decision: Migrate APM agent configuration directly to typed Kibana client resolution
 
-`internal/apm/agent_configuration` only needs Kibana OpenAPI access. It will stop storing `*clients.APIClient` and instead resolve a typed Kibana client from `ProviderClientFactory`, then call `GetKibanaOapiClient()` on that typed client.
+`internal/apm/agent_configuration` only needs Kibana OpenAPI access. It will add the shared Plugin Framework `kibana_connection` block so the resource can either inherit provider defaults or scope Kibana-derived operations per resource. The resource will stop storing `*clients.APIClient` and instead resolve a typed Kibana client from `ProviderClientFactory`, then call `GetKibanaOapiClient()` on that typed client.
 
-This keeps the resource aligned with the same typed contract already used elsewhere and removes the last known Framework production use of `ConvertProviderData`.
+This keeps the resource aligned with the same typed contract already used elsewhere, closes the requirements gap called out in review, and removes the last known Framework production use of `ConvertProviderData`.
 
 Alternatives considered:
+- Keep the resource on provider-default resolution only and just remove the misleading override wording from the spec. Rejected because the cleanup is already touching APM client resolution, and adding the shared block now keeps the resource aligned with the broader `kibana_connection` model instead of leaving APM as a special case.
 - Keep using `ConvertProviderData` and accept one broad-client exception. Rejected because it preserves the exact bridge this cleanup is meant to remove.
 - Introduce a new APM-specific provider data adapter. Rejected because it adds another special case instead of converging on the factory pattern.
+
+### Decision: Make the connection-schema fixtures an explicit partition of the registered entity inventory
+
+The two fixture files, `provider/kibana_connection_schema_test.go` and `provider/elasticsearch_connection_schema_test.go`, will stop acting like independent prefix scans and instead become an explicit partition over the entities registered by `provider.New(...)` and `provider.NewFrameworkProvider(...)`.
+
+The Kibana fixture will own all registered `elasticstack_kibana_*` entities, all registered `elasticstack_fleet_*` entities, and `elasticstack_apm_agent_configuration`. The Elasticsearch fixture will own all registered `elasticstack_elasticsearch_*` entities. A shared completeness check will compare the union of those ownership sets against the full registry returned by the provider constructors and fail if any entity is uncovered or claimed by both fixtures.
+
+This keeps fixture ownership aligned with the actual provider surface, documents the current entity split in one place, and turns future registry changes into immediate test failures instead of silent omissions.
+
+Alternatives considered:
+- Keep prefix-based selection and add APM as a one-off exception in the Kibana fixture. Rejected because it would still lack any guarantee that the combined fixtures cover the full provider registry.
+- Maintain separate hand-written inventories in each test without a completeness check. Rejected because drift between the fixture inventories and the provider registrations would remain easy to miss.
 
 ### Decision: Keep a private provider-default bootstrap client, but remove it from the supported API surface
 
@@ -62,12 +77,13 @@ Alternatives considered:
 
 - `xpprovider` consumers may rely on `APIClient` today -> Mitigation: call out the break in the proposal, replace it with typed factory/scoped surfaces where possible, and verify downstream compile failures early.
 - Acceptance test churn may be larger than production code churn -> Mitigation: centralize replacement helpers first, then migrate package tests mechanically.
+- Fixture ownership can drift from the real provider registry -> Mitigation: derive the full registered entity inventory from provider constructors, encode fixture ownership explicitly, and fail on omissions or overlaps.
 - Private bootstrap logic may still temporarily resemble the old broad client -> Mitigation: remove exported access paths in the same change, then trim remaining private-only methods once no callers require them.
 - Some synced specs still reference deleted helper names -> Mitigation: include delta specs in this change and update canonical specs when the change is applied and archived.
 
 ## Migration Plan
 
-1. Move `internal/apm/agent_configuration` onto factory-resolved typed Kibana client usage.
+1. Add the shared `kibana_connection` block to `internal/apm/agent_configuration` and move it onto factory-resolved typed Kibana client usage.
 2. Remove production bridge helpers and `GetDefaultClient()` from the supported factory surface.
 3. Privatize the broad client type and delete duplicated exported helper behavior that scoped clients now own.
 4. Update `xpprovider`, tests, and acceptance helpers to consume typed surfaces.

--- a/openspec/changes/cleanup-scoped-client-resolution/proposal.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/proposal.md
@@ -4,7 +4,10 @@ The typed Kibana/Fleet and Elasticsearch client-resolution changes are archived,
 
 ## What Changes
 
-- Migrate the remaining Framework holdout, `elasticstack_apm_agent_configuration`, from provider data conversion through a broad `APIClient` to factory-resolved typed scoped clients.
+- Add an optional entity-local `kibana_connection` block to `elasticstack_apm_agent_configuration` using the shared Plugin Framework Kibana connection schema helper so the resource can either inherit provider defaults or target a scoped Kibana connection.
+- Migrate the remaining Framework holdout, `elasticstack_apm_agent_configuration`, from provider data conversion through a broad `APIClient` to factory-resolved typed scoped clients resolved from that effective Kibana connection.
+- Define the connection-schema fixture ownership explicitly: `provider/kibana_connection_schema_test.go` owns registered `elasticstack_kibana_*`, registered `elasticstack_fleet_*`, and `elasticstack_apm_agent_configuration`; `provider/elasticsearch_connection_schema_test.go` owns registered `elasticstack_elasticsearch_*` entities.
+- Add a registry-completeness assertion so the union of those two fixture ownership sets matches all entities registered by `provider.New(...)` and `provider.NewFrameworkProvider(...)`, failing on uncovered or doubly covered entities.
 - Remove legacy broad-client bridge helpers from `internal/clients` once no production call sites remain, including `ConvertProviderData`, `MaybeNewAPIClientFromFrameworkResource`, `MaybeNewKibanaAPIClientFromFrameworkResource`, `NewAPIClientFromSDKResource`, and `NewKibanaAPIClientFromSDKResource`.
 - Remove broad-client behavior from `APIClient` where the same behavior is already provided by `KibanaScopedClient` or `ElasticsearchScopedClient`.
 - **BREAKING** Stop exporting `clients.APIClient` as a supported public surface; keep exported client-resolution APIs focused on `ProviderClientFactory`, `KibanaScopedClient`, and `ElasticsearchScopedClient`.
@@ -17,12 +20,17 @@ The typed Kibana/Fleet and Elasticsearch client-resolution changes are archived,
 
 ### Modified Capabilities
 - `provider-client-factory`: remove the remaining broad-client bridge from the factory contract and make the typed factory/scoped-client surface the only supported provider injection path.
-- `provider-kibana-connection`: ensure Framework resources that need Kibana-derived operations consume factory-resolved typed Kibana scoped clients rather than broad `APIClient` adapters.
+- `provider-kibana-connection`: extend the typed `kibana_connection` contract to `elasticstack_apm_agent_configuration`, and ensure Framework resources that need Kibana-derived operations consume factory-resolved typed Kibana scoped clients rather than broad `APIClient` adapters.
+- `provider-kibana-connection-coverage`: expand the Kibana connection schema fixture so it explicitly owns all registered Kibana-, Fleet-, and APM-scoped entities and participates in a complete provider-registry coverage partition.
+- `provider-elasticsearch-connection`: make the Elasticsearch connection schema fixture the explicit owner for registered Elasticsearch entities and use it in the complete provider-registry coverage partition.
 - `provider-elasticsearch-scoped-client-resolution`: finish the cleanup by removing overlapping Elasticsearch helper behavior from the broad client surface once scoped clients fully own it.
-- `apm-agent-configuration`: update the resource contract to acquire its Kibana OpenAPI client through typed scoped-client resolution instead of the broad provider API client.
+- `apm-agent-configuration`: update the resource schema and client-resolution contract so it accepts an optional `kibana_connection` override and acquires its Kibana OpenAPI client through typed scoped-client resolution instead of the broad provider API client.
 
 ## Impact
 
-- Affected code is concentrated in `internal/clients`, `internal/apm/agent_configuration`, `xpprovider`, acceptance test helpers, and tests/mocks that still construct or depend on `APIClient`.
+- Affected code is concentrated in `internal/clients`, `internal/apm/agent_configuration`, shared Kibana connection schema helpers, `xpprovider`, acceptance test helpers, and tests/mocks that still construct or depend on `APIClient`.
+- Affected code also includes `provider/kibana_connection_schema_test.go`, `provider/elasticsearch_connection_schema_test.go`, and any shared test helpers used to enumerate and classify registered provider entities.
 - This change narrows the provider's supported client-resolution API surface and may require compatibility decisions for external `xpprovider` consumers.
+- `elasticstack_apm_agent_configuration` gains a new optional `kibana_connection` block, so acceptance coverage and requirements must verify both provider-default and entity-local override paths.
+- Connection-schema coverage can no longer rely on partial naming heuristics; the two fixture files must classify the complete registered entity inventory so future additions fail fast if they are not assigned to exactly one fixture.
 - Synced OpenSpec requirements under `openspec/specs/` will need cleanup so they stop naming helper paths that are being removed.

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/apm-agent-configuration/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/apm-agent-configuration/spec.md
@@ -1,11 +1,15 @@
 ## MODIFIED Requirements
 
 ### Requirement: Kibana client usage (REQ-005)
-The resource SHALL obtain its Kibana OpenAPI client through typed scoped-client resolution from the provider-configured `*clients.ProviderClientFactory`. The resource SHALL use `GetKibanaOapiClient()` on the resolved `*clients.KibanaScopedClient` for all API operations. The resource SHALL use the Elastic API version `2023-10-31` in all API requests.
+The resource SHALL expose an optional entity-local `kibana_connection` block using the shared Plugin Framework Kibana connection schema helper. The resource SHALL obtain its Kibana OpenAPI client through typed scoped-client resolution from the provider-configured `*clients.ProviderClientFactory`. When `kibana_connection` is absent, the resource SHALL resolve the provider-default `*clients.KibanaScopedClient`. When `kibana_connection` is configured, the resource SHALL resolve a `*clients.KibanaScopedClient` rebuilt from that scoped connection. The resource SHALL use `GetKibanaOapiClient()` on the resolved `*clients.KibanaScopedClient` for all API operations. The resource SHALL use the Elastic API version `2023-10-31` in all API requests.
 
 #### Scenario: Resource resolves typed Kibana client from provider defaults
-- **WHEN** the resource is configured without an entity-local Kibana override
+- **WHEN** the resource is configured without `kibana_connection`
 - **THEN** it SHALL resolve a `*clients.KibanaScopedClient` from the provider client factory and use that typed client for Kibana API operations
+
+#### Scenario: Resource resolves typed Kibana client from entity-local override
+- **WHEN** the resource is configured with `kibana_connection`
+- **THEN** it SHALL resolve a `*clients.KibanaScopedClient` rebuilt from that entity-local connection and use that typed client for Kibana API operations
 
 #### Scenario: Kibana client acquisition failure
 - **WHEN** the provider cannot provide a typed Kibana client or Kibana OpenAPI client

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/provider-elasticsearch-connection/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/provider-elasticsearch-connection/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Fixture ownership inventory (REQ-006)
+For provider-level registry completeness, `provider/elasticsearch_connection_schema_test.go` SHALL own every registered SDK and Plugin Framework entity whose type name starts with `elasticstack_elasticsearch_`. When a registered Elasticsearch entity remains excluded from the `elasticsearch_connection` contract, that fixture SHALL still classify it explicitly as Elasticsearch-owned so the completeness check can distinguish intentional exclusion from missing coverage.
+
+#### Scenario: Registered Elasticsearch entity is owned by the Elasticsearch fixture
+- **WHEN** a resource or data source registered by `provider.New(...)` or `provider.NewFrameworkProvider(...)` has type name `elasticstack_elasticsearch_*`
+- **THEN** `provider/elasticsearch_connection_schema_test.go` SHALL classify that entity into its owned set for coverage and completeness enforcement
+
+### Requirement: Automated enforcement (REQ-005)
+Provider-level coverage SHALL be enforced by automated tests in the provider test suite so that adding a new covered entity without the expected connection classification or schema definition fails continuous integration. The Elasticsearch fixture SHALL participate in the combined fixture partition with `provider/kibana_connection_schema_test.go` so every registered provider entity is accounted for exactly once.
+
+#### Scenario: New registered Elasticsearch entity without fixture ownership fails CI
+- **GIVEN** a new `elasticstack_elasticsearch_*` resource or data source is registered
+- **WHEN** neither the Elasticsearch fixture nor the combined completeness check accounts for it correctly
+- **THEN** the provider unit tests SHALL fail and identify the entity by name

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/provider-kibana-connection-coverage/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/provider-kibana-connection-coverage/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Kibana-fixture entity coverage
+`provider/kibana_connection_schema_test.go` SHALL own the registered SDK and Plugin Framework entities whose connection contract is Kibana-derived: all registered `elasticstack_kibana_*` entities, all registered `elasticstack_fleet_*` entities, and `elasticstack_apm_agent_configuration`. For those owned entities, the fixture SHALL continue to assert the expected `kibana_connection` helper equivalence and non-deprecated schema metadata for the entity's implementation style.
+
+#### Scenario: APM agent configuration is covered by the Kibana fixture
+- **WHEN** `elasticstack_apm_agent_configuration` is registered by `provider.NewFrameworkProvider(...)`
+- **THEN** `provider/kibana_connection_schema_test.go` SHALL include that entity in its owned set and assert the shared `kibana_connection` block contract
+
+### Requirement: Registry partition completeness
+When the provider coverage tests enumerate entities from `provider.New(...)` and `provider.NewFrameworkProvider(...)`, every registered entity SHALL be owned by exactly one of `provider/kibana_connection_schema_test.go` or `provider/elasticsearch_connection_schema_test.go`. The automated coverage checks SHALL fail if an entity is not owned by either fixture or is owned by both.
+
+#### Scenario: Newly registered entity is not assigned to a fixture
+- **WHEN** a new provider entity is registered and neither connection-schema fixture claims it
+- **THEN** the provider coverage tests SHALL fail and identify that entity as uncovered
+
+#### Scenario: Entity is claimed by both fixtures
+- **WHEN** the same registered provider entity is classified into both connection-schema fixtures
+- **THEN** the provider coverage tests SHALL fail and identify that entity as doubly covered

--- a/openspec/changes/cleanup-scoped-client-resolution/specs/provider-kibana-connection/spec.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/specs/provider-kibana-connection/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: Framework scoped Kibana client resolution
-The provider SHALL expose Plugin Framework Kibana-derived client resolution through `*clients.ProviderClientFactory` methods that return a `*clients.KibanaScopedClient`. When an entity-local `kibana_connection` block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`. Covered Framework resources that need Kibana-derived operations SHALL consume that typed scoped client rather than a broad `*clients.APIClient` adapter.
+The provider SHALL expose Plugin Framework Kibana-derived client resolution through `*clients.ProviderClientFactory` methods that return a `*clients.KibanaScopedClient`. When an entity-local `kibana_connection` block is not configured, the factory SHALL return a `*clients.KibanaScopedClient` built from provider-level defaults. When the block is configured, the factory SHALL return a `*clients.KibanaScopedClient` whose Kibana legacy client, Kibana OpenAPI client, SLO client, and Fleet client are rebuilt from the scoped `kibana_connection`. Covered Framework resources that need Kibana-derived operations, including `elasticstack_apm_agent_configuration`, SHALL consume that typed scoped client rather than a broad `*clients.APIClient` adapter.
 
 #### Scenario: Framework factory falls back to provider defaults
 - **WHEN** a covered Framework entity resolves its effective Kibana client through the factory and `kibana_connection` is absent
@@ -14,3 +14,7 @@ The provider SHALL expose Plugin Framework Kibana-derived client resolution thro
 #### Scenario: Framework entity does not downcast to a broad client
 - **WHEN** a covered Framework entity performs Kibana-derived operations
 - **THEN** it SHALL use the typed `*clients.KibanaScopedClient` contract rather than converting provider data into a broad `*clients.APIClient`
+
+#### Scenario: APM agent configuration exposes the shared Kibana connection block
+- **WHEN** `elasticstack_apm_agent_configuration` defines `kibana_connection`
+- **THEN** it SHALL use the shared Plugin Framework Kibana connection block and resolve its effective typed Kibana client through the factory from either provider defaults or that entity-local override

--- a/openspec/changes/cleanup-scoped-client-resolution/tasks.md
+++ b/openspec/changes/cleanup-scoped-client-resolution/tasks.md
@@ -1,7 +1,11 @@
 ## 1. Migrate the remaining production holdout
 
-- [ ] 1.1 Update `internal/apm/agent_configuration` to configure from `ConvertProviderDataToFactory` and store a typed Kibana scoped client instead of `*clients.APIClient`.
-- [ ] 1.2 Switch APM create/read/update/delete operations to obtain the Kibana OpenAPI client from the typed scoped client and remove the remaining `ConvertProviderData` production dependency.
+- [ ] 1.1 Add the shared Plugin Framework `kibana_connection` block to `internal/apm/agent_configuration` and configure the resource from `ConvertProviderDataToFactory` so it can resolve either provider-default or entity-local typed Kibana scoped clients.
+- [ ] 1.2 Switch APM create/read/update/delete operations to obtain the Kibana OpenAPI client from the typed scoped client selected by the effective `kibana_connection`, and remove the remaining `ConvertProviderData` production dependency.
+- [ ] 1.3 Update `provider/kibana_connection_schema_test.go` so it explicitly owns the registered `elasticstack_kibana_*`, `elasticstack_fleet_*`, and `elasticstack_apm_agent_configuration` entities rather than relying on partial prefix heuristics.
+- [ ] 1.4 Update `provider/elasticsearch_connection_schema_test.go` so it explicitly owns the registered `elasticstack_elasticsearch_*` entities in a form that can participate in a shared registry-completeness check.
+- [ ] 1.5 Add a shared provider-registry completeness assertion for the two connection-schema fixtures that enumerates entities from `provider.New(...)` and `provider.NewFrameworkProvider(...)` and fails on uncovered or doubly covered entities.
+- [ ] 1.6 Add or update acceptance coverage for `elasticstack_apm_agent_configuration` so both provider-default and entity-local `kibana_connection` paths are exercised.
 
 ## 2. Remove legacy broad-client bridges
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add optional `kibana_connection` block to APM agent configuration and enforce connection-schema fixture ownership
- Extends the `elasticstack_apm_agent_configuration` resource to accept an optional `kibana_connection` block, resolving the Kibana client via a typed scoped factory from either provider defaults or the entity-local override.
- Defines explicit ownership rules for Kibana and Elasticsearch connection-schema fixtures, partitioning all registered `elasticstack_kibana_*`, `elasticstack_fleet_*`, and `elasticstack_elasticsearch_*` entities across their respective fixture files.
- Adds a registry-completeness assertion that fails CI when any registered provider entity is uncovered or doubly covered by the fixture ownership partition.
- Updates specs, design docs, and task list in `openspec/changes/cleanup-scoped-client-resolution/` to reflect the expanded scope.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46f4598.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->