### PR TITLE
Dashboards optional field

### DIFF
--- a/internal/kibana/dashboard/acc_metric_panels_test.go
+++ b/internal/kibana/dashboard/acc_metric_panels_test.go
@@ -28,6 +28,47 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// TestAccResourceDashboardMetricChartMinimalConfig is a regression test for
+// https://github.com/elastic/terraform-provider-elasticstack/issues/2355.
+// It applies a metric_chart_config that deliberately omits all optional attributes
+// that have Kibana-side defaults (ignore_global_filters, sampling, query.language,
+// and per-metric config_json fields: empty_as_null, color, format.decimals, format.compact).
+// If the issue is not fixed the first apply step fails with
+// "Provider produced inconsistent result after apply".
+// The second plan-only step verifies no drift remains after a clean apply.
+func TestAccResourceDashboardMetricChartMinimalConfig(t *testing.T) {
+	dashboardTitle := "Test Dashboard Metric Chart Minimal " + sdkacctest.RandStringFromCharSet(4, sdkacctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minDashboardAPISupport),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("minimal"),
+				ConfigVariables: config.Variables{
+					"dashboard_title": config.StringVariable(dashboardTitle),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("elasticstack_kibana_dashboard.test", "id"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_dashboard.test", "panels.#", "1"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_dashboard.test", "panels.0.type", "vis"),
+				),
+			},
+			{
+				// Same config, plan only — must show no changes after a clean apply.
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minDashboardAPISupport),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("minimal"),
+				ConfigVariables: config.Variables{
+					"dashboard_title": config.StringVariable(dashboardTitle),
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceDashboardMetricChart(t *testing.T) {
 	dashboardTitle := "Test Dashboard with Metric Chart " + sdkacctest.RandStringFromCharSet(4, sdkacctest.CharSetAlphaNum)
 

--- a/internal/kibana/dashboard/acc_xy_panels_test.go
+++ b/internal/kibana/dashboard/acc_xy_panels_test.go
@@ -28,6 +28,47 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// TestAccResourceDashboardXYChartMinimalConfig is a regression test for
+// https://github.com/elastic/terraform-provider-elasticstack/issues/2355.
+// It applies an xy_chart_config that deliberately omits all optional attributes
+// that have Kibana-side defaults (e.g. legend.position, axis.y.scale,
+// decorations.fill_opacity, query.language, data_layer.sampling, …).
+// If the issue is not fixed the first apply step fails with
+// "Provider produced inconsistent result after apply".
+// The second plan-only step verifies no drift remains after a clean apply.
+func TestAccResourceDashboardXYChartMinimalConfig(t *testing.T) {
+	dashboardTitle := "Test Dashboard XY Chart Minimal " + sdkacctest.RandStringFromCharSet(4, sdkacctest.CharSetAlphaNum)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minDashboardAPISupport),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("minimal"),
+				ConfigVariables: config.Variables{
+					"dashboard_title": config.StringVariable(dashboardTitle),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("elasticstack_kibana_dashboard.test", "id"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_dashboard.test", "panels.#", "1"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_dashboard.test", "panels.0.type", "vis"),
+				),
+			},
+			{
+				// Same config, plan only — must show no changes after a clean apply.
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minDashboardAPISupport),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("minimal"),
+				ConfigVariables: config.Variables{
+					"dashboard_title": config.StringVariable(dashboardTitle),
+				},
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 const xyChartDataLayerBreakdownExpected = `{"collapse_by":"avg","color":{"mapping":[{"color":{"type":"color_code","value":"#54B399"},` +
 	`"values":["host-a"]}],"mode":"categorical","palette":"default","unassigned":{"type":"color_code","value":"#D3DAE6"}},` +
 	`"column":"host.name","format":{"type":"number"}}`

--- a/internal/kibana/dashboard/models_metric_panel.go
+++ b/internal/kibana/dashboard/models_metric_panel.go
@@ -105,8 +105,16 @@ func (c metricChartPanelConfigConverter) populateFromAttributes(ctx context.Cont
 	//
 	// Disambiguate variant 0 vs 1 using dataset type. The regenerated API can
 	// return an empty standard-query object, so query presence is not reliable.
-	if pm.MetricChartConfig == nil {
-		pm.MetricChartConfig = &metricChartConfigModel{}
+	//
+	// Always allocate a fresh metricChartConfigModel so that fromAPIVariant0/1
+	// does not mutate the plan's struct (pm is seeded from the plan via pm = *tfPanel,
+	// so pm.MetricChartConfig is aliased to the plan's pointer). Seed the fresh
+	// struct with the prior metrics slice so the inline priorMetrics preservation
+	// inside fromAPIVariant0 can still compare against plan values.
+	priorConfig := pm.MetricChartConfig
+	pm.MetricChartConfig = &metricChartConfigModel{}
+	if priorConfig != nil {
+		pm.MetricChartConfig.Metrics = priorConfig.Metrics
 	}
 	if variant0, err := attrs.AsMetricNoESQL(); err == nil && !isMetricNoESQLCandidateActuallyESQL(variant0) {
 		return pm.MetricChartConfig.fromAPIVariant0(ctx, variant0)

--- a/internal/kibana/dashboard/models_plan_state_alignment.go
+++ b/internal/kibana/dashboard/models_plan_state_alignment.go
@@ -106,6 +106,7 @@ func alignMetricStateFromPlan(plan, state *metricChartConfigModel) {
 		return
 	}
 	alignTitleAndDescriptionFromPlan(plan.Title, plan.Description, &state.Title, &state.Description)
+	preservePlanJSONIfStateAddsOptionalKeys(plan.DataSourceJSON, &state.DataSourceJSON, "time_field")
 	preservePlanJSONIfStateAddsOptionalKeys(plan.BreakdownByJSON, &state.BreakdownByJSON, "rank_by")
 	m := min(len(plan.Metrics), len(state.Metrics))
 	for i := range m {

--- a/internal/kibana/dashboard/models_xy_chart_panel.go
+++ b/internal/kibana/dashboard/models_xy_chart_panel.go
@@ -1315,7 +1315,12 @@ func alignXYAxisStateFromPlan(plan, state *xyAxisModel) {
 		return
 	}
 
-	alignXYXAxisStateFromPlan(plan.X, state.X)
+	// When the user omits axis.x entirely, suppress any server-filled defaults.
+	if plan.X == nil {
+		state.X = nil
+	} else {
+		alignXYXAxisStateFromPlan(plan.X, state.X)
+	}
 	alignXYYAxisStateFromPlan(plan.Y, state.Y)
 
 	if plan.Y2 != nil && state.Y2 == nil {
@@ -1338,6 +1343,10 @@ func alignXYXAxisStateFromPlan(plan, state *xyAxisConfigModel) {
 	preserveKnownBoolIfStateNull(plan.Ticks, &state.Ticks)
 	preserveKnownStringIfStateNull(plan.LabelOrientation, &state.LabelOrientation)
 	preserveKnownStringIfStateNull(plan.Scale, &state.Scale)
+	// When axis.title is omitted from config, suppress any server-filled defaults.
+	if plan.Title == nil {
+		state.Title = nil
+	}
 	preserveKnownAxisTitleIfStateBlank(plan.Title, &state.Title)
 	preserveNullJSONIfStateMatches(plan.DomainJSON, &state.DomainJSON, `{"type":"fit","rounding":false}`)
 	preservePlanJSONIfStateAddsOptionalKeys(plan.DomainJSON, &state.DomainJSON, "rounding")
@@ -1355,6 +1364,10 @@ func alignXYYAxisStateFromPlan(plan, state *yAxisConfigModel) {
 	preserveKnownBoolIfStateNull(plan.Ticks, &state.Ticks)
 	preserveKnownStringIfStateNull(plan.LabelOrientation, &state.LabelOrientation)
 	preserveKnownStringIfStateNull(plan.Scale, &state.Scale)
+	// When axis.title is omitted from config, suppress any server-filled defaults.
+	if plan.Title == nil {
+		state.Title = nil
+	}
 	preserveKnownAxisTitleIfStateBlank(plan.Title, &state.Title)
 	preservePlanJSONIfStateAddsOptionalKeys(plan.DomainJSON, &state.DomainJSON, "rounding")
 }
@@ -1368,6 +1381,10 @@ func alignXYY2AxisStateFromPlan(plan, state *yAxisConfigModel) {
 	preserveKnownBoolIfStateNull(plan.Ticks, &state.Ticks)
 	preserveKnownStringIfStateNull(plan.LabelOrientation, &state.LabelOrientation)
 	preserveKnownStringIfStateNull(plan.Scale, &state.Scale)
+	// When axis.title is omitted from config, suppress any server-filled defaults.
+	if plan.Title == nil {
+		state.Title = nil
+	}
 	preserveKnownAxisTitleIfStateBlank(plan.Title, &state.Title)
 	preservePlanJSONIfStateAddsOptionalKeys(plan.DomainJSON, &state.DomainJSON, "rounding")
 }

--- a/internal/kibana/dashboard/schema.go
+++ b/internal/kibana/dashboard/schema.go
@@ -1479,20 +1479,24 @@ func getXYAxisSchema() map[string]schema.Attribute {
 						"visible": schema.BoolAttribute{
 							MarkdownDescription: "Whether to show the title.",
 							Optional:            true,
+							Computed:            true,
 						},
 					},
 				},
 				"ticks": schema.BoolAttribute{
 					MarkdownDescription: "Whether to show tick marks on the axis.",
 					Optional:            true,
+					Computed:            true,
 				},
 				"grid": schema.BoolAttribute{
 					MarkdownDescription: "Whether to show grid lines for this axis.",
 					Optional:            true,
+					Computed:            true,
 				},
 				"label_orientation": schema.StringAttribute{
 					MarkdownDescription: "Orientation of the axis labels.",
 					Optional:            true,
+					Computed:            true,
 					Validators: []validator.String{
 						stringvalidator.OneOf("horizontal", "vertical", "angled"),
 					},
@@ -1508,6 +1512,7 @@ func getXYAxisSchema() map[string]schema.Attribute {
 					MarkdownDescription: "Axis domain configuration as JSON. Can be 'fit' mode or 'custom' mode with min, max, and optional fit flags.",
 					CustomType:          jsontypes.NormalizedType{},
 					Optional:            true,
+					Computed:            true,
 				},
 			},
 		},
@@ -1538,6 +1543,7 @@ func getYAxisAttributes() map[string]schema.Attribute {
 				"visible": schema.BoolAttribute{
 					MarkdownDescription: "Whether to show the title.",
 					Optional:            true,
+					Computed:            true,
 				},
 			},
 		},
@@ -1559,6 +1565,7 @@ func getYAxisAttributes() map[string]schema.Attribute {
 		"scale": schema.StringAttribute{
 			MarkdownDescription: "Y-axis scale type for data transformation.",
 			Optional:            true,
+			Computed:            true,
 			Validators: []validator.String{
 				stringvalidator.OneOf("time", "linear", "log", "sqrt"),
 			},
@@ -1607,6 +1614,7 @@ func getXYDecorationsSchema() map[string]schema.Attribute {
 		"fill_opacity": schema.Float64Attribute{
 			MarkdownDescription: "Area chart fill opacity (0-1 typical, max 2 for legacy).",
 			Optional:            true,
+			Computed:            true,
 		},
 	}
 }
@@ -1641,6 +1649,7 @@ func getXYLegendSchema() map[string]schema.Attribute {
 		"visibility": schema.StringAttribute{
 			MarkdownDescription: "Legend visibility (auto, visible, hidden).",
 			Optional:            true,
+			Computed:            true,
 			Validators: []validator.String{
 				stringvalidator.OneOf(dashboardValueAuto, "visible", "hidden"),
 			},
@@ -1657,10 +1666,12 @@ func getXYLegendSchema() map[string]schema.Attribute {
 		"inside": schema.BoolAttribute{
 			MarkdownDescription: "Position legend inside the chart. When true, use 'columns' and 'alignment'. When false or omitted, use 'position' and 'size'.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"position": schema.StringAttribute{
 			MarkdownDescription: "Legend position when positioned outside the chart. Valid when 'inside' is false or omitted.",
 			Optional:            true,
+			Computed:            true,
 			Validators: []validator.String{
 				stringvalidator.OneOf("top", "bottom", "left", "right"),
 			},
@@ -1693,6 +1704,7 @@ func getFilterSimple() map[string]schema.Attribute {
 		"language": schema.StringAttribute{
 			MarkdownDescription: "Query language (default: 'kql').",
 			Optional:            true,
+			Computed:            true,
 			Validators: []validator.String{
 				stringvalidator.OneOf("kql", "lucene"),
 			},
@@ -1757,10 +1769,12 @@ func getDataLayerAttributes() map[string]schema.Attribute {
 		"ignore_global_filters": schema.BoolAttribute{
 			MarkdownDescription: "If true, ignore global filters when fetching data for this layer. Default is false.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"sampling": schema.Float64Attribute{
 			MarkdownDescription: "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"x_json": schema.StringAttribute{
 			MarkdownDescription: "X-axis configuration as JSON. For ES|QL: column and operation. For standard: field, operation, and optional parameters.",
@@ -1799,10 +1813,12 @@ func getReferenceLineLayerAttributes() map[string]schema.Attribute {
 		"ignore_global_filters": schema.BoolAttribute{
 			MarkdownDescription: "If true, ignore global filters when fetching data for this layer. Default is false.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"sampling": schema.Float64Attribute{
 			MarkdownDescription: "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"thresholds": schema.ListNestedAttribute{
 			MarkdownDescription: "Array of reference line thresholds.",
@@ -1986,10 +2002,12 @@ func lensChartBaseAttributes() map[string]schema.Attribute {
 		"sampling": schema.Float64Attribute{
 			MarkdownDescription: "Sampling factor between 0 (no sampling) and 1 (full sampling). Default is 1.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"ignore_global_filters": schema.BoolAttribute{
 			MarkdownDescription: "If true, ignore global filters when fetching data for this chart. Default is false.",
 			Optional:            true,
+			Computed:            true,
 		},
 		"filters": schema.ListNestedAttribute{
 			MarkdownDescription: "Additional filters to apply to the chart data (maximum 100).",

--- a/internal/kibana/dashboard/testdata/TestAccResourceDashboardMetricChartMinimalConfig/minimal/main.tf
+++ b/internal/kibana/dashboard/testdata/TestAccResourceDashboardMetricChartMinimalConfig/minimal/main.tf
@@ -1,0 +1,42 @@
+# Regression config for https://github.com/elastic/terraform-provider-elasticstack/issues/2355
+#
+# Intentionally omits optional metric_chart_config attributes that have Kibana API defaults:
+#   - ignore_global_filters        (default: false)
+#   - sampling                     (default: 1)
+#   - query.language               (default: "kql")
+#   - metrics[].config_json fields: empty_as_null (default: false), color (default: {"type":"auto"}),
+#                                   format.decimals (default: 2), format.compact (default: false)
+#
+# If the issue is not fixed, applying this config will fail with
+# "Provider produced inconsistent result after apply".
+
+variable "dashboard_title" {
+  type = string
+}
+
+resource "elasticstack_kibana_dashboard" "test" {
+  title            = var.dashboard_title
+  time_range       = { from = "now-15m", to = "now" }
+  refresh_interval = { pause = true, value = 0 }
+  query            = { language = "kql", text = "" }
+
+  panels = [{
+    type = "vis"
+    grid = { x = 0, y = 0, w = 24, h = 15 }
+    metric_chart_config = {
+      data_source_json = jsonencode({ type = "data_view_spec", index_pattern = "metrics-*" })
+      query            = { expression = "" }
+      metrics = [{
+        # type, operation and format.type are required by the API.
+        # Intentionally omitting optional fields with API defaults:
+        #   empty_as_null (default: false), color (default: {"type":"auto"}),
+        #   format.decimals (default: 2), format.compact (default: false).
+        config_json = jsonencode({
+          type      = "primary"
+          operation = "count"
+          format    = { type = "number" }
+        })
+      }]
+    }
+  }]
+}

--- a/internal/kibana/dashboard/testdata/TestAccResourceDashboardXYChartMinimalConfig/minimal/main.tf
+++ b/internal/kibana/dashboard/testdata/TestAccResourceDashboardXYChartMinimalConfig/minimal/main.tf
@@ -1,0 +1,50 @@
+# Regression config for https://github.com/elastic/terraform-provider-elasticstack/issues/2355
+#
+# Intentionally omits optional xy_chart_config attributes that have Kibana API defaults:
+#   - axis.x.title.visible (default: true)
+#   - axis.y.title.visible (default: true)
+#   - axis.y.scale         (default: "linear")
+#   - legend.visibility    (default: "visible")
+#   - legend.inside        (default: false)
+#   - legend.position      (default: "right")
+#   - decorations.fill_opacity                  (default: 0.3)
+#   - query.language                            (default: "kql")
+#   - layers[].data_layer.ignore_global_filters (default: false)
+#   - layers[].data_layer.sampling              (default: 1)
+#
+# If the issue is not fixed, applying this config will fail with
+# "Provider produced inconsistent result after apply".
+
+variable "dashboard_title" {
+  type = string
+}
+
+resource "elasticstack_kibana_dashboard" "test" {
+  title            = var.dashboard_title
+  time_range       = { from = "now-15m", to = "now" }
+  refresh_interval = { pause = true, value = 0 }
+  query            = { language = "kql", text = "" }
+
+  panels = [{
+    type = "vis"
+    grid = { x = 0, y = 0, w = 24, h = 15 }
+    xy_chart_config = {
+      axis = {
+        y = { domain_json = jsonencode({ type = "fit" }) }
+      }
+      legend      = {}
+      fitting     = { type = "none" }
+      decorations = {}
+      query       = { expression = "" }
+      layers = [{
+        type = "area"
+        data_layer = {
+          data_source_json = jsonencode({ type = "data_view_spec", index_pattern = "logs-*" })
+          y = [{
+            config_json = jsonencode({ operation = "count", empty_as_null = true })
+          }]
+        }
+      }]
+    }
+  }]
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/2355

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix post-apply drift in dashboard metric and XY chart configs by marking optional fields as computed
> - Marks several optional XY chart axis, legend, filter, and layer attributes as `Computed: true` in [schema.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2395/files#diff-307633980a1d45403b5ec8f8ca0d258d605705aea21e3968da1615e977c1bcb3) so server-filled defaults no longer cause plan diffs when omitted.
> - Adds nil-checks in XY axis alignment functions in [models_xy_chart_panel.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2395/files#diff-2a5d0321079c4f7c31ccdc84c12fc5fdfacb9e88ba35f8aa3258dd0e1a101c51) to suppress server-provided `title` and `x` axis defaults when the plan omits them.
> - Fixes mutation of plan-aliased state in [models_metric_panel.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2395/files#diff-2fb74f1450ba27038a72dc90d70ad63b13049643ecc04af7ec86982e84b0d5b3) by allocating a fresh config model during `populateFromAttributes`.
> - Adds `time_field` preservation in [models_plan_state_alignment.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2395/files#diff-b5c1727ce2e9b272a80bc76b26ce66549e60ae35fe716a607c388791c583651d) so server-added `time_field` in metric chart `data_source_json` does not cause drift.
> - Adds acceptance tests for minimal metric and XY chart configs to catch post-apply drift regressions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f445e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->