### PR TITLE
Fix: metric_custom_indicator field must not be sent for doc_count aggregation

### DIFF
--- a/openspec/changes/slo-metric-custom-indicator-doc-count/.openspec.yaml
+++ b/openspec/changes/slo-metric-custom-indicator-doc-count/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/slo-metric-custom-indicator-doc-count/design.md
+++ b/openspec/changes/slo-metric-custom-indicator-doc-count/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The Kibana SLO `metric_custom_indicator` supports a `doc_count` aggregation type that counts documents without referencing a specific field. The generated kbapi client models this as a union discriminated by the `aggregation` key: `Metrics0` (all non-doc_count aggregations, has a required `field` string) and `Metrics1` (doc_count only, no `field`). The read path in `populateFromMetricCustomIndicator` already dispatches on this union correctly. The write path (`buildGoodMetricItem` / `buildTotalMetricItem`) and the schema both treat `field` as required, making `doc_count` unusable.
+
+The `timeslice_metric_indicator` has an identical union structure and was already fixed: its schema marks `field` optional, and its write path switches on the aggregation value.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `field` optional on `metric_custom_indicator.{good,total}.metrics`.
+- Fix the write path to send `Metrics1` (no `field`) for `doc_count` and `Metrics0` (with `field`) for all other aggregations.
+- Add unit tests for the write path and acceptance test for end-to-end coverage.
+
+**Non-Goals:**
+- Validating that `field` is present for non-doc_count aggregations at plan time (the API returns a clear error; schema-level cross-attribute validation is out of scope).
+- Changes to `histogram_custom_indicator` (its aggregation types never include doc_count).
+- Schema version bump or state migration (making an attribute optional is backwards-compatible with existing state).
+
+## Decisions
+
+**Dispatch on aggregation string, not union variant**
+
+The write path switches on `metric.Aggregation.ValueString() == "doc_count"` rather than attempting to infer the intended variant from the field nullability. This mirrors the `timeslice_metric_indicator` approach and is unambiguous: the aggregation type is the canonical discriminant.
+
+Alternative considered: check `metric.Field.IsNull()`. Rejected — null field could be an authoring mistake for a non-doc_count aggregation; the aggregation value is the source of truth.
+
+**Reuse existing kbapi constant**
+
+The doc_count string is compared against `kbapi.SLOsIndicatorPropertiesCustomMetricParamsGoodMetrics1AggregationDocCount` (and the total equivalent), not a hardcoded `"doc_count"` literal. This keeps the code consistent with how `timeslice_metric_indicator` uses `timesliceMetricAggregationDocCount` constants defined in `constants.go`. No new constant is needed because the kbapi package already exports the typed value.
+
+**No schema-level cross-attribute validation**
+
+Adding a `validator.String` that requires `field` when aggregation is not `doc_count` would be correct but is outside the scope of this fix (the analogous `timeslice_metric_indicator` does not have it either). The API's own 400 error provides sufficient feedback.
+
+## Risks / Trade-offs
+
+[Existing configs with `field = ""`] → No risk. Existing configs that set a non-null `field` continue to work unchanged; the new dispatch only activates when `aggregation = "doc_count"`.
+
+[Null `field` for non-doc_count aggregations] → The API will return a 400 error. This is acceptable; adding plan-time validation is a separate, optional improvement.
+
+[kbapi `As*` calls always succeed] → Both `AsSLOsIndicatorPropertiesCustomMetricParamsGoodMetrics1()` and `AsSLOsIndicatorPropertiesCustomMetricParamsGoodMetrics0()` succeed on any union value because they just unmarshal the raw JSON. The read path must continue to dispatch on the `aggregation` field value (already done correctly).

