### PR TITLE
Proposed fixes to the spec impact workflow

### DIFF
--- a/openspec/changes/fix-kibana-spec-impact-workflow/.openspec.yaml
+++ b/openspec/changes/fix-kibana-spec-impact-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/fix-kibana-spec-impact-workflow/design.md
+++ b/openspec/changes/fix-kibana-spec-impact-workflow/design.md
@@ -1,0 +1,102 @@
+## Context
+
+The `kibana-spec-impact` GH AW workflow is currently split across three incompatible execution contexts:
+
+- pre-activation runs an inline `actions/github-script` wrapper that shells out to the Go helper, computes gate outputs, and writes the report into the repository workspace;
+- repo memory is configured for the workflow, but pre-activation does not have the checkout and initialization needed to rely on that memory path by default;
+- the agent job expects the deterministic report to still exist as a repo-root file even though job boundaries only preserve explicit artifacts.
+
+That split makes the workflow fragile. The deterministic report and gate contract are partly in JavaScript and partly in Go, pre-activation cannot reliably consume persisted repo memory, and the agent instructions describe file paths that are not durable between jobs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the deterministic pre-activation flow self-contained around repository-local Go helper logic.
+- Ensure pre-activation has the repository checkout and repo-memory context it needs before computing Kibana spec impact.
+- Preserve the impact report across job boundaries using an explicit workflow artifact downloaded into `/tmp/gh-aw/agent`.
+- Align the agent instructions with the actual runtime paths used in the agent job.
+- Keep the authored template and compiled workflow artifacts in sync.
+
+**Non-Goals:**
+
+- Changing the matching heuristics for `high_confidence_impacts`, transform hints, or duplicate suppression semantics.
+- Changing the issue body policy, issue cap, or repo-memory branch layout beyond what is needed for correct workflow execution.
+- Replacing GH AW with a plain GitHub Actions workflow.
+
+## Decisions
+
+### 1. Move pre-activation orchestration into the Go helper
+
+The Go helper under `scripts/kibana-spec-impact/` will own the deterministic pre-activation flow: memory bootstrap if needed, impact report generation, gate derivation, and report-file writing.
+
+Rationale:
+
+- It removes the current split where JavaScript computes gate outputs after parsing Go output.
+- It keeps the workflow contract in repository-local code that is easier to test with existing Go tests.
+- It reduces template complexity and avoids embedding brittle orchestration logic in `actions/github-script`.
+
+Alternatives considered:
+
+- Keep the current inline script and only change paths. Rejected because it preserves the current duplication and leaves gate logic split across languages.
+- Move all computation into shell steps. Rejected because structured JSON and gate outputs are better handled in the existing Go helper surface.
+
+### 2. Initialize checkout and repo memory during pre-activation
+
+`on.steps` will explicitly check out the repository before Go setup and use a custom pre-activation sequence that makes repo memory available before the compute step runs. The workflow will declare the repo-memory `branch-name` explicitly and use a dedicated checkout/init step that targets that same branch for pre-activation setup.
+
+Rationale:
+
+- Pre-activation is where the workflow chooses the baseline and emits the deterministic report, so it must have the same memory context the agent later persists.
+- The current agent-only memory initialization is too late for report generation and gating.
+- Making the branch explicit avoids relying on GH AW defaults and ensures the pre-activation bootstrap step and the `repo-memory` tool definition stay aligned.
+
+Alternatives considered:
+
+- Continue using fallback temporary memory during pre-activation. Rejected because it breaks continuity with the persisted workflow baseline.
+- Recompute or repair memory state in the agent job only. Rejected because the agent should consume precomputed deterministic evidence, not rebuild it.
+- Rely on the implicit default repo-memory branch. Rejected because the design now depends on a separate initialization step, so the branch contract should be explicit in frontmatter and in the checkout/init step.
+
+### 3. Use an artifact handoff for the deterministic report
+
+Pre-activation will upload the report as a named GitHub Actions artifact, and the agent job will download it into `/tmp/gh-aw/agent`.
+
+Rationale:
+
+- Artifacts are the durable workflow primitive for passing files between jobs.
+- This matches an existing repository pattern already used by the changelog workflow.
+- It lets the prompt reference a stable agent-local path rather than an implicit workspace carry-over.
+
+Alternatives considered:
+
+- Keep writing to the repo root. Rejected because job-local workspaces do not survive automatically.
+- Encode the full report into job outputs. Rejected because the report is structured file content and can grow beyond what is comfortable to manage as outputs.
+
+### 4. Make agent instructions path-accurate
+
+The prompt will describe the report and issued-file locations under `/tmp/gh-aw/agent`, while memory persistence will continue to target `/tmp/gh-aw/repo-memory/kibana-spec-impact/...`.
+
+Rationale:
+
+- The agent instructions should describe the real filesystem contract of the generated workflow.
+- Separating ephemeral agent artifacts from durable repo memory keeps the workflow model clear.
+
+## Risks / Trade-offs
+
+- [Workflow generation drift] -> Regenerate both the source-derived markdown and the compiled lockfile as part of the change and verify them with workflow-specific checks.
+- [Helper interface churn] -> Keep the new Go helper surface narrow and reuse existing report and memory code paths rather than rewriting them.
+- [Artifact/path mismatch] -> Update both workflow orchestration and prompt text in the same change so the generated workflow and agent instructions stay consistent.
+
+## Migration Plan
+
+1. Extend the Go helper to support the pre-activation gate-and-report contract.
+2. Update the workflow source template to add an explicit repo-memory `branch-name`, pre-activation checkout/memory setup for that branch, and artifact upload/download wiring.
+3. Rewrite prompt references to the agent artifact paths.
+4. Regenerate the committed workflow artifacts.
+5. Run focused workflow checks before merge.
+
+Rollback is straightforward: revert the change to restore the previous inline-script and workspace-file behavior if the generated workflow fails unexpectedly.
+
+## Open Questions
+
+- Whether the Go helper should expose the new pre-activation contract as a dedicated subcommand or as an extension of the existing `report` command can be finalized during implementation, as long as the deterministic outputs remain testable and the workflow no longer depends on inline JavaScript gate logic.

