### PR TITLE
No changelog for dependency bumps

### DIFF
--- a/.agents/hooks/use_npx_openspec.js
+++ b/.agents/hooks/use_npx_openspec.js
@@ -1,5 +1,23 @@
 #!/usr/bin/env node
 
+function createPiExtension(pi) {
+  pi.on("tool_call", async (event) => {
+    if (event?.toolName !== "bash") {
+      return;
+    }
+
+    const command = typeof event.input?.command === "string" ? event.input.command : "";
+    if (!command) {
+      return;
+    }
+
+    const rewrittenCommand = rewriteOpenSpecCommand(command);
+    if (rewrittenCommand !== command) {
+      event.input.command = rewrittenCommand;
+    }
+  });
+}
+
 async function readStdin(stream = process.stdin) {
   const chunks = [];
 
@@ -61,6 +79,7 @@ async function main({ input = process.stdin, output = process.stdout } = {}) {
 module.exports = {
   allow,
   buildHookResponse,
+  createPiExtension,
   main,
   readStdin,
   rewriteOpenSpecCommand,

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,11 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "no-changelog"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "no-changelog"

--- a/.pi/extensions/use-npx-openspec.ts
+++ b/.pi/extensions/use-npx-openspec.ts
@@ -1,0 +1,10 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import hookModule from "../../.agents/hooks/use_npx_openspec.js";
+
+const { createPiExtension } = hookModule as {
+  createPiExtension: (pi: ExtensionAPI) => void;
+};
+
+export default function (pi: ExtensionAPI) {
+  createPiExtension(pi);
+}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
   "extends": [
     "local>elastic/renovate-config"
   ],
+  "labels": [
+    "no-changelog"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add 'no-changelog' label to Dependabot and Renovate dependency bump PRs
Configures both Dependabot ([dependabot.yml](.github/dependabot.yml)) and Renovate ([renovate.json](renovate.json)) to automatically apply a `no-changelog` label to dependency update PRs, keeping the changelog free of routine version bumps.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 560ce27.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->