### PR TITLE
PR centric changelog generation

### DIFF
--- a/openspec/changes/pr-centric-changelog-generation/.openspec.yaml
+++ b/openspec/changes/pr-centric-changelog-generation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/pr-centric-changelog-generation/design.md
+++ b/openspec/changes/pr-centric-changelog-generation/design.md
@@ -1,0 +1,92 @@
+## Context
+
+`ci-changelog-generation` currently performs changelog synthesis late, from merged pull-request history, inside a GH AW workflow that gathers PR evidence and asks an agent to draft the release-note text. That architecture has proven fragile for this repo's needs: the strongest signal is often the PR title, customer-impact filtering is inferred too loosely from paths and labels, and the final bullets drift away from the tone and structure already established in `CHANGELOG.md`.
+
+The requested pivot splits the problem into two workflows with different responsibilities:
+
+1. A **PR-time agentic workflow** runs after `Build/Lint/Test` completes and ensures the pull request body contains a valid `## Changelog` section unless the PR is explicitly exempt with `no-changelog`.
+2. A **scheduled/release deterministic workflow** reads merged PR bodies, parses the structured changelog contract, and rebuilds the target `CHANGELOG.md` section without asking an agent to summarize merged history.
+
+This is cross-cutting because it affects workflow authoring format, trigger model, PR metadata handling, changelog parsing/validation helpers, and the canonical OpenSpec contract for CI/release automation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move changelog authorship to PR time so authors/reviewers provide the user-facing summary while the change context is fresh.
+- Keep the normal changelog entry structured and easy to validate: `Customer impact` plus `Summary`.
+- Allow an optional `### Breaking changes` subsection in PR bodies to remain free-form markdown, including paragraphs, lists, and fenced code blocks, while still being extractable deterministically by boundary.
+- Trigger the PR-time workflow from `workflow_run` on `Build/Lint/Test` completion so authors have an opportunity to fill in the PR body before the workflow intervenes.
+- Keep the release assembly workflow authoritative and deterministic: full-section regeneration from an authoritative merge range, no LLM summary of merged PRs, and only light normalization of output.
+- Replace GH AW safe-output PR management in release assembly with explicit GitHub Actions logic for branch reuse, PR lookup, PR creation, and PR body refresh.
+
+**Non-Goals:**
+
+- Changing the existing `Build/Lint/Test` workflow's behavior beyond using its completion as the trigger source for the PR-time workflow.
+- Replacing authoritative rebuilds with append-only changelog mutation on every merge.
+- Parsing the internal semantics of breaking-change prose or rewriting breaking-change markdown into a more structured schema.
+- Performing deep diff analysis during scheduled/release assembly.
+
+## Decisions
+
+1. **Split the problem into PR-time authoring and release-time assembly**  
+   **Decision:** Add a new PR-time workflow capability for changelog authoring, and convert `ci-changelog-generation` into a deterministic assembly workflow.  
+   **Rationale:** This keeps the agent where interpretation is useful and limits deterministic release assembly to parsing known structure.  
+   **Alternative considered:** Keep one workflow and enrich the merged-PR evidence manifest with PR bodies/examples. Rejected because it still centralizes interpretation too late and keeps the release-time workflow responsible for both authorship and assembly.
+
+2. **Use `workflow_run` on `Build/Lint/Test` completion for the PR-time workflow**  
+   **Decision:** Trigger the PR-time workflow from `workflow_run` for the `Build/Lint/Test` workflow name and use deterministic steps to resolve the PR from the source run metadata.  
+   **Rationale:** This gives humans time to add the changelog themselves, and it aligns with the intended required-check flow. It also allows the follow-up workflow to have the permissions needed to update the PR body.  
+   **Alternative considered:** Trigger directly on `pull_request` events. Rejected because it races earlier in the authoring flow and is more likely to overwrite or duplicate human-authored changelog text before CI completes.
+
+3. **Treat `workflow_run` as privileged metadata automation only**  
+   **Decision:** The PR-time workflow SHALL avoid checking out or executing untrusted PR code. Deterministic gating, validation, and agent prompting will operate only on PR metadata (title, description, labels, body) and repository-authored examples/instructions.  
+   **Rationale:** `workflow_run` carries elevated privileges; keeping it metadata-only avoids the standard pwn-request class of problems while still allowing PR body mutation.  
+   **Alternative considered:** Allow checkout after deterministic gating for same-repository PRs. Rejected because checkout is unnecessary for this task and increases security risk without clear benefit.
+
+4. **Keep the normal changelog summary structured but allow free-form breaking changes**  
+   **Decision:** The PR-body contract will require structured `Customer impact` and `Summary` fields, but `### Breaking changes` will be optional free-form markdown preserved as a delimited block.  
+   **Rationale:** Normal release notes need consistency and simple parsing, while breaking changes often require migration prose and code blocks that do not fit a tight schema.  
+   **Alternative considered:** Make breaking changes a structured bullet list. Rejected because it would force unnatural formatting and lose important migration detail.
+
+5. **The PR agent should fill a fixed template rather than free-write**  
+   **Decision:** Constrain the PR-time agent to producing the `## Changelog` template fields instead of writing arbitrary release-note prose.  
+   **Rationale:** The workflow's job is to populate a deterministic contract, not to create polished final changelog output. This also makes validator design simpler.  
+   **Alternative considered:** Let the agent draft a loose changelog section and normalize it later. Rejected because it reintroduces the title-dump and style-drift problem.
+
+6. **Scheduled/release assembly remains full-range and deterministic**  
+   **Decision:** Preserve the existing authoritative-range rebuild model for both `## [Unreleased]` and release sections, but replace the agentic summary step with deterministic parsing of merged PR bodies and labels.  
+   **Rationale:** Full rebuilds are easier to reason about and self-heal if a previous run missed or misrendered something.  
+   **Alternative considered:** Replace the rebuild with merge-triggered append-only logic. Rejected as the primary model because it is more prone to drift, race conditions, and correction difficulties after merge.
+
+7. **Simple normalization only during release assembly**  
+   **Decision:** Assembly may normalize bullets, citations, whitespace, and placement of breaking-change blocks, but it SHALL NOT semantically rewrite the author-provided content.  
+   **Rationale:** The PR contract is now the source of truth; deterministic assembly should render it consistently, not reinterpret it.  
+   **Alternative considered:** Add a second agent or complex deterministic heuristics to polish output. Rejected because that recreates the same source-of-truth ambiguity the pivot is meant to remove.
+
+8. **Use normal GitHub Actions PR management for deterministic assembly**  
+   **Decision:** Scheduled/manual runs will update the `generated-changelog` branch, look up or create the singleton PR, and update its body if it already exists. Release runs will update only the triggering `prep-release-*` branch and use the PR number from event metadata when refreshing PR metadata.  
+   **Rationale:** Once release assembly is deterministic, GH AW safe outputs are no longer appropriate or necessary.  
+   **Alternative considered:** Keep the current GH AW wrapper just for PR creation/update. Rejected because it couples deterministic release assembly to an agentic runtime that is otherwise being removed.
+
+## Risks / Trade-offs
+
+- **[Risk] Authors may leave low-quality or stale changelog sections in PR bodies** → **Mitigation:** make the PR workflow a required check, validate structure deterministically, and let the agent only fill gaps rather than replace valid author input.
+- **[Risk] `workflow_run` may be used unsafely** → **Mitigation:** keep the PR-time workflow metadata-only, with no checkout or execution of untrusted branch code.
+- **[Risk] The free-form `### Breaking changes` block could be malformed or hard to place cleanly** → **Mitigation:** validate only that the block is present and non-empty when declared, and preserve it by heading boundaries rather than attempting semantic parsing.
+- **[Risk] Scheduled/release assembly may have to handle mixed historical PRs that predate the new contract** → **Mitigation:** keep authoritative rebuilds, add explicit handling for missing contract cases, and use `no-changelog` plus deterministic fallbacks where needed during rollout.
+- **[Risk] Moving PR update logic from GH AW to normal Actions may create branch/PR drift bugs** → **Mitigation:** centralize lookup/create/update logic in repository-authored scripts or helper steps, and cover singleton `generated-changelog` reuse plus release-PR refresh behavior with tests.
+
+## Migration Plan
+
+1. Define the new PR-time workflow capability and update `ci-changelog-generation` spec requirements to describe deterministic assembly rather than merged-history summarization.
+2. Introduce repository-authored parser/validator helpers for the PR-body changelog contract, including optional breaking-change block extraction.
+3. Implement the PR-time agentic workflow triggered from `workflow_run` on `Build/Lint/Test`, with deterministic PR resolution, skip logic, validation, and PR body update behavior.
+4. Refactor the changelog-generation workflow source and compiled outputs to remove the merged-history agent phase, replace GH AW PR update safe outputs, and rebuild changelog sections from parsed merged PR metadata.
+5. Validate the resulting workflows and OpenSpec artifacts, then make the PR-time workflow a required check after maintainers confirm its ergonomics.
+
+## Open Questions
+
+- Whether the PR-time workflow should treat an empty `## Changelog` section as “missing” and always invoke the agent, or whether some partial-but-invalid shapes should hard-fail instead of being auto-filled.
+- Whether rollout needs a temporary deterministic fallback for merged PRs that predate the new PR-body contract but still fall inside the authoritative release range.
+- Whether a merge-triggered convenience rerun is worth adding in the first implementation, or whether scheduled/manual plus release-preparation triggers are sufficient until the deterministic assembly stabilizes.

