### PR TITLE
proposal(ci): replace pr-changelog-authoring with deterministic check

### DIFF
--- a/openspec/changes/deterministic-pr-changelog-check/.openspec.yaml
+++ b/openspec/changes/deterministic-pr-changelog-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/deterministic-pr-changelog-check/design.md
+++ b/openspec/changes/deterministic-pr-changelog-check/design.md
@@ -40,7 +40,7 @@ PR data is read directly from `context.payload.pull_request` — no API call req
 
 ### Parser/validator: inline verbatim from deleted source files
 
-`parseChangelogSectionFull` and `validateChangelogSectionFull` are copied inline unchanged from the deleted `.github/workflows-src/pr-changelog-authoring/scripts/validate-pr-changelog.inline.js`. The existing unit tests in `.github/workflows-src/lib/*.test.mjs` continue to cover this logic and are not affected by the workflow change.
+`parseChangelogSectionFull` and `validateChangelogSectionFull` are copied inline unchanged from `.github/workflows-src/lib/pr-changelog-parser.js` — the canonical source of these functions. `validate-pr-changelog.inline.js` only included that file; it does not define the functions itself. The existing unit tests in `.github/workflows-src/lib/*.test.mjs` continue to cover this logic and are not affected by the workflow change.
 
 ### Comment upsert with hidden HTML marker
 

--- a/openspec/changes/deterministic-pr-changelog-check/design.md
+++ b/openspec/changes/deterministic-pr-changelog-check/design.md
@@ -1,0 +1,78 @@
+## Context
+
+The current `pr-changelog-authoring` workflow is a GitHub Agentic Workflow (gh-aw) that:
+1. Triggers via `workflow_run` after `Build/Lint/Test` completes
+2. Resolves the PR from the triggering `workflow_run` payload via API search (head_sha + branch lookup)
+3. Skips fork PRs entirely (write access unavailable under `workflow_run` for forks)
+4. Runs an LLM agent to draft and append a `## Changelog` section when one is missing
+
+The replacement is a plain GitHub Actions workflow — no gh-aw framework, no agent, no PR body mutation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give PR authors immediate changelog feedback (on open, not after CI)
+- Handle fork PRs without special-casing (full write access via `pull_request_target`)
+- Remove all non-determinism and LLM involvement from the changelog gate
+- Simplify the source footprint (no compiled templates, no lock files)
+
+**Non-Goals:**
+- Drafting changelog sections on behalf of authors — authors must supply the section
+- Changing the changelog format (`Customer impact` / `Summary` / `### Breaking changes`)
+- Adding `PR Changelog Check` as a required status check (follow-on step post-deployment)
+- Modifying `test.yml` (the `workflow_run` dependency lived in `pr-changelog-authoring`)
+
+## Decisions
+
+### Trigger: `pull_request_target` over `pull_request`
+
+`pull_request_target` runs in the context of the base repository for all PRs, including forks. This gives the workflow `pull-requests: write` permission unconditionally, enabling PR comments for fork contributors.
+
+`pull_request` was rejected: fork PRs run with restricted permissions, making PR comments impossible for fork contributors.
+
+`pull_request_target` security note: no code checkout happens in this workflow. The workflow only reads `context.payload.pull_request` (event metadata) and calls `github.rest.issues` to upsert comments. There is no untrusted code execution path.
+
+### Single `actions/github-script` step
+
+All logic (label check, parse, validate, comment upsert) lives in one `actions/github-script` step. No separate shell steps, no file I/O, no artifact upload/download.
+
+PR data is read directly from `context.payload.pull_request` — no API call required to fetch the PR body or labels.
+
+### Parser/validator: inline verbatim from deleted source files
+
+`parseChangelogSectionFull` and `validateChangelogSectionFull` are copied inline unchanged from the deleted `.github/workflows-src/pr-changelog-authoring/scripts/validate-pr-changelog.inline.js`. The existing unit tests in `.github/workflows-src/lib/*.test.mjs` continue to cover this logic and are not affected by the workflow change.
+
+### Comment upsert with hidden HTML marker
+
+Failure and pass comments are identified by the marker `<!-- pr-changelog-check -->` embedded in the comment body. On each run:
+- Find existing bot comment by `github-actions[bot]` login containing the marker
+- **Fail**: update existing comment or create new one
+- **Pass with existing comment**: update to a "check passed" message
+- **Pass with no existing comment**: do nothing (no noise on first-valid push)
+
+This avoids comment accumulation on repeated pushes and provides a clean audit trail.
+
+### Plain `.yml` workflow, not gh-aw compiled
+
+Since there is no agent, the gh-aw framework adds no value. A plain `.yml` file is directly readable, directly editable, and has no compilation step. The `manifest.json` entry and the entire `workflows-src/pr-changelog-authoring/` source directory are deleted.
+
+## Risks / Trade-offs
+
+- **Authors must write their own changelog section** → Mitigation: clear failure comment with format hint and link to docs; PR template should document the format
+- **`pull_request_target` is a privileged trigger** → Mitigation: no code checkout, no shell execution of PR content; only metadata reads and REST API writes
+- **`unlabeled` event not in trigger list** → If `no-changelog` label is removed, the check won't re-run until next push. Acceptable: removing the label implies the author intends to add a section, which requires a push anyway
+- **Parser logic is inlined, not imported** → Unit tests in `lib/*.test.mjs` still cover the shared logic; the inline copy stays in sync because it's verbatim
+
+## Migration Plan
+
+1. Delete the three gh-aw files (`pr-changelog-authoring.md`, `.lock.yml`, `workflows-src/pr-changelog-authoring/`)
+2. Remove the entry from `manifest.json`
+3. Create `.github/workflows/pr-changelog-check.yml`
+4. Verify the old `workflow_run`-based check no longer appears on new PRs
+5. (Follow-on) Add `PR Changelog Check` as a required status check in branch protection
+
+Rollback: restore the deleted files from git history and re-add the manifest entry.
+
+## Open Questions
+
+_(none — all design decisions resolved during exploration)_

