### PR TITLE
Fix SLO objective float32 precision loss (#2396)

### DIFF
--- a/generated/kbapi/transform_schema.go
+++ b/generated/kbapi/transform_schema.go
@@ -607,6 +607,7 @@ var transformers = []TransformFunc{
 	fixSyntheticsMonitorModels,
 	fixSyntheticsMonitorParams,
 	fixAlertingRuleBody,
+	fixSloFloatFormats,
 	transformRemoveExamples,
 	transformRemoveUnusedComponents,
 	transformOmitEmptyNullable,
@@ -1451,6 +1452,36 @@ func fixAlertingRuleBody(schema *Schema) {
 	postEndpoint.CreateRef(schema, "Alerting_Rule_API_Body", "requestBody.content.application/json.schema.anyOf.0")
 	postEndpoint.CreateRef(schema, "Alerting_Rule_API_Body_Generic", "requestBody.content.application/json.schema.anyOf.1")
 	postEndpoint.CreateRef(schema, "Alerting_Rule_API_Body_Union", "requestBody.content.application/json.schema")
+}
+
+// fixSloFloatFormats adds format: double to all floating-point fields in SLO
+// schemas that the Terraform provider surfaces as Float64 attributes. Without
+// an explicit format the Kibana spec uses "type: number" which oapi-codegen
+// maps to float32, causing silent precision loss when users write values such
+// as 0.999 (see https://github.com/elastic/terraform-provider-elasticstack/issues/2396).
+// format: double instructs oapi-codegen to emit float64 instead, preserving
+// full IEEE-754 double precision throughout the read/write cycle.
+func fixSloFloatFormats(schema *Schema) {
+	// Objective target and timeslice target (the fields reported in issue #2396)
+	schema.Components.Set("schemas.SLOs_objective.properties.target.format", "double")
+	schema.Components.Set("schemas.SLOs_objective.properties.timesliceTarget.format", "double")
+
+	// Histogram range indicator good/total from & to
+	const histGoodFrom = "schemas.SLOs_indicator_properties_histogram.properties.params.properties.good.properties.from.format"
+	const histGoodTo = "schemas.SLOs_indicator_properties_histogram.properties.params.properties.good.properties.to.format"
+	const histTotalFrom = "schemas.SLOs_indicator_properties_histogram.properties.params.properties.total.properties.from.format"
+	const histTotalTo = "schemas.SLOs_indicator_properties_histogram.properties.params.properties.total.properties.to.format"
+	schema.Components.Set(histGoodFrom, "double")
+	schema.Components.Set(histGoodTo, "double")
+	schema.Components.Set(histTotalFrom, "double")
+	schema.Components.Set(histTotalTo, "double")
+
+	// APM latency threshold (milliseconds)
+	schema.Components.Set("schemas.SLOs_indicator_properties_apm_latency.properties.params.properties.threshold.format", "double")
+
+	// Timeslice metric threshold and percentile
+	schema.Components.Set("schemas.SLOs_indicator_properties_timeslice_metric.properties.params.properties.metric.properties.threshold.format", "double")
+	schema.Components.Set("schemas.SLOs_timeslice_metric_percentile_metric.properties.percentile.format", "double")
 }
 
 func fixAlertingRuleParams(schema *Schema) {

--- a/internal/kibana/slo/acc_test.go
+++ b/internal/kibana/slo/acc_test.go
@@ -780,6 +780,34 @@ func TestAccResourceSloFloatPrecision(t *testing.T) {
 	})
 }
 
+// TestAccResourceSloHistogramFloatPrecision verifies that histogram_custom_indicator
+// range fields (from, to) round-trip without precision loss.
+// See https://github.com/elastic/terraform-provider-elasticstack/issues/2400:
+// float64(float32(0.001)) = 0.0010000000474974513, causing a "provider produced
+// inconsistent result after apply" error when those fields were float32 in the client.
+func TestAccResourceSloHistogramFloatPrecision(t *testing.T) {
+	sloName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceSloDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(sloTimesliceMetricsMinVersion),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("test"),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(sloName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.from", "0.001"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "histogram_custom_indicator.0.good.0.to", "1"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "objective.0.target", "0.999"),
+				),
+			},
+		},
+	})
+}
+
 func checkResourceSloDestroy(s *terraform.State) error {
 	client, err := clients.NewAcceptanceTestingKibanaScopedClient()
 	if err != nil {

--- a/internal/kibana/slo/acc_test.go
+++ b/internal/kibana/slo/acc_test.go
@@ -750,6 +750,36 @@ func TestAccResourceSloRangeFromZero(t *testing.T) {
 	})
 }
 