--- a/openspec/changes/pr-centric-changelog-generation/proposal.md
+++ b/openspec/changes/pr-centric-changelog-generation/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The current changelog workflow tries to synthesize release notes from merged pull requests at release-assembly time, which has led to title-shaped entries, weak customer-impact filtering, and output that drifts from the established `CHANGELOG.md` voice. Moving changelog authorship closer to each pull request lets authors and reviewers supply the intent while keeping release assembly deterministic and consistent.
+
+## What Changes
+
+- Add a new PR-time agentic workflow that runs after `Build/Lint/Test` completes, validates whether a pull request already contains a valid `## Changelog` section, and only invokes the agent when the PR is missing that section and is not labeled `no-changelog`.
+- Define a structured PR-body changelog contract with required `Customer impact` and `Summary` fields plus an optional free-form `### Breaking changes` markdown subsection that may include prose, lists, and fenced code blocks.
+- Refactor changelog release assembly so scheduled/manual and release-preparation runs deterministically parse merged PR bodies and labels, rebuild changelog sections from those structured PR entries, and stop relying on agentic PR-history summarization.
+- Replace GH AW safe-output PR management in changelog release assembly with normal GitHub Actions branch and pull-request update logic, including singleton `generated-changelog` PR reuse and release-PR updates from event metadata.
+- Preserve authoritative full-section regeneration for `## [Unreleased]` and concrete release sections, while allowing any merged-PR-triggered follow-on workflow only as a convenience rerun of the same deterministic rebuild logic rather than as a separate append-only path.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-pr-changelog-authoring`: A PR-time workflow that ensures pull requests either contain a valid `## Changelog` section or explicitly opt out with `no-changelog`, and that can draft the missing PR-body changelog section from the PR title and description.
+
+### Modified Capabilities
+
+- `ci-changelog-generation`: Replace agentic merged-history summarization with deterministic assembly from merged PR-body changelog sections, preserve optional breaking-change blocks, and manage generated/release PR updates with standard GitHub Actions logic instead of GH AW safe outputs.
+
+## Impact
+
+- **Workflow sources:** new PR-time workflow under `.github/workflows-src/` plus the compiled workflow under `.github/workflows/`; significant changes to `.github/workflows-src/changelog-generation/workflow.md.tmpl` and its compiled outputs.
+- **Deterministic helpers:** new or updated repository-authored parsers/validators for PR-body changelog sections, merged PR aggregation, breaking-change block extraction, and branch/PR update logic.
+- **Specifications:** new canonical spec for the PR-time workflow capability and updates to `openspec/specs/ci-changelog-generation/spec.md`; possibly minor alignment in related CI specs where they reference changelog generation behavior.
+- **Repository process:** pull requests gain a required changelog check after `Build/Lint/Test`, and changelog intent moves from release-time inference to PR-time authoring/review.