--- a/openspec/changes/deterministic-pr-changelog-check/proposal.md
+++ b/openspec/changes/deterministic-pr-changelog-check/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The current PR changelog authoring workflow uses a GitHub Agentic Workflow (gh-aw) that triggers after `Build/Lint/Test` completes and invokes an LLM agent to draft missing `## Changelog` sections. This introduces non-determinism, latency (feedback arrives after CI, not on PR open), unnecessary LLM cost, and significant workflow complexity (gh-aw compilation, lock files, PR body mutation). The goal is to replace it with a purely deterministic check that fails fast with actionable feedback.
+
+## What Changes
+
+- **Remove** `.github/workflows/pr-changelog-authoring.md` (compiled gh-aw workflow)
+- **Remove** `.github/workflows/pr-changelog-authoring.lock.yml` (gh-aw lock file)
+- **Remove** `.github/workflows-src/pr-changelog-authoring/` (source template and inline scripts)
+- **Remove** the `pr-changelog-authoring` entry from `.github/workflows-src/manifest.json`
+- **Create** `.github/workflows/pr-changelog-check.yml` — a plain GitHub Actions workflow triggered by `pull_request_target` that validates the changelog section and fails with a PR comment if it is missing or malformed
+
+The workflow no longer drafts changelog sections on behalf of authors. Authors must supply the section themselves; the workflow tells them why it failed if they do not.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this change replaces an existing capability)_
+
+### Modified Capabilities
+
+- `ci-pr-changelog-authoring`: Requirements change substantially — trigger moves from `workflow_run` to `pull_request_target`, the agent authoring phase is removed entirely, and failing checks now post a PR comment with the failure reason instead of drafting a section.
+
+## Impact
+
+- `.github/workflows/pr-changelog-authoring.md` and `.lock.yml` — deleted
+- `.github/workflows-src/pr-changelog-authoring/` — deleted (source template, `resolve-pr.inline.js`, `validate-pr-changelog.inline.js`)
+- `.github/workflows-src/manifest.json` — one entry removed
+- `.github/workflows/pr-changelog-check.yml` — created
+- `test.yml` — no changes required (the `workflow_run` dependency was in `pr-changelog-authoring`, not `test.yml`)
+- Branch protection — `PR Changelog Check` is not yet a required status check; enabling it is a follow-on step after deployment