--- a/openspec/changes/slo-metric-custom-indicator-doc-count/proposal.md
+++ b/openspec/changes/slo-metric-custom-indicator-doc-count/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `metric_custom_indicator` schema marks `field` as required on every metric entry, but the Kibana API rejects `field` when `aggregation = "doc_count"` — `doc_count` counts documents and has no field operand. Users who configure a `doc_count` metric receive a 400 error ("Excess keys are not allowed: ...field"), making this aggregation type entirely unusable from Terraform. The `timeslice_metric_indicator` already handles this correctly; `metric_custom_indicator` needs the same treatment.
+
+## What Changes
+
+- `metric_custom_indicator.good.metrics.field`: change from required to optional.
+- `metric_custom_indicator.total.metrics.field`: change from required to optional.
+- Write path (`buildGoodMetricItem` / `buildTotalMetricItem`): when `aggregation = "doc_count"`, send the no-field API variant (`Metrics1`) instead of the field-bearing variant (`Metrics0`).
+- Add unit tests covering the `doc_count` write path and read-path round-trip.
+- Add an acceptance test (`TestAccResourceSlo_metric_custom_indicator_doc_count`) with a testdata TF config that exercises `doc_count` on both good and total metrics.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `kibana-slo`: `metric_custom_indicator.{good,total}.metrics.field` changes from required to optional — must not be set when `aggregation = "doc_count"`, must be set for all other aggregations.
+
+## Impact
+
+- `internal/kibana/slo/schema.go` — two attribute definitions
+- `internal/kibana/slo/models_metric_custom_indicator.go` — write-path helpers
+- `internal/kibana/slo/models_metric_custom_indicator_test.go` — unit tests
+- `internal/kibana/slo/acc_test.go` — acceptance test function
+- `internal/kibana/slo/testdata/TestAccResourceSlo_metric_custom_indicator_doc_count/test/test.tf` — new testdata config
+- No API client changes, no schema version bump, no state migration needed (adding optional attribute is backwards-compatible with existing state).