--- a/openspec/changes/pr-centric-changelog-generation/specs/ci-changelog-generation/spec.md
+++ b/openspec/changes/pr-centric-changelog-generation/specs/ci-changelog-generation/spec.md
@@ -1,0 +1,122 @@
+# `ci-changelog-generation` — Deterministic changelog assembly
+
+Workflow implementation: authored source under `.github/workflows-src/`, compiled to `.github/workflows/`.
+
+## MODIFIED Requirements
+
+### Requirement: Workflow artifacts and operating modes
+The changelog generator SHALL be authored as a deterministic repository workflow source under `.github/workflows-src/` and SHALL compile to the checked-in workflow artifacts under `.github/workflows/`. The workflow SHALL support:
+
+- a scheduled mode
+- a manual `workflow_dispatch` mode
+- a `pull_request_target` mode for same-repository release-preparation branches matching the repository's `prep-release-*` naming contract
+
+#### Scenario: Source and compiled workflow stay paired
+- **WHEN** maintainers change changelog generator behavior
+- **THEN** the authored source and committed compiled workflow SHALL match the current repository compiler output
+
+#### Scenario: Release-preparation pull request activates release mode
+- **GIVEN** a same-repository pull request whose head branch matches the configured `prep-release-*` pattern
+- **WHEN** the changelog generator runs for that pull request through `pull_request_target`
+- **THEN** it SHALL enter release-section generation mode for the triggering pull request branch
+
+### Requirement: Full-section regeneration uses authoritative ranges
+The changelog generator SHALL regenerate the full target section on each run from an authoritative range rather than appending only “since last run” changes.
+
+- In scheduled/manual mode, it SHALL regenerate the full `## [Unreleased]` section from the previous semver release tag to `main`.
+- In release-pull-request mode, it SHALL regenerate the full concrete `## [x.y.z] - <date>` section for the triggering release branch from the previous semver release tag to that branch head.
+- In both modes, release-note content SHALL be assembled from merged pull requests in that authoritative range by parsing their PR-body changelog contract and labels.
+
+#### Scenario: Scheduled run rebuilds full Unreleased
+- **WHEN** the changelog generator runs in scheduled or manual mode
+- **THEN** it SHALL regenerate the entire `## [Unreleased]` section from the authoritative release range instead of incrementally appending entries
+
+#### Scenario: Release PR run rebuilds full release section
+- **WHEN** the changelog generator runs for a `prep-release-*` pull request
+- **THEN** it SHALL regenerate the full `## [x.y.z] - <date>` section for that branch from the authoritative release range instead of incrementally appending entries
+
+### Requirement: Deterministic validation gates changelog mutation
+Before updating `CHANGELOG.md`, deterministic repository-authored validation SHALL verify that parsed changelog content from merged PRs is structurally valid and matches the repository changelog format for the target section. The validator SHALL reject output when referenced PR metadata cannot be resolved from the authoritative merged range, when the rendered changelog shape is invalid for the target section, or when extracted breaking-change content cannot be preserved as markdown inside the top-level breaking-changes section.
+
+#### Scenario: Unsupported pull request metadata is rejected
+- **WHEN** deterministic assembly encounters rendered changelog content that references merged PR metadata outside the authoritative range
+- **THEN** changelog mutation SHALL fail before `CHANGELOG.md` is updated
+
+#### Scenario: Invalid breaking-changes block is rejected
+- **WHEN** deterministic assembly encounters an extracted `### Breaking changes` subsection that cannot be preserved as markdown content in the target changelog section
+- **THEN** changelog mutation SHALL fail before `CHANGELOG.md` is updated
+
+### Requirement: Scheduled/manual mode updates the singleton generated changelog PR
+In scheduled/manual mode, after deterministic validation succeeds, the workflow SHALL rewrite only the `## [Unreleased]` section of `CHANGELOG.md` and SHALL push the result to the singleton branch named `generated-changelog`. The workflow SHALL use repository-authored GitHub Actions logic to look up an existing pull request from `generated-changelog` to `main`, create that pull request when none exists, and update the existing PR body when one already exists.
+
+#### Scenario: Generated changelog branch PR is reused
+- **GIVEN** the singleton branch `generated-changelog` already has an open pull request to `main`
+- **WHEN** the scheduled/manual changelog generator runs again
+- **THEN** it SHALL update that same branch and refresh the existing pull request instead of opening a duplicate
+
+#### Scenario: Missing generated changelog PR is created
+- **GIVEN** the singleton branch `generated-changelog` has no open pull request to `main`
+- **WHEN** the scheduled/manual changelog generator produces an updated `CHANGELOG.md`
+- **THEN** the workflow SHALL create the pull request after pushing the branch update
+
+### Requirement: Release-pull-request mode updates only the triggering release section
+In release-pull-request mode, after deterministic validation succeeds, repository-authored helper logic SHALL update only the concrete `## [x.y.z] - <date>` section for the triggering release branch and SHALL push that change only to the triggering release pull request branch. When the workflow refreshes release PR metadata, it SHALL use the pull request number from event metadata rather than performing branch-based PR discovery.
+
+#### Scenario: Release mode updates only the triggering branch
+- **WHEN** the changelog generator runs for a `prep-release-*` pull request
+- **THEN** it SHALL push changelog updates only to the triggering release pull request branch
+
+#### Scenario: Release mode does not rewrite Unreleased on the release branch
+- **WHEN** the changelog generator runs for a release-preparation pull request
+- **THEN** it SHALL regenerate the concrete release section needed for that branch without treating the branch as the singleton `Unreleased` maintenance branch
+
+## REMOVED Requirements
+
+### Requirement: Release evidence manifest is written to the agent directory before agent reasoning starts
+
+**Reason:** Changelog assembly is no longer driven by an agent that reads `/tmp/gh-aw/agent/evidence.json`; merged PR metadata is now gathered and consumed deterministically inside normal workflow steps.
+
+**Migration:** Move any metadata gathering, parsing, and validation into repository-authored scripts or workflow steps. Do not depend on the GH AW pre-activation-to-agent manifest handoff contract.
+
+### Requirement: Agent changelog synthesis is PR-based and proof-carrying
+
+**Reason:** Changelog prose is now authored at PR time under the `## Changelog` contract, and scheduled/release assembly only renders deterministic inputs from merged PR metadata.
+
+**Migration:** Add or update PR-time changelog authoring workflows and validators so release-note text is present in PR bodies before merge; remove any reliance on merged-history prompt synthesis or provenance JSON generated by a release-time agent.
+
+### Requirement: Workflow setup follows repository GH AW conventions
+
+**Reason:** The release assembly workflow is no longer an agentic runtime and no longer requires GH AW-specific bootstrap, engine configuration, or agent-directory conventions.
+
+**Migration:** Keep only the repository toolchain and helper setup needed by deterministic GitHub Actions steps and repository-authored scripts.
+
+## ADDED Requirements
+
+### Requirement: Merged PR changelog metadata is gathered for deterministic assembly
+Before changelog rendering starts, deterministic repository-authored steps SHALL gather the merged pull requests in the authoritative release range and capture the metadata needed for rendering from those PRs. For each merged PR, the workflow SHALL capture at least the pull request number, URL, merge commit SHA, labels, and pull request body.
+
+#### Scenario: Merged PR body is available to the renderer
+- **WHEN** deterministic pre-render steps resolve merged pull requests in the authoritative range
+- **THEN** each merged PR considered for changelog assembly SHALL include its body and labels in the renderer input
+
+### Requirement: Parsed PR-body changelog sections drive release-note assembly
+The changelog generator SHALL parse the `## Changelog` section from each merged PR body and SHALL treat that contract as the authoritative source for release-note content. PRs labeled `no-changelog` and PR changelog entries with `Customer impact: none` SHALL be excluded from rendered changelog bullets. The optional `### Breaking changes` subsection, when present, SHALL be preserved as markdown content and rendered under the target version's top-level `### Breaking changes` section.
+
+#### Scenario: User-facing summary becomes a changelog bullet
+- **WHEN** a merged PR body contains a valid `## Changelog` section with `Customer impact` other than `none`
+- **THEN** the rendered target section SHALL include a changelog bullet derived from that PR's `Summary` and citation
+
+#### Scenario: `Customer impact: none` is excluded
+- **WHEN** a merged PR body contains `Customer impact: none`
+- **THEN** the rendered target section SHALL omit a normal changelog bullet for that PR
+
+#### Scenario: Breaking changes block is preserved
+- **WHEN** a merged PR body contains a non-empty `### Breaking changes` subsection
+- **THEN** the rendered target version SHALL include that markdown block under the top-level `### Breaking changes` section
+
+### Requirement: Output normalization stays minimal
+The changelog generator SHALL apply only simple normalization needed to keep `CHANGELOG.md` consistent. It MAY normalize bullet prefixes, pull-request citation shape, whitespace, and placement of preserved breaking-change blocks, but it SHALL NOT semantically rewrite author-provided summaries or breaking-change prose during scheduled/release assembly.
+
+#### Scenario: Simple formatting is normalized without semantic rewrite
+- **WHEN** deterministic assembly renders PR-body changelog content into `CHANGELOG.md`
+- **THEN** it SHALL preserve the author-provided meaning while applying only the minimal formatting normalization required by repository changelog conventions

