### PR TITLE
Proposed duplicate change detector

### DIFF
--- a/openspec/changes/duplicate-code-detector-workflow/.openspec.yaml
+++ b/openspec/changes/duplicate-code-detector-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/duplicate-code-detector-workflow/design.md
+++ b/openspec/changes/duplicate-code-detector-workflow/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The repository has added a `duplicate-code-detector` GitHub Agentic Workflow that periodically inspects recent repository changes for meaningful code duplication and opens follow-up issues for refactoring. The repository-authored workflow is derived from the upstream `gh-aw` source at `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md` and then adapted to fit the existing repository pattern: authored workflow source lives under `.github/workflows-src/`, checked-in generated artifacts live under `.github/workflows/`, and workflow behavior is partly deterministic before the agent starts reasoning.
+
+The design needs to preserve the separation between deterministic gates and agent-driven analysis. Counting existing open issues, enforcing a per-run issue cap, and exposing that gate to the prompt are repository-authored concerns that must remain stable and testable. The agent should only handle the semantic duplicate-detection task and issue writing within those precomputed limits.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a new CI capability for the duplicate-code detection workflow and its compiled artifacts.
+- Capture a deterministic issue-slot gate keyed by the `duplicate-code` issue label and a workflow-configured issue cap.
+- Specify the workflow's triggers, analysis scope, and issue-reporting contract in a reviewable requirements change.
+- Keep issue creation bounded and focused so the workflow does not flood the repository with broad or duplicate reports.
+
+**Non-Goals:**
+
+- Implementing automated refactoring or code changes as part of this workflow.
+- Defining a repository-wide duplicate-detection algorithm outside the workflow contract.
+- Persisting historical workflow memory beyond the open-issue slot gate in the initial version.
+- Covering non-code duplication concerns such as duplicated documentation or workflow definitions.
+
+## Decisions
+
+### 1. Use a generated GH AW workflow with authored source under `workflows-src`
+
+The workflow will be treated as a GitHub Agentic Workflow whose repository source is authored under `.github/workflows-src/duplicate-code-detector/`, generated to `.github/workflows/duplicate-code-detector.md`, and compiled to `.github/workflows/duplicate-code-detector.lock.yml`. That repository source is expected to stay intentionally aligned with the upstream `gh-aw` duplicate-code detector workflow at `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md`, except where this repository needs explicit local adaptations such as issue-slot gating, labels, engine configuration, or generated-artifact handling.
+
+Why:
+- It matches the repository's existing pattern for authored workflow sources plus checked-in generated artifacts.
+- It keeps the editable source concise while preserving generated outputs for review and execution.
+- It records the upstream workflow source of truth while still making repository-specific deltas reviewable.
+- It makes regeneration and drift checking compatible with existing `scripts/compile-workflow-sources` and `gh aw compile` workflows.
+
+Alternative considered:
+- Author the `.md` workflow directly under `.github/workflows/`: rejected because the repository is already standardizing agentic workflow authoring under `.github/workflows-src/`.
+
+### 2. Keep issue-slot gating deterministic and label-based
+
+Before agent execution, the workflow will count open issues with the `duplicate-code` label, subtract that count from a workflow-configured issue cap, and expose the remaining slot count and gate reason through pre-activation outputs.
+
+Why:
+- The repository needs a stable, inspectable cap on how many duplicate-code issues can be open or created at once.
+- Label-based counting is a simple contract maintainers can understand and manage directly in GitHub.
+- Keeping the gate deterministic avoids asking the agent to discover issue capacity ad hoc.
+
+Alternative considered:
+- Let the agent search existing issues and decide whether to create more: rejected because issue budgeting should be deterministic and testable.
+
+### 3. Open one issue per actionable duplication pattern
+
+The workflow will report each significant duplication pattern as its own issue rather than bundling multiple patterns into one report, and it will stop at the number of available issue slots.
+
+Why:
+- Separate issues are easier to triage, assign, and remediate.
+- Per-pattern issues align with the workflow prompt and prevent one noisy report from hiding unrelated refactors.
+- The slot cap remains meaningful only if each issue maps to one actionable pattern.
+
+Alternative considered:
+- Bundle all detected duplication into a single periodic report: rejected because the resulting issue would be harder to act on and easier to ignore.
+
+### 4. Scope the analysis to meaningful source-code duplication
+
+The workflow contract will require the agent to focus on recently changed source files, cross-reference the broader codebase, and skip tests, generated artifacts, workflow files, and small or boilerplate snippets.
+
+Why:
+- The most valuable findings come from maintainability issues introduced or surfaced by recent changes.
+- Excluding well-known noisy areas reduces false positives and preserves issue quality.
+- The prompt can still allow broader repository cross-reference without turning the workflow into a full-repo style audit every run.
+
+Alternative considered:
+- Analyze the entire repository uniformly on every run: rejected because it increases noise and cost without prioritizing recent, actionable changes.
+
+## Risks / Trade-offs
+
+- [Semantic duplicate detection can over-report weak similarities] -> Mitigation: require significance thresholds, exclude noisy file classes, and demand concrete examples in each issue.
+- [Open-issue label counts can be wrong if maintainers relabel issues inconsistently] -> Mitigation: make the `duplicate-code` label part of the workflow contract and use it consistently in safe outputs and gating.
+- [Generated workflow artifacts can drift from source] -> Mitigation: require authored source, generated `.md`, and compiled `.lock.yml` to stay paired through repository generation commands.
+- [A daily schedule can create issue churn if the cap is too high] -> Mitigation: use a conservative cap and expose the gate reason and available slot count to the agent.
+
+## Migration Plan
+
+1. Add the OpenSpec change for the new workflow capability.
+2. Implement or refine the authored workflow source, slot helper logic, and generated workflow artifacts while preserving a clear mapping back to the upstream `gh-aw` workflow source.
+3. Add or update focused workflow-source tests for the deterministic slot helper behavior.
+4. Regenerate the workflow outputs and validate the resulting change.
+5. Enable the workflow through the normal repository workflow rollout path.
+
+Rollback is straightforward: remove or disable the workflow source and generated artifacts, and archive or supersede the capability change if the automation is not kept.
+
+## Open Questions
+
+- None for the initial capability definition. Future changes can refine duplicate-detection heuristics or add repo-memory-based deduplication if needed.

