### PR TITLE
Manage TF versions in docs generation

### DIFF
--- a/openspec/changes/pin-terraform-docs-toolchain/.openspec.yaml
+++ b/openspec/changes/pin-terraform-docs-toolchain/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/pin-terraform-docs-toolchain/design.md
+++ b/openspec/changes/pin-terraform-docs-toolchain/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The repo's docs target is currently:
+
+```make
+ docs-generate:
+ 	go tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name terraform-provider-elasticstack
+```
+
+`tfplugindocs` builds the provider and extracts schema using Terraform CLI (`terraform init` and `terraform providers schema -json`). Upstream supports two relevant control points:
+
+- `--tf-version <x.y.z>`: download/use that exact Terraform version
+- `--providers-schema <path>`: skip Terraform invocation entirely and consume a precomputed schema file
+
+For this change we intentionally keep the existing `tfplugindocs`-managed flow and only take control of version selection.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make docs generation deterministic across developer machines.
+- Keep the implementation small and close to current tooling.
+- Make the Terraform version choice explicit in repository-owned configuration.
+- Keep CI and local docs generation aligned on the same Terraform version.
+- Use a repository convention that Renovate can manage without custom regex-manager logic.
+
+**Non-Goals:**
+- Rebuilding docs generation around precomputed schema JSON files.
+- Pinning every Terraform usage in the repo in this same change (for example `terraform fmt` can be addressed separately if desired).
+- Changing the generated docs structure, templates, or examples.
+
+## Decisions
+
+### Use `.terraform-version` as the single source of truth
+
+A root `.terraform-version` file SHALL define the Terraform CLI version used by docs generation and relevant CI validation jobs. This makes the Terraform version a repository-level toolchain decision rather than a docs-target-local detail, and it aligns with Renovate's built-in support for `.terraform-version` updates.
+
+This is preferred over a Makefile-local variable because the version becomes visible as a top-level toolchain file, can be reused by CI and local tooling, and does not require custom Renovate regex-manager configuration.
+
+### Pass `--tf-version` to `tfplugindocs` using `.terraform-version`
+
+`docs-generate` SHALL read `.terraform-version` and pass the resulting pinned version via `tfplugindocs generate --tf-version <version>`. This uses upstream-supported behavior while keeping the tool invocation deterministic even on machines whose local Terraform installation does not respect `.terraform-version` automatically.
+
+This is preferred over `--providers-schema` because the latter would require the repo to reimplement provider build + plugin layout + schema extraction orchestration that `tfplugindocs` already handles correctly.
+
+### Align CI with `.terraform-version`
+
+The lint/docs validation path in CI SHALL install the same Terraform version declared in `.terraform-version`. This prevents situations where contributors regenerate docs with one CLI version while CI validates with another.
+
+The most likely implementation is for the workflow to read `.terraform-version` and pass that value into `hashicorp/setup-terraform`, but the exact wiring can follow the current workflow source conventions.
+
+### Document the policy where contributors look for docs guidance
+
+Contributor-facing documentation under `dev-docs/high-level/documentation.md` SHALL explain that docs generation uses the Terraform version pinned in `.terraform-version` via `tfplugindocs`, rather than whichever Terraform binary happens to be installed locally. The docs SHOULD also note that Renovate maintains `.terraform-version` over time.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| `.terraform-version` broadens the scope from docs-only to a repo-level Terraform convention | Accept this intentionally because the shared file simplifies CI/local alignment and future tooling integration |
+| CI and local config diverge if one side is updated without the other | Update both in the same change and capture the requirement in OpenSpec specs/docs |
+| Contributors assume their local Terraform binary or version manager alone controls docs generation | Document that `docs-generate` reads `.terraform-version` and passes it explicitly to `tfplugindocs` |
+| Renovate does not pick up `.terraform-version` as expected in this repo's inherited config | Verify Renovate behavior/config as part of implementation and adjust only if the built-in manager is being suppressed |
+
+## Migration Plan
+
+1. Add `.terraform-version` with the current latest stable Terraform release.
+2. Wire `docs-generate` to read `.terraform-version` and pass it to `--tf-version`.
+3. Update CI Terraform setup for lint/docs validation to read the same version.
+4. Update contributor docs, Renovate expectations, and OpenSpec requirements.
+5. Verify docs generation and docs freshness checks still behave as expected.
+
+## Open Questions
+
+1. **Initial pinned version** — use the current latest stable Terraform release in `.terraform-version` (currently `1.14.9`) unless verification during implementation shows a repo-specific incompatibility.

