### PR TITLE
Proposal for code factory worker

### DIFF
--- a/openspec/changes/code-factory-issue-workflow/.openspec.yaml
+++ b/openspec/changes/code-factory-issue-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/code-factory-issue-workflow/design.md
+++ b/openspec/changes/code-factory-issue-workflow/design.md
@@ -1,0 +1,107 @@
+## Context
+
+This change adds the first `code-factory` GitHub agentic workflow for the repository. Unlike the existing issue-opening workflows, this one consumes a single GitHub issue as the source of truth and is allowed to modify the repository by implementing the issue and opening a pull request. That makes the deterministic pre-activation gate more important than usual: the workflow must establish that the event is eligible, that the actor is trusted, and that the issue is not already being served by an open linked `code-factory` pull request before the agent begins making changes.
+
+The repository already has a stable pattern for authored workflow sources under `.github/workflows-src/`, generated workflow artifacts under `.github/workflows/`, and extracted GitHub-script helper logic under `.github/workflows-src/lib/`. This change should follow that pattern so trigger classification and duplicate detection remain reviewable and unit testable outside the compiled workflow.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one repository-authored GH AW workflow that reacts to trusted `code-factory` issue triggers.
+- Support both `issues.opened` and `issues.labeled` so labeling during issue creation activates the same workflow contract.
+- Keep actor validation deterministic by treating `github-actions[bot]` as trusted and requiring `write`, `maintain`, or `admin` for human actors.
+- Prevent duplicate work by deterministically detecting an existing open linked `code-factory` pull request before agent activation.
+- Give the agent a clear contract for creating exactly one linked PR with stable metadata that future reruns can detect.
+
+**Non-Goals:**
+
+- PR follow-up behavior for reviews, comments, or failed CI.
+- General issue triage or label management outside the `code-factory` trigger contract.
+- A fuzzy or heuristic duplicate detector based only on similar titles or semantic issue text.
+
+## Decisions
+
+### 1. Use one issue-intake workflow authored under `.github/workflows-src/`
+
+The workflow will be authored under `.github/workflows-src/code-factory-issue/`, generated into `.github/workflows/code-factory-issue.md`, and compiled through the repository's existing workflow-generation path.
+
+Why:
+- It matches the repository's established GH AW authoring model.
+- It keeps deterministic pre-activation steps, helper scripts, and generated outputs aligned with existing review patterns.
+- It makes the workflow behavior easy to test and regenerate without editing compiled outputs directly.
+
+Alternative considered:
+- Author the generated `.md` workflow directly under `.github/workflows/`: rejected because the repository already standardizes authored workflow sources under `.github/workflows-src/`.
+
+### 2. Accept both `issues.opened` and `issues.labeled`, but only when `code-factory` is present
+
+The workflow will subscribe to `issues` activity for both `opened` and `labeled`. Pre-activation will allow `labeled` only when the incoming label is exactly `code-factory`, and will allow `opened` only when the issue's initial label set already contains `code-factory`.
+
+Why:
+- It covers both maintainer labeling after issue creation and automation that applies the label during issue creation.
+- It keeps trigger policy deterministic and easy to reason about from the event payload alone.
+
+Alternative considered:
+- Support only `issues.labeled`: rejected because it would miss workflows or automations that create the issue with `code-factory` already attached.
+
+### 3. Treat GitHub Actions as a first-class trusted trigger source
+
+Pre-activation will trust `github-actions[bot]` directly. For all other actors, it will query repository collaborator permissions and require `write`, `maintain`, or `admin`.
+
+Why:
+- Repository automation already opens issues that should be eligible for downstream automation, such as schema-coverage issues created by GitHub Actions.
+- Using explicit repository permission checks for human actors is more precise than `author_association`.
+- The bot exception stays narrow because it is limited to the platform-owned GitHub Actions actor rather than any bot account.
+
+Alternative considered:
+- Rely on `author_association` alone: rejected because it is less precise than permission-level checks.
+- Allow all bot actors: rejected because it would broaden trust without a clear repository policy.
+
+### 4. Define duplicate linkage through stable branch and PR metadata
+
+The workflow will treat a PR as the existing linked `code-factory` PR for an issue when it is open and all of the following are true:
+- it carries the `code-factory` label
+- it uses the deterministic head branch `code-factory/issue-<number>`
+- its title or body includes the triggering issue reference in a deterministic form such as `Closes #<number>`
+
+The agent will be instructed to preserve this branch and linkage format when creating or updating the PR.
+
+Why:
+- A stable branch name gives reruns a cheap deterministic key.
+- Explicit issue linkage in the PR body makes the relationship visible to maintainers and robust against title edits.
+- Requiring both workflow label and linkage metadata avoids reusing unrelated PRs that happen to mention the issue.
+
+Alternative considered:
+- Match only on PR title similarity or branch name: rejected because either signal alone is too easy to collide with or edit accidentally.
+
+### 5. Skip agent activation when the deterministic gate fails
+
+Pre-activation will emit scalar outputs describing eligibility, trust, duplicate status, and skip reasons. The agent job will only run when the trigger is valid, trusted, and not already represented by an open linked PR.
+
+Why:
+- The workflow should not spend agent capacity re-checking trust or duplicate state.
+- Deterministic skip reasons help maintainers understand why a run did not proceed.
+- This keeps the agent prompt focused on implementation rather than repository-policy discovery.
+
+Alternative considered:
+- Let the agent inspect the issue, actor, and PR list itself before deciding whether to act: rejected because the trust and duplicate policy should be stable, testable, and outside agent judgment.
+
+## Risks / Trade-offs
+
+- [A too-strict duplicate-matching rule could miss a valid previously opened PR] -> Mitigation: require the workflow itself to create the canonical branch and explicit issue reference so reruns converge on one format.
+- [Trusting `github-actions[bot]` could allow unintended internally generated issues to trigger work] -> Mitigation: still require the `code-factory` label and issue-event checks before activation.
+- [Different issue authors may expect manual relabeling semantics] -> Mitigation: publish deterministic skip reasons so maintainers can see when actor trust or duplicate detection prevented execution.
+
+## Migration Plan
+
+1. Add the new change artifacts for the `ci-code-factory-issue-intake` capability.
+2. Implement the authored workflow source, helper logic, and generated workflow artifacts.
+3. Add focused tests for event qualification, trust checks, and duplicate-PR detection.
+4. Regenerate workflow outputs and validate the OpenSpec change.
+
+Rollback is straightforward: disable or remove the workflow source and generated artifacts, then supersede or archive the capability change if the automation is not retained.
+
+## Open Questions
+
+- None for this initial phase. PR follow-up behavior can be specified in a later change if the repository decides to automate review or CI response flows.