--- a/openspec/changes/duplicate-code-detector-workflow/proposal.md
+++ b/openspec/changes/duplicate-code-detector-workflow/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The repository now has a `duplicate-code-detector` GitHub Agentic Workflow derived from the upstream `gh-aw` workflow source at `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md`. This behavior should be captured as an OpenSpec change so the upstream source reference, repository-authored adaptations, generated artifacts, issue-slot gating, and reporting expectations are reviewable and maintainable as requirements rather than implicit implementation details.
+
+## What Changes
+
+- Add a new OpenSpec capability for the `duplicate-code-detector` workflow.
+- Define the workflow as repository-authored source under `.github/workflows-src/`, derived from the upstream `gh-aw` duplicate-code detector workflow, and generating checked-in workflow artifacts under `.github/workflows/`, including the compiled `.lock.yml`.
+- Define deterministic pre-activation issue-slot gating based on open issues carrying the `duplicate-code` label and a workflow-configured issue cap.
+- Define the analysis scope, significance threshold, and issue-creation behavior for duplicate-code findings.
+- Define the reporting contract so each issue covers exactly one actionable duplication pattern with concrete evidence and refactoring guidance.
+
+## Capabilities
+
+### New Capabilities
+- `ci-duplicate-code-detector`: scheduled and manually triggered duplicate-code analysis that opens bounded, actionable GitHub issues from a generated GH AW workflow
+
+### Modified Capabilities
+<!-- None. -->
+
+## Impact
+
+- New authored workflow source under `.github/workflows-src/duplicate-code-detector/`, maintained against the upstream `gh-aw` source at `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md`, and generated workflow artifacts under `.github/workflows/`
+- Shared workflow helper logic for deterministic issue-slot computation under `.github/workflows-src/lib/`
+- GitHub Actions permissions, safe outputs, and compiled lock metadata for the new GH AW workflow
+- Maintainer expectations for how duplicate-code issues are capped, labeled, and structured for follow-up remediation