--- a/openspec/changes/pin-terraform-docs-toolchain/proposal.md
+++ b/openspec/changes/pin-terraform-docs-toolchain/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`make docs-generate` currently invokes `tfplugindocs` without pinning a Terraform CLI version. `terraform-plugin-docs` falls back to whatever `terraform` binary is on a developer's `PATH`, and if none is present it may download the latest Terraform release. That makes documentation generation depend on local machine state instead of repository-owned configuration.
+
+This repo already pins other tooling versions in repository-controlled files (for example Go via `go.mod`, Node via contributor docs/setup, and `golangci-lint` in `Makefile`). Docs generation should follow the same pattern so contributors and CI regenerate the same docs from the same provider schema extraction behavior.
+
+## What Changes
+
+- **Introduce** a root `.terraform-version` file as the repository-owned source of truth for the Terraform CLI version used by docs generation and relevant CI validation jobs.
+- **Update** `make docs-generate` to read `.terraform-version` and pass that version to `tfplugindocs`.
+- **Document** the pinned Terraform version policy and where it is configured.
+- **Align** CI Terraform setup for docs/lint validation with `.terraform-version` so local and CI docs generation use the same CLI version.
+- **Adopt** the current latest stable Terraform release as the initial pinned value, with future updates managed through Renovate's built-in `.terraform-version` support.
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `makefile-workflows`: Documentation generation becomes deterministic with respect to Terraform CLI selection. The repository, via `.terraform-version`, not the developer workstation, decides which Terraform version `tfplugindocs` uses.
+- `ci-build-lint-test`: Lint/docs validation jobs that exercise docs generation use the same `.terraform-version`-pinned Terraform CLI version.
+
+## Impact
+
+- `.terraform-version` — add the repository-owned Terraform CLI version file, initially pinned to the current latest stable release.
+- `Makefile` — update `docs-generate` to read `.terraform-version` and use it in `tfplugindocs` invocation.
+- `dev-docs/high-level/documentation.md` and possibly `dev-docs/high-level/contributing.md` — explain the pinned Terraform version policy and contributor expectations.
+- `.github/workflows/test.yml` and/or generated workflow sources — align Terraform setup in lint/docs-related jobs with `.terraform-version`.
+- `renovate.json` — verify the repository's Renovate configuration allows built-in `.terraform-version` updates as the ongoing maintenance path.
+- OpenSpec specs — update `makefile-workflows` (and CI specs if needed) to reflect deterministic Terraform version selection for docs generation and CI.

