### PR TITLE
Watch kibana spec changes

### DIFF
--- a/openspec/changes/kibana-spec-impact-workflow/.openspec.yaml
+++ b/openspec/changes/kibana-spec-impact-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/kibana-spec-impact-workflow/design.md
+++ b/openspec/changes/kibana-spec-impact-workflow/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The repository already tracks Kibana OpenAPI updates by bumping `generated/kbapi/Makefile` through Renovate and regenerating `generated/kbapi/kibana.gen.go`. What is missing is a repeatable mechanism that turns those upstream API changes into actionable provider follow-up.
+
+This change introduces a hybrid agentic workflow. Deterministic repository-local code handles the parts that need to be testable and stable: trigger gating, baseline selection, generated client diffing, entity inventory, reverse indexing, impact matching, and duplicate suppression. The agent only receives structured impact evidence plus limited repository context and is responsible for turning that evidence into maintainable issue summaries.
+
+The design needs to fit existing repository conventions:
+
+- workflow sources are authored under `.github/workflows-src/` and compiled into checked-in workflow artifacts;
+- repo memory is used to persist workflow state across runs;
+- provider entity discovery should come from the registered Plugin Framework and SDK providers rather than from handwritten lists;
+- Kibana coverage is strongest for entities that use `generated/kbapi` through `internal/clients/kibanaoapi`, while legacy `go-kibana-rest` and `generated/slo` consumers remain follow-up scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect Kibana spec or generated client changes from a stable stored baseline rather than from only the immediately previous commit.
+- Determine impacted Kibana Terraform entities using deterministic matching with inspectable evidence.
+- Open one issue per impacted entity with a concise summary of likely new fields, widened options, or new capabilities.
+- Avoid repeatedly creating equivalent issues for the same baseline-to-target transition.
+- Reuse existing repository patterns for gh-aw workflows, repo memory, and script testing.
+
+**Non-Goals:**
+
+- Fully model every Kibana-facing client in the first version.
+- Guarantee semantic understanding of all upstream behavioral changes when no tracked symbol changes.
+- Produce implementation plans inside the created issue; a later agent workflow will handle that.
+- Replace Renovate or change how `generated/kbapi` is regenerated.
+
+## Decisions
+
+### Use a hybrid workflow instead of a fully agent-driven classifier
+
+The workflow will separate evidence collection from summarization. Deterministic helpers under `scripts/kibana-spec-impact/` will compute the baseline, diff tracked artifacts, build the entity reverse index, and emit a JSON impact report. The gh-aw workflow will then instruct the agent to read that report and create issues only for supported high-confidence matches.
+
+Alternative considered: let the agent inspect raw diffs and infer impacted entities directly. This would be faster to implement but harder to test, harder to debug, and more likely to drift in issue quality over time.
+
+### Use provider registrations as the canonical entity inventory
+
+Entity discovery will be derived from `provider/plugin_framework.go` and `provider/provider.go`, following the same pattern already used by the schema-coverage rotation helper. This prevents the workflow from relying on manual allowlists that can go stale when resources or data sources are added or removed.
+
+Alternative considered: maintain a handwritten manifest of Kibana entities. This was rejected because it duplicates provider truth and adds maintenance burden.
+
+### Persist processed state in repo memory
+
+The workflow will maintain repo memory that stores at least:
+
+- the last processed baseline revision,
+- fingerprints for previously reported entity impacts,
+- optional metadata needed to suppress duplicates or resume after partial runs.
+
+This keeps duplicate suppression deterministic and aligned with existing repository automation patterns.
+
+Alternative considered: rely only on open-issue title matching or issue search. This was rejected because issue text is an unstable dedupe key and cannot reliably represent baseline-to-target equivalence.
+
+### Limit V1 deterministic matching to `generated/kbapi` consumers
+
+The first implementation will only claim high-confidence impact for entities that can be matched through `generated/kbapi` and `internal/clients/kibanaoapi` symbol usage. The workflow may surface weaker evidence for `transform_schema.go` changes, but those should remain agent-reviewed and conservative in V1.
+
+Alternative considered: include `generated/slo` and `go-kibana-rest` from day one. This was rejected for V1 because those surfaces use different client-generation and call patterns, increasing complexity before the base approach is proven.
+
+### Define a strict evidence contract between helper and agent
+
+The helper output will include baseline and target revisions, changed symbols grouped by kind, impacted entities, matched implementation paths, and a confidence level per entity. The agent prompt will instruct the agent not to create issues without deterministic evidence unless the workflow explicitly opts into lower-confidence handling in a later version.
+
+Alternative considered: pass arbitrary helper logs to the agent. This was rejected because it makes the agent prompt brittle and weakens testability.
+
+## Risks / Trade-offs
+
+- [Shared generated types create broad match sets] → Restrict V1 issue creation to high-confidence entity-local matches and let the agent suppress weak generic matches.
+- [Transform-only spec changes may not map cleanly to symbols] → Include transform file changes in the evidence report and document them as lower-confidence cases rather than silently ignoring them.
+- [Repo memory can suppress needed follow-up if fingerprints are too coarse] → Use baseline-to-target revision data plus changed-symbol fingerprints rather than title-only or entity-only dedupe.
+- [Push-only triggering can miss nonstandard update paths] → Include `workflow_dispatch` and a scheduled safety-net run.
+- [Deterministic matching misses legacy Kibana clients] → Explicitly scope V1 to `generated/kbapi` consumers and leave extension points for `generated/slo` and `go-kibana-rest`.
+
+## Migration Plan
+
+1. Add the new OpenSpec capability and implementation tasks.
+2. Implement the helper command and its unit tests.
+3. Add repo-memory seed state for the new workflow.
+4. Author the gh-aw workflow source and compile the checked-in workflow artifacts.
+5. Validate the helper logic and workflow generation locally.
+6. Roll out with conservative issue caps and high-confidence issue creation only.
+
+Rollback is straightforward: disable or revert the workflow source and generated artifacts, and remove or ignore the corresponding repo-memory branch or seed file.
+
+## Resolved decisions (implementation)
+
+- **Initial baseline when repo memory is empty**: resolve to `git rev-parse <target>~1` so the first run compares the parent commit to the current target; after each successful workflow completion, `last_analyzed_target_sha` advances to the analyzed `target_sha`.
+- **Schedule frequency**: weekly (`cron: "0 6 * * 1"`) with push-based triggers on `main` for kbapi/kibanaoapi paths; maintainers can use `workflow_dispatch`.
+- **Transform-only changes (V1)**: surface paths under `transform_schema_hints` in the report and keep the gate active for agent review, but **do not** open issues from transform hints alone; issues are only for `high_confidence_impacts` from kbapi/kibanaoapi matching.
+- **Issue cap vs dedupe**: the workflow caps new issues per run; repo memory records dedupe fingerprints **only** for entities that actually received an issue (`--issued` list). The analysis baseline always advances after a successful run so stale baselines do not block future diffs.