--- a/openspec/changes/pr-centric-changelog-generation/specs/ci-changelog-generation/spec.md
+++ b/openspec/changes/pr-centric-changelog-generation/specs/ci-changelog-generation/spec.md
@@ -1,11 +1,11 @@
 # `ci-changelog-generation` — Deterministic changelog assembly
 
-Workflow implementation: authored source under `.github/workflows-src/`, compiled to `.github/workflows/`.
+Workflow implementation: authored source template under `.github/workflows-src/changelog-generation/workflow.yml.tmpl`, generated workflow YAML under `.github/workflows/changelog-generation.yml` via `scripts/compile-workflow-sources/main.go`, with no GH AW `.lock.yml`.
 
 ## MODIFIED Requirements
 
 ### Requirement: Workflow artifacts and operating modes
-The changelog generator SHALL be authored as a deterministic repository workflow source under `.github/workflows-src/` and SHALL compile to the checked-in workflow artifacts under `.github/workflows/`. The workflow SHALL support:
+The changelog generator SHALL be authored as a deterministic workflow template under `.github/workflows-src/` and SHALL generate a checked-in workflow YAML artifact under `.github/workflows/` via `scripts/compile-workflow-sources/main.go`. The workflow SHALL NOT require a GH AW markdown source or a compiled `.lock.yml`. The workflow SHALL support:
 
 - a scheduled mode
 - a manual `workflow_dispatch` mode