--- a/openspec/changes/fix-kibana-spec-impact-workflow/proposal.md
+++ b/openspec/changes/fix-kibana-spec-impact-workflow/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `kibana-spec-impact` workflow currently splits deterministic pre-activation logic across an inline GitHub Script step, agent-only repo-memory initialization, and repo-root JSON files that do not survive the handoff into later jobs. That leaves the workflow brittle: pre-activation cannot reliably use repo memory, the report path is not durable between jobs, and the agent instructions point at files that are not guaranteed to exist in the agent environment.
+
+## What Changes
+
+- Move the pre-activation compute-and-gate flow behind the repository Go helper so the workflow does not depend on an inline `actions/github-script` step for Kibana spec-impact computation.
+- Update `on.steps` to check out the repository before Go setup and to initialize repo memory during pre-activation rather than only in the agent job, using a dedicated checkout/init step against the same explicit repo-memory branch configured in the workflow.
+- Upload the deterministic Kibana spec-impact report as a GitHub Actions artifact in pre-activation and download it into `/tmp/gh-aw/agent` for the agent job.
+- Update the agent instructions to read the downloaded report artifact and to write any agent-produced JSON support files under `/tmp/gh-aw/agent`.
+- Regenerate the derived workflow markdown and lockfile so the authored template and compiled workflow stay aligned.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `ci-kibana-spec-impact-issues`: tighten the workflow contract so pre-activation has access to repo memory through an explicit configured branch, deterministic impact evidence is handed off durably between jobs via artifact download into `/tmp/gh-aw/agent`, and the agent consumes the downloaded artifact paths rather than ephemeral repo-root files.
+
+## Impact
+
+- Workflow source under `.github/workflows-src/kibana-spec-impact/`
+- Compiled workflow artifacts under `.github/workflows/`
+- Kibana spec-impact helper CLI under `scripts/kibana-spec-impact/`
+- Workflow generation and validation flows (`workflow-generate`, `make workflow-test`, `make check-workflows`)