--- a/openspec/changes/kibana-spec-impact-workflow/proposal.md
+++ b/openspec/changes/kibana-spec-impact-workflow/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Kibana OpenAPI and generated client changes can land through Renovate or direct updates without any systematic follow-up on which Terraform resources or data sources may need work. Maintainers need an automated way to detect likely impacted entities and open focused issues before implementation planning begins.
+
+## What Changes
+
+- Add a GitHub agentic workflow that reacts to Kibana spec or generated client changes on `main` and on manual or scheduled runs.
+- Add deterministic helper tooling that computes a baseline, diffs Kibana client artifacts, and maps changed API symbols to registered Kibana Terraform entities.
+- Add repo memory for processed baselines and duplicate suppression so the workflow does not repeatedly open equivalent issues.
+- Add agent instructions that turn deterministic impact evidence into one actionable GitHub issue per impacted entity.
+
+## Capabilities
+
+### New Capabilities
+- `ci-kibana-spec-impact-issues`: Detect Kibana spec or generated client changes, determine impacted Terraform entities, and open one issue per impacted entity with a summarized impact report.
+
+### Modified Capabilities
+
+## Impact
+
+- GitHub workflow sources and generated workflow outputs under `.github/workflows-src/` and `.github/workflows/`.
+- New helper tooling under `scripts/` for baseline tracking, symbol diffing, and entity impact mapping.
+- Repo memory under `.github/aw/memory/` for dedupe and processed baseline state.
+- Kibana provider packages under `provider/`, `internal/clients/kibanaoapi/`, and `internal/kibana/` as discovery inputs for deterministic impact mapping.