@@ -13,7 +13,7 @@ The changelog generator SHALL be authored as a deterministic repository workflow
 
 #### Scenario: Source and compiled workflow stay paired
 - **WHEN** maintainers change changelog generator behavior
-- **THEN** the authored source and committed compiled workflow SHALL match the current repository compiler output
+- **THEN** the `.github/workflows-src/` template and generated `.github/workflows/changelog-generation.yml` SHALL match the current repository compiler output
 
 #### Scenario: Release-preparation pull request activates release mode
 - **GIVEN** a same-repository pull request whose head branch matches the configured `prep-release-*` pattern
@@ -100,7 +100,7 @@ Before changelog rendering starts, deterministic repository-authored steps SHALL
 - **THEN** each merged PR considered for changelog assembly SHALL include its body and labels in the renderer input
 
 ### Requirement: Parsed PR-body changelog sections drive release-note assembly
-The changelog generator SHALL parse the `## Changelog` section from each merged PR body and SHALL treat that contract as the authoritative source for release-note content. PRs labeled `no-changelog` and PR changelog entries with `Customer impact: none` SHALL be excluded from rendered changelog bullets. The optional `### Breaking changes` subsection, when present, SHALL be preserved as markdown content and rendered under the target version's top-level `### Breaking changes` section.
+The changelog generator SHALL parse the `## Changelog` section from each merged PR body and SHALL treat that contract as the authoritative source for release-note content. PRs labeled `no-changelog` and PR changelog entries with `Customer impact: none` SHALL be excluded from rendered changelog bullets. The optional `### Breaking changes` subsection, when present, SHALL be preserved as markdown content and rendered under the target version's top-level `### Breaking changes` section. A merged PR in the authoritative range that lacks both the `no-changelog` label and a parseable `## Changelog` section SHALL cause deterministic assembly to fail rather than being silently omitted or summarized from fallback text.
 
 #### Scenario: User-facing summary becomes a changelog bullet
 - **WHEN** a merged PR body contains a valid `## Changelog` section with `Customer impact` other than `none`