--- a/openspec/changes/slo-metric-custom-indicator-doc-count/specs/kibana-slo/spec.md
+++ b/openspec/changes/slo-metric-custom-indicator-doc-count/specs/kibana-slo/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Mapping — `metric_custom_indicator` doc_count aggregation (REQ-035)
+
+When a `metric_custom_indicator` metric entry uses `aggregation = "doc_count"`, the `field` attribute SHALL be optional and the provider SHALL NOT send `field` to the Kibana API. For all other aggregation types, `field` SHALL be provided by the user. The schema SHALL declare `field` as optional (not required) for `metric_custom_indicator.{good,total}.metrics`.
+
+On write, when `aggregation = "doc_count"` the provider SHALL serialise the metric using the no-field API variant (`Metrics1`). For all other aggregations the provider SHALL use the field-bearing API variant (`Metrics0`). After a successful read-back, when the API returns a `doc_count` metric the provider SHALL store `field = null` in state.
+
+This aligns `metric_custom_indicator` with the already-correct `timeslice_metric_indicator` behavior (REQ already present in that indicator's schema definition).
+
+Schema change (replaces lines 83–88 and 93–98 of the schema block):
+
+```hcl
+    good {                                        # exactly 1 block
+      equation = <required, string>
+      metrics {                                   # at least 1 block
+        name        = <required, string>
+        aggregation = <required, string>
+        field       = <optional, string>          # required for all aggregations except doc_count; must NOT be set for doc_count
+        filter      = <optional, string>
+      }
+    }
+
+    total {                                       # exactly 1 block
+      equation = <required, string>
+      metrics {                                   # at least 1 block
+        name        = <required, string>
+        aggregation = <required, string>
+        field       = <optional, string>          # required for all aggregations except doc_count; must NOT be set for doc_count
+        filter      = <optional, string>
+      }
+    }
+```
+
+#### Scenario: doc_count metric written without field
+
+- **WHEN** a `metric_custom_indicator` good or total metric has `aggregation = "doc_count"` and `field` is not set
+- **THEN** the provider SHALL send the metric to the Kibana API without a `field` key
+
+#### Scenario: doc_count metric read back with null field
+
+- **WHEN** the Kibana API returns a `metric_custom_indicator` metric with `aggregation = "doc_count"`
+- **THEN** the provider SHALL store `field = null` in state for that metric
+
+#### Scenario: non-doc_count metric still requires field
+
+- **WHEN** a `metric_custom_indicator` metric has `aggregation != "doc_count"` and a non-null `field`
+- **THEN** the provider SHALL send `field` in the API request as before

--- a/openspec/changes/slo-metric-custom-indicator-doc-count/tasks.md
+++ b/openspec/changes/slo-metric-custom-indicator-doc-count/tasks.md
@@ -1,0 +1,21 @@
+## 1. Unit Tests
+
+- [ ] 1.1 Add `buildGoodItemDocCount` and `buildTotalItemDocCount` helpers (using `Metrics1`) inside `TestMetricCustomIndicator_PopulateFromAPI` in `models_metric_custom_indicator_test.go`
+- [ ] 1.2 Add subtest "uses Metrics1 for doc_count aggregation" to `TestMetricCustomIndicator_ToAPI` — builds a model with `aggregation = "doc_count"` and `Field: types.StringNull()`, calls `metricCustomIndicatorToAPI()`, asserts the result decodes as `GoodMetrics1`/`TotalMetrics1` with correct name, aggregation, and filter
+- [ ] 1.3 Add subtest "maps doc_count metrics without field" to `TestMetricCustomIndicator_PopulateFromAPI` — constructs `Metrics1` API items using the helpers from 1.1, calls `populateFromMetricCustomIndicator`, asserts `Field.IsNull()` for both good and total
+
+## 2. Fix
+
+- [ ] 2.1 In `schema.go` `metricCustomIndicatorSchema()`, change `field` from `Required: true` to `Optional: true` (with description) for both `good.metrics` and `total.metrics`
+- [ ] 2.2 In `models_metric_custom_indicator.go`, update `buildGoodMetricItem` to dispatch on `aggregation = "doc_count"`: use `SLOsIndicatorPropertiesCustomMetricParamsGoodMetrics1` (no field) for doc_count, keep existing `Metrics0` path for all other aggregations
+- [ ] 2.3 In `models_metric_custom_indicator.go`, apply the same dispatch to `buildTotalMetricItem` using `SLOsIndicatorPropertiesCustomMetricParamsTotalMetrics1`
+
+## 3. Acceptance Test
+
+- [ ] 3.1 Create `internal/kibana/slo/testdata/TestAccResourceSlo_metric_custom_indicator_doc_count/test/test.tf` — SLO with `metric_custom_indicator` using `doc_count` for good (with filter) and total (no filter, no field)
+- [ ] 3.2 Add `TestAccResourceSlo_metric_custom_indicator_doc_count` to `acc_test.go` (after `TestAccResourceSlo_timeslice_metric_indicator_multiple_mixed_metrics`) — single-step test with `SkipFunc: versionutils.CheckIfVersionIsUnsupported(sloTimesliceMetricsMinVersion)`, asserting index, metric names, aggregations, filter presence, field absence, and equations
+
+## 4. Verification
+
+- [ ] 4.1 Run `make build` and confirm it compiles cleanly
+- [ ] 4.2 Run unit tests: `go test ./internal/kibana/slo/... -run TestMetricCustomIndicator` and confirm all subtests pass


### PR DESCRIPTION
## Summary

- `metric_custom_indicator.{good,total}.metrics.field` is currently `Required: true` in the schema, but the Kibana API rejects `field` when `aggregation = "doc_count"` (400: "Excess keys are not allowed: ...field"), making this aggregation type entirely unusable from Terraform.
- This PR adds the OpenSpec change proposal (`slo-metric-custom-indicator-doc-count`) that tracks the fix: make `field` optional, dispatch to the no-field API variant (`Metrics1`) for `doc_count` on the write path, add unit + acceptance tests.

## Test plan

- [ ] Unit tests added for write path (doc_count → Metrics1) and read-back round-trip
- [ ] Acceptance test `TestAccResourceSlo_metric_custom_indicator_doc_count` added with testdata config
- [ ] `make build` passes
- [ ] `go test ./internal/kibana/slo/... -run TestMetricCustomIndicator` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `metric_custom_indicator` to omit `field` for `doc_count` aggregation
> - Makes the `field` attribute optional for good/total metrics in `metric_custom_indicator`, since `doc_count` does not accept a field parameter.
> - Updates the write path to serialize using `Metrics1` (no field) when aggregation is `doc_count`, and `Metrics0` (with field) otherwise.
> - Adds an OpenSpec design, proposal, and requirement (REQ-035) documenting the behavior, including that reads of `doc_count` should store `field = null` in state.
> - Adds unit and acceptance test tasks to cover both the `doc_count` (no field) and non-`doc_count` (field required) scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4121db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->