--- a/openspec/changes/kibana-spec-impact-workflow/specs/ci-kibana-spec-impact-issues/spec.md
+++ b/openspec/changes/kibana-spec-impact-workflow/specs/ci-kibana-spec-impact-issues/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: Workflow runs for Kibana spec-impact analysis
+
+The repository SHALL provide a GitHub workflow for Kibana spec-impact analysis that can run automatically for Kibana generated-client changes on the default branch and can also be started manually. The workflow SHALL evaluate a persisted baseline revision so that analysis compares the current target revision to the last processed Kibana spec-impact baseline rather than only to the immediately previous commit.
+
+#### Scenario: Push to default branch triggers analysis
+- **WHEN** a push to the default branch includes changes to the Kibana spec-impact inputs for this workflow
+- **THEN** the workflow SHALL evaluate those changes against the stored baseline revision
+
+#### Scenario: Maintainer reruns analysis manually
+- **WHEN** a maintainer starts the workflow manually
+- **THEN** the workflow SHALL run the same baseline-aware analysis flow without requiring a new Kibana spec change to arrive first
+
+### Requirement: Deterministic helper emits entity impact evidence
+
+The workflow SHALL use deterministic repository-local helper tooling to derive the canonical Kibana entity inventory from provider registrations, diff tracked Kibana generated-client inputs against the selected baseline, and emit structured impact evidence for matching entities. In V1, the helper SHALL only claim high-confidence impact for entities that can be matched through `generated/kbapi` and `internal/clients/kibanaoapi` usage.
+
+#### Scenario: Helper discovers registered entities from provider code
+- **WHEN** the helper prepares entity inventory for a workflow run
+- **THEN** it SHALL derive Kibana resources and data sources from the repository's registered provider implementations rather than from a handwritten entity manifest
+
+#### Scenario: Helper reports matched entities with evidence
+- **WHEN** the helper finds changed Kibana client symbols referenced by a supported entity
+- **THEN** it SHALL emit structured evidence that includes the impacted entity name, entity type, matched implementation path, and the changed methods or types that produced the match
+
+#### Scenario: Unsupported client surfaces remain out of high-confidence scope
+- **WHEN** a changed Kibana-facing entity depends only on unsupported V1 client surfaces such as legacy `go-kibana-rest` or `generated/slo`
+- **THEN** the helper SHALL NOT classify that entity as a high-confidence impacted entity in V1
+
+### Requirement: Agent creates one issue per impacted entity from deterministic evidence
+
+The workflow agent SHALL use deterministic helper output as the primary source of truth for impacted entities and SHALL create at most one issue per impacted entity in a run. Each created issue SHALL summarize the affected Terraform entity, the evidence that caused the match, and the likely impact in terms of new fields, widened options, or newly exposed capability when that can be inferred from the deterministic evidence and local repository context.
+
+#### Scenario: High-confidence match creates a focused issue
+- **WHEN** the helper reports a high-confidence impacted entity
+- **THEN** the agent SHALL create one issue for that entity summarizing the matched evidence and likely provider follow-up areas
+
+#### Scenario: Weak generic evidence does not force an issue
+- **WHEN** the helper output indicates only broad or weak evidence that is not actionable for a single entity
+- **THEN** the agent SHALL refrain from creating an issue for that weak match
+
+### Requirement: Workflow suppresses duplicate impact issues
+
+The workflow SHALL persist repo-memory state for processed Kibana spec-impact runs and SHALL use that state to suppress duplicate issue creation for equivalent entity impacts. Duplicate suppression SHALL be based on deterministic impact identity such as baseline revision, target revision, and entity-level impact fingerprint rather than only on issue-title matching.
+
+#### Scenario: Equivalent impact is not reopened
+- **WHEN** a workflow run encounters an entity impact that matches a previously processed deterministic impact identity
+- **THEN** the workflow SHALL NOT create a duplicate issue for that entity
+
+#### Scenario: New target revision can create a fresh issue
+- **WHEN** a later workflow run reaches a new target revision or a changed entity-level impact fingerprint for the same entity
+- **THEN** the workflow SHALL treat that impact as eligible for a new issue
+
+### Requirement: Issue cap does not suppress never-filed entities
+
+The workflow SHALL cap the number of new issues created per run while ensuring duplicate-suppression fingerprints are recorded **only** for entities that actually received an issue in that run. Entities that were eligible but not issued due to the cap SHALL remain eligible in a future run until an issue is created for them.
+
+#### Scenario: Capped entity is not fingerprinted
+- **WHEN** more high-confidence impacted entities exist than the per-run issue cap allows to be filed
+- **THEN** repo memory SHALL NOT record a dedupe fingerprint for entities that did not receive an issue in that run
+
+### Requirement: Baseline advances after successful analysis
+
+The helper/workflow SHALL advance the persisted last-analyzed target revision after each successful analysis completion, including when **zero** new high-confidence issues are created or when all matches were duplicate-suppressed, so future diffs are not stuck on stale baselines.
+
+#### Scenario: Analysis with no new issues still advances baseline
+- **WHEN** a workflow run completes successfully and no new issues are created
+- **THEN** the persisted baseline SHALL still advance to the analyzed target revision
+
+#### Scenario: Partial issuance still advances baseline
+- **WHEN** some high-confidence entities receive issues under the cap but others do not
+- **THEN** the baseline SHALL advance and memory SHALL record fingerprints only for entities that were actually issued
+
+### Requirement: Generated kbapi file lifecycle is tolerantly diffed
+
+The helper SHALL tolerate `generated/kbapi/kibana.gen.go` being absent at the baseline revision, target revision, or both (introduce/rename/remove lifecycle) without failing the entire impact report; it SHALL treat missing content as an empty kbapi surface for that side of the diff.
+
+#### Scenario: Baseline revision lacks generated kbapi file
+- **WHEN** `git show` for the baseline revision cannot resolve `generated/kbapi/kibana.gen.go` because the path does not exist in that commit
+- **THEN** the helper SHALL still emit an impact report (treating that side as an empty kbapi surface) instead of failing the entire command
+
+### Requirement: `memory-record-from-report` issuance contract
+
+The `memory-record-from-report` helper SHALL require an `--issued` JSON file path **when** the report contains one or more `high_confidence_impacts` entries, so accidental omission cannot advance the baseline without explicit issuance intent (including an empty issuance list via `[]` when no issues were intentionally created despite impacts).
+
+#### Scenario: High-confidence report requires issued file
+- **WHEN** the impact report includes at least one `high_confidence_impacts` entry
+- **THEN** the memory-record command SHALL fail unless `--issued` is provided
+
+### Requirement: Root internal/kibana entity scan robustness
+
+For Terraform entities implemented in the root `internal/kibana` package, the helper SHALL fall back to scanning the full package directory when no filename prefix mapping exists, so new entities do not fail inventory impact scanning solely for lack of a prefix table entry.
+
+#### Scenario: New root-package Kibana entity without prefix mapping
+- **WHEN** a Terraform entity uses the root `internal/kibana` Go package and has no dedicated filename-prefix mapping yet
+- **THEN** the helper SHALL still select implementation sources under that package directory for impact matching without returning an inventory error

