### PR TITLE
Ensure changelog is up to date in release prep

### DIFF
--- a/openspec/changes/shared-changelog-engine/.openspec.yaml
+++ b/openspec/changes/shared-changelog-engine/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/shared-changelog-engine/design.md
+++ b/openspec/changes/shared-changelog-engine/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The current changelog automation mixes two concerns in one workflow: scheduled maintenance of the `## [Unreleased]` section and release-specific regeneration of a concrete `## [x.y.z] - <date>` section. Release mode is currently activated from `pull_request_target` events on `prep-release-*` branches, which makes final release changelog generation depend on PR event delivery and timing rather than on the release-preparation workflow that actually owns the release branch contents.
+
+The repository already contains deterministic changelog parsing and rendering logic spread across inline `actions/github-script` steps, small shared JavaScript helpers under `.github/workflows-src/lib/`, and a small `scripts/changelog-generation` Go entrypoint. The target design should preserve deterministic assembly and existing PR-body changelog-contract rules, while moving release-mode invocation to an explicit synchronous step in release preparation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Introduce a shared repository-authored changelog engine that can be invoked from multiple workflows with explicit mode inputs.
+- Make `prep-release.yml` responsible for invoking release-mode changelog generation before it creates or updates the release PR.
+- Keep scheduled unreleased generation in `changelog-generation.yml` and add an explicit manual `workflow_dispatch` release-mode fallback in the same workflow.
+- Keep changelog assembly fail-fast: invalid or missing PR changelog contracts in the authoritative range must fail release preparation and manual release regeneration.
+- Keep workflow orchestration responsibilities separate from changelog assembly responsibilities.
+
+**Non-Goals:**
+- Changing the PR-body changelog contract itself.
+- Changing the singleton `generated-changelog` branch/PR model for unreleased maintenance.
+- Introducing agentic changelog synthesis or LLM-authored release notes.
+- Generalizing the engine into a cross-repository tool.
+
+## Decisions
+
+### Use an explicit shared changelog engine instead of event-inferred release mode
+The changelog engine will be invoked with explicit workflow inputs that select `release` or `unreleased` mode. Release-mode behavior will no longer be inferred from `pull_request_target` event metadata.
+
+This makes release preparation deterministic and enables a manual release fallback without needing synthetic PR events. It also removes the need for the changelog engine to interpret GitHub event shape as its primary control surface.
+
+**Alternatives considered:**
+- Keep `pull_request_target` as the release trigger: rejected because release preparation should not depend on downstream PR-event timing.
+- Use `workflow_run` or dispatch from `prep-release.yml`: rejected because explicit synchronous invocation inside release preparation is simpler and provides fail-fast semantics.
+
+### The shared engine resolves merged PRs through the GitHub API using the workflow token
+The engine will own authoritative-range discovery and merged-PR resolution, including GitHub API lookups needed to map commits in the compare range to merged pull requests and to retrieve their bodies, labels, and other required metadata. Workflows will provide authenticated environment context through the built-in workflow token.
+
+This keeps the core changelog assembly path self-contained and reusable across release and unreleased modes. It also avoids splitting the authoritative changelog assembly pipeline between workflow glue and engine internals.
+
+**Alternatives considered:**
+- Have workflows gather merged PR metadata and pass a manifest into the engine: rejected because it leaves key release-note semantics distributed across multiple workflows.
+- Use only local git metadata without GitHub API resolution: rejected because PR labels and bodies are authoritative inputs to changelog assembly.
+
+### Workflows remain responsible for checkout, commit/push, and PR management
+The shared engine will mutate `CHANGELOG.md` in the checked-out worktree and emit structured outputs such as compare range, target version, and whether user-facing changes were rendered. Workflows will continue to own branch checkout, commit creation, push destination, PR create/reuse logic, `no-changelog` labeling, and PR body refresh.
+
+This keeps the engine focused on deterministic content generation and preserves straightforward workflow ownership of repository mutations beyond the changelog file itself.
+
+**Alternatives considered:**
+- Move PR creation/editing into the engine: rejected because it would blur content generation with branch/PR orchestration and make testing/retries more complex.
+
+### Release preparation produces a single release-preparation commit
+`prep-release.yml` will combine the version bump and final release changelog update into a single deterministic release-preparation commit before pushing the branch.
+
+This matches the desired operator experience: the workflow should leave behind a ready-to-review release PR whose content already reflects the final version bump and release changelog section.
+
+**Alternatives considered:**
+- Separate commits for version bump and changelog update: rejected because it adds orchestration complexity without meaningful review benefits in a squash-merge workflow.
+
+### Manual release fallback lives in the existing changelog-generation workflow via dispatch inputs
+`changelog-generation.yml` will continue to serve scheduled unreleased maintenance, and its `workflow_dispatch` entrypoint will accept explicit inputs for release-mode execution (including target version) so maintainers can manually regenerate a release section when needed.
+
+This preserves a single operational place for changelog regeneration without keeping automatic release-mode triggers.
+
+**Alternatives considered:**
+- Create a separate manual recovery workflow: rejected because the same engine and workflow can support both scheduled unreleased runs and explicit release-mode recovery cleanly.
+
+## Risks / Trade-offs
+
+- **Engine extraction touches multiple existing code paths** → Mitigation: preserve current parsing/rendering semantics and move logic behind stable tests before simplifying workflow glue.
+- **Using the workflow token for GitHub API resolution couples the engine to Actions execution context** → Mitigation: make the token/env contract explicit and keep workflow-side authentication simple and standard.
+- **Removing `pull_request_target` eliminates automatic release-mode retries on PR activity** → Mitigation: release preparation becomes the primary synchronous path, and `workflow_dispatch` provides explicit manual recovery.
+- **Single-commit release preparation changes commit shape** → Mitigation: document the new deterministic commit behavior in the release-preparation spec and workflow output.
+
+## Migration Plan
+
+1. Extract or consolidate the deterministic changelog engine behind a reusable repository-authored script interface.
+2. Update `prep-release.yml` to invoke the engine in release mode after applying the version bump and before creating/updating the PR.
+3. Update `changelog-generation.yml` and its template to remove `pull_request_target`, add explicit `workflow_dispatch` inputs for release mode, and invoke the shared engine in unreleased or release mode accordingly.
+4. Preserve or adapt PR-management helper logic so unreleased mode still maintains the singleton `generated-changelog` PR and release mode can refresh release PR metadata when manually dispatched.
+5. Regenerate the compiled workflow YAML and validate behavior through existing and new tests.
+
+## Open Questions
+
+- None at proposal time.