--- a/openspec/changes/deterministic-pr-changelog-check/specs/ci-pr-changelog-authoring/spec.md
+++ b/openspec/changes/deterministic-pr-changelog-check/specs/ci-pr-changelog-authoring/spec.md
@@ -1,0 +1,92 @@
+## REMOVED Requirements
+
+### Requirement: Workflow artifacts and compilation
+**Reason**: The workflow is replaced by a plain GitHub Actions `.yml` file. There is no longer a source template, compiled `.md`, or `.lock.yml` to maintain.
+**Migration**: Delete `.github/workflows/pr-changelog-authoring.md`, `.github/workflows/pr-changelog-authoring.lock.yml`, `.github/workflows-src/pr-changelog-authoring/`, and remove the `pr-changelog-authoring` entry from `.github/workflows-src/manifest.json`. Create `.github/workflows/pr-changelog-check.yml` as a plain workflow.
+
+### Requirement: Trigger on `Build/Lint/Test` workflow completion
+**Reason**: The `workflow_run` trigger introduced latency (feedback only after CI completes), could not comment on fork PRs, and required a complex PR resolution step. Direct `pull_request_target` triggering provides immediate feedback and full write access for all PRs.
+**Migration**: The new workflow triggers on `pull_request_target` with types `[opened, synchronize, labeled]`. No changes to `test.yml` are required.
+
+### Requirement: Deterministic pull-request resolution and opt-out gate
+**Reason**: Under `pull_request_target`, `context.payload.pull_request` is populated directly in the event payload. API-based PR resolution (head_sha + branch search) is no longer needed.
+**Migration**: The `no-changelog` opt-out remains. The workflow reads `context.payload.pull_request.labels` directly without an API call.
+
+### Requirement: Missing changelog sections are drafted from PR metadata
+**Reason**: LLM-based drafting introduces non-determinism and cost. Authors are expected to supply their own `## Changelog` section; the workflow fails with actionable feedback when it is absent.
+**Migration**: Authors must add a `## Changelog` section to their PR body manually. The failure comment explains the required format.
+
+## MODIFIED Requirements
+
+### Requirement: Existing changelog section is validated deterministically
+The workflow SHALL parse and validate the `## Changelog` section from the pull request body using `parseChangelogSectionFull` and `validateChangelogSectionFull`. The validator SHALL require `Customer impact` to be exactly one of `none`, `fix`, `enhancement`, or `breaking` (case-sensitive). The validator SHALL require a `Summary` line when `Customer impact` is not `none`. The validator SHALL reject a `### Breaking changes` subsection that is present but empty, and SHALL require that subsection when `Customer impact` is `breaking`.
+
+When validation fails, the workflow SHALL post or update a PR comment identifying the failure reason. When validation passes, the workflow SHALL update any existing failure comment to indicate the check passed.
+
+#### Scenario: Valid changelog section passes the check
+- **WHEN** the pull request body contains a `## Changelog` section that satisfies all validation rules
+- **THEN** the workflow SHALL succeed, and if a prior failure comment exists it SHALL be updated to a "check passed" message
+
+#### Scenario: Malformed changelog section fails with comment
+- **WHEN** the pull request body contains a `## Changelog` section that does not satisfy the validation rules
+- **THEN** the workflow SHALL fail and SHALL upsert a PR comment listing each validation error
+
+#### Scenario: Missing changelog section fails with comment
+- **WHEN** the pull request body contains no `## Changelog` section and the PR does not carry the `no-changelog` label
+- **THEN** the workflow SHALL fail and SHALL upsert a PR comment stating that no `## Changelog` section was found
+
+### Requirement: Breaking changes subsection may be free-form markdown
+Within the `## Changelog` contract, the optional `### Breaking changes` subsection SHALL allow free-form markdown content, including prose, bullet lists, and fenced code blocks. Validation SHALL treat that subsection as a delimited markdown block rather than a structured schema.
+
+#### Scenario: Breaking changes block contains fenced code
+- **WHEN** the pull request body includes `### Breaking changes` with fenced code blocks or migration prose
+- **THEN** the workflow SHALL accept that subsection as valid when the block is non-empty
+
+### Requirement: Minimal permissions for validation and PR comments
+The workflow SHALL request only the permissions needed to read pull request metadata and post or update PR comments. At minimum the workflow SHALL declare `pull-requests: write`.
+
+#### Scenario: Workflow can comment on fork PRs
+- **WHEN** the triggering pull request originates from a fork repository
+- **THEN** the workflow SHALL have sufficient permissions to post or update a comment on that pull request
+
+## ADDED Requirements
+
+### Requirement: Trigger on pull request open, update, or label change
+The workflow SHALL trigger on `pull_request_target` events with types `opened`, `synchronize`, and `labeled`. It SHALL evaluate the changelog contract immediately on each trigger without waiting for any other workflow to complete.
+
+#### Scenario: Check runs on PR open
+- **WHEN** a pull request is opened against the base repository
+- **THEN** the workflow SHALL evaluate the changelog section within the same CI round as other immediate checks
+
+#### Scenario: Check re-runs on new push
+- **WHEN** new commits are pushed to an open pull request
+- **THEN** the workflow SHALL re-evaluate the changelog section and update any existing comment accordingly
+
+#### Scenario: Check re-runs when label is applied
+- **WHEN** a label is applied to an open pull request
+- **THEN** the workflow SHALL re-evaluate the changelog section, allowing a freshly applied `no-changelog` label to immediately pass the check
+
+### Requirement: `no-changelog` label suppresses the check
+The workflow SHALL pass immediately when the pull request carries the `no-changelog` label, without parsing or validating the PR body.
+
+#### Scenario: `no-changelog` label causes immediate pass
+- **WHEN** the pull request labels include `no-changelog`
+- **THEN** the workflow SHALL succeed without inspecting the PR body
+
+### Requirement: Comment upsert uses a stable hidden marker
+The workflow SHALL identify its own PR comments by the hidden HTML marker `<!-- pr-changelog-check -->` embedded in the comment body. It SHALL update an existing marked comment rather than creating a new one, preventing comment accumulation on repeated pushes.
+
+#### Scenario: Repeated failures update rather than accumulate
+- **WHEN** the changelog check fails on multiple successive pushes to the same pull request
+- **THEN** only one failure comment from the workflow SHALL be present; each failure SHALL update the existing comment rather than posting a new one
+
+#### Scenario: Pass after failure updates the failure comment
+- **WHEN** a pull request that previously had a workflow failure comment is updated to include a valid `## Changelog` section
+- **THEN** the workflow SHALL update the existing failure comment to indicate the check passed
+
+### Requirement: Workflow does not check out pull request code
+The workflow SHALL NOT check out or execute any code from the pull request branch. It SHALL operate exclusively on pull request metadata available in the event payload.
+
+#### Scenario: Fork PR is evaluated without code execution
+- **WHEN** the triggering pull request originates from a fork repository
+- **THEN** the workflow SHALL read only `context.payload.pull_request` metadata and post a comment via the REST API, without checking out the fork's code