--- a/openspec/changes/kibana-spec-impact-workflow/tasks.md
+++ b/openspec/changes/kibana-spec-impact-workflow/tasks.md
@@ -1,0 +1,23 @@
+## 1. Deterministic impact helper
+
+- [x] 1.1 Create `scripts/kibana-spec-impact/` with commands for baseline selection, entity inventory, diff analysis, and impact reporting.
+- [x] 1.2 Derive the canonical Kibana entity inventory from `provider/plugin_framework.go` and `provider/provider.go` instead of a handwritten manifest.
+- [x] 1.3 Build reverse-index and diff logic that maps changed `generated/kbapi` methods or types to supported Kibana entities with structured evidence and confidence.
+
+## 2. Repo memory and duplicate suppression
+
+- [x] 2.1 Add a repo-memory seed file under `.github/aw/memory/` for Kibana spec-impact workflow state.
+- [x] 2.2 Persist processed baseline and entity-level impact fingerprints so equivalent impacts are not reported twice.
+- [x] 2.3 Add helper tests for baseline handling, entity matching, and duplicate-suppression behavior.
+
+## 3. Agentic workflow
+
+- [x] 3.1 Author `.github/workflows-src/kibana-spec-impact/workflow.md.tmpl` using the existing gh-aw workflow conventions.
+- [x] 3.2 Add deterministic workflow gating for Kibana spec-impact inputs plus manual execution support, and configure the workflow bootstrap and safe outputs.
+- [x] 3.3 Write the agent prompt so it consumes deterministic helper output, creates at most one issue per impacted entity, and suppresses weak or non-actionable matches.
+- [x] 3.4 Regenerate checked-in workflow artifacts and ensure the source and generated outputs stay in sync.
+
+## 4. Validation
+
+- [x] 4.1 Add or update tests covering workflow-source generation and any deterministic inline scripts used by the workflow.
+- [x] 4.2 Run focused helper and workflow checks, then update the change artifacts if implementation constraints differ from the current proposal or design.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec design and requirements for Kibana spec-impact CI workflow
- Adds a [proposal](https://github.com/elastic/terraform-provider-elasticstack/pull/2322/files#diff-26a1a01431991f9b60cc23777112e9f38eb4e6d65eed186201629a03d5ad9779) and [design doc](https://github.com/elastic/terraform-provider-elasticstack/pull/2322/files#diff-87b5f7c15a0bd66d074ccac06d784811558ae11e6e42ddbc3dbcc662f66878b8) for a hybrid CI workflow that detects when Kibana API specs change and opens tracking issues.
- Adds a [requirements spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2322/files#diff-8a368ea5388e1638283cef7bcfbc29fa572875fcec9fb59a2d0da7e6457187c2) for the `ci-kibana-spec-impact-issues` capability, covering workflow triggers, duplicate suppression via repo memory, issue caps, baseline advancement policy, and tolerant diffing for generated `kbapi` lifecycle changes.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65eb478.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->