--- a/openspec/changes/shared-changelog-engine/proposal.md
+++ b/openspec/changes/shared-changelog-engine/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The final release changelog update currently depends on `ci-changelog-generation` being triggered indirectly from release-preparation pull-request activity. That coupling makes release preparation less reliable than it should be, because the release PR can exist before the final changelog section has been regenerated. Release preparation should deterministically produce a ready-to-review PR, including the final concrete changelog section, and still preserve a manual recovery path.
+
+## What Changes
+
+- Refactor changelog-generation logic into a shared repository-authored script/engine that resolves merged PRs via the GitHub API using the workflow token, parses PR-body changelog contracts, and rewrites `CHANGELOG.md` deterministically.
+- Update `prep-release.yml` to invoke the shared changelog engine directly in release mode during release preparation, so release preparation fails immediately when changelog assembly fails.
+- Simplify `changelog-generation.yml` so its automatic triggers only cover scheduled unreleased maintenance, while `workflow_dispatch` also supports an explicit release mode via inputs.
+- Remove the `pull_request_target` release trigger path from the changelog-generation workflow and replace event-inferred release mode with explicit workflow inputs.
+- Keep workflow responsibilities limited to checkout, commit/push, PR create/reuse/labeling, and PR metadata updates around the shared engine.
+
+## Capabilities
+
+### New Capabilities
+<!-- None -->
+
+### Modified Capabilities
+- `ci-changelog-generation`: Change workflow triggering and operating-mode selection so scheduled automation maintains the unreleased changelog, while release-mode execution is invoked explicitly and uses a shared repository-authored engine.
+- `ci-release-pr-preparation`: Change release preparation so the workflow deterministically generates the final release changelog section during preparation and creates a single ready-to-review release-preparation commit/PR.
+
+## Impact
+
+- `.github/workflows/prep-release.yml`
+- `.github/workflows/changelog-generation.yml`
+- `.github/workflows-src/changelog-generation/workflow.yml.tmpl`
+- changelog-generation helper code under `.github/workflows-src/lib/` and/or `scripts/changelog-generation/`
+- OpenSpec specs for `ci-changelog-generation` and `ci-release-pr-preparation`

