### PR TITLE
Propose import support for Elasticsearch enrich policy resource

### DIFF
--- a/openspec/changes/enrich-policy-import/.openspec.yaml
+++ b/openspec/changes/enrich-policy-import/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-23

--- a/openspec/changes/enrich-policy-import/design.md
+++ b/openspec/changes/enrich-policy-import/design.md
@@ -1,0 +1,39 @@
+## Context
+
+The `elasticstack_elasticsearch_enrich_policy` resource uses the Terraform Plugin Framework and stores its identity as `<cluster_uuid>/<policy_name>`. All other resource attributes (`name`, `policy_type`, `indices`, `match_field`, `enrich_fields`, `query`, `execute`) require replacement, so the resource is effectively immutable once created.
+
+The `execute` attribute is Terraform-only (not returned by the Elasticsearch Get enrich policy API). On normal read, it retains the value persisted from the previous create — the framework reads existing state then calls `Read`, which does not overwrite `Execute`. On import, however, the initial state has only `id` set; after `Read`, `execute` would remain null. Because `execute` has `RequiresReplace`, a subsequent `terraform plan` would see null-in-state vs. default-true-in-plan and mark the resource for replacement — defeating the purpose of the import.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow `terraform import elasticstack_elasticsearch_enrich_policy.<name> <cluster_uuid>/<policy_name>` to succeed.
+- Ensure that a `terraform plan` immediately after import shows no diff (no spurious replacement).
+- Add acceptance test coverage for the import step.
+
+**Non-Goals:**
+- Changing the ID format.
+- Adding import support to the enrich policy data source (data sources do not support import).
+- Detecting the actual historical value of `execute` from Elasticsearch (not available from the API).
+
+## Decisions
+
+### Use a custom `ImportState` method rather than `ImportStatePassthroughID` alone
+
+`ImportStatePassthroughID` copies the raw import ID into the `id` attribute and leaves all other attributes null. For most resources this is fine because `Read` repopulates everything from the API. For the enrich policy, `execute` is not in the API response. Leaving it null in state after import means the next plan will compare null (state) with the default `true` (plan), triggering a spurious replacement.
+
+**Decision**: Implement a custom `ImportState` that:
+1. Validates and copies the import ID into the `id` attribute (`resource.ImportStatePassthroughID`).
+2. Also sets `execute = true` in the response state — matching the computed default.
+
+**Alternative considered**: Set `execute` to null and document that a plan diff is expected after import. Rejected: users would not understand why import forces a replacement of a perfectly healthy policy.
+
+**Alternative considered**: Use `ImportStatePassthroughID` only, and teach `Read` to default `execute` to `true` when it finds a null value. Rejected: would silently mutate state during normal refresh, which is a broader change with more surface area. The custom `ImportState` keeps the fix isolated.
+
+## Risks / Trade-offs
+
+- [Risk]: A user imports a policy that was originally created with `execute = false`. The import will set `execute = true` in state. If they later specify `execute = false` in config, a replacement will be planned. → **Mitigation**: Document in the import guidance that `execute` defaults to `true` on import. Because `execute` is `RequiresReplace` anyway, the user must explicitly configure it; the imported default of `true` is correct for almost every real policy (one that has been executed and has an enrich index).
+
+## Migration Plan
+
+Additive change only. No existing state is affected; the new `ImportState` method is only invoked during `terraform import`.