--- a/openspec/changes/code-factory-issue-workflow/proposal.md
+++ b/openspec/changes/code-factory-issue-workflow/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The repository wants a controlled way to turn selected GitHub issues into implementation pull requests through a GitHub agentic workflow. That workflow needs explicit rules for who may trigger it, when issue labels should activate it, and how it avoids opening duplicate `code-factory` pull requests for the same issue.
+
+## What Changes
+
+- Add a new OpenSpec capability for a `code-factory` issue-intake workflow.
+- Define the workflow as repository-authored source under `.github/workflows-src/` that generates checked-in workflow artifacts under `.github/workflows/`.
+- Define deterministic pre-activation gating for `issues.opened` and `issues.labeled` events so the workflow only activates when the issue carries the `code-factory` label.
+- Define trigger trust rules that allow either GitHub Actions or a human actor with repository permission `write`, `maintain`, or `admin`.
+- Define duplicate-prevention behavior so the workflow no-ops when an open linked `code-factory` pull request already exists for the triggering issue.
+- Define the agent contract for implementing the issue and creating exactly one linked `code-factory` pull request.
+
+## Capabilities
+
+### New Capabilities
+- `ci-code-factory-issue-intake`: issue-driven GitHub agentic workflow that validates trusted `code-factory` triggers, prevents duplicate pull requests, and opens a linked implementation PR
+
+### Modified Capabilities
+<!-- None. -->
+
+## Impact
+
+- New authored workflow source under `.github/workflows-src/code-factory-issue/` and generated workflow artifacts under `.github/workflows/`
+- Deterministic GitHub-script helper logic under `.github/workflows-src/lib/` and inline workflow scripts under `.github/workflows-src/code-factory-issue/scripts/`
+- Workflow tests covering trigger gating, issue-opened-with-label handling, and duplicate-PR detection
+- Maintainer expectations for how `code-factory` issue automation is triggered and how linked PR reuse is enforced