--- a/openspec/changes/duplicate-code-detector-workflow/specs/ci-duplicate-code-detector/spec.md
+++ b/openspec/changes/duplicate-code-detector-workflow/specs/ci-duplicate-code-detector/spec.md
@@ -1,0 +1,86 @@
+# `ci-duplicate-code-detector` — bounded duplicate-code issue detection workflow
+
+Workflow implementation: repository-authored source under `.github/workflows-src/`, derived from `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md`, and compiled to `.github/workflows/`.
+
+## Purpose
+
+Define requirements for a GitHub Agentic Workflow that analyzes recent repository changes for meaningful code duplication and opens bounded, actionable GitHub issues for refactoring follow-up.
+
+## ADDED Requirements
+
+### Requirement: Workflow artifacts and compilation
+The duplicate-code detector SHALL be authored as a GitHub Agentic Workflow markdown source under `.github/workflows-src/` and SHALL include generated workflow artifacts under `.github/workflows/`, including a compiled `.lock.yml` derived from the authored source. The repository-authored source SHALL identify `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md` as its upstream baseline. Contributors SHALL NOT hand-edit the generated workflow artifacts.
+
+#### Scenario: Source and generated artifacts stay paired
+- **WHEN** maintainers change duplicate-code detector behavior
+- **THEN** the authored workflow source, generated workflow markdown, and compiled lock artifact SHALL match the repository compiler output
+
+#### Scenario: Upstream workflow source remains referenced
+- **WHEN** maintainers review or update the repository-authored duplicate-code detector workflow source
+- **THEN** the change artifacts SHALL continue to reference `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md` as the upstream workflow source
+
+### Requirement: Scheduled and manual triggering
+The duplicate-code detector SHALL support scheduled execution and manual `workflow_dispatch` execution.
+
+#### Scenario: Scheduled run is supported
+- **WHEN** the duplicate-code detector reaches its configured schedule
+- **THEN** the workflow SHALL start a duplicate-code analysis run
+
+#### Scenario: Manual dispatch is supported
+- **WHEN** a maintainer triggers the workflow with `workflow_dispatch`
+- **THEN** the workflow SHALL start a duplicate-code analysis run
+
+### Requirement: Deterministic issue-slot gating
+Before agent analysis begins, deterministic repository-authored steps SHALL compute available issue slots by counting open GitHub issues with the `duplicate-code` label and subtracting that count from a workflow-configured issue cap. The workflow SHALL expose the open-issue count, available slot count, and gate reason through pre-activation outputs, and it SHALL skip the agent job when the available slot count is zero.
+
+#### Scenario: Open issues leave slots available
+- **WHEN** the number of open `duplicate-code` issues is below the configured issue cap
+- **THEN** the workflow SHALL expose a positive `issue_slots_available` value and proceed to agent analysis
+
+#### Scenario: Open issues reach the cap
+- **WHEN** the number of open `duplicate-code` issues is equal to or greater than the configured issue cap
+- **THEN** the workflow SHALL expose `issue_slots_available` as zero and SHALL skip the agent job
+
+### Requirement: Analysis scope is constrained to actionable source-code duplication
+The workflow SHALL instruct the agent to analyze recently changed source files first, cross-reference duplication against the broader repository, and skip test files, generated artifacts, workflow files, standard boilerplate, vendored code, and small snippets below the configured minimum significance threshold.
+
+#### Scenario: Changed source files are primary input
+- **WHEN** the workflow analyzes a new run
+- **THEN** it SHALL direct the agent to prioritize recently changed source files before broader repository cross-reference
+
+#### Scenario: Noisy file classes are excluded
+- **WHEN** the workflow encounters tests, generated files, or workflow definitions during duplicate analysis
+- **THEN** it SHALL exclude those files from duplicate-code reporting
+
+### Requirement: Significant duplication threshold
+The workflow SHALL open issues only for significant duplication findings. A finding SHALL be considered significant only when it exceeds the workflow's documented threshold for duplicated code size or repeated occurrences.
+
+#### Scenario: Significant duplication is eligible for issue creation
+- **WHEN** the workflow identifies a duplication pattern above the configured significance threshold
+- **THEN** that pattern SHALL be eligible for issue creation subject to the available issue slots
+
+#### Scenario: Minor duplication is not reported
+- **WHEN** the workflow identifies only small or low-signal duplication below the configured threshold
+- **THEN** it SHALL NOT create a duplicate-code issue for that finding
+
+### Requirement: One issue per duplication pattern
+The workflow SHALL create at most one issue per distinct duplication pattern and SHALL NOT create more issues in a run than the computed number of available issue slots.
+
+#### Scenario: Multiple patterns are capped by available slots
+- **WHEN** the workflow identifies more significant duplication patterns than the computed number of available issue slots
+- **THEN** it SHALL create issues only for the highest-priority patterns up to the available slot count
+
+#### Scenario: Distinct patterns are not bundled
+- **WHEN** the workflow creates an issue for a significant duplication finding
+- **THEN** that issue SHALL describe exactly one distinct duplication pattern rather than bundling unrelated patterns together
+
+### Requirement: Duplicate-code issue contents are actionable
+Each duplicate-code issue created by the workflow SHALL include a concise summary of the duplication pattern, concrete affected locations, a severity or impact assessment, and actionable refactoring guidance sufficient for a follow-up coding agent or maintainer to act on the issue.
+
+#### Scenario: Issue contains evidence and guidance
+- **WHEN** the workflow creates a duplicate-code issue
+- **THEN** the issue body SHALL include the duplicated locations and actionable refactoring recommendations for that pattern
+
+#### Scenario: Issue titles and labels identify the workflow output
+- **WHEN** the workflow creates a duplicate-code issue
+- **THEN** the issue SHALL carry the workflow's configured title prefix and the `duplicate-code` label