--- a/openspec/changes/deterministic-pr-changelog-check/specs/ci-pr-changelog-authoring/spec.md
+++ b/openspec/changes/deterministic-pr-changelog-check/specs/ci-pr-changelog-authoring/spec.md
@@ -1,18 +1,50 @@
 ## REMOVED Requirements
 
 ### Requirement: Workflow artifacts and compilation
+The PR changelog authoring workflow SHALL be authored from a repository template under `.github/workflows-src/` that generates a GitHub Agentic Workflow markdown file under `.github/workflows/` via `scripts/compile-workflow-sources/main.go`. The repository SHALL commit the generated `.md` workflow and the compiled `.lock.yml` produced by `gh aw compile`. Contributors SHALL NOT hand-edit the generated `.md` or `.lock.yml` artifacts.
+
+#### Scenario: Source and compiled artifacts stay paired
+- **WHEN** maintainers change the PR changelog authoring workflow behavior
+- **THEN** the `.github/workflows-src/` template, generated `.md` workflow, and compiled `.lock.yml` SHALL match the committed compiler output
+
 **Reason**: The workflow is replaced by a plain GitHub Actions `.yml` file. There is no longer a source template, compiled `.md`, or `.lock.yml` to maintain.
 **Migration**: Delete `.github/workflows/pr-changelog-authoring.md`, `.github/workflows/pr-changelog-authoring.lock.yml`, `.github/workflows-src/pr-changelog-authoring/`, and remove the `pr-changelog-authoring` entry from `.github/workflows-src/manifest.json`. Create `.github/workflows/pr-changelog-check.yml` as a plain workflow.
 
 ### Requirement: Trigger on `Build/Lint/Test` workflow completion