--- a/openspec/changes/shared-changelog-engine/specs/ci-changelog-generation/spec.md
+++ b/openspec/changes/shared-changelog-engine/specs/ci-changelog-generation/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Workflow artifacts and operating modes
+The changelog generator SHALL be authored as a deterministic workflow template under `.github/workflows-src/` and SHALL generate a checked-in workflow YAML artifact under `.github/workflows/` via `scripts/compile-workflow-sources/main.go`. The workflow SHALL NOT require a GH AW markdown source or a compiled `.lock.yml`. The workflow SHALL support:
+
+- a scheduled mode
+- a manual `workflow_dispatch` mode
+- explicit workflow-dispatch inputs that allow maintainers to select `unreleased` or `release` execution mode
+
+#### Scenario: Source and compiled workflow stay paired
+- **WHEN** maintainers change changelog generator behavior
+- **THEN** the `.github/workflows-src/` template and generated `.github/workflows/changelog-generation.yml` SHALL match the current repository compiler output
+
+#### Scenario: Manual dispatch can enter release mode explicitly
+- **WHEN** a maintainer dispatches the changelog generator with inputs selecting `release` mode and a target version
+- **THEN** the workflow SHALL enter release-section generation mode for the checked out target branch without relying on pull-request event metadata
+
+### Requirement: Full-section regeneration uses authoritative ranges
+The changelog generator SHALL regenerate the full target section on each run from an authoritative range rather than appending only “since last run” changes.
+
+- In scheduled/manual unreleased mode, it SHALL regenerate the full `## [Unreleased]` section from the previous semver release tag to `main`.
+- In explicit release mode, it SHALL regenerate the full concrete `## [x.y.z] - <date>` section for the checked out release branch from the previous semver release tag to that branch head.
+- In both modes, release-note content SHALL be assembled from merged pull requests in that authoritative range by parsing their PR-body changelog contract and labels.
+
+#### Scenario: Scheduled run rebuilds full Unreleased
+- **WHEN** the changelog generator runs in scheduled mode
+- **THEN** it SHALL regenerate the entire `## [Unreleased]` section from the authoritative release range instead of incrementally appending entries
+
+#### Scenario: Manual release run rebuilds full release section
+- **WHEN** the changelog generator runs in explicit release mode for a checked out `prep-release-*` branch
+- **THEN** it SHALL regenerate the full `## [x.y.z] - <date>` section for that branch from the authoritative release range instead of incrementally appending entries
+
+### Requirement: Scheduled/manual mode updates the singleton generated changelog PR
+In scheduled or manually dispatched unreleased mode, after deterministic validation succeeds, the workflow SHALL rewrite only the `## [Unreleased]` section of `CHANGELOG.md` and SHALL push the result to the singleton branch named `generated-changelog`. The workflow SHALL use repository-authored GitHub Actions logic to look up an existing pull request from `generated-changelog` to `main`, create that pull request when none exists, and update the existing PR body when one already exists.
+
+#### Scenario: Generated changelog branch PR is reused
+- **GIVEN** the singleton branch `generated-changelog` already has an open pull request to `main`
+- **WHEN** the scheduled/manual unreleased changelog generator runs again
+- **THEN** it SHALL update that same branch and refresh the existing pull request instead of opening a duplicate
+
+#### Scenario: Missing generated changelog PR is created
+- **GIVEN** the singleton branch `generated-changelog` has no open pull request to `main`
+- **WHEN** the scheduled/manual unreleased changelog generator produces an updated `CHANGELOG.md`
+- **THEN** the workflow SHALL create the pull request after pushing the branch update
+
+### Requirement: Explicit release mode updates only the targeted release section
+In explicit release mode, after deterministic validation succeeds, repository-authored helper logic SHALL update only the concrete `## [x.y.z] - <date>` section for the checked out release branch and SHALL push that change only to the targeted release branch. Manual release-mode execution MAY refresh release PR metadata when the corresponding pull request is known, but release-mode changelog generation SHALL NOT depend on `pull_request_target` event metadata or automatic pull-request triggers.
+
+#### Scenario: Release mode updates only the targeted branch
+- **WHEN** the changelog generator runs in explicit release mode for a release-preparation branch
+- **THEN** it SHALL push changelog updates only to that targeted release branch
+
+#### Scenario: Release mode does not rewrite Unreleased on the release branch
+- **WHEN** the changelog generator runs in explicit release mode
+- **THEN** it SHALL regenerate the concrete release section needed for that branch without treating the branch as the singleton `Unreleased` maintenance branch
+
+### Requirement: Merged PR changelog metadata is gathered for deterministic assembly
+Before changelog rendering starts, a shared repository-authored changelog engine SHALL gather the merged pull requests in the authoritative release range and capture the metadata needed for rendering from those PRs by using the GitHub API with the workflow's repository token. For each merged PR, the engine SHALL capture at least the pull request number, URL, merge commit SHA, labels, and pull request body.
+
+#### Scenario: Merged PR body is available to the renderer
+- **WHEN** the shared changelog engine resolves merged pull requests in the authoritative range
+- **THEN** each merged PR considered for changelog assembly SHALL include its body and labels in the renderer input
+
+#### Scenario: Engine uses workflow token for GitHub API lookups
+- **WHEN** changelog assembly needs to resolve merged PRs in the authoritative range
+- **THEN** the shared changelog engine SHALL authenticate GitHub API requests with the workflow-provided repository token rather than requiring a separate credential source