--- a/openspec/changes/duplicate-code-detector-workflow/tasks.md
+++ b/openspec/changes/duplicate-code-detector-workflow/tasks.md
@@ -1,0 +1,16 @@
+## 1. Author the duplicate-code detector workflow contract
+
+- [ ] 1.1 Add the authored duplicate-code detector workflow source under `.github/workflows-src/`, with the source derived from and traceable to `https://github.com/github/gh-aw/blob/main/.github/workflows/duplicate-code-detector.md`, and register or retain its generated output in the workflow-source manifest.
+- [ ] 1.2 Define deterministic pre-activation issue-slot gating for the `duplicate-code` label and workflow-configured issue cap before agent analysis starts.
+- [ ] 1.3 Write the workflow prompt contract for duplicate-detection scope, significance thresholds, and one-issue-per-pattern reporting.
+
+## 2. Add deterministic helper logic and generated artifacts
+
+- [ ] 2.1 Implement or refine shared helper logic and inline scripts needed to compute issue-slot availability for the workflow.
+- [ ] 2.2 Generate and commit `.github/workflows/duplicate-code-detector.md`, `.github/workflows/duplicate-code-detector.lock.yml`, and any related lock metadata updates.
+- [ ] 2.3 Add or update focused workflow-source tests covering the issue-slot gate and generated workflow expectations.
+
+## 3. Validate and document the workflow
+
+- [ ] 3.1 Run the relevant workflow generation, workflow-source tests, and OpenSpec validation for the duplicate-code detector change.
+- [ ] 3.2 Ensure maintainer-facing workflow behavior is documented through the upstream source reference, issue labels, title prefix, cap, and actionable issue-content contract captured by the change.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design proposal for a duplicate-code-detector GitHub Actions workflow
Adds OpenSpec documentation proposing a new `ci-duplicate-code-detector` GitHub Actions workflow. The workflow would run on a schedule and manual trigger, detect meaningful source-code duplication above a significance threshold, and file one GitHub issue per duplication pattern using deterministic label-based (`duplicate-code`) issue-slot gating. Workflow source is authored under `workflows-src/` and artifacts are generated from it, following an existing authored-source/generation pattern.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd8cef5.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->