### PR TITLE
chore(openspec): add release-pr-no-changelog-label change proposal

### DIFF
--- a/openspec/changes/release-pr-no-changelog-label/.openspec.yaml
+++ b/openspec/changes/release-pr-no-changelog-label/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/release-pr-no-changelog-label/design.md
+++ b/openspec/changes/release-pr-no-changelog-label/design.md
@@ -1,0 +1,25 @@
+## Context
+
+The `prep-release.yml` workflow creates (or reuses) a pull request targeting `main` that bumps the provider version. The changelog generator workflow (`ci-changelog-generation`) runs on pull requests and may generate a changelog entry for this PR. Since the release-prep PR only contains a version bump (and changelog content is injected separately), it must carry the `no-changelog` label so the changelog generator knows to skip it.
+
+The `gh` CLI (already available in the workflow) supports adding labels via `--label` on `gh pr create` and via `gh pr edit --add-label` for existing PRs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure the `no-changelog` label is present on the release PR whenever the workflow runs — whether the PR is newly created or already exists.
+
+**Non-Goals:**
+- Creating the `no-changelog` label in the repo (it must already exist; documented as a pre-condition).
+- Modifying how the changelog generator identifies release PRs.
+
+## Decisions
+
+**Apply label at creation and on reuse** — `gh pr create` accepts `--label` directly, so new PRs get the label atomically. For reused PRs, a dedicated `gh pr edit --add-label` step is added immediately after the existing-PR check to ensure idempotency regardless of how the PR was originally created.
+
+Applying the label separately (rather than only at creation) means the label will be present even when the workflow is rerun on an existing PR that lacked the label.
+
+## Risks / Trade-offs
+
+- **Label must exist in the repo**: `gh pr create --label no-changelog` fails if the label doesn't exist. → Pre-condition is documented in the spec; the label is expected to already be present in the repository.
+- **Minimal blast radius**: Only two lines of the workflow change — one `--label` flag addition and one new `gh pr edit` step. No other workflow logic is affected.

--- a/openspec/changes/release-pr-no-changelog-label/proposal.md
+++ b/openspec/changes/release-pr-no-changelog-label/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The prepare-release workflow creates a PR that bumps the `VERSION` in `Makefile`, but this PR should not itself appear as a changelog entry. Without the `no-changelog` label, the changelog generator may attempt to generate a changelog entry for the release-preparation PR itself, which is incorrect.
+
+## What Changes
+
+- The `prep-release.yml` workflow will apply the `no-changelog` label to the release PR when creating it, and will also apply it to any existing (reused) PR.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None — this is a behaviour fix to an existing workflow -->
+
+### Modified Capabilities
+
+- `ci-release-pr-preparation`: The release PR creation and reuse steps must apply the `no-changelog` label to the PR.
+
+## Impact
+
+- `.github/workflows/prep-release.yml` — `gh pr create` call gains `--label no-changelog`; a new step is added to label an existing PR when it is reused.
+- `openspec/specs/ci-release-pr-preparation/spec.md` — new requirement and scenario for the `no-changelog` label.
+- No API, dependency, or other system changes required.

--- a/openspec/changes/release-pr-no-changelog-label/specs/ci-release-pr-preparation/spec.md
+++ b/openspec/changes/release-pr-no-changelog-label/specs/ci-release-pr-preparation/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Release PR carries the no-changelog label
+The release preparation workflow SHALL apply the `no-changelog` label to the release PR. This label SHALL be present whether the PR is newly created or already exists (reused on a rerun). The `no-changelog` label is assumed to exist in the repository as a pre-condition.
+
+#### Scenario: New PR is created with no-changelog label
+- **WHEN** the workflow creates a new release PR
+- **THEN** the PR SHALL have the `no-changelog` label applied at creation time
+
+#### Scenario: Existing PR is labelled on reuse
+- **GIVEN** a release PR for the target version already exists
+- **WHEN** the workflow reruns and reuses that existing PR
+- **THEN** the workflow SHALL apply the `no-changelog` label to the existing PR
+- **AND** the label application SHALL be idempotent (re-applying an already-present label SHALL NOT cause an error)

--- a/openspec/changes/release-pr-no-changelog-label/tasks.md
+++ b/openspec/changes/release-pr-no-changelog-label/tasks.md
@@ -1,0 +1,8 @@
+## 1. Update prep-release workflow
+
+- [ ] 1.1 Add `--label no-changelog` to the `gh pr create` call in the "Create release PR" step of `.github/workflows/prep-release.yml`
+- [ ] 1.2 Add a new step after "Check if release PR already exists" that runs `gh pr edit --add-label no-changelog` when the PR already exists (`steps.pr-check.outputs.EXISTS == 'true'`)
+
+## 2. Update spec
+
+- [ ] 2.1 Sync the delta spec (`openspec/changes/release-pr-no-changelog-label/specs/ci-release-pr-preparation/spec.md`) into the canonical spec at `openspec/specs/ci-release-pr-preparation/spec.md`


### PR DESCRIPTION
## Summary

Adds an OpenSpec change proposal to apply the `no-changelog` label to PRs created by the prepare-release workflow.

## Why

The `prep-release.yml` workflow creates a PR that bumps `VERSION` in `Makefile`. Without the `no-changelog` label, the changelog generator may generate a spurious changelog entry for this release-prep PR. This change ensures the label is applied both when creating new PRs and when reusing existing ones (idempotent).

## Artifacts

- `proposal.md` — problem statement and scope
- `design.md` — implementation approach (`--label` flag + `gh pr edit` step for existing PRs)
- `specs/ci-release-pr-preparation/spec.md` — delta spec with two new scenarios
- `tasks.md` — implementation checklist

## Next steps

Implementation tasks are tracked in `tasks.md`. Run `/opsx:apply` to implement.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenSpec change proposal for applying `no-changelog` label to release PRs
> - adds a proposal, design doc, spec, and task list under `openspec/changes/release-pr-no-changelog-label/` to ensure release PRs carry the `no-changelog` label
> - the design specifies applying the label on PR creation via `gh pr create --label` and idempotently on PR reuse via `gh pr edit --add-label`
> - tasks cover updating the prep-release workflow and syncing the delta spec into the canonical spec
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e543a25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->