### PR TITLE
Remove go-kibana-rest

### DIFF
--- a/openspec/changes/remove-go-kibana-rest/.openspec.yaml
+++ b/openspec/changes/remove-go-kibana-rest/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/remove-go-kibana-rest/design.md
+++ b/openspec/changes/remove-go-kibana-rest/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The archived wiring cleanup removed the last production uses of `*kibana.Client` for Kibana status reads, but the provider still carries `github.com/disaster37/go-kibana-rest/v8` in the module graph for two narrow reasons: the config builders still materialize `kibana.Config` in parallel with `kibanaoapi.Config`, and `internal/kibana/synthetics/parameter/read.go` still imports the legacy `kbapi` subpackage for an error-type assertion. Those residual edges keep the vendored `libs/go-kibana-rest` fork alive, force `go.mod` to retain a local replace, and leave canonical specs describing the removal as unfinished follow-up work.
+
+This change is intentionally narrower than the existing `remove-deprecated-kibana-clients` proposal. It focuses only on retiring `go-kibana-rest` and leaves any standalone `generated/slo` cleanup to its own scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove all first-party imports of `github.com/disaster37/go-kibana-rest/v8` and `github.com/disaster37/go-kibana-rest/v8/kbapi`.
+- Delete `config.Client.Kibana` and make `config.Client.KibanaOapi` the only Kibana connection surface used by provider wiring.
+- Preserve existing user-visible behavior for provider-level and scoped `kibana_connection` resolution, including acceptance-test inputs and synthetics parameter 404 handling.
+- Remove the root `go.mod` dependency, delete the vendored `libs/go-kibana-rest` fork, and align docs/specs with the final state.
+
+**Non-Goals:**
+
+- Removing `generated/slo` or changing SLO-specific provider wiring.
+- Reworking the Kibana authentication model beyond translating existing field semantics onto `kibanaoapi.Config`.
+- Changing the behavior of Kibana `/api/status` reads, version gating, or `kibana_connection` fallback rules.
+
+## Decisions
+
+1. **Use `kibanaoapi.Config` as the sole Kibana connection contract.**  
+   The provider already constructs the generated Kibana client and Fleet client from `kibanaoapi.Config`, so the cleanup should delete `Client.Kibana` rather than introduce a new local compatibility type. This removes the duplicate config surface instead of just renaming it.
+
+   **Alternative considered:** Keep a local struct with legacy field names (`Address`, `ApiKey`, `DisableVerifySSL`, `CAs`) and translate it later. Rejected because it would preserve the same duplication and keep tests/helpers anchored to a deprecated shape.
+
+2. **Translate legacy field expectations at the call sites that still read them.**  
+   The main drift is naming, not semantics: `Address -> URL`, `ApiKey -> APIKey`, `DisableVerifySSL -> Insecure`, and `CAs -> CACerts`. The config builders should stop generating legacy values, and the small number of remaining consumers such as `provider/provider_test.go` should switch to the OAPI names directly.
+
+   **Alternative considered:** Add compatibility accessors on `config.Client` so test code can keep using legacy names. Rejected because it would reintroduce a legacy contract after the module is removed.
+
+3. **Treat synthetics parameter 404 handling as a generated-client response concern.**  
+   `GetParameterWithResponse` already returns a typed response object with HTTP status access, so the legacy `errors.As(..., *kbapi.APIError)` branch should be replaced with response-status handling. This preserves the existing state-removal semantics for 404 without depending on a legacy error type that does not belong to the generated client stack.
+
+   **Alternative considered:** Create a small wrapper that mimics the legacy `APIError` shape. Rejected because it adds new compatibility code solely to preserve a dependency being removed.
+
+4. **Update canonical requirements to describe the post-cleanup state, not the migration gap.**  
+   The canonical `provider-kibana-connection` and `provider-client-factory` specs currently leave room for residual `go-kibana-rest` owners. This change should remove that caveat and add a module-level capability documenting that the dependency and vendored fork are gone.
+
+## Risks / Trade-offs
+
+- **[Risk] Field-name translation misses a test helper or config path** -> **Mitigation:** Search for `cfg.Kibana`, `Address`, `ApiKey`, `DisableVerifySSL`, and `CAs` uses before removing the field, then run targeted config/provider tests plus `go test ./...` if practical.
+- **[Risk] Synthetics read behavior changes for transport or unexpected non-200 responses** -> **Mitigation:** Keep transport-error handling separate from HTTP-status handling and preserve the current 404-only state removal behavior.
+- **[Risk] Overlap with the broader `remove-deprecated-kibana-clients` change causes duplicate requirement text** -> **Mitigation:** Keep this change explicitly scoped to `go-kibana-rest`, and treat `generated/slo` as out of scope in proposal, design, and spec deltas.
+- **[Risk] Repo docs/specs drift from implementation order** -> **Mitigation:** Update OpenSpec deltas and contributor docs in the same change so the final state is internally consistent.
+
+## Migration Plan
+
+1. Remove `Client.Kibana` and legacy `kibanaConfig` construction from `internal/clients/config`, leaving `KibanaOapi` as the only Kibana config surface.
+2. Update `internal/clients/provider_client_factory.go` and any remaining tests/helpers to validate and consume `cfg.KibanaOapi` directly.
+3. Replace the synthetics parameter read `kbapi.APIError` assertion with response-based 404 handling.
+4. Remove the `go-kibana-rest` `require` and `replace` directives from `go.mod`, delete `libs/go-kibana-rest`, and run `go mod tidy`.
+5. Update docs and OpenSpec deltas, then verify with build/tests, repository search, and OpenSpec validation.
+
+## Open Questions
+
+- Whether any non-obvious test-only or tool-only code paths still assume `config.Client.Kibana` exists outside the already identified provider acceptance helpers.
+- Whether repository policy wants all textual references to `go-kibana-rest` removed from active specs immediately, while archived change text naturally remains historical.