--- a/openspec/changes/pin-terraform-docs-toolchain/specs/makefile-workflows/spec.md
+++ b/openspec/changes/pin-terraform-docs-toolchain/specs/makefile-workflows/spec.md
@@ -1,0 +1,18 @@
+# Delta Spec: Makefile Workflows
+
+On sync or archive, this content is intended to land in `openspec/specs/makefile-workflows/spec.md`.
+
+Implementation: [`Makefile`](../../../../Makefile)
+
+## MODIFIED Requirements
+
+### Requirement: Documentation, workflow, and code generation (REQ-038–REQ-042)
+
+The `docs-generate` target SHALL regenerate Terraform provider website/markdown documentation using **HashiCorp `terraform-plugin-docs`** (`tfplugindocs`) for provider name `terraform-provider-elasticstack`. `docs-generate` SHALL read the Terraform CLI version from the repository root `.terraform-version` file and SHALL pass that exact version to `tfplugindocs` via `--tf-version`, so documentation generation does not depend on whichever Terraform binary happens to be installed locally. The `workflow-generate` target SHALL regenerate the checked-in GitHub workflow artifacts from the repository-authored workflow sources, and it SHALL run only when explicitly requested. Aggregate targets such as `gen`, `lint`, `check-lint`, and `build` SHALL NOT depend on `workflow-generate`. The `workflow-test` target SHALL run the repository tests that cover workflow source generation. The `hook-test` target SHALL run `node --test .agents/hooks/*.test.mjs`. The `check-workflows` target SHALL verify that generated workflow artifacts are up to date without regenerating them. The `gen` target SHALL run documentation generation and `go generate` for the repository.
+
+#### Scenario: Docs generation
+
+- GIVEN `make docs-generate`
+- WHEN it succeeds
+- THEN `tfplugindocs` SHALL have regenerated provider docs to match the current schema
+- AND the Terraform CLI version used for schema extraction SHALL come from `.terraform-version`

--- a/openspec/changes/pin-terraform-docs-toolchain/tasks.md
+++ b/openspec/changes/pin-terraform-docs-toolchain/tasks.md
@@ -1,0 +1,24 @@
+## 1. Establish `.terraform-version` as the shared Terraform source of truth
+
+- [ ] 1.1 Add a root `.terraform-version` file pinned to the current latest stable Terraform release.
+- [ ] 1.2 Update `docs-generate` to read `.terraform-version` and pass that value to `tfplugindocs generate --tf-version ...`.
+- [ ] 1.3 Ensure related aggregate targets (`gen`, `lint`, `check-docs`, `check-lint`) continue to exercise the pinned docs-generation path through `docs-generate`.
+
+## 2. Align CI with `.terraform-version`
+
+- [ ] 2.1 Update the lint/docs validation workflow configuration so the Terraform setup step reads and uses the same `.terraform-version` value as local docs generation.
+- [ ] 2.2 Regenerate workflow artifacts if the source workflow templates are the canonical edit point.
+- [ ] 2.3 Verify CI source/tests covering workflow generation still pass after the Terraform version source change.
+
+## 3. Update requirements, contributor docs, and Renovate expectations
+
+- [ ] 3.1 Update the relevant OpenSpec requirements (at minimum `openspec/specs/makefile-workflows/spec.md`) to state that `docs-generate` uses the Terraform CLI version pinned in `.terraform-version` rather than a developer-installed version.
+- [ ] 3.2 Update `dev-docs/high-level/documentation.md` to document the `.terraform-version` policy for docs generation and where it is configured.
+- [ ] 3.3 Update any additional contributor guidance that mentions docs generation if needed for consistency.
+- [ ] 3.4 Verify the repository's `renovate.json` configuration allows built-in `.terraform-version` updates, and adjust only if necessary.
+
+## 4. Verify behavior
+
+- [ ] 4.1 Run targeted validation for docs generation (for example `make docs-generate` and/or `make check-docs`) and confirm docs generation succeeds while reading the pinned version from `.terraform-version`.
+- [ ] 4.2 Run workflow validation/tests required by the repo (`make check-workflows` / `make workflow-test`) if workflow sources changed.
+- [ ] 4.3 Run the relevant aggregate validation (`make check-lint` or an equivalent targeted subset) to confirm the deterministic docs-generation path integrates cleanly.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Pin Terraform CLI version used by `tfplugindocs` for docs generation
- Adds a `.terraform-version` file at the repo root as the single source of truth for the Terraform CLI version used during docs generation.
- Updates the `docs-generate` Makefile target to pass `--tf-version` to `tfplugindocs`, reading the version from `.terraform-version`.
- Aligns CI Terraform setup to use the same pinned version and documents the versioning policy for contributors.
- Adds OpenSpec proposal, design, delta spec, and task checklist covering the full implementation plan.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30f59cc.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->