--- a/openspec/changes/code-factory-issue-workflow/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/code-factory-issue-workflow/specs/ci-code-factory-issue-intake/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Workflow source is repository-authored and generated
+The repository SHALL define the `code-factory` issue-intake automation as a repository-authored GitHub agentic workflow source under `.github/workflows-src/` that generates checked-in workflow artifacts under `.github/workflows/`. Deterministic GitHub-script logic used for trigger qualification, trust checks, or duplicate detection SHALL be factored into repository-local helper code that can be unit tested independently of the compiled workflow.
+
+#### Scenario: Maintainer updates the workflow source
+- **WHEN** maintainers modify the `code-factory` issue-intake workflow
+- **THEN** the authored source SHALL live under `.github/workflows-src/` and generate the checked-in workflow artifacts under `.github/workflows/`
+
+#### Scenario: Deterministic gating logic is tested outside the workflow wrapper
+- **WHEN** maintainers validate trigger qualification, trust policy, or duplicate detection
+- **THEN** the repository SHALL support focused tests for the extracted helper logic without requiring execution of the compiled workflow
+
+### Requirement: Workflow activates only for `code-factory` issue events
+The workflow SHALL subscribe to GitHub `issues` events and SHALL activate only for eligible `code-factory` issue triggers. Eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `code-factory`, and `issues.opened` when the issue already includes the `code-factory` label at creation time.
+
+#### Scenario: Label applied after issue creation
+- **WHEN** an `issues.labeled` event is received and `github.event.label.name` is `code-factory`
+- **THEN** the workflow SHALL treat the event as an eligible trigger
+
+#### Scenario: Issue opens with the trigger label already present
+- **WHEN** an `issues.opened` event is received and the issue's initial labels include `code-factory`
+- **THEN** the workflow SHALL treat the event as an eligible trigger
+
+#### Scenario: Non-trigger issue event is ignored
+- **WHEN** an `issues` event is received without the `code-factory` label in the qualifying position for that event type
+- **THEN** the workflow SHALL NOT activate the implementation agent for that event
+
+### Requirement: Trigger actor must be trusted
+Before agent activation, the workflow SHALL determine whether the triggering actor is trusted. The actor SHALL be trusted if the sender is `github-actions[bot]`; otherwise the workflow SHALL query repository collaborator permissions and SHALL require effective repository permission `write`, `maintain`, or `admin`.
+
+#### Scenario: GitHub Actions opens a labeled issue
+- **WHEN** the sender is `github-actions[bot]` and the event otherwise qualifies for `code-factory` issue intake
+- **THEN** the workflow SHALL treat the trigger as trusted without requiring a collaborator-permission lookup
+
+#### Scenario: Maintainer applies the label
+- **WHEN** a human actor triggers an otherwise eligible `code-factory` issue event and the repository permission lookup returns `write`, `maintain`, or `admin`
+- **THEN** the workflow SHALL treat the trigger as trusted
+
+#### Scenario: Untrusted actor attempts to trigger automation
+- **WHEN** a non-bot actor triggers an otherwise eligible `code-factory` issue event and the repository permission lookup does not return `write`, `maintain`, or `admin`
+- **THEN** the workflow SHALL skip agent activation
+
+### Requirement: Workflow suppresses duplicate linked pull requests
+Before agent activation, the workflow SHALL detect whether an open linked `code-factory` pull request already exists for the triggering issue. A pull request SHALL be treated as linked only when it is open, carries the `code-factory` label, uses the deterministic branch name `code-factory/issue-<issue-number>`, and includes an explicit reference to the issue in stable metadata such as `Closes #<issue-number>`.
+
+#### Scenario: Existing linked PR prevents a duplicate run
+- **WHEN** the workflow finds an open pull request that satisfies the linked `code-factory` PR criteria for the triggering issue
+- **THEN** the workflow SHALL skip agent activation instead of opening a duplicate pull request
+
+#### Scenario: Unrelated PR does not block issue intake
+- **WHEN** an open pull request mentions the issue or has a similar title but does not satisfy the full linked `code-factory` PR criteria
+- **THEN** the workflow SHALL NOT treat that pull request as the canonical linked PR for duplicate suppression
+
+### Requirement: Agent creates exactly one linked `code-factory` pull request
+When the deterministic gate passes, the workflow agent SHALL treat the triggering issue as the source of truth for implementation, SHALL work on the deterministic branch `code-factory/issue-<issue-number>`, and SHALL create or update exactly one linked pull request labeled `code-factory`. The linked pull request SHALL preserve explicit issue linkage in its title or body so future reruns can deterministically identify it.
+
+#### Scenario: Eligible issue creates a linked implementation PR
+- **WHEN** the workflow runs for a trusted eligible issue event and no open linked `code-factory` pull request already exists
+- **THEN** the agent SHALL implement the issue on branch `code-factory/issue-<issue-number>` and open one linked pull request carrying the `code-factory` label
+
+#### Scenario: Pull request metadata preserves deterministic linkage
+- **WHEN** the agent creates the `code-factory` pull request
+- **THEN** the pull request SHALL include explicit issue linkage metadata so later workflow runs can identify it as the canonical PR for the issue

--- a/openspec/changes/code-factory-issue-workflow/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/code-factory-issue-workflow/specs/ci-code-factory-issue-intake/spec.md
@@ -1,3 +1,11 @@
+# `ci-code-factory-issue-intake` — Issue-intake agentic workflow for `code-factory` issues
+
+Workflow implementation: authored source under `.github/workflows-src/`, compiled to `.github/workflows/`.
+
+## Purpose
+
+Define requirements for a GitHub Agentic Workflow that reacts to qualifying `code-factory` issue events, verifies the triggering actor is trusted, suppresses duplicate linked pull requests, and delegates implementation to an agent that creates exactly one linked pull request per issue.
+
 ## ADDED Requirements
 
 ### Requirement: Workflow source is repository-authored and generated