--- a/openspec/changes/remove-go-kibana-rest/proposal.md
+++ b/openspec/changes/remove-go-kibana-rest/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The provider still depends on `github.com/disaster37/go-kibana-rest/v8` even after the legacy Kibana status wiring was removed. The remaining dependency edges are now narrow and mechanical, so this is the right point to fully retire the deprecated module, its vendored fork, and the residual follow-up language that assumes the cleanup is still pending.
+
+## What Changes
+
+- Remove the last first-party `go-kibana-rest` imports from `internal/clients/config` by deleting the legacy `Client.Kibana` surface and making `KibanaOapi` the only Kibana connection shape used by provider wiring.
+- Update the provider client factory and test helpers to treat the OpenAPI Kibana config as canonical, including scoped `kibana_connection` validation and acceptance-test variable builders.
+- Replace the remaining `github.com/disaster37/go-kibana-rest/v8/kbapi` error assertion in synthetics parameter read with generated-client response handling that preserves existing 404 state-removal behavior.
+- Remove `github.com/disaster37/go-kibana-rest/v8` from the root module, delete the `replace` directive and vendored `libs/go-kibana-rest` fork, and tidy the module graph.
+- Update docs and OpenSpec requirements that currently describe `go-kibana-rest` removal as residual follow-up work so they reflect the final post-cleanup state.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-go-module-kibana-clients`: Defines the requirement that the provider module and first-party source tree exclude the deprecated `go-kibana-rest` module and vendored fork once Kibana wiring has fully migrated to `generated/kbapi` and `internal/clients/kibanaoapi`.
+
+### Modified Capabilities
+
+- `provider-kibana-connection`: Tighten the scoped Kibana connection requirements so they no longer allow residual `go-kibana-rest` ownership in config wiring or synthetics read paths after the cleanup completes.
+- `provider-client-factory`: Tighten the Kibana scoped client contract so the factory surface is fully OpenAPI-based and no longer carries any legacy Kibana client configuration contract.
+
+## Impact
+
+- **Affected code:** `internal/clients/config/`, `internal/clients/provider_client_factory.go`, `internal/kibana/synthetics/parameter/read.go`, `provider/provider_test.go`, `go.mod`, `go.sum`, and `libs/go-kibana-rest/`.
+- **Affected docs/specs:** `dev-docs/high-level/generated-clients.md`, `dev-docs/high-level/coding-standards.md`, `openspec/specs/provider-kibana-connection/spec.md`, `openspec/specs/provider-client-factory/spec.md`, and the change-local delta specs for this cleanup.
+- **Verification:** `make build`, targeted tests for config/synthetics behavior or `go test ./...`, repository search for `disaster37/go-kibana-rest`, and OpenSpec validation after the deltas are written.

--- a/openspec/changes/remove-go-kibana-rest/specs/provider-client-factory/spec.md
+++ b/openspec/changes/remove-go-kibana-rest/specs/provider-client-factory/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Kibana scoped client contract
+
+The typed Kibana-scoped client returned by the factory SHALL expose the Kibana OpenAPI client, SLO client, Fleet client, Kibana auth-context helpers, and Kibana-derived version and flavor checks required by covered Kibana and Fleet entities. The factory contract SHALL use the Kibana OpenAPI configuration surface as the only Kibana connection contract for provider-level and scoped `kibana_connection` resolution and SHALL NOT expose or require `github.com/disaster37/go-kibana-rest` as part of provider wiring.
+
+#### Scenario: Scoped client supports Kibana and Fleet operations
+- **WHEN** a covered Kibana or Fleet entity uses a typed Kibana-scoped client
+- **THEN** the client SHALL provide the typed client surfaces needed for Kibana HTTP workloads through the OpenAPI client, plus SLO and Fleet API operations as applicable
+
+#### Scenario: Scoped client supports version gating
+- **WHEN** a covered Kibana or Fleet entity performs version or flavor checks through the typed Kibana-scoped client
+- **THEN** the client SHALL provide `ServerVersion()`, `ServerFlavor()`, or equivalent typed behavior needed for those checks
+
+#### Scenario: Factory does not require a legacy Kibana config surface
+- **WHEN** the provider client factory resolves a Kibana-scoped client from provider configuration or `kibana_connection`
+- **THEN** it SHALL validate and build that client from the Kibana OpenAPI config surface without relying on a parallel legacy Kibana REST config object

--- a/openspec/changes/remove-go-kibana-rest/specs/provider-go-module-kibana-clients/spec.md
+++ b/openspec/changes/remove-go-kibana-rest/specs/provider-go-module-kibana-clients/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: No go-kibana-rest module dependency
+
+The root `go.mod` SHALL NOT contain a `require` directive for `github.com/disaster37/go-kibana-rest/v8` and SHALL NOT contain a `replace` directive mapping that module path to `./libs/go-kibana-rest` or any other local path. After removal, `go mod tidy` SHALL leave no requirement edge to that module for the provider.
+
+#### Scenario: Module file excludes legacy client
+- **WHEN** a reviewer opens the root `go.mod` after this change
+- **THEN** neither `github.com/disaster37/go-kibana-rest/v8` nor a `replace` stanza for it SHALL appear
+
+### Requirement: Vendored go-kibana-rest fork removed
+
+The directory `libs/go-kibana-rest` SHALL NOT remain in the repository when its only purpose was to satisfy the removed `replace` directive for `github.com/disaster37/go-kibana-rest/v8`.
+
+#### Scenario: Fork directory absent
+- **WHEN** the change is applied and the branch builds successfully
+- **THEN** the path `libs/go-kibana-rest` SHALL not exist in the tree
+
+### Requirement: No legacy Kibana REST import paths in first-party code
+
+No first-party Go source under the provider module SHALL import `github.com/disaster37/go-kibana-rest/v8` or subpackages such as `github.com/disaster37/go-kibana-rest/v8/kbapi`.
+
+#### Scenario: Repository search shows no deprecated imports
+- **WHEN** a maintainer searches the repository for `disaster37/go-kibana-rest`
+- **THEN** no matches SHALL appear in first-party Go sources, the root `go.mod`, or the root `Makefile`

--- a/openspec/changes/remove-go-kibana-rest/specs/provider-kibana-connection/spec.md
+++ b/openspec/changes/remove-go-kibana-rest/specs/provider-kibana-connection/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Scoped Kibana status reads use OpenAPI client
+
+For `*clients.KibanaScopedClient`, implementations that need the Kibana server version number or build flavor SHALL obtain them from the Kibana `/api/status` response using the generated OpenAPI Kibana client (`generated/kbapi`) for the same effective scoped Kibana connection (via `internal/clients/kibanaoapi` or equivalent provider-internal wiring). The provider SHALL NOT depend on `github.com/disaster37/go-kibana-rest` anywhere in the `kibana_connection` resolution path after this change is complete, including config wiring used to build scoped clients and synthetics read paths that consume those scoped clients. When `version.build_flavor` is absent (older Kibana releases), the flavor result SHALL be an empty string, matching prior behavior for traditional deployments.
+
+#### Scenario: Scoped version uses OpenAPI status
+- **WHEN** a covered entity uses `ServerVersion()` on a `*clients.KibanaScopedClient` resolved from `kibana_connection` or provider defaults
+- **THEN** the version SHALL be derived from `version.number` in the `/api/status` payload retrieved through the OpenAPI client for that scoped connection
+
+#### Scenario: Scoped flavor uses OpenAPI status
+- **WHEN** a covered entity uses `ServerFlavor()` on a `*clients.KibanaScopedClient` resolved from `kibana_connection` or provider defaults
+- **THEN** the flavor SHALL be derived from `version.build_flavor` when present in that same `/api/status` payload and SHALL otherwise be an empty string
+
+#### Scenario: Scoped connection path excludes legacy Kibana REST wiring
+- **WHEN** a covered Kibana or Fleet entity resolves a provider-level or entity-local `kibana_connection`
+- **THEN** the resulting scoped client path SHALL not require `github.com/disaster37/go-kibana-rest` configuration or error handling to perform version, flavor, or synthetics parameter read behavior

--- a/openspec/changes/remove-go-kibana-rest/tasks.md
+++ b/openspec/changes/remove-go-kibana-rest/tasks.md
@@ -1,0 +1,24 @@
+## 1. Remove legacy Kibana config wiring
+
+- [ ] 1.1 Delete `Client.Kibana` and the legacy `kibanaConfig` type from `internal/clients/config`, leaving `KibanaOapi` as the only Kibana connection surface built by env, SDK, and Framework config paths.
+- [ ] 1.2 Update any config-related tests or helper assertions to use `kibanaoapi.Config` field names and semantics instead of legacy `kibana.Config` names.
+
+## 2. Re-anchor factory and consumers on OpenAPI config
+
+- [ ] 2.1 Update `internal/clients/provider_client_factory.go` so Kibana scoped client validation and construction rely on `cfg.KibanaOapi` rather than `cfg.Kibana`.
+- [ ] 2.2 Update remaining first-party consumers such as `provider/provider_test.go` to read Kibana connection details from the OpenAPI config surface only.
+
+## 3. Remove the final legacy import path
+
+- [ ] 3.1 Refactor `internal/kibana/synthetics/parameter/read.go` to replace the legacy `kbapi.APIError` assertion with response-based 404 handling using the generated Kibana client response object.
+- [ ] 3.2 Confirm repository-wide that no first-party Go source still imports `github.com/disaster37/go-kibana-rest/v8` or its `kbapi` subpackage.
+
+## 4. Clean up module and repository artifacts
+
+- [ ] 4.1 Remove the `go-kibana-rest` `require` and `replace` directives from `go.mod`, delete `libs/go-kibana-rest`, and run `go mod tidy`.
+- [ ] 4.2 Update contributor docs and OpenSpec text that still describe `go-kibana-rest` removal as pending follow-up work.
+
+## 5. Verify and finalize
+
+- [ ] 5.1 Run `make build` and targeted tests for the touched areas, or `go test ./...` if targeted coverage is insufficient, and fix any regressions caused by the cleanup.
+- [ ] 5.2 Run repository search for `disaster37/go-kibana-rest` and OpenSpec validation for this change so the tree and change artifacts reflect the final removed state.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove go-kibana-rest dependency and consolidate on OpenAPI client config
- Adds OpenSpec design docs, proposals, specs, and tasks for retiring the `go-kibana-rest` module from the provider.
- Kibana connection config and client factory are re-anchored to `kibanaoapi.Config` as the sole contract; all legacy `go-kibana-rest` wiring is removed.
- Synthetics parameter 404 handling switches from `kbapi.APIError` assertions to response-based checks.
- `libs/go-kibana-rest` vendor fork and all `go.mod` require/replace directives for `github.com/disaster37/go-kibana-rest/v8` are removed.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 288a400.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->