+The workflow SHALL run from a `workflow_run` trigger for the repository workflow named `Build/Lint/Test` and SHALL continue only when the source workflow run completed for a pull-request event.
+
+#### Scenario: Pull-request CI completion is eligible for gating
+- **WHEN** the `Build/Lint/Test` workflow completes for a `pull_request` event
+- **THEN** the PR changelog authoring workflow SHALL continue to deterministic pull-request resolution and gating
+
+#### Scenario: Non-pull-request workflow run is skipped
+- **WHEN** the `Build/Lint/Test` workflow completes for a non-`pull_request` event such as `push` or `workflow_dispatch`
+- **THEN** the PR changelog authoring workflow SHALL NOT invoke changelog validation or authoring for that run
+
 **Reason**: The `workflow_run` trigger introduced latency (feedback only after CI completes), could not comment on fork PRs, and required a complex PR resolution step. Direct `pull_request_target` triggering provides immediate feedback and full write access for all PRs.
 **Migration**: The new workflow triggers on `pull_request_target` with types `[opened, synchronize, labeled]`. No changes to `test.yml` are required.
 
 ### Requirement: Deterministic pull-request resolution and opt-out gate
+Before agent reasoning starts, deterministic repository-authored steps SHALL resolve the pull request associated with the triggering `workflow_run`. The workflow SHALL skip agent authoring when the resolved pull request carries the `no-changelog` label.
+
+#### Scenario: `no-changelog` label suppresses authoring
+- **WHEN** deterministic resolution finds the triggering pull request and that pull request carries the `no-changelog` label
+- **THEN** the workflow SHALL treat the pull request as explicitly exempt from changelog authoring
+
+#### Scenario: Missing pull request fails gating
+- **WHEN** deterministic resolution cannot identify exactly one pull request for the triggering workflow run
+- **THEN** the workflow SHALL fail gating without invoking the agent, with the deterministic resolution step exiting non-zero and emitting an error message prefixed with `PR_CHANGELOG_GATING:`
+
 **Reason**: Under `pull_request_target`, `context.payload.pull_request` is populated directly in the event payload. API-based PR resolution (head_sha + branch search) is no longer needed.
 **Migration**: The `no-changelog` opt-out remains. The workflow reads `context.payload.pull_request.labels` directly without an API call.
 
 ### Requirement: Missing changelog sections are drafted from PR metadata