@@ -11,16 +19,16 @@ The repository SHALL define the `code-factory` issue-intake automation as a repo
 - **WHEN** maintainers validate trigger qualification, trust policy, or duplicate detection
 - **THEN** the repository SHALL support focused tests for the extracted helper logic without requiring execution of the compiled workflow
 
-### Requirement: Workflow activates only for `code-factory` issue events
-The workflow SHALL subscribe to GitHub `issues` events and SHALL activate only for eligible `code-factory` issue triggers. Eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `code-factory`, and `issues.opened` when the issue already includes the `code-factory` label at creation time.
+### Requirement: Workflow activates the implementation agent only for qualifying `code-factory` issue events
+The workflow MAY subscribe to GitHub `issues.opened` and `issues.labeled` events, but it SHALL activate the implementation agent only for eligible `code-factory` issue triggers. Eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `code-factory`, and `issues.opened` when the issue already includes the `code-factory` label at creation time.
 
 #### Scenario: Label applied after issue creation
 - **WHEN** an `issues.labeled` event is received and `github.event.label.name` is `code-factory`
-- **THEN** the workflow SHALL treat the event as an eligible trigger
+- **THEN** the workflow SHALL treat the event as eligible to activate the implementation agent
 
 #### Scenario: Issue opens with the trigger label already present
 - **WHEN** an `issues.opened` event is received and the issue's initial labels include `code-factory`
-- **THEN** the workflow SHALL treat the event as an eligible trigger
+- **THEN** the workflow SHALL treat the event as eligible to activate the implementation agent
 
 #### Scenario: Non-trigger issue event is ignored
 - **WHEN** an `issues` event is received without the `code-factory` label in the qualifying position for that event type

--- a/openspec/changes/code-factory-issue-workflow/tasks.md
+++ b/openspec/changes/code-factory-issue-workflow/tasks.md
@@ -1,0 +1,17 @@
+## 1. Author the `code-factory` issue-intake workflow contract
+
+- [ ] 1.1 Add the authored workflow source under `.github/workflows-src/code-factory-issue/` and register its generated output in `.github/workflows-src/manifest.json`.
+- [ ] 1.2 Define deterministic pre-activation handling for `issues.opened` and `issues.labeled`, including `code-factory` label qualification and trusted-actor evaluation for `github-actions[bot]` versus repository collaborators.
+- [ ] 1.3 Write the workflow prompt contract so the agent treats the triggering issue as the source of truth and creates exactly one linked `code-factory` PR on branch `code-factory/issue-<issue-number>`.
+
+## 2. Implement deterministic helper logic and duplicate suppression
+
+- [ ] 2.1 Add extracted helper logic and inline scripts under `.github/workflows-src/lib/` and `.github/workflows-src/code-factory-issue/scripts/` for event qualification, actor trust checks, and duplicate linked-PR detection.
+- [ ] 2.2 Implement the duplicate linked-PR check so open PRs are matched using the `code-factory` label, deterministic head branch, and explicit issue reference metadata.
+- [ ] 2.3 Generate and commit the resulting workflow artifacts under `.github/workflows/`, including the compiled `.lock.yml` and any related lock metadata updates.
+
+## 3. Validate workflow behavior and OpenSpec artifacts
+
+- [ ] 3.1 Add or update focused workflow-source tests covering issue-opened-with-label detection, trusted-actor gating, duplicate-PR suppression, and generated workflow expectations.
+- [ ] 3.2 Run the relevant workflow generation and workflow-source tests for the new `code-factory` issue workflow.
+- [ ] 3.3 Validate the OpenSpec change with `./node_modules/.bin/openspec validate code-factory-issue-workflow --type change` or an equivalent repository OpenSpec check.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add proposal and specification for a code-factory issue intake agentic workflow
- Adds a design doc, proposal, formal spec, and task checklist under `openspec/changes/code-factory-issue-workflow/` describing a new GitHub Actions agentic workflow for `code-factory`-labeled issues.
- The workflow activates on `issues.opened` (when the label is already present) and `issues.labeled` (when the `code-factory` label is added), with a pre-activation gate that skips and emits deterministic skip reasons on failure.
- Trust policy auto-approves `github-actions[bot]` and requires collaborator `write`/`maintain`/`admin` permission for other actors.
- Duplicate PR suppression uses a stable branch `code-factory/issue-<number>`, the `code-factory` label, and an explicit `Closes #<number>` linkage to detect existing open PRs.
- Workflow sources are authored under `.github/workflows-src` with generated artifacts output to `.github/workflows` and testable helper logic extracted separately.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 170b216.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->