### PR TITLE
Proposal for custom fleet integrations

### DIFF
--- a/openspec/changes/fleet-custom-integration/.openspec.yaml
+++ b/openspec/changes/fleet-custom-integration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/fleet-custom-integration/design.md
+++ b/openspec/changes/fleet-custom-integration/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The existing `elasticstack_fleet_integration` resource installs packages from the Elastic package registry using `POST /api/fleet/epm/packages/{name}/{version}`. The Fleet API also supports installing a custom package by uploading a binary zip/gzip archive to `POST /api/fleet/epm/packages` (no path params, binary body). This endpoint is already present in the generated kbapi client as `PostFleetEpmPackagesWithBodyWithResponse` but is not yet used by any Terraform resource.
+
+The generated response type (`PostFleetEpmPackagesResponse`) has only `Body []byte` — no typed JSON200 field — so the response must be manually unmarshalled. The `_meta.name` field in the response gives the package name; `items[].version` is marked optional in the API spec, so version is obtained via a follow-up `GetPackages` call filtered by name.
+
+## Goals / Non-Goals
+
+**Goals:**
+- New resource `elasticstack_fleet_custom_integration` that uploads a local zip/gzip package file to Fleet and manages its lifecycle
+- File-content change detection: re-upload automatically when the file content changes
+- Computed `package_name` and `package_version` attributes for downstream resource references
+- Space-awareness and `skip_destroy` parity with `elasticstack_fleet_integration`
+
+**Non-Goals:**
+- Building or validating the zip format (that is the user's responsibility)
+- Supporting directory input (only prebuilt zip/gzip files)
+- Diff/patching of individual assets inside the package
+- Upgrading via the registry path — this resource is upload-only
+
+## Decisions
+
+### 1. File-content change detection via computed `checksum`
+
+**Decision**: Store a SHA256 hash of the uploaded file as a computed `checksum` attribute. A plan modifier on `package_path` reads the file at plan time, computes the hash, and if it differs from the state checksum, marks `checksum`, `package_name`, and `package_version` as Unknown to signal pending changes.
+
+**Rationale**: This is the standard Terraform pattern (analogous to `aws_lambda_function.source_code_hash`). It detects content changes regardless of filename and avoids re-uploading when only the path is renamed. Computing the hash at plan time gives users a preview of changes before apply.
+
+**Alternative considered**: Require users to supply the hash explicitly (like `source_code_hash` on AWS Lambda). Rejected — it adds friction and is error-prone. Computing automatically is strictly better here.
+
+### 2. Version extraction via GetPackages fallback
+
+**Decision**: After upload, extract `_meta.name` from the response body. Then call `GetPackages` (existing wrapper) and filter by name to obtain the installed version. Store both in state.
+
+**Rationale**: `items[].version` in the upload response is marked optional in the API spec. Relying on it would be fragile. `GetPackages` returns `PackageListItem` which includes both `name` and `version` and is the same mechanism used by the existing read path.
+
+**Alternative considered**: Parse the zip manifest (`manifest.yml`) at plan time to extract name and version. Rejected — adds a zip-parsing dependency and complexity. The `GetPackages` approach is simpler and consistent with how reads work.
+
+### 3. Update path handles package name changes
+
+**Decision**: `package_name` is computed and does NOT use `RequiresReplace`. If a re-upload results in a different package name, the update handler uninstalls the old name+version before uploading the new file.
+
+**Rationale**: Making `package_name` ForceNew would mean any file content change (even a version bump of the same package) would force a destroy+create cycle, which could cascade destructively to integration policies that reference the package. Handling name changes in the update path is safer.
+
+**Trade-off**: If the old package uninstall fails, the new package may still be uploaded, leaving the system in a partially updated state. This is mitigated by checking errors at each step and reporting diagnostics without further state mutation.
+
+### 4. New resource package, minimal fleet.go additions
+
+**Decision**: New Go package `internal/fleet/customintegration/`. Add a single `UploadPackage` wrapper to `internal/clients/fleet/fleet.go`. No other shared code changes.
+
+**Rationale**: Follows the established per-resource package pattern. Keeps the fleet.go wrapper thin — business logic stays in the resource CRUD files.
+
+### 5. Content-type determined from file extension
+
+**Decision**: Determine `Content-Type` from the file extension: `.zip` → `application/zip`, `.gz` / `.tar.gz` → `application/gzip`. Fall back to `application/zip` for unknown extensions.
+
+**Rationale**: The Fleet API accepts both. Extension-based detection is simple and sufficient; users building packages with `elastic-package` always produce standard zip files.
+
+## Risks / Trade-offs
+
+- **Upload is not idempotent for different versions**: Uploading a package with the same name but a different version installs both versions. The resource tracks only one version; the previous version must be explicitly uninstalled during update. The update path handles this.
+- **GetPackages may be slow for large registries**: The post-upload GetPackages call lists all packages. This is a single API call and is consistent with existing patterns, so acceptable.
+- **Plan modifier reads the file on every plan**: For large package files this adds latency at plan time. Users who want to avoid this can pin the file to a path where content changes are intentional.
+- **Package name changes mid-lifecycle**: If the embedded package name changes between versions, the update path uninstalls the old name. If the old package is referenced by an integration policy, the uninstall will fail in Fleet. Users must remove policy references first — this mirrors the behavior of `skip_destroy = false` on the integration resource.
+
+## Migration Plan
+
+No migration needed. This is an additive new resource with no impact on existing resources or state.
+
+## Open Questions
+
+None — design is fully specified based on API exploration and established codebase patterns.

--- a/openspec/changes/fleet-custom-integration/proposal.md
+++ b/openspec/changes/fleet-custom-integration/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Users need to manage custom Fleet integration packages (built with `elastic-package`) via Terraform, but the provider only supports installing packages from the Elastic package registry by name+version. There is no resource for uploading a locally-built package zip to Fleet, forcing users to use raw API calls or manual Kibana UI steps.
+
+## What Changes
+
+- **New resource** `elasticstack_fleet_custom_integration`: accepts a path to a local `.zip` or `.tar.gz` custom integration package, uploads it to Fleet via the EPM upload API, and manages its lifecycle (re-upload on content change, uninstall on destroy).
+- The resource exposes computed `package_name` and `package_version` attributes populated from the upload response so downstream resources (e.g. `elasticstack_fleet_integration_policy`) can reference them without hard-coding values.
+- File-content-based change detection: the resource tracks a SHA256 checksum of the uploaded file and re-uploads automatically when the content changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `fleet-custom-integration`: Terraform resource for uploading and managing a locally-built Fleet custom integration package via the EPM binary upload API (`POST /api/fleet/epm/packages`). Covers create (upload), read (verify installed), update (re-upload on content change), and delete (uninstall).
+
+### Modified Capabilities
+
+## Impact
+
+- New package: `internal/fleet/customintegration/`
+- New fleet client wrapper: `UploadPackage` added to `internal/clients/fleet/fleet.go`
+- Provider registration: `provider/plugin_framework.go` (new import + resource entry)
+- No changes to existing resources or API clients
+- Depends on generated kbapi function `PostFleetEpmPackagesWithBodyWithResponse` (already present in `generated/kbapi/kibana.gen.go`)

--- a/openspec/changes/fleet-custom-integration/proposal.md
+++ b/openspec/changes/fleet-custom-integration/proposal.md
@@ -21,5 +21,5 @@ Users need to manage custom Fleet integration packages (built with `elastic-pack
 - New package: `internal/fleet/customintegration/`
 - New fleet client wrapper: `UploadPackage` added to `internal/clients/fleet/fleet.go`
 - Provider registration: `provider/plugin_framework.go` (new import + resource entry)
-- No changes to existing resources or API clients
+- No changes to existing resource behavior; the shared Fleet client is extended with a new `UploadPackage` method
 - Depends on generated kbapi function `PostFleetEpmPackagesWithBodyWithResponse` (already present in `generated/kbapi/kibana.gen.go`)

--- a/openspec/changes/fleet-custom-integration/specs/fleet-custom-integration/spec.md
+++ b/openspec/changes/fleet-custom-integration/specs/fleet-custom-integration/spec.md
@@ -1,0 +1,112 @@
+## ADDED Requirements
+
+### Requirement: Resource exists
+The provider SHALL expose a `elasticstack_fleet_custom_integration` managed resource that uploads a locally-built Fleet integration package archive to Kibana Fleet via the EPM binary upload API and manages its full lifecycle.
+
+#### Scenario: Resource appears in provider schema
+- **WHEN** a practitioner runs `terraform providers schema`
+- **THEN** `elasticstack_fleet_custom_integration` is listed as a managed resource type
+
+### Requirement: Create uploads package archive
+When the resource is created, the provider SHALL read the file at `package_path`, upload its binary contents to `POST /api/fleet/epm/packages` with the appropriate `Content-Type` header (`application/zip` for `.zip` files, `application/gzip` for `.gz` / `.tar.gz` files), and record the resulting package name and version in state.
+
+#### Scenario: Successful upload of a zip archive
+- **WHEN** `package_path` points to a valid custom integration `.zip` file
+- **THEN** the provider uploads the file contents with `Content-Type: application/zip`
+- **THEN** `package_name` is set from `_meta.name` in the upload response
+- **THEN** `package_version` is set from the installed package version retrieved via the packages list API
+- **THEN** `checksum` is set to the SHA256 hex digest of the uploaded file
+- **THEN** `id` is set to a stable hash of `package_name` and `package_version`
+
+#### Scenario: Successful upload of a gzip archive
+- **WHEN** `package_path` points to a valid custom integration `.tar.gz` or `.gz` file
+- **THEN** the provider uploads the file contents with `Content-Type: application/gzip`
+- **THEN** all computed attributes (`package_name`, `package_version`, `checksum`, `id`) are populated
+
+#### Scenario: Upload fails with non-200 response
+- **WHEN** the Fleet API returns a non-200 status code
+- **THEN** the provider returns an error diagnostic describing the failure
+- **THEN** no state is written
+
+#### Scenario: Package file does not exist
+- **WHEN** `package_path` references a file that cannot be read
+- **THEN** the provider returns an error diagnostic
+- **THEN** no state is written
+
+### Requirement: Read verifies installation
+On each refresh, the provider SHALL verify the package is still installed by calling the Fleet package info API using the `package_name` and `package_version` stored in state.
+
+#### Scenario: Package is installed
+- **WHEN** the Fleet package info API returns a package with status `installed`
+- **THEN** the resource remains in state unchanged
+
+#### Scenario: Package is not found
+- **WHEN** the Fleet package info API returns a 404 or the package status is not `installed`
+- **THEN** the provider removes the resource from state, signalling drift
+
+### Requirement: Plan detects file content changes
+The provider SHALL compute the SHA256 hash of the file at `package_path` during plan and compare it to the stored `checksum`. If they differ, `package_name`, `package_version`, and `checksum` SHALL be marked as unknown in the plan, indicating a pending change.
+
+#### Scenario: File content has changed
+- **WHEN** the file at `package_path` has different content from the last apply (different SHA256)
+- **THEN** `terraform plan` shows `package_name`, `package_version`, and `checksum` as `(known after apply)`
+
+#### Scenario: File content is unchanged
+- **WHEN** the file at `package_path` has the same content as the last apply (same SHA256)
+- **THEN** `terraform plan` shows no changes for this resource (assuming other attributes are also unchanged)
+
+#### Scenario: File at package_path cannot be read during plan
+- **WHEN** the file at `package_path` is missing or unreadable at plan time
+- **THEN** the provider returns an error diagnostic during plan
+
+### Requirement: Update re-uploads on content change
+When an apply is triggered because the file content has changed, the provider SHALL re-upload the new file. If the new package has a different `package_name` from the one stored in state, the provider SHALL uninstall the old package before uploading the new one.
+
+#### Scenario: File content changed, same package name
+- **WHEN** the uploaded file has a different SHA256 but the resulting `package_name` matches the state value
+- **THEN** the provider re-uploads the file and updates `package_version` and `checksum` in state
+
+#### Scenario: File content changed, package name changed
+- **WHEN** the uploaded file results in a `package_name` that differs from state
+- **THEN** the provider uninstalls the old package (using the name and version from state)
+- **THEN** the provider uploads the new file
+- **THEN** `package_name`, `package_version`, `checksum`, and `id` are updated in state
+
+#### Scenario: Query parameters changed only
+- **WHEN** `ignore_mapping_update_errors` or `skip_data_stream_rollover` are changed and `checksum` is unchanged
+- **THEN** the provider re-uploads the file with the updated query parameters
+
+### Requirement: Delete uninstalls package
+When the resource is destroyed and `skip_destroy` is `false` (default), the provider SHALL uninstall the package using the `package_name` and `package_version` stored in state.
+
+#### Scenario: Destroy with skip_destroy false
+- **WHEN** `terraform destroy` is run and `skip_destroy = false`
+- **THEN** the provider calls the Fleet uninstall API for the package
+- **THEN** the resource is removed from state
+
+#### Scenario: Destroy with skip_destroy true
+- **WHEN** `terraform destroy` is run and `skip_destroy = true`
+- **THEN** the provider skips the uninstall API call
+- **THEN** the resource is removed from state, leaving the package installed in Fleet
+
+### Requirement: Space-aware operation
+The resource SHALL support the `space_id` attribute and route all Fleet API calls through the appropriate Kibana space path when `space_id` is set.
+
+#### Scenario: Upload with space_id set
+- **WHEN** `space_id` is set to a non-default space identifier
+- **THEN** all Fleet API calls (upload, read, delete) are routed through `/s/{space_id}/api/fleet/epm/packages`
+
+#### Scenario: Upload without space_id
+- **WHEN** `space_id` is not set or is set to the default space
+- **THEN** Fleet API calls use the standard `/api/fleet/epm/packages` path
+
+### Requirement: Optional upload query parameters
+The resource SHALL support `ignore_mapping_update_errors` and `skip_data_stream_rollover` as optional boolean attributes that are forwarded as query parameters on the upload API call.
+
+#### Scenario: ignore_mapping_update_errors set to true
+- **WHEN** `ignore_mapping_update_errors = true`
+- **THEN** the upload request includes `ignoreMappingUpdateErrors=true` as a query parameter
+
+#### Scenario: skip_data_stream_rollover set to true
+- **WHEN** `skip_data_stream_rollover = true`
+- **THEN** the upload request includes `skipDataStreamRollover=true` as a query parameter

--- a/openspec/changes/fleet-custom-integration/specs/fleet-custom-integration/spec.md
+++ b/openspec/changes/fleet-custom-integration/specs/fleet-custom-integration/spec.md
@@ -1,3 +1,30 @@
+# `elasticstack_fleet_custom_integration` — Schema and Functional Requirements
+
+Resource implementation: `internal/fleet/customintegration`
+
+## Purpose
+
+Upload and manage a locally-built Fleet custom integration package archive via the Kibana EPM binary upload API (`POST /api/fleet/epm/packages`). Unlike `elasticstack_fleet_integration`, which installs packages from the Elastic package registry by name and version, this resource accepts a local `.zip` or `.tar.gz` archive and manages the full lifecycle: upload on create, verify on read, re-upload on content change, and uninstall on destroy.
+
+## Schema
+
+```hcl
+resource "elasticstack_fleet_custom_integration" "example" {
+  id              = <computed, string>   # schemautil.StringToHash(package_name + package_version)
+  package_path    = <required, string>   # path to local .zip or .tar.gz archive
+  package_name    = <computed, string>   # extracted from upload response
+  package_version = <computed, string>   # resolved via packages list API after upload
+  checksum        = <computed, string>   # SHA256 hex digest of the file at package_path
+
+  ignore_mapping_update_errors = <optional, bool>
+  skip_data_stream_rollover    = <optional, bool>
+  skip_destroy                 = <optional, bool>
+  space_id                     = <optional, string>
+
+  kibana_connection = <optional, block>  # overrides provider-level Kibana connection
+}
+```
+
 ## ADDED Requirements
 
 ### Requirement: Resource exists
@@ -8,7 +35,7 @@ The provider SHALL expose a `elasticstack_fleet_custom_integration` managed reso
 - **THEN** `elasticstack_fleet_custom_integration` is listed as a managed resource type
 
 ### Requirement: Create uploads package archive
-When the resource is created, the provider SHALL read the file at `package_path`, upload its binary contents to `POST /api/fleet/epm/packages` with the appropriate `Content-Type` header (`application/zip` for `.zip` files, `application/gzip` for `.gz` / `.tar.gz` files), and record the resulting package name and version in state.
+When the resource is created, the provider SHALL read the file at `package_path`, upload its binary contents to `POST /api/fleet/epm/packages` with the appropriate `Content-Type` header (`application/zip` for `.zip` files, `application/gzip` for `.gz` / `.tar.gz` files), and record the resulting package name and version in state. `package_version` SHALL be resolved from the upload response when present; if the upload response does not include a version, the provider SHALL query the packages list API for the matching `package_name` and select the highest semver version among entries with status `installed`. If no matching installed entry is found, the provider SHALL return an error diagnostic.
 
 #### Scenario: Successful upload of a zip archive
 - **WHEN** `package_path` points to a valid custom integration `.zip` file
@@ -16,15 +43,15 @@ When the resource is created, the provider SHALL read the file at `package_path`
 - **THEN** `package_name` is set from `_meta.name` in the upload response
 - **THEN** `package_version` is set from the installed package version retrieved via the packages list API
 - **THEN** `checksum` is set to the SHA256 hex digest of the uploaded file
-- **THEN** `id` is set to a stable hash of `package_name` and `package_version`
+- **THEN** `id` is set to `schemautil.StringToHash(package_name + package_version)`
 
 #### Scenario: Successful upload of a gzip archive
 - **WHEN** `package_path` points to a valid custom integration `.tar.gz` or `.gz` file
 - **THEN** the provider uploads the file contents with `Content-Type: application/gzip`
 - **THEN** all computed attributes (`package_name`, `package_version`, `checksum`, `id`) are populated
 
-#### Scenario: Upload fails with non-200 response
-- **WHEN** the Fleet API returns a non-200 status code
+#### Scenario: Upload fails with a non-success response
+- **WHEN** the Fleet API returns a non-success (non-2xx) status code
 - **THEN** the provider returns an error diagnostic describing the failure
 - **THEN** no state is written
 
@@ -110,3 +137,14 @@ The resource SHALL support `ignore_mapping_update_errors` and `skip_data_stream_
 #### Scenario: skip_data_stream_rollover set to true
 - **WHEN** `skip_data_stream_rollover = true`
 - **THEN** the upload request includes `skipDataStreamRollover=true` as a query parameter
+
+### Requirement: Connection
+The resource SHALL use the provider-level Fleet client obtained from provider configuration by default. When `kibana_connection` is configured on the resource, the resource SHALL resolve an effective scoped client from that block and SHALL use the Fleet client derived from the scoped connection for all CRUD operations.
+
+#### Scenario: Provider Fleet client used by default
+- **WHEN** `kibana_connection` is not configured on the resource
+- **THEN** the resource SHALL obtain its Fleet client from the provider configuration
+
+#### Scenario: Scoped Fleet client used when overridden
+- **WHEN** `kibana_connection` is configured on the resource
+- **THEN** the resource SHALL obtain its effective Fleet client from the scoped connection for all lifecycle operations

--- a/openspec/changes/fleet-custom-integration/tasks.md
+++ b/openspec/changes/fleet-custom-integration/tasks.md
@@ -1,0 +1,32 @@
+## 1. Fleet Client Wrapper
+
+- [ ] 1.1 Define `UploadPackageOptions` and `UploadPackageResult` types in `internal/clients/fleet/fleet.go`
+- [ ] 1.2 Implement `UploadPackage` wrapper: call `PostFleetEpmPackagesWithBodyWithResponse`, unmarshal response body to extract `_meta.name`, call `GetPackages` to resolve version, return `UploadPackageResult`
+
+## 2. Resource Package Skeleton
+
+- [ ] 2.1 Create `internal/fleet/customintegration/` directory with `resource.go`: define `customIntegrationResource` struct, `NewResource()` constructor, `Metadata` (type name `elasticstack_fleet_custom_integration`), `Configure`
+- [ ] 2.2 Create `models.go`: define `customIntegrationModel` struct with all schema fields (`tfsdk` tags), and `getPackageID(name, version string) string` helper
+
+## 3. Schema and Plan Modifier
+
+- [ ] 3.1 Create `schema.go`: define all attributes (`package_path`, `package_name`, `package_version`, `checksum`, `id`, `ignore_mapping_update_errors`, `skip_data_stream_rollover`, `skip_destroy`, `space_id`, `kibana_connection`)
+- [ ] 3.2 Implement plan modifier for `package_path`: at plan time, read the file, compute SHA256; if different from state `checksum`, mark `package_name`, `package_version`, and `checksum` as Unknown; return error diagnostic if file is unreadable
+
+## 4. CRUD Operations
+
+- [ ] 4.1 Create `create.go`: read file, detect content-type from extension, call `fleet.UploadPackage`, compute SHA256, populate all computed fields in state
+- [ ] 4.2 Create `read.go`: use `package_name` + `package_version` from state to call `fleet.GetPackage`; remove from state if nil or not installed
+- [ ] 4.3 Create `update.go`: re-upload file if checksum changed; if new `package_name` ≠ state value, uninstall old package first; update all computed fields in state
+- [ ] 4.4 Create `delete.go`: uninstall package via `fleet.Uninstall` unless `skip_destroy = true`
+
+## 5. Provider Registration
+
+- [ ] 5.1 Add import of `customintegration` package to `provider/plugin_framework.go`
+- [ ] 5.2 Add `customintegration.NewResource` to the resources slice in `provider/plugin_framework.go`
+
+## 6. Tests and Verification
+
+- [ ] 6.1 Write acceptance test in `acc_test.go`: upload a minimal valid custom integration zip, verify computed attributes are populated, verify clean plan on second apply, verify destroy removes the package
+- [ ] 6.2 Run `make build` to verify compilation
+- [ ] 6.3 Run the acceptance test against a live Kibana instance to verify end-to-end behaviour


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design proposal for `elasticstack_fleet_custom_integration` Terraform resource
- Adds OpenSpec design documents ([proposal.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2390/files#diff-5cb57f909e15de3206f8e1d24ea7206cf871e27a79f6c197ac2c34d5d6f7cc4b), [design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2390/files#diff-dda8665dece29547d3fb0bbdfa142d2a36cf2949eac4d90fd315be6831dbca80), [spec.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2390/files#diff-f1321f7a60dc9c254181872c49c3f49e2317e96d28ce316e37e969911f825749)) outlining a new resource for uploading custom Fleet integration packages.
- The resource uses checksum-based change detection to trigger updates and resolves current versions via a `GetPackages` call.
- A new `UploadPackage` fleet client wrapper method will handle package uploads, with content-type inferred from file extension.
- Handles package name changes on update and supports space-aware operations with optional query parameters.
- Includes a [task list](https://github.com/elastic/terraform-provider-elasticstack/pull/2390/files#diff-c00ddfd7999a6818622acd34e196f0882b808bc2543c2d9481b44dcecb00a171) covering CRUD operations, plan modifier, provider registration, and acceptance tests — no implementation code is included in this PR.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2387df.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->