+When the resolved pull request lacks a `## Changelog` section and is not exempt via `no-changelog`, the agent SHALL draft the missing section from the pull request title and description and SHALL update the pull request body with that drafted section.
+
+#### Scenario: Missing changelog section is added
+- **WHEN** deterministic gating concludes the pull request requires a changelog section and none is present
+- **THEN** the workflow SHALL invoke the agent to draft the `## Changelog` section and update the pull request body with the result
+
 **Reason**: LLM-based drafting introduces non-determinism and cost. Authors are expected to supply their own `## Changelog` section; the workflow fails with actionable feedback when it is absent.
 **Migration**: Authors must add a `## Changelog` section to their PR body manually. The failure comment explains the required format.
 
@@ -43,7 +75,7 @@ Within the `## Changelog` contract, the optional `### Breaking changes` subsecti
 - **THEN** the workflow SHALL accept that subsection as valid when the block is non-empty
 
 ### Requirement: Minimal permissions for validation and PR comments
-The workflow SHALL request only the permissions needed to read pull request metadata and post or update PR comments. At minimum the workflow SHALL declare `pull-requests: write`.
+The workflow SHALL request only the permissions needed to read pull request metadata and post or update PR comments. At minimum the workflow SHALL declare `pull-requests: write` and `issues: write`. The `issues: write` scope is required because PR comments are created and updated via the `issues` REST API endpoints (`github.rest.issues.listComments`, `github.rest.issues.createComment`, `github.rest.issues.updateComment`).
 
 #### Scenario: Workflow can comment on fork PRs
 - **WHEN** the triggering pull request originates from a fork repository

--- a/openspec/changes/deterministic-pr-changelog-check/tasks.md
+++ b/openspec/changes/deterministic-pr-changelog-check/tasks.md
@@ -1,0 +1,24 @@
+## 1. Remove gh-aw workflow artifacts
+
+- [ ] 1.1 Delete `.github/workflows/pr-changelog-authoring.md`
+- [ ] 1.2 Delete `.github/workflows/pr-changelog-authoring.lock.yml`
+- [ ] 1.3 Delete `.github/workflows-src/pr-changelog-authoring/` (entire directory: `workflow.md.tmpl`, `scripts/resolve-pr.inline.js`, `scripts/validate-pr-changelog.inline.js`)
+- [ ] 1.4 Remove the `pr-changelog-authoring` entry from `.github/workflows-src/manifest.json`
+
+## 2. Create the plain workflow
+
+- [ ] 2.1 Create `.github/workflows/pr-changelog-check.yml` with trigger `pull_request_target` (types: `opened`, `synchronize`, `labeled`) and `permissions: pull-requests: write`
+- [ ] 2.2 Add a single `actions/github-script` step that reads `context.payload.pull_request` (labels, body, number) directly from the event payload
+- [ ] 2.3 Implement the `no-changelog` label early-exit path (pass without inspecting body)
+- [ ] 2.4 Inline the `parseChangelogSectionFull` and `validateChangelogSectionFull` functions verbatim from the deleted `validate-pr-changelog.inline.js`
+- [ ] 2.5 Implement the comment upsert: search for an existing `github-actions[bot]` comment containing `<!-- pr-changelog-check -->`, update it if found, create it if not
+- [ ] 2.6 On pass with existing failure comment: update the comment to a "check passed" message
+- [ ] 2.7 On fail: upsert failure comment listing each validation error, then call `core.setFailed`
+
+## 3. Verify
+
+- [ ] 3.1 Confirm `make check-compile-workflows` (or equivalent) passes with the manifest entry removed and no orphaned source template
+- [ ] 3.2 Confirm existing unit tests in `.github/workflows-src/lib/*.test.mjs` still pass (parser/validator logic is unchanged)
+- [ ] 3.3 Open a test PR against the repo and confirm the `PR Changelog Check` status appears immediately (not after CI) and fails with a comment when no `## Changelog` section is present
+- [ ] 3.4 Add a valid `## Changelog` section and confirm the check passes and the failure comment is updated
+- [ ] 3.5 Apply the `no-changelog` label and confirm the check passes immediately

--- a/openspec/changes/deterministic-pr-changelog-check/tasks.md
+++ b/openspec/changes/deterministic-pr-changelog-check/tasks.md
@@ -7,17 +7,17 @@
 
 ## 2. Create the plain workflow
 