--- a/openspec/changes/fix-kibana-spec-impact-workflow/specs/ci-kibana-spec-impact-issues/spec.md
+++ b/openspec/changes/fix-kibana-spec-impact-workflow/specs/ci-kibana-spec-impact-issues/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Workflow runs for Kibana spec-impact analysis
+
+The repository SHALL provide a GitHub workflow for Kibana spec-impact analysis that can run automatically for Kibana generated-client changes on the default branch and can also be started manually. The workflow SHALL evaluate a persisted baseline revision so that analysis compares the current target revision to the last processed Kibana spec-impact baseline rather than only to the immediately previous commit. Before deterministic pre-activation analysis runs, the workflow SHALL initialize the repository checkout and the configured repo-memory context needed for baseline-aware computation. The repo-memory configuration SHALL declare the memory branch explicitly, and pre-activation initialization SHALL use that same configured branch.
+
+#### Scenario: Push to default branch triggers analysis
+- **WHEN** a push to the default branch includes changes to the Kibana spec-impact inputs for this workflow
+- **THEN** the workflow SHALL evaluate those changes against the stored baseline revision
+
+#### Scenario: Maintainer reruns analysis manually
+- **WHEN** a maintainer starts the workflow manually
+- **THEN** the workflow SHALL run the same baseline-aware analysis flow without requiring a new Kibana spec change to arrive first
+
+#### Scenario: Pre-activation computes against initialized repo memory
+- **WHEN** the workflow enters its pre-activation phase to determine whether agent analysis should run
+- **THEN** the workflow SHALL have already checked out the repository and initialized the configured repo-memory path used for Kibana spec-impact baseline state
+
+#### Scenario: Pre-activation init uses explicit repo-memory branch
+- **WHEN** the workflow configures repo memory for Kibana spec-impact analysis
+- **THEN** it SHALL declare the repo-memory `branch-name` explicitly and the pre-activation checkout/init step SHALL target that same branch rather than relying on an implicit default
+
+### Requirement: Deterministic helper emits entity impact evidence
+
+The workflow SHALL use deterministic repository-local helper tooling to derive the canonical Kibana entity inventory from provider registrations, diff tracked Kibana generated-client inputs against the selected baseline, emit structured impact evidence for matching entities, and derive workflow gate outputs from that deterministic report. In V1, the helper SHALL only claim high-confidence impact for entities that can be matched through `generated/kbapi` and `internal/clients/kibanaoapi` usage.
+
+#### Scenario: Helper discovers registered entities from provider code
+- **WHEN** the helper prepares entity inventory for a workflow run
+- **THEN** it SHALL derive Kibana resources and data sources from the repository's registered provider implementations rather than from a handwritten entity manifest
+
+#### Scenario: Helper reports matched entities with evidence
+- **WHEN** the helper finds changed Kibana client symbols referenced by a supported entity
+- **THEN** it SHALL emit structured evidence that includes the impacted entity name, entity type, matched implementation path, and the changed methods or types that produced the match
+
+#### Scenario: Helper derives workflow gate from deterministic report
+- **WHEN** pre-activation computes the Kibana spec-impact report
+- **THEN** the repository-local helper SHALL also emit the gate values needed by the workflow, including whether the agent should run, the issue cap, the high-confidence count, and the gate reason
+
+#### Scenario: Unsupported client surfaces remain out of high-confidence scope
+- **WHEN** a changed Kibana-facing entity depends only on unsupported V1 client surfaces such as `generated/slo`
+- **THEN** the helper SHALL NOT classify that entity as a high-confidence impacted entity in V1
+
+## ADDED Requirements
+
+### Requirement: Deterministic report is handed to the agent via artifact
+
+The workflow SHALL preserve the deterministic Kibana spec-impact report across job boundaries by uploading it as a workflow artifact during pre-activation and downloading it into `/tmp/gh-aw/agent` for the agent job. The agent SHALL read the report from the downloaded artifact location and SHALL write any run-local JSON support files for this flow under `/tmp/gh-aw/agent`, while continuing to persist durable repo-memory state under the configured `/tmp/gh-aw/repo-memory/...` path.
+
+#### Scenario: Pre-activation uploads the deterministic report
+- **WHEN** pre-activation successfully generates the Kibana spec-impact report
+- **THEN** the workflow SHALL upload that report as an artifact for later jobs instead of relying on a repo-root workspace file surviving job handoff
+
+#### Scenario: Agent consumes downloaded report artifact
+- **WHEN** the agent job starts after a successful pre-activation run
+- **THEN** the workflow SHALL download the report artifact into `/tmp/gh-aw/agent`, and the agent instructions SHALL reference that downloaded path as the source of truth for report input
+
+#### Scenario: Agent writes issued entities beside the downloaded report
+- **WHEN** the agent records which high-confidence entities actually received issues in the current run
+- **THEN** it SHALL write the issued-entities JSON file under `/tmp/gh-aw/agent` and use that file when invoking repo-memory persistence