@@ -109,6 +109,10 @@ The changelog generator SHALL parse the `## Changelog` section from each merged 
 #### Scenario: `Customer impact: none` is excluded
 - **WHEN** a merged PR body contains `Customer impact: none`
 - **THEN** the rendered target section SHALL omit a normal changelog bullet for that PR
+
+#### Scenario: Missing changelog contract fails assembly
+- **WHEN** a merged PR in the authoritative range lacks both a parseable `## Changelog` section and the `no-changelog` label
+- **THEN** deterministic assembly SHALL fail before mutating `CHANGELOG.md`, with a repository-authored validation error that identifies the offending pull request
 
 #### Scenario: Breaking changes block is preserved
 - **WHEN** a merged PR body contains a non-empty `### Breaking changes` subsection

--- a/openspec/changes/pr-centric-changelog-generation/specs/ci-pr-changelog-authoring/spec.md
+++ b/openspec/changes/pr-centric-changelog-generation/specs/ci-pr-changelog-authoring/spec.md
@@ -1,6 +1,6 @@
 # `ci-pr-changelog-authoring` — PR-time changelog contract enforcement
 
-Workflow implementation: authored source under `.github/workflows-src/`, compiled to `.github/workflows/`.
+Workflow implementation: authored source template under `.github/workflows-src/`, generated GH AW markdown under `.github/workflows/`, and compiled `.lock.yml` via `gh aw compile`.
 
 ## Purpose
 
@@ -9,11 +9,11 @@ Define a GitHub Agentic Workflow that runs after pull-request CI completes and e
 ## ADDED Requirements
 
 ### Requirement: Workflow artifacts and compilation
-The PR changelog authoring workflow SHALL be authored as a GitHub Agentic Workflow source and SHALL include the compiled workflow artifacts committed in the repository. Contributors SHALL NOT hand-edit the compiled lock artifact.
+The PR changelog authoring workflow SHALL be authored from a repository template under `.github/workflows-src/` that generates a GitHub Agentic Workflow markdown file under `.github/workflows/` via `scripts/compile-workflow-sources/main.go`. The repository SHALL commit the generated `.md` workflow and the compiled `.lock.yml` produced by `gh aw compile`. Contributors SHALL NOT hand-edit the generated `.md` or `.lock.yml` artifacts.
 
 #### Scenario: Source and compiled artifacts stay paired
 - **WHEN** maintainers change the PR changelog authoring workflow behavior
-- **THEN** the authored source and compiled workflow artifacts SHALL match the committed compiler output
+- **THEN** the `.github/workflows-src/` template, generated `.md` workflow, and compiled `.lock.yml` SHALL match the committed compiler output
 
 ### Requirement: Trigger on `Build/Lint/Test` workflow completion
 The workflow SHALL run from a `workflow_run` trigger for the repository workflow named `Build/Lint/Test` and SHALL continue only when the source workflow run completed for a pull-request event.
@@ -35,10 +35,10 @@ Before agent reasoning starts, deterministic repository-authored steps SHALL res
 
 #### Scenario: Missing pull request fails gating
 - **WHEN** deterministic resolution cannot identify exactly one pull request for the triggering workflow run
-- **THEN** the workflow SHALL fail or skip with a clear repository-authored reason instead of invoking the agent against ambiguous metadata
+- **THEN** the workflow SHALL fail gating without invoking the agent, with the deterministic resolution step exiting non-zero and emitting an error message prefixed with `PR_CHANGELOG_GATING:`
 
 ### Requirement: Existing changelog section is validated deterministically
-When the pull request body already contains a `## Changelog` section, deterministic repository-authored validation SHALL verify the contract shape before the workflow reports success. The validator SHALL require a supported `Customer impact` value, a `Summary` line whenever `Customer impact` is not `none`, and a non-empty optional `### Breaking changes` subsection when that subsection is present.
+When the pull request body already contains a `## Changelog` section, deterministic repository-authored validation SHALL verify the contract shape before the workflow reports success. The validator SHALL require `Customer impact` to be exactly one of `none`, `fix`, `enhancement`, or `breaking`; these values are case-sensitive and SHALL be matched literally. The validator SHALL require a `Summary` line whenever `Customer impact` is not `none`, and a non-empty optional `### Breaking changes` subsection when that subsection is present.
 
 #### Scenario: Valid changelog section suppresses the agent
 - **WHEN** the pull request body already contains a valid `## Changelog` section
@@ -61,6 +61,13 @@ When the resolved pull request lacks a `## Changelog` section and is not exempt 
 #### Scenario: Missing changelog section is added
 - **WHEN** deterministic gating concludes the pull request requires a changelog section and none is present
 - **THEN** the workflow SHALL invoke the agent to draft the `## Changelog` section and update the pull request body with the result