--- a/openspec/changes/enrich-policy-import/proposal.md
+++ b/openspec/changes/enrich-policy-import/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `elasticstack_elasticsearch_enrich_policy` resource does not implement `ImportState`, so running `terraform import` against an existing enrich policy fails. Users cannot adopt pre-existing policies into Terraform state without destroying and recreating them, causing policy downtime and enrich index loss. This was reported in [elastic/terraform-provider-elasticstack#2402](https://github.com/elastic/terraform-provider-elasticstack/issues/2402).
+
+## What Changes
+
+- Add `ImportState` to the enrich policy resource, accepting an import ID of `<cluster_uuid>/<policy_name>` — the same format already used as the resource `id`.
+- Add acceptance test coverage for the import path.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None -->
+
+### Modified Capabilities
+
+- `elasticsearch-enrich-policy`: Add import requirements to the existing spec (REQ-023+) covering `ImportState` behavior, accepted ID format, and acceptance test expectations.
+
+## Impact
+
+- `internal/elasticsearch/enrich/resource.go`: implement `resource.ResourceWithImportState`
+- `internal/elasticsearch/enrich/acc_test.go`: extend acceptance tests with an import step
+- `openspec/specs/elasticsearch-enrich-policy/spec.md`: add import requirements

--- a/openspec/changes/enrich-policy-import/specs/elasticsearch-enrich-policy/spec.md
+++ b/openspec/changes/enrich-policy-import/specs/elasticsearch-enrich-policy/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Import state (REQ-023)
+
+The resource SHALL implement `resource.ResourceWithImportState`. The import ID SHALL be the full resource `id` in the format `<cluster_uuid>/<policy_name>`. On import, the resource SHALL set `id` to the provided import ID and SHALL set `execute` to `true` in state (the computed default), so that a subsequent `terraform plan` shows no diff when `execute` is not explicitly configured.
+
+#### Scenario: Import with valid id sets state
+
+- **GIVEN** a valid import ID of the form `<cluster_uuid>/<policy_name>`
+- **WHEN** `terraform import` runs
+- **THEN** `id` in state SHALL equal the provided import ID
+- **AND** `execute` in state SHALL be `true`
+- **AND** all other resource attributes SHALL be populated from the API by the subsequent Read call
+
+#### Scenario: Import followed by plan shows no diff
+
+- **GIVEN** a resource was successfully imported with no `execute` configured
+- **WHEN** `terraform plan` runs after the import
+- **THEN** no attribute differences SHALL be shown and no replacement SHALL be planned
+
+### Requirement: Import acceptance test (REQ-024)
+
+The resource acceptance test suite SHALL include an import step that verifies round-trip import integrity: after importing an existing policy, `terraform plan` SHALL show no diff and all policy attributes SHALL match the pre-import configuration.
+
+#### Scenario: Acceptance test import step
+
+- **GIVEN** an existing enrich policy created in a prior acceptance test step
+- **WHEN** an `ImportState: true, ImportStateVerify: true` step runs with the resource's composite ID
+- **THEN** all attributes in the imported state SHALL match the originally configured attributes

--- a/openspec/changes/enrich-policy-import/tasks.md
+++ b/openspec/changes/enrich-policy-import/tasks.md
@@ -1,0 +1,13 @@
+## 1. Resource Implementation
+
+- [ ] 1.1 Add `resource.ResourceWithImportState` to the `var _` compile-time interface check in `internal/elasticsearch/enrich/resource.go`
+- [ ] 1.2 Implement `ImportState` method on `enrichPolicyResource`: call `resource.ImportStatePassthroughID` to copy the import ID into `id`, then set `execute = true` via `resp.State.SetAttribute`
+
+## 2. Acceptance Tests
+
+- [ ] 2.1 Add an `ImportState: true, ImportStateVerify: true` step to the existing enrich policy acceptance test in `internal/elasticsearch/enrich/acc_test.go`, using `ImportStateIdFunc` to return `<cluster_uuid>/<policy_name>` (matching the pattern from `internal/elasticsearch/cluster/script/acc_test.go`)
+
+## 3. Verification
+
+- [ ] 3.1 Run `make build` to confirm the provider compiles with no errors
+- [ ] 3.2 Run the enrich policy acceptance tests to confirm the import step passes


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/2402

## Summary

- Adds an OpenSpec change (`enrich-policy-import`) proposing `terraform import` support for `elasticstack_elasticsearch_enrich_policy` (fixes #2402)
- Key design decision: custom `ImportState` that seeds `execute = true` in state, preventing a spurious replacement on the first plan after import (the `execute` attribute is Terraform-only and not in the API response)
- Artifacts: proposal, design, delta spec (REQ-023/024 added to `elasticsearch-enrich-policy`), and implementation tasks

## Test plan

- [ ] Review proposal, design, and delta spec for correctness
- [ ] Approve to unblock `/opsx:apply` for implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add import support design and spec for the `elasticsearch-enrich-policy` resource
> - Adds a design document, proposal, spec requirements, and task checklist under `openspec/changes/enrich-policy-import/` to define how import will be implemented for the `elasticsearch-enrich-policy` resource.
> - The resource currently lacks `ImportState`; the design proposes implementing `ResourceWithImportState` that accepts a `<cluster_uuid>/<policy_name>` ID and sets `execute=true` on import to handle the resource's immutability.
> - New spec requirements (REQ-023, REQ-024) mandate a no-diff guarantee after import and an acceptance test covering the full import round-trip.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb4651d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->