-- [ ] 2.1 Create `.github/workflows/pr-changelog-check.yml` with trigger `pull_request_target` (types: `opened`, `synchronize`, `labeled`) and `permissions: pull-requests: write`
+- [ ] 2.1 Create `.github/workflows/pr-changelog-check.yml` with trigger `pull_request_target` (types: `opened`, `synchronize`, `labeled`) and permissions `pull-requests: write` and `issues: write`
 - [ ] 2.2 Add a single `actions/github-script` step that reads `context.payload.pull_request` (labels, body, number) directly from the event payload
 - [ ] 2.3 Implement the `no-changelog` label early-exit path (pass without inspecting body)
-- [ ] 2.4 Inline the `parseChangelogSectionFull` and `validateChangelogSectionFull` functions verbatim from the deleted `validate-pr-changelog.inline.js`
+- [ ] 2.4 Inline the `parseChangelogSectionFull` and `validateChangelogSectionFull` functions verbatim from `.github/workflows-src/lib/pr-changelog-parser.js` (the actual source; `validate-pr-changelog.inline.js` only included it)
 - [ ] 2.5 Implement the comment upsert: search for an existing `github-actions[bot]` comment containing `<!-- pr-changelog-check -->`, update it if found, create it if not
 - [ ] 2.6 On pass with existing failure comment: update the comment to a "check passed" message
 - [ ] 2.7 On fail: upsert failure comment listing each validation error, then call `core.setFailed`
 
 ## 3. Verify
 
-- [ ] 3.1 Confirm `make check-compile-workflows` (or equivalent) passes with the manifest entry removed and no orphaned source template
+- [ ] 3.1 Confirm `make check-workflows` passes with the manifest entry removed and no orphaned source template; confirm `make workflow-test` passes (covers `lib/*.test.mjs`)
 - [ ] 3.2 Confirm existing unit tests in `.github/workflows-src/lib/*.test.mjs` still pass (parser/validator logic is unchanged)
 - [ ] 3.3 Open a test PR against the repo and confirm the `PR Changelog Check` status appears immediately (not after CI) and fails with a comment when no `## Changelog` section is present
 - [ ] 3.4 Add a valid `## Changelog` section and confirm the check passes and the failure comment is updated


### PR DESCRIPTION
## Summary

- Proposes replacing the `pr-changelog-authoring` GitHub Agentic Workflow with a plain `pull_request_target` workflow
- The new workflow validates `## Changelog` sections immediately on PR open/update/label, without waiting for CI to complete
- Removes LLM drafting — authors supply their own section; the check fails fast with a PR comment explaining why

## Change proposal

`openspec/changes/deterministic-pr-changelog-check/`

- **`proposal.md`** — motivation and scope
- **`design.md`** — trigger choice (`pull_request_target`), single-step architecture, comment upsert strategy
- **`specs/ci-pr-changelog-authoring/spec.md`** — delta spec against the existing `ci-pr-changelog-authoring` capability
- **`tasks.md`** — 12 implementation tasks across remove / create / verify

## Test plan

- [ ] Review proposal, design, and delta spec for accuracy
- [ ] Confirm tasks cover all files to delete, create, and verify

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace LLM-based PR changelog authoring with a deterministic GitHub Actions check
> - Adds an OpenSpec proposal, design doc, and spec to replace the `gh-aw`-based PR changelog authoring workflow with a plain `pr-changelog-check.yml` using `pull_request_target`.
> - The new workflow uses a single `actions/github-script` step with an inlined parser/validator — no code checkout, no LLM calls.
> - A `no-changelog` label suppresses the check; comment upsert uses a hidden marker for idempotent behavior.
> - Removes requirements for compiled `gh-aw` artifacts, `workflow_run` triggers, and LLM-drafted changelog sections.
> - Motivation: eliminate non-determinism, latency, cost, and complexity of the agent-based approach.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6ad6fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->