--- a/openspec/changes/shared-changelog-engine/specs/ci-release-pr-preparation/spec.md
+++ b/openspec/changes/shared-changelog-engine/specs/ci-release-pr-preparation/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Release preparation changes are limited to deterministic version bump plumbing
+The release preparation workflow SHALL apply only the deterministic release-preparation changes owned by that workflow. It SHALL update the top-level provider `VERSION` in `Makefile` to the target version, and it SHALL invoke the shared deterministic changelog engine in release mode to regenerate the concrete release section in `CHANGELOG.md` before opening or reusing the release pull request. The workflow SHALL NOT perform agentic changelog synthesis.
+
+#### Scenario: Release-preparation branch includes version bump and final changelog update
+- **WHEN** the workflow prepares a release branch for version `X`
+- **THEN** the branch SHALL contain the deterministic version bump changes owned by the workflow
+- **AND** it SHALL contain the regenerated concrete changelog section for version `X` before the release PR is created or reused
+
+### Requirement: Release branch and pull request are managed deterministically
+After applying its deterministic changes, the workflow SHALL create or update a deterministic release branch named from the target version, SHALL commit the release-preparation changes with a stable release-preparation commit message, SHALL push that branch, and SHALL create or reuse a pull request targeting `main` with a stable release-preparation title.
+
+#### Scenario: Existing release PR is reused on rerun
+- **GIVEN** a release pull request for the target version already exists
+- **WHEN** the workflow is rerun for the same version
+- **THEN** the workflow SHALL update or reuse that release branch and pull request rather than opening a duplicate
+
+#### Scenario: Release preparation uses a single deterministic commit
+- **WHEN** the workflow prepares a release branch for version `X`
+- **THEN** it SHALL combine the deterministic version bump and release changelog update into a single release-preparation commit before pushing the branch
+
+### Requirement: Release PR can be regenerated manually without pull-request-triggered automation
+The release preparation workflow SHALL prepare release branches so that the changelog-generation workflow can be rerun manually in explicit release mode for the same target version, without requiring `pull_request_target` or other pull-request-triggered changelog automation.
+
+#### Scenario: Manual release regeneration targets an existing prep-release branch
+- **GIVEN** a release-preparation branch for version `X` already exists
+- **WHEN** a maintainer manually dispatches the changelog-generation workflow in release mode for version `X`
+- **THEN** the workflow SHALL be able to regenerate the concrete release changelog section for that branch without requiring a new pull-request event