+// TestAccResourceSloFloatPrecision verifies that objective fields (target,
+// timeslice_target) round-trip through the provider without precision loss.
+// Prior to the fix in https://github.com/elastic/terraform-provider-elasticstack/issues/2396,
+// the generated client used float32 for these fields. Values like 0.999 are not
+// exactly representable in float32, so reading them back produced different bits
+// (e.g. float64(float32(0.999)) = 0.9990000128746033), causing a "provider
+// produced inconsistent result after apply" error.
+func TestAccResourceSloFloatPrecision(t *testing.T) {
+	sloName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceSloDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(sloTimesliceMetricsMinVersion),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("test"),
+				ConfigVariables: config.Variables{
+					"name": config.StringVariable(sloName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "objective.0.target", "0.999"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "objective.0.timeslice_target", "0.95"),
+					resource.TestCheckResourceAttr("elasticstack_kibana_slo.test_slo", "objective.0.timeslice_window", "5m"),
+				),
+			},
+		},
+	})
+}
+
 func checkResourceSloDestroy(s *terraform.State) error {
 	client, err := clients.NewAcceptanceTestingKibanaScopedClient()
 	if err != nil {

--- a/internal/kibana/slo/models.go
+++ b/internal/kibana/slo/models.go
@@ -19,7 +19,6 @@ package slo
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
@@ -100,10 +99,10 @@ func (m tfModel) toAPIModel() (models.Slo, diag.Diagnostics) {
 	}
 
 	obj := kbapi.SLOsObjective{
-		Target: float32(m.Objective[0].Target.ValueFloat64()),
+		Target: m.Objective[0].Target.ValueFloat64(),
 	}
 	if typeutils.IsKnown(m.Objective[0].TimesliceTarget) {
-		v := float32(m.Objective[0].TimesliceTarget.ValueFloat64())
+		v := m.Objective[0].TimesliceTarget.ValueFloat64()
 		obj.TimesliceTarget = &v
 	}
 	if typeutils.IsKnown(m.Objective[0].TimesliceWindow) {
@@ -225,10 +224,10 @@ func (m *tfModel) populateFromAPI(apiModel *models.Slo) diag.Diagnostics {
 	}}
 
 	obj := tfObjective{
-		Target: types.Float64Value(float32ToFloat64(apiModel.Objective.Target)),
+		Target: types.Float64Value(apiModel.Objective.Target),
 	}
 	if apiModel.Objective.TimesliceTarget != nil {
-		obj.TimesliceTarget = types.Float64Value(float32ToFloat64(*apiModel.Objective.TimesliceTarget))
+		obj.TimesliceTarget = types.Float64Value(*apiModel.Objective.TimesliceTarget)
 	} else {
 		obj.TimesliceTarget = types.Float64Null()
 	}
@@ -356,19 +355,6 @@ func (s tfSettings) toAPIModel() *kbapi.SLOsSettings {
 		return nil
 	}
 	return &settings
-}
-
-// float32ToFloat64 converts a float32 to float64 via its canonical shortest
-// decimal representation. This avoids false precision: a direct float64(f32)
-// cast adds spurious low-order bits (e.g. float64(float32(0.999)) produces
-// 0.9990000128746033, not 0.999). By formatting as the shortest float32
-// decimal and re-parsing as float64 we get the value Terraform would store
-// for the user-written literal (e.g. "0.999" → 0.99899999999999999911, which
-// is the same IEEE 754 double that strconv.ParseFloat("0.999", 64) returns).
-func float32ToFloat64(v float32) float64 {
-	s := strconv.FormatFloat(float64(v), 'f', -1, 32)
-	f, _ := strconv.ParseFloat(s, 64)
-	return f
 }
 
 func stringPtr(v types.String) *string {

--- a/internal/kibana/slo/models_apm_latency_indicator.go
+++ b/internal/kibana/slo/models_apm_latency_indicator.go
@@ -50,7 +50,7 @@ func (m tfModel) apmLatencyIndicatorToAPI() (bool, kbapi.SLOsSloWithSummaryRespo
 			Filter          *string `json:"filter,omitempty"`
 			Index           string  `json:"index"`
 			Service         string  `json:"service"`
-			Threshold       float32 `json:"threshold"`
+			Threshold       float64 `json:"threshold"`
 			TransactionName string  `json:"transactionName"`
 			TransactionType string  `json:"transactionType"`
 		}{
@@ -60,7 +60,7 @@ func (m tfModel) apmLatencyIndicatorToAPI() (bool, kbapi.SLOsSloWithSummaryRespo
 			TransactionName: ind.TransactionName.ValueString(),
 			Filter:          stringPtr(ind.Filter),
 			Index:           ind.Index.ValueString(),
-			Threshold:       float32(ind.Threshold.ValueInt64()),
+			Threshold:       float64(ind.Threshold.ValueInt64()),
 		},
 	}
 

--- a/internal/kibana/slo/models_apm_latency_indicator_test.go
+++ b/internal/kibana/slo/models_apm_latency_indicator_test.go
@@ -88,7 +88,7 @@ func TestApmLatencyIndicator_PopulateFromAPI(t *testing.T) {
 				Filter          *string `json:"filter,omitempty"`
 				Index           string  `json:"index"`
 				Service         string  `json:"service"`
-				Threshold       float32 `json:"threshold"`
+				Threshold       float64 `json:"threshold"`
 				TransactionName string  `json:"transactionName"`
 				TransactionType string  `json:"transactionType"`
 			}{
@@ -121,7 +121,7 @@ func TestApmLatencyIndicator_PopulateFromAPI(t *testing.T) {
 				Filter          *string `json:"filter,omitempty"`
 				Index           string  `json:"index"`
 				Service         string  `json:"service"`
-				Threshold       float32 `json:"threshold"`
+				Threshold       float64 `json:"threshold"`
 				TransactionName string  `json:"transactionName"`
 				TransactionType string  `json:"transactionType"`
 			}{

--- a/internal/kibana/slo/models_histogram_custom_indicator.go
+++ b/internal/kibana/slo/models_histogram_custom_indicator.go
@@ -40,24 +40,6 @@ type tfHistogramRange struct {
 	To          types.Float64 `tfsdk:"to"`
 }
 
-// float64PtrToFloat32Ptr converts a *float64 to *float32, returning nil when the input is nil.
-func float64PtrToFloat32Ptr(v *float64) *float32 {
-	if v == nil {
-		return nil
-	}
-	f := float32(*v)
-	return &f
-}
-
-// float32PtrToFloat64Ptr converts a *float32 to *float64, returning nil when the input is nil.
-func float32PtrToFloat64Ptr(v *float32) *float64 {
-	if v == nil {
-		return nil
-	}
-	f := float64(*v)
-	return &f
-}
-
 func (m tfModel) histogramCustomIndicatorToAPI() (bool, kbapi.SLOsSloWithSummaryResponse_Indicator, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	if len(m.HistogramCustomIndicator) != 1 {
@@ -79,8 +61,8 @@ func (m tfModel) histogramCustomIndicatorToAPI() (bool, kbapi.SLOsSloWithSummary
 				Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation `json:"aggregation"`
 				Field       string                                                      `json:"field"`
 				Filter      *string                                                     `json:"filter,omitempty"`
-				From        *float32                                                    `json:"from,omitempty"`
-				To          *float32                                                    `json:"to,omitempty"`
+				From        *float64                                                    `json:"from,omitempty"`
+				To          *float64                                                    `json:"to,omitempty"`
 			} `json:"good"`
 			Index          string `json:"index"`
 			TimestampField string `json:"timestampField"`
@@ -88,8 +70,8 @@ func (m tfModel) histogramCustomIndicatorToAPI() (bool, kbapi.SLOsSloWithSummary
 				Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation `json:"aggregation"`
 				Field       string                                                       `json:"field"`
 				Filter      *string                                                      `json:"filter,omitempty"`
-				From        *float32                                                     `json:"from,omitempty"`
-				To          *float32                                                     `json:"to,omitempty"`
+				From        *float64                                                     `json:"from,omitempty"`
+				To          *float64                                                     `json:"to,omitempty"`
 			} `json:"total"`
 		}{
 			Index:          ind.Index.ValueString(),
@@ -100,27 +82,27 @@ func (m tfModel) histogramCustomIndicatorToAPI() (bool, kbapi.SLOsSloWithSummary
 				Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation `json:"aggregation"`
 				Field       string                                                      `json:"field"`
 				Filter      *string                                                     `json:"filter,omitempty"`
-				From        *float32                                                    `json:"from,omitempty"`
-				To          *float32                                                    `json:"to,omitempty"`
+				From        *float64                                                    `json:"from,omitempty"`
+				To          *float64                                                    `json:"to,omitempty"`
 			}{
 				Field:       ind.Good[0].Field.ValueString(),
 				Aggregation: kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation(ind.Good[0].Aggregation.ValueString()),
 				Filter:      stringPtr(ind.Good[0].Filter),
-				From:        float64PtrToFloat32Ptr(float64Ptr(ind.Good[0].From)),
-				To:          float64PtrToFloat32Ptr(float64Ptr(ind.Good[0].To)),
+				From:        float64Ptr(ind.Good[0].From),
+				To:          float64Ptr(ind.Good[0].To),
 			},
 			Total: struct {
 				Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation `json:"aggregation"`
 				Field       string                                                       `json:"field"`
 				Filter      *string                                                      `json:"filter,omitempty"`
-				From        *float32                                                     `json:"from,omitempty"`
-				To          *float32                                                     `json:"to,omitempty"`
+				From        *float64                                                     `json:"from,omitempty"`
+				To          *float64                                                     `json:"to,omitempty"`
 			}{
 				Field:       ind.Total[0].Field.ValueString(),
 				Aggregation: kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation(ind.Total[0].Aggregation.ValueString()),
 				Filter:      stringPtr(ind.Total[0].Filter),
-				From:        float64PtrToFloat32Ptr(float64Ptr(ind.Total[0].From)),
-				To:          float64PtrToFloat32Ptr(float64Ptr(ind.Total[0].To)),
+				From:        float64Ptr(ind.Total[0].From),
+				To:          float64Ptr(ind.Total[0].To),
 			},
 		},
 	}
@@ -146,15 +128,15 @@ func (m *tfModel) populateFromHistogramCustomIndicator(apiIndicator kbapi.SLOsIn
 			Field:       types.StringValue(p.Good.Field),
 			Aggregation: types.StringValue(string(p.Good.Aggregation)),
 			Filter:      stringOrNull(p.Good.Filter),
-			From:        float64OrNull(float32PtrToFloat64Ptr(p.Good.From)),
-			To:          float64OrNull(float32PtrToFloat64Ptr(p.Good.To)),
+			From:        float64OrNull(p.Good.From),
+			To:          float64OrNull(p.Good.To),
 		}},
 		Total: []tfHistogramRange{{
 			Field:       types.StringValue(p.Total.Field),
 			Aggregation: types.StringValue(string(p.Total.Aggregation)),
 			Filter:      stringOrNull(p.Total.Filter),
-			From:        float64OrNull(float32PtrToFloat64Ptr(p.Total.From)),
-			To:          float64OrNull(float32PtrToFloat64Ptr(p.Total.To)),
+			From:        float64OrNull(p.Total.From),
+			To:          float64OrNull(p.Total.To),
 		}},
 	}
 	if p.DataViewId != nil {

--- a/internal/kibana/slo/models_histogram_custom_indicator_test.go
+++ b/internal/kibana/slo/models_histogram_custom_indicator_test.go
@@ -100,8 +100,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 	t.Run("maps ranges and optional pointers", func(t *testing.T) {
 		dvID := "dv-1"
 		goodFilter := "status:200"
-		goodFrom := float32(0.0)
-		totalTo := float32(10.0)
+		goodFrom := float64(0.0)
+		totalTo := float64(10.0)
 
 		api := kbapi.SLOsIndicatorPropertiesHistogram{
 			Params: struct {
@@ -111,8 +111,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation `json:"aggregation"`
 					Field       string                                                      `json:"field"`
 					Filter      *string                                                     `json:"filter,omitempty"`
-					From        *float32                                                    `json:"from,omitempty"`
-					To          *float32                                                    `json:"to,omitempty"`
+					From        *float64                                                    `json:"from,omitempty"`
+					To          *float64                                                    `json:"to,omitempty"`
 				} `json:"good"`
 				Index          string `json:"index"`
 				TimestampField string `json:"timestampField"`
@@ -120,8 +120,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation `json:"aggregation"`
 					Field       string                                                       `json:"field"`
 					Filter      *string                                                      `json:"filter,omitempty"`
-					From        *float32                                                     `json:"from,omitempty"`
-					To          *float32                                                     `json:"to,omitempty"`
+					From        *float64                                                     `json:"from,omitempty"`
+					To          *float64                                                     `json:"to,omitempty"`
 				} `json:"total"`
 			}{
 				Index:          "logs-*",
@@ -132,8 +132,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation `json:"aggregation"`
 					Field       string                                                      `json:"field"`
 					Filter      *string                                                     `json:"filter,omitempty"`
-					From        *float32                                                    `json:"from,omitempty"`
-					To          *float32                                                    `json:"to,omitempty"`
+					From        *float64                                                    `json:"from,omitempty"`
+					To          *float64                                                    `json:"to,omitempty"`
 				}{
 					Aggregation: "sum",
 					Field:       "latency",
@@ -145,8 +145,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation `json:"aggregation"`
 					Field       string                                                       `json:"field"`
 					Filter      *string                                                      `json:"filter,omitempty"`
-					From        *float32                                                     `json:"from,omitempty"`
-					To          *float32                                                     `json:"to,omitempty"`
+					From        *float64                                                     `json:"from,omitempty"`
+					To          *float64                                                     `json:"to,omitempty"`
 				}{
 					Aggregation: "sum",
 					Field:       "latency",
@@ -182,8 +182,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation `json:"aggregation"`
 					Field       string                                                      `json:"field"`
 					Filter      *string                                                     `json:"filter,omitempty"`
-					From        *float32                                                    `json:"from,omitempty"`
-					To          *float32                                                    `json:"to,omitempty"`
+					From        *float64                                                    `json:"from,omitempty"`
+					To          *float64                                                    `json:"to,omitempty"`
 				} `json:"good"`
 				Index          string `json:"index"`
 				TimestampField string `json:"timestampField"`
@@ -191,8 +191,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation `json:"aggregation"`
 					Field       string                                                       `json:"field"`
 					Filter      *string                                                      `json:"filter,omitempty"`
-					From        *float32                                                     `json:"from,omitempty"`
-					To          *float32                                                     `json:"to,omitempty"`
+					From        *float64                                                     `json:"from,omitempty"`
+					To          *float64                                                     `json:"to,omitempty"`
 				} `json:"total"`
 			}{
 				Index:          "logs-*",
@@ -203,8 +203,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsGoodAggregation `json:"aggregation"`
 					Field       string                                                      `json:"field"`
 					Filter      *string                                                     `json:"filter,omitempty"`
-					From        *float32                                                    `json:"from,omitempty"`
-					To          *float32                                                    `json:"to,omitempty"`
+					From        *float64                                                    `json:"from,omitempty"`
+					To          *float64                                                    `json:"to,omitempty"`
 				}{
 					Aggregation: "sum",
 					Field:       "latency",
@@ -216,8 +216,8 @@ func TestHistogramCustomIndicator_PopulateFromAPI(t *testing.T) {
 					Aggregation kbapi.SLOsIndicatorPropertiesHistogramParamsTotalAggregation `json:"aggregation"`
 					Field       string                                                       `json:"field"`
 					Filter      *string                                                      `json:"filter,omitempty"`
-					From        *float32                                                     `json:"from,omitempty"`
-					To          *float32                                                     `json:"to,omitempty"`
+					From        *float64                                                     `json:"from,omitempty"`
+					To          *float64                                                     `json:"to,omitempty"`
 				}{
 					Aggregation: "sum",
 					Field:       "latency",

--- a/internal/kibana/slo/models_timeslice_metric_indicator.go
+++ b/internal/kibana/slo/models_timeslice_metric_indicator.go
@@ -76,7 +76,7 @@ func buildTimesliceMetricItem(metric tfTimesliceMetricMetric, idx int) (kbapi.SL
 			Name:        metric.Name.ValueString(),
 			Aggregation: kbapi.SLOsTimesliceMetricPercentileMetricAggregation(agg),
 			Field:       metric.Field.ValueString(),
-			Percentile:  float32(metric.Percentile.ValueFloat64()),
+			Percentile:  metric.Percentile.ValueFloat64(),
 			Filter:      filter,
 		}
 		if err := item.FromSLOsTimesliceMetricPercentileMetric(pm); err != nil {
@@ -130,7 +130,7 @@ func (m tfModel) timesliceMetricIndicatorToAPI() (bool, kbapi.SLOsSloWithSummary
 				Comparator kbapi.SLOsIndicatorPropertiesTimesliceMetricParamsMetricComparator        `json:"comparator"`
 				Equation   string                                                                    `json:"equation"`
 				Metrics    []kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item `json:"metrics"`
-				Threshold  float32                                                                   `json:"threshold"`
+				Threshold  float64                                                                   `json:"threshold"`
 			} `json:"metric"`
 			TimestampField string `json:"timestampField"`
 		}{
@@ -142,12 +142,12 @@ func (m tfModel) timesliceMetricIndicatorToAPI() (bool, kbapi.SLOsSloWithSummary
 				Comparator kbapi.SLOsIndicatorPropertiesTimesliceMetricParamsMetricComparator        `json:"comparator"`
 				Equation   string                                                                    `json:"equation"`
 				Metrics    []kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item `json:"metrics"`
-				Threshold  float32                                                                   `json:"threshold"`
+				Threshold  float64                                                                   `json:"threshold"`
 			}{
 				Metrics:    metrics,
 				Equation:   metricDef.Equation.ValueString(),
 				Comparator: kbapi.SLOsIndicatorPropertiesTimesliceMetricParamsMetricComparator(metricDef.Comparator.ValueString()),
-				Threshold:  float32(metricDef.Threshold.ValueFloat64()),
+				Threshold:  metricDef.Threshold.ValueFloat64(),
 			},
 		},
 	}
@@ -188,7 +188,7 @@ func (m *tfModel) populateFromTimesliceMetricIndicator(apiIndicator kbapi.SLOsIn
 			metric.Name = types.StringValue(pm.Name)
 			metric.Aggregation = types.StringValue(string(pm.Aggregation))
 			metric.Field = types.StringValue(pm.Field)
-			metric.Percentile = types.Float64Value(float64(pm.Percentile))
+			metric.Percentile = types.Float64Value(pm.Percentile)
 			metric.Filter = types.StringPointerValue(pm.Filter)
 		} else if dm, err := mm.AsSLOsTimesliceMetricDocCountMetric(); err == nil && string(dm.Aggregation) == timesliceMetricAggregationDocCount {
 			metric.Name = types.StringValue(dm.Name)
@@ -213,7 +213,7 @@ func (m *tfModel) populateFromTimesliceMetricIndicator(apiIndicator kbapi.SLOsIn
 		Metrics:    tm,
 		Equation:   types.StringValue(p.Metric.Equation),
 		Comparator: types.StringValue(string(p.Metric.Comparator)),
-		Threshold:  types.Float64Value(float64(p.Metric.Threshold)),
+		Threshold:  types.Float64Value(p.Metric.Threshold),
 	}}
 
 	m.TimesliceMetricIndicator = []tfTimesliceMetricIndicator{ind}

--- a/internal/kibana/slo/models_timeslice_metric_indicator_test.go
+++ b/internal/kibana/slo/models_timeslice_metric_indicator_test.go
@@ -47,7 +47,7 @@ func buildBasicMetricItem(t *testing.T, name, agg, field string, filter *string)
 }
 
 // buildPercentileItem builds a timeslice metric item containing a percentile metric.
-func buildPercentileItem(t *testing.T, name, agg, field string, percentile float32, filter *string) kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item {
+func buildPercentileItem(t *testing.T, name, agg, field string, percentile float64, filter *string) kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item {
 	t.Helper()
 	var item kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item
 	pm := kbapi.SLOsTimesliceMetricPercentileMetric{
@@ -85,7 +85,7 @@ func buildTimesliceAPI(dvID *string, filter *string, items []kbapi.SLOsIndicator
 				Comparator kbapi.SLOsIndicatorPropertiesTimesliceMetricParamsMetricComparator        `json:"comparator"`
 				Equation   string                                                                    `json:"equation"`
 				Metrics    []kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item `json:"metrics"`
-				Threshold  float32                                                                   `json:"threshold"`
+				Threshold  float64                                                                   `json:"threshold"`
 			} `json:"metric"`
 			TimestampField string `json:"timestampField"`
 		}{
@@ -97,7 +97,7 @@ func buildTimesliceAPI(dvID *string, filter *string, items []kbapi.SLOsIndicator
 				Comparator kbapi.SLOsIndicatorPropertiesTimesliceMetricParamsMetricComparator        `json:"comparator"`
 				Equation   string                                                                    `json:"equation"`
 				Metrics    []kbapi.SLOsIndicatorPropertiesTimesliceMetric_Params_Metric_Metrics_Item `json:"metrics"`
-				Threshold  float32                                                                   `json:"threshold"`
+				Threshold  float64                                                                   `json:"threshold"`
 			}{
 				Equation:   "a",
 				Comparator: "GT",

--- a/internal/kibana/slo/testdata/TestAccResourceSloFloatPrecision/test/test.tf
+++ b/internal/kibana/slo/testdata/TestAccResourceSloFloatPrecision/test/test.tf
@@ -1,0 +1,47 @@
+variable "name" {
+  type = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+}
+
+resource "elasticstack_elasticsearch_index" "my_index" {
+  name                = "my-index-${var.name}"
+  deletion_protection = false
+}
+
+# This config uses float64 literal values that are not exactly representable in
+# float32 (e.g. 0.999). When the objective fields were float32 in the generated
+# client, the provider corrupted these values on read:
+#   float64(float32(0.999)) = 0.9990000128746033
+# causing a "provider produced inconsistent result after apply" error.
+# See https://github.com/elastic/terraform-provider-elasticstack/issues/2396.
+resource "elasticstack_kibana_slo" "test_slo" {
+  name        = var.name
+  slo_id      = "id-${var.name}"
+  description = "SLO to test float64 precision in objective fields"
+
+  kql_custom_indicator {
+    index           = "my-index-${var.name}"
+    good            = "latency < 300"
+    total           = "*"
+    timestamp_field = "@timestamp"
+  }
+
+  time_window {
+    duration = "7d"
+    type     = "rolling"
+  }
+
+  budgeting_method = "timeslices"
+
+  objective {
+    target           = 0.999
+    timeslice_target = 0.95
+    timeslice_window = "5m"
+  }
+
+  depends_on = [elasticstack_elasticsearch_index.my_index]
+}

--- a/internal/kibana/slo/testdata/TestAccResourceSloHistogramFloatPrecision/test/test.tf
+++ b/internal/kibana/slo/testdata/TestAccResourceSloHistogramFloatPrecision/test/test.tf
@@ -1,0 +1,54 @@
+variable "name" {
+  type = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+}
+
+resource "elasticstack_elasticsearch_index" "my_index" {
+  name                = "my-index-${var.name}"
+  deletion_protection = false
+}
+
+# Regression test for https://github.com/elastic/terraform-provider-elasticstack/issues/2400.
+# The histogram_custom_indicator good/total from and to fields were float32 in the
+# generated client. Values like 0.001 are not exactly representable in float32:
+#   float64(float32(0.001)) = 0.0010000000474974513
+# causing a "provider produced inconsistent result after apply" error.
+resource "elasticstack_kibana_slo" "test_slo" {
+  name        = var.name
+  slo_id      = "id-${var.name}"
+  description = "SLO to test float64 precision in histogram range fields"
+
+  histogram_custom_indicator {
+    index           = "my-index-${var.name}"
+    timestamp_field = "@timestamp"
+
+    good {
+      field       = "duration"
+      aggregation = "range"
+      from        = 0.001
+      to          = 1.0
+    }
+
+    total {
+      field       = "duration"
+      aggregation = "value_count"
+    }
+  }
+
+  time_window {
+    duration = "7d"
+    type     = "rolling"
+  }
+
+  budgeting_method = "occurrences"
+
+  objective {
+    target = 0.999
+  }
+
+  depends_on = [elasticstack_elasticsearch_index.my_index]
+}


### PR DESCRIPTION
## Summary

Fixes #2396. Fixes #2400.

PR #2323 migrated the SLO resource to the shared \`kbapi\` client. The Kibana OpenAPI spec uses \`type: number\` (without \`format\`) for SLO floating-point fields; oapi-codegen maps this to \`float32\`. This caused a **\`Provider produced inconsistent result after apply\`** error for any value not exactly representable in float32:

```
float64(float32(0.999))  = 0.9990000128746033   ≠   0.999   (objective target)
float64(float32(0.001))  = 0.0010000000474974513 ≠   0.001   (histogram range from)
```

**Fix:** add a \`fixSloFloatFormats\` transformer in \`generated/kbapi/transform_schema.go\` that injects \`format: double\` on all SLO floating-point fields before codegen runs. oapi-codegen then emits \`float64\`, preserving full IEEE-754 double precision through the provider read/write cycle.

Fields updated (all previously \`float32\`, now \`float64\`):
- \`SLOs_objective\`: \`target\`, \`timesliceTarget\`
- \`SLOs_indicator_properties_histogram\`: \`good.from\`, \`good.to\`, \`total.from\`, \`total.to\`
- \`SLOs_indicator_properties_apm_latency\`: \`params.threshold\`
- \`SLOs_indicator_properties_timeslice_metric\`: \`metric.threshold\`
- \`SLOs_timeslice_metric_percentile_metric\`: \`percentile\`

The now-unnecessary conversion helpers (\`float32ToFloat64\`, \`float64PtrToFloat32Ptr\`, \`float32PtrToFloat64Ptr\`) are removed.

## Test plan

- [x] Unit tests pass (\`go test ./internal/kibana/slo/\` — 44 tests)
- [x] New acceptance test \`TestAccResourceSloFloatPrecision\` creates an SLO with \`target = 0.999\` / \`timeslice_target = 0.95\` and verifies both values round-trip without corruption (#2396)
- [x] New acceptance test \`TestAccResourceSloHistogramFloatPrecision\` creates a histogram-indicator SLO with \`good.from = 0.001\` and verifies it round-trips without corruption (#2400)
- [x] Full SLO acceptance test suite passes (14 tests, stack 9.4.0-SNAPSHOT)

## Changelog
Customer impact: fix
Summary: Fix "provider produced inconsistent result after apply" for SLO resources when objective target, timeslice target, or histogram range from/to values are not exactly representable in float32

🤖 Generated with [Claude Code](https://claude.com/claude-code)