### PR TITLE
Add tests verifying current behaviour

### DIFF
--- a/internal/kibana/alertingrule/validate_test.go
+++ b/internal/kibana/alertingrule/validate_test.go
@@ -134,6 +134,58 @@ func TestValidateRuleParamsApmAnomalyRequiredKeys(t *testing.T) {
 	}
 }
 
+func TestValidateRuleParamsApmTransactionRulesAllowSearchConfiguration(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ruleType string
+		params   map[string]any
+	}{
+		{
+			name:     "transaction error rate",
+			ruleType: "apm.transaction_error_rate",
+			params: map[string]any{
+				"environment": "ENVIRONMENT_ALL",
+				"searchConfiguration": map[string]any{
+					"query": map[string]any{
+						"language": "kuery",
+						"query":    "test*",
+					},
+				},
+				"threshold":    30.0,
+				"useKqlFilter": true,
+				"windowSize":   5.0,
+				"windowUnit":   "m",
+			},
+		},
+		{
+			name:     "transaction duration",
+			ruleType: "apm.transaction_duration",
+			params: map[string]any{
+				"aggregationType": "avg",
+				"environment":     "ENVIRONMENT_ALL",
+				"searchConfiguration": map[string]any{
+					"query": map[string]any{
+						"language": "kuery",
+						"query":    "test*",
+					},
+				},
+				"threshold":    1500.0,
+				"useKqlFilter": true,
+				"windowSize":   5.0,
+				"windowUnit":   "m",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if errs := validateRuleParams(tc.ruleType, tc.params); len(errs) > 0 {
+				t.Fatalf("expected no validation errors, got: %v", errs)
+			}
+		})
+	}
+}
+
 func TestValidateRuleParamsRejectsUnexpectedKeys(t *testing.T) {
 	params := map[string]any{
 		"windowSize":          5.0,


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/2202 (well not really, it was fixed earlier but this demonstrates it's fixed). 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests verifying `validateRuleParams` accepts `searchConfiguration` for APM transaction rules
> Adds a table-driven test `TestValidateRuleParamsApmTransactionRulesAllowSearchConfiguration` in [validate_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2305/files#diff-f18d3a80b9862498107a229f6e3929d6d433c8ba056e767600b90dcd546ffc9c) that covers `apm.transaction_error_rate` and `apm.transaction_duration` rule types with `searchConfiguration` containing a kuery query. The test documents current behavior by asserting no validation errors are returned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adc6437.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->