--- a/openspec/changes/shared-changelog-engine/tasks.md
+++ b/openspec/changes/shared-changelog-engine/tasks.md
@@ -1,0 +1,17 @@
+## 1. Extract the shared changelog engine
+
+- [ ] 1.1 Identify the current changelog-generation logic that must move behind a shared repository-authored script interface, including release-context resolution, merged-PR discovery, changelog parsing/validation, rendering, and `CHANGELOG.md` rewriting
+- [ ] 1.2 Implement the shared engine so it accepts explicit mode inputs (`unreleased` or `release`, with explicit target version for release mode), resolves merged PRs through the GitHub API using the workflow token, and emits structured outputs needed by workflows
+- [ ] 1.3 Preserve or add automated tests covering deterministic assembly, release/unreleased mode selection, GitHub-backed merged-PR resolution, and changelog-section rewriting behavior
+
+## 2. Update changelog-generation workflow behavior
+
+- [ ] 2.1 Refactor `.github/workflows-src/changelog-generation/workflow.yml.tmpl` and generated workflow output to remove `pull_request_target`, add explicit `workflow_dispatch` inputs for release mode, and invoke the shared engine in both scheduled unreleased mode and manual release mode
+- [ ] 2.2 Keep unreleased-mode branch/PR management in workflow orchestration, ensuring scheduled or manually dispatched unreleased runs still maintain the singleton `generated-changelog` PR
+- [ ] 2.3 Preserve or update workflow-source helper tests/fixtures so compiled workflow behavior and manual release-mode dispatch semantics are covered
+
+## 3. Update release preparation workflow
+
+- [ ] 3.1 Refactor `.github/workflows/prep-release.yml` to invoke the shared changelog engine in release mode after applying the version bump and before PR creation/reuse
+- [ ] 3.2 Update release preparation to produce a single deterministic commit containing both the version bump and final release changelog update, while retaining deterministic branch naming, PR reuse, and `no-changelog` labeling
+- [ ] 3.3 Verify the updated workflow behavior and sync the canonical specs affected by release preparation and changelog generation


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec design and requirements for a shared changelog engine in release preparation
- Documents a planned refactor to extract a shared changelog engine that operates in two explicit modes: `unreleased` (scheduled/manual) and `release` (triggered during release prep).
- The release preparation workflow will invoke the engine before PR creation, producing a single deterministic commit that includes the versioned changelog section.
- The changelog-generation workflow drops `pull_request_target` triggers in favor of `schedule` and `workflow_dispatch` with explicit mode inputs, and manages a singleton generated-changelog PR in unreleased mode.
- The shared engine resolves merged PRs via GitHub API using the workflow token, capturing PR body and labels as changelog data sources.
- Added specs, a design doc, a proposal, and a task checklist under [openspec/changes/shared-changelog-engine/](https://github.com/elastic/terraform-provider-elasticstack/pull/2411/files#diff-ea4666340d01ca8d9bb8d101ddf23edf9c6524857b9bcc58b27dd5c9cb20d018).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized a77d77d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->