--- a/openspec/changes/fix-kibana-spec-impact-workflow/tasks.md
+++ b/openspec/changes/fix-kibana-spec-impact-workflow/tasks.md
@@ -1,0 +1,16 @@
+## 1. Helper contract
+
+- [ ] 1.1 Extend `scripts/kibana-spec-impact/` so the repository-local Go helper can perform the deterministic pre-activation flow: initialize memory when needed, compute the report, derive gate outputs, and write the report file used by the workflow.
+- [ ] 1.2 Add or update focused Go tests covering the pre-activation gate/report contract, including the emitted gate fields and report-file behavior.
+
+## 2. Workflow orchestration
+
+- [ ] 2.1 Update `.github/workflows-src/kibana-spec-impact/workflow.md.tmpl` so `on.steps` checks out the repository before Go setup, declares the repo-memory `branch-name` explicitly, and initializes repo memory with a dedicated checkout/init step against that same branch before computing Kibana spec impact.
+- [ ] 2.2 Replace the current pre-activation report handoff with an explicit artifact upload in pre-activation and artifact download into `/tmp/gh-aw/agent` in the agent job.
+- [ ] 2.3 Rewrite the agent instructions so report and issued-file references point at `/tmp/gh-aw/agent`, while repo-memory persistence continues to use the configured `/tmp/gh-aw/repo-memory/...` path.
+
+## 3. Generated artifacts and verification
+
+- [ ] 3.1 Remove or retire obsolete inline workflow helper code if it is no longer referenced after the Go-based pre-activation flow lands.
+- [ ] 3.2 Regenerate `.github/workflows/kibana-spec-impact.md` and `.github/workflows/kibana-spec-impact.lock.yml` from the updated source template.
+- [ ] 3.3 Run `make workflow-test` and `make check-workflows`, then confirm the generated workflow contains the new checkout, repo-memory initialization, artifact handoff, and `/tmp/gh-aw/agent` prompt paths.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design, proposal, and spec for fixing the Kibana spec-impact workflow
- Adds an OpenSpec change descriptor, design doc, proposal, spec, and task list under [openspec/changes/fix-kibana-spec-impact-workflow/](https://github.com/elastic/terraform-provider-elasticstack/pull/2417/files#diff-091b18f7e01155927fade8c49096c3d7ebe3c2d219fdfd1422a7d69739c58173) to document and plan fixes to the `ci-kibana-spec-impact-issues` workflow.
- Moves pre-activation orchestration (checkout, repo-memory initialization with explicit branch) into the Go helper to reduce workflow complexity.
- Defines an artifact handoff pattern where the helper writes the spec-impact report to `/tmp/gh-aw/agent` and the agent writes issued entities beside it, replacing the current ad-hoc path handling.
- Updates agent instructions to align with the new runtime paths and helper contract.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6933982.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->