+
+### Requirement: Minimal permissions are available to deterministic gating and PR updates
+The workflow SHALL request only the minimal permissions needed to resolve the triggering pull request, validate its body, and update that body when necessary. At minimum the workflow SHALL grant `contents: read` and `pull-requests: write`, and those scopes SHALL be available to the deterministic pre-agent steps rather than only to the agent phase.
+
+#### Scenario: Deterministic pre-agent steps can update PR body
+- **WHEN** deterministic resolution, validation, or PR-body update steps execute
+- **THEN** the workflow permissions SHALL allow those steps to read repository-authored context and update the pull request body without requiring broader repository write scopes
 
 ### Requirement: `workflow_run` execution remains metadata-only
 Because the workflow runs from `workflow_run`, it SHALL NOT checkout or execute code from the pull-request head branch. Deterministic gating, validation, and agent authoring SHALL operate only on pull-request metadata and repository-authored prompt context.

--- a/openspec/changes/pr-centric-changelog-generation/specs/ci-pr-changelog-authoring/spec.md
+++ b/openspec/changes/pr-centric-changelog-generation/specs/ci-pr-changelog-authoring/spec.md
@@ -1,0 +1,70 @@
+# `ci-pr-changelog-authoring` — PR-time changelog contract enforcement
+
+Workflow implementation: authored source under `.github/workflows-src/`, compiled to `.github/workflows/`.
+
+## Purpose
+
+Define a GitHub Agentic Workflow that runs after pull-request CI completes and ensures each pull request either contains a valid `## Changelog` section in its body or explicitly opts out with the `no-changelog` label.
+
+## ADDED Requirements
+
+### Requirement: Workflow artifacts and compilation
+The PR changelog authoring workflow SHALL be authored as a GitHub Agentic Workflow source and SHALL include the compiled workflow artifacts committed in the repository. Contributors SHALL NOT hand-edit the compiled lock artifact.
+
+#### Scenario: Source and compiled artifacts stay paired
+- **WHEN** maintainers change the PR changelog authoring workflow behavior
+- **THEN** the authored source and compiled workflow artifacts SHALL match the committed compiler output
+
+### Requirement: Trigger on `Build/Lint/Test` workflow completion
+The workflow SHALL run from a `workflow_run` trigger for the repository workflow named `Build/Lint/Test` and SHALL continue only when the source workflow run completed for a pull-request event.
+
+#### Scenario: Pull-request CI completion is eligible for gating
+- **WHEN** the `Build/Lint/Test` workflow completes for a `pull_request` event
+- **THEN** the PR changelog authoring workflow SHALL continue to deterministic pull-request resolution and gating
+
+#### Scenario: Non-pull-request workflow run is skipped
+- **WHEN** the `Build/Lint/Test` workflow completes for a non-`pull_request` event such as `push` or `workflow_dispatch`
+- **THEN** the PR changelog authoring workflow SHALL NOT invoke changelog validation or authoring for that run
+
+### Requirement: Deterministic pull-request resolution and opt-out gate
+Before agent reasoning starts, deterministic repository-authored steps SHALL resolve the pull request associated with the triggering `workflow_run`. The workflow SHALL skip agent authoring when the resolved pull request carries the `no-changelog` label.
+
+#### Scenario: `no-changelog` label suppresses authoring
+- **WHEN** deterministic resolution finds the triggering pull request and that pull request carries the `no-changelog` label
+- **THEN** the workflow SHALL treat the pull request as explicitly exempt from changelog authoring
+
+#### Scenario: Missing pull request fails gating
+- **WHEN** deterministic resolution cannot identify exactly one pull request for the triggering workflow run
+- **THEN** the workflow SHALL fail or skip with a clear repository-authored reason instead of invoking the agent against ambiguous metadata
+
+### Requirement: Existing changelog section is validated deterministically
+When the pull request body already contains a `## Changelog` section, deterministic repository-authored validation SHALL verify the contract shape before the workflow reports success. The validator SHALL require a supported `Customer impact` value, a `Summary` line whenever `Customer impact` is not `none`, and a non-empty optional `### Breaking changes` subsection when that subsection is present.
+
+#### Scenario: Valid changelog section suppresses the agent
+- **WHEN** the pull request body already contains a valid `## Changelog` section
+- **THEN** the workflow SHALL complete successfully without invoking the agent
+
+#### Scenario: Malformed changelog section fails validation
+- **WHEN** the pull request body contains a `## Changelog` section that does not satisfy the deterministic contract
+- **THEN** the workflow SHALL fail with a clear validation error instead of overwriting the existing section
+
+### Requirement: Breaking changes subsection may be free-form markdown
+Within the `## Changelog` contract, the optional `### Breaking changes` subsection SHALL allow free-form markdown content, including prose, bullet lists, and fenced code blocks. Deterministic validation SHALL treat that subsection as a delimited markdown block rather than as a structured bullet schema.
+
+#### Scenario: Breaking changes block contains fenced code
+- **WHEN** the pull request body includes `### Breaking changes` with fenced code blocks or migration prose
+- **THEN** the workflow SHALL accept that subsection as valid markdown content when the block is non-empty
+
+### Requirement: Missing changelog sections are drafted from PR metadata
+When the resolved pull request lacks a `## Changelog` section and is not exempt via `no-changelog`, the agent SHALL draft the missing section from the pull request title and description and SHALL update the pull request body with that drafted section.
+
+#### Scenario: Missing changelog section is added
+- **WHEN** deterministic gating concludes the pull request requires a changelog section and none is present
+- **THEN** the workflow SHALL invoke the agent to draft the `## Changelog` section and update the pull request body with the result
+
+### Requirement: `workflow_run` execution remains metadata-only
+Because the workflow runs from `workflow_run`, it SHALL NOT checkout or execute code from the pull-request head branch. Deterministic gating, validation, and agent authoring SHALL operate only on pull-request metadata and repository-authored prompt context.
+
+#### Scenario: PR workflow never checks out untrusted code
+- **WHEN** the workflow evaluates or updates the changelog contract for a pull request
+- **THEN** it SHALL do so without checking out or executing code from the pull-request branch

--- a/openspec/changes/pr-centric-changelog-generation/tasks.md
+++ b/openspec/changes/pr-centric-changelog-generation/tasks.md
@@ -1,0 +1,27 @@
+## 1. PR changelog contract helpers
+
+- [ ] 1.1 Add repository-authored helpers to parse and validate the PR-body `## Changelog` contract, including `Customer impact`, `Summary`, and boundary-based extraction of an optional free-form `### Breaking changes` subsection.
+- [ ] 1.2 Add fixtures and unit tests for valid sections, malformed structured fields, `Customer impact: none`, and free-form breaking-changes markdown with lists and fenced code blocks.
+
+## 2. PR-time agentic workflow
+
+- [ ] 2.1 Add the new PR changelog authoring workflow source and compiled artifacts, triggered from `workflow_run` on `Build/Lint/Test` completion for pull-request events.
+- [ ] 2.2 Implement deterministic pull-request resolution, `no-changelog` skip logic, and format validation so the agent only runs when a required changelog section is missing.
+- [ ] 2.3 Implement the metadata-only agent prompt and PR body update path so missing `## Changelog` sections are drafted from the PR title and description without checking out or executing PR code.
+
+## 3. Deterministic changelog assembly workflow
+
+- [ ] 3.1 Refactor the changelog-generation workflow source and compiled outputs to remove merged-history agent synthesis and instead gather merged PR bodies and labels for the authoritative release range.
+- [ ] 3.2 Implement deterministic rendering from parsed PR-body changelog sections, excluding `no-changelog` PRs and `Customer impact: none`, while preserving optional `### Breaking changes` blocks under the top-level breaking-changes section.
+- [ ] 3.3 Keep output normalization minimal by standardizing only bullet/citation/whitespace shape and breaking-change placement, without semantically rewriting author-provided content.
+
+## 4. Branch and PR management
+
+- [ ] 4.1 Replace GH AW safe-output PR management in scheduled/manual mode with normal GitHub Actions logic that updates the `generated-changelog` branch, reuses an existing PR when present, and creates the PR when absent.
+- [ ] 4.2 Implement release-mode PR metadata refresh using the triggering release PR number from event metadata while updating only the target `prep-release-*` branch.
+
+## 5. Verification and rollout
+
+- [ ] 5.1 Add or update tests for workflow gating, parser/renderer behavior, singleton generated-changelog PR reuse, and release-PR update logic.
+- [ ] 5.2 Regenerate compiled workflow artifacts and run the relevant workflow/unit test suite plus `make check-openspec`, fixing any resulting issues.
+- [ ] 5.3 After maintainer review of the workflow ergonomics, make the PR-time changelog authoring workflow a required pull-request check.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design specs for PR-centric changelog generation
- Adds a design document, proposal, and implementation task list for shifting changelog authorship from release time to PR merge time.
- Defines two new workflow specs: [ci-pr-changelog-authoring](https://github.com/elastic/terraform-provider-elasticstack/pull/2332/files#diff-0f29b41034163acc125cc80c6f228529d266da2688a495df78e2abb58d6b421e) drafts/validates changelog sections on each PR via an agent triggered by `workflow_run`, and [ci-changelog-generation](https://github.com/elastic/terraform-provider-elasticstack/pull/2332/files#diff-79f7b9ef088b65548770ccad1955cc0ce4b4c7c7ccca4ea51040326101532106) assembles the full changelog deterministically from merged PR metadata at release time.
- Removes legacy agentic requirements (evidence manifest, agent synthesis, GH AW bootstrap) in favor of parsing structured PR-body changelog sections with strict validation rules.
- Introduces a singleton `generated-changelog` PR managed by GitHub Actions for scheduled/manual runs, and defines `pull_request_target` mode behavior for release PRs.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce177d7.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->