### PR TITLE
Refactor changelog generation to shared Go engine

### DIFF
--- a/.github/workflows-src/changelog-generation/scripts/refresh-release-pr.inline.js
+++ b/.github/workflows-src/changelog-generation/scripts/refresh-release-pr.inline.js
@@ -1,8 +1,8 @@
 //include: ../../lib/changelog-pr-management.js
 
 const { owner, repo } = context.repo;
-const prNumber = context.payload.pull_request?.number ?? null;
 const compareRange = process.env.COMPARE_RANGE;
 const targetVersion = process.env.TARGET_VERSION;
+const targetBranch = process.env.TARGET_BRANCH;
 
-await refreshReleasePR({ github, core, owner, repo, prNumber, compareRange, targetVersion });
+await refreshReleasePR({ github, core, owner, repo, targetBranch, compareRange, targetVersion });

--- a/.github/workflows-src/changelog-generation/scripts/resolve-release-context.inline.js
+++ b/.github/workflows-src/changelog-generation/scripts/resolve-release-context.inline.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process');
 //include: ../../lib/changelog-release-context.js
 
-// Determine mode from event
+// Determine mode from event or explicit workflow_dispatch inputs
 const eventName = context.eventName;
 const headBranch =
   context.payload.pull_request?.head?.ref ??
@@ -9,6 +9,13 @@ const headBranch =
   process.env.GITHUB_HEAD_REF ??
   process.env.GITHUB_REF_NAME ??
   '';
+const dispatchMode = core.getInput('mode') || 'unreleased';
+const targetVersionInput = core.getInput('target_version') || '';
+
+if (eventName === 'workflow_dispatch' && dispatchMode === 'release' && !targetVersionInput.trim()) {
+  core.setFailed('workflow_dispatch release mode requires a target_version input');
+  process.exit(1);
+}
 
 let tags = [];
 try {
@@ -23,7 +30,13 @@ try {
   core.warning(`Failed to list git tags: ${err.message}`);
 }
 
-const releaseContext = buildReleaseContext({ eventName, headBranch, tags });
+const releaseContext = buildReleaseContext({
+  eventName,
+  headBranch,
+  dispatchMode,
+  targetVersion: targetVersionInput,
+  tags,
+});
 
 if (releaseContext.mode === 'release') {
   core.info(`Release mode: branch=${headBranch}, version=${releaseContext.targetVersion}`);

--- a/.github/workflows-src/changelog-generation/workflow.md.tmpl
+++ b/.github/workflows-src/changelog-generation/workflow.md.tmpl
@@ -2,18 +2,23 @@
 name: Changelog Generation
 description: >-
   Generates or updates CHANGELOG.md from merged pull requests. On schedule or workflow_dispatch,
-  rewrites the Unreleased section. On prep-release-* pull requests, rewrites the concrete release
-  section. Uses a deterministic pre-activation phase to resolve the previous release tag, compare
-  range, merged PR set, and target section mode, then an agent phase to generate changelog content
-  strictly from PR-level summaries with full provenance.
+  rewrites the Unreleased section. Maintainers can also use workflow_dispatch with explicit
+  release-mode inputs to rewrite the concrete release section for a prep-release-* branch.
 on:
   schedule:
     - cron: daily
   workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
+    inputs:
+      mode:
+        description: Changelog generation mode
+        required: true
+        default: unreleased
+        type: choice
+        options: [unreleased, release]
+      target_version:
+        description: Release target version (required when mode=release)
+        required: false
+        type: string
   steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -45,8 +50,6 @@ on:
         path: ${{ steps.gather_pr_evidence.outputs.evidence_file_path }}
         if-no-files-found: error
 if: >-
-  (github.event_name != 'pull_request_target' ||
-  startsWith(github.head_ref, 'prep-release-')) &&
   needs.pre_activation.outputs.has_evidence == 'true'
 steps:
   - name: Download release evidence artifact
@@ -119,7 +122,7 @@ You generate or update `CHANGELOG.md` strictly from the merged pull-request evid
 
 Deterministic pre-activation steps have already resolved the release context and gathered PR evidence. Do **not** re-query git or GitHub for commit lists or PR metadata; use the values below and the evidence manifest in workflow memory.
 
-- **Mode**: `${{ needs.pre_activation.outputs.mode }}` — either `unreleased` (schedule/dispatch) or `release` (prep-release-* PR)
+- **Mode**: `${{ needs.pre_activation.outputs.mode }}` — either `unreleased` (schedule/manual dispatch) or `release` (explicit workflow_dispatch inputs)
 - **Previous tag**: `${{ needs.pre_activation.outputs.previous_tag }}`
 - **Compare range**: `${{ needs.pre_activation.outputs.compare_range }}`
 - **Target version** (release mode only): `${{ needs.pre_activation.outputs.target_version }}`

--- a/.github/workflows-src/changelog-generation/workflow.yml.tmpl
+++ b/.github/workflows-src/changelog-generation/workflow.yml.tmpl
@@ -50,6 +50,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+        env:
+          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
         run: |
           set -euo pipefail
           args=(
@@ -58,8 +60,8 @@ jobs:
             -changelog CHANGELOG.md
           )
 
-          if [[ -n "${{ steps.resolve_release_context.outputs.target_version }}" ]]; then
-            args+=(-target-version "${{ steps.resolve_release_context.outputs.target_version }}")
+          if [[ -n "${TARGET_VERSION}" ]]; then
+            args+=(-target-version "${TARGET_VERSION}")
           fi
 
           go "${args[@]}"

--- a/.github/workflows-src/changelog-generation/workflow.yml.tmpl
+++ b/.github/workflows-src/changelog-generation/workflow.yml.tmpl
@@ -50,7 +50,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        env:
           TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
         run: |
           set -euo pipefail

--- a/.github/workflows-src/changelog-generation/workflow.yml.tmpl
+++ b/.github/workflows-src/changelog-generation/workflow.yml.tmpl
@@ -46,45 +46,23 @@ jobs:
           x-script-include: scripts/resolve-release-context.inline.js
 
       - name: Run shared changelog engine
-        id: run_changelog_engine
+        id: changelog_engine
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           args=(
-            run ./scripts/changelog-engine
+            run ./scripts/changelog-engine/cmd/changelog-engine
             -mode "${{ steps.resolve_release_context.outputs.mode }}"
             -changelog CHANGELOG.md
-            -output "$RUNNER_TEMP/changelog-engine-outputs"
           )
 
           if [[ -n "${{ steps.resolve_release_context.outputs.target_version }}" ]]; then
             args+=(-target-version "${{ steps.resolve_release_context.outputs.target_version }}")
           fi
 
-          if [[ -n "${{ steps.resolve_release_context.outputs.previous_tag }}" ]]; then
-            args+=(-previous-tag "${{ steps.resolve_release_context.outputs.previous_tag }}")
-          fi
-
           go "${args[@]}"
-
-      - name: Load changelog engine outputs
-        id: changelog_engine
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          output_path = Path(os.environ['RUNNER_TEMP']) / 'changelog-engine-outputs'
-          github_output = Path(os.environ['GITHUB_OUTPUT'])
-          data = json.loads(output_path.read_text())
-
-          with github_output.open('a', encoding='utf-8') as fh:
-            for key, value in data.get('outputs', {}).items():
-              fh.write(f"{key}={str(value).lower() if isinstance(value, bool) else value}\n")
-          PY
 
       - name: Commit changelog (release mode)
         id: commit_release

--- a/.github/workflows-src/changelog-generation/workflow.yml.tmpl
+++ b/.github/workflows-src/changelog-generation/workflow.yml.tmpl
@@ -72,9 +72,19 @@ jobs:
       - name: Load changelog engine outputs
         id: changelog_engine
         run: |
-          while IFS='=' read -r key value; do
-            echo "${key}=${value}" >> "$GITHUB_OUTPUT"
-          done < "$RUNNER_TEMP/changelog-engine-outputs"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          output_path = Path(os.environ['RUNNER_TEMP']) / 'changelog-engine-outputs'
+          github_output = Path(os.environ['GITHUB_OUTPUT'])
+          data = json.loads(output_path.read_text())
+
+          with github_output.open('a', encoding='utf-8') as fh:
+            for key, value in data.get('outputs', {}).items():
+              fh.write(f"{key}={str(value).lower() if isinstance(value, bool) else value}\n")
+          PY
 
       - name: Commit changelog (release mode)
         id: commit_release
@@ -105,8 +115,9 @@ jobs:
           steps.commit_release.outputs.ran == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          COMPARE_RANGE: ${{ steps.resolve_release_context.outputs.compare_range }}
-          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
+          COMPARE_RANGE: ${{ steps.changelog_engine.outputs.compare_range }}
+          TARGET_VERSION: ${{ steps.changelog_engine.outputs.target_version }}
+          TARGET_BRANCH: ${{ steps.changelog_engine.outputs.target_branch }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           x-script-include: scripts/refresh-release-pr.inline.js

--- a/.github/workflows-src/changelog-generation/workflow.yml.tmpl
+++ b/.github/workflows-src/changelog-generation/workflow.yml.tmpl
@@ -3,10 +3,19 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
+    inputs:
+      mode:
+        description: Changelog generation mode
+        required: true
+        default: unreleased
+        type: choice
+        options:
+          - unreleased
+          - release
+      target_version:
+        description: Release target version (required when mode=release)
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -16,10 +25,6 @@ jobs:
   generate-changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      (startsWith(github.head_ref, 'prep-release-') &&
-       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -27,46 +32,55 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          ref: >-
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release' &&
+                format('refs/heads/prep-release-{0}', github.event.inputs.target_version) || '' }}
 
       - name: Resolve release context
         id: resolve_release_context
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          mode: ${{ github.event.inputs.mode || 'unreleased' }}
+          target_version: ${{ github.event.inputs.target_version || '' }}
           x-script-include: scripts/resolve-release-context.inline.js
 
-      - name: Gather merged PRs
-        id: gather_merged_prs
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Run shared changelog engine
+        id: run_changelog_engine
         env:
-          PREVIOUS_TAG: ${{ steps.resolve_release_context.outputs.previous_tag }}
-          COMPARE_RANGE: ${{ steps.resolve_release_context.outputs.compare_range }}
-          MODE: ${{ steps.resolve_release_context.outputs.mode }}
-          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          x-script-include: scripts/gather-merged-prs.inline.js
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          args=(
+            run ./scripts/changelog-engine
+            -mode "${{ steps.resolve_release_context.outputs.mode }}"
+            -changelog CHANGELOG.md
+            -output "$RUNNER_TEMP/changelog-engine-outputs"
+          )
 
-      - name: Render changelog section
-        id: render_changelog
-        if: steps.gather_merged_prs.outputs.has_prs == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          MERGED_PRS_PATH: ${{ steps.gather_merged_prs.outputs.merged_prs_path }}
-          MODE: ${{ steps.resolve_release_context.outputs.mode }}
-          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
-          CHANGELOG_PATH: CHANGELOG.md
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          x-script-include: scripts/render-changelog.inline.js
+          if [[ -n "${{ steps.resolve_release_context.outputs.target_version }}" ]]; then
+            args+=(-target-version "${{ steps.resolve_release_context.outputs.target_version }}")
+          fi
+
+          if [[ -n "${{ steps.resolve_release_context.outputs.previous_tag }}" ]]; then
+            args+=(-previous-tag "${{ steps.resolve_release_context.outputs.previous_tag }}")
+          fi
+
+          go "${args[@]}"
+
+      - name: Load changelog engine outputs
+        id: changelog_engine
+        run: |
+          while IFS='=' read -r key value; do
+            echo "${key}=${value}" >> "$GITHUB_OUTPUT"
+          done < "$RUNNER_TEMP/changelog-engine-outputs"
 
       - name: Commit changelog (release mode)
         id: commit_release
         if: >-
           steps.resolve_release_context.outputs.mode == 'release' &&
-          steps.gather_merged_prs.outputs.has_prs == 'true' &&
-          steps.render_changelog.outputs.has_user_facing_changes == 'true'
+          steps.changelog_engine.outputs.has_user_facing_changes == 'true'
         env:
           TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
           TARGET_BRANCH: ${{ steps.resolve_release_context.outputs.target_branch }}
@@ -101,8 +115,7 @@ jobs:
         id: push_unreleased
         if: >-
           steps.resolve_release_context.outputs.mode == 'unreleased' &&
-          steps.gather_merged_prs.outputs.has_prs == 'true' &&
-          steps.render_changelog.outputs.has_user_facing_changes == 'true'
+          steps.changelog_engine.outputs.has_user_facing_changes == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows-src/lib/changelog-pr-management.js
+++ b/.github/workflows-src/lib/changelog-pr-management.js
@@ -98,17 +98,32 @@ async function manageUnreleasedPR({ github, owner, repo, compareRange }) {
 /**
  * Refresh the release prep PR body with generated metadata.
  *
- * If prNumber is null/undefined, emits a warning and returns without failing.
+ * Finds the release PR by its `prep-release-*` head branch and updates its body.
+ * If no open release PR exists, emits a warning and returns without failing.
  *
- * @param {{ github: object, core: object, owner: string, repo: string, prNumber: number|null, compareRange: string, targetVersion: string }} opts
+ * @param {{ github: object, core: object, owner: string, repo: string, targetBranch: string, compareRange: string, targetVersion: string }} opts
  * @returns {Promise<void>}
  */
-async function refreshReleasePR({ github, core, owner, repo, prNumber, compareRange, targetVersion }) {
-  if (!prNumber) {
-    core.warning('No pull_request.number in event metadata; skipping PR metadata refresh');
+async function refreshReleasePR({ github, core, owner, repo, targetBranch, compareRange, targetVersion }) {
+  if (!targetBranch) {
+    core.warning('No target release branch provided; skipping PR metadata refresh');
     return;
   }
 
+  const { data: releasePRs } = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    head: `${owner}:${targetBranch}`,
+    base: 'main',
+  });
+
+  if (releasePRs.length === 0) {
+    core.warning(`No open release PR found for branch ${targetBranch}; skipping PR metadata refresh`);
+    return;
+  }
+
+  const prNumber = releasePRs[0].number;
   const prBody = buildReleasePRBody({ targetVersion, compareRange });
 
   core.info(`Refreshing release PR #${prNumber} metadata`);

--- a/.github/workflows-src/lib/changelog-pr-management.test.mjs
+++ b/.github/workflows-src/lib/changelog-pr-management.test.mjs
@@ -136,16 +136,23 @@ test('manageUnreleasedPR: no existing PR → creates new PR, returns action=crea
 });
 
 // ---------------------------------------------------------------------------
-// refreshReleasePR: prNumber present → pulls.update called
+// refreshReleasePR: release PR found by target branch → pulls.update called
 // ---------------------------------------------------------------------------
 
-test('refreshReleasePR: prNumber present → calls pulls.update with correct body', async () => {
+test('refreshReleasePR: release PR found by target branch → calls pulls.update with correct body', async () => {
+  const listCalls = [];
   const updateCalls = [];
   const warnings = [];
 
   const github = {
     rest: {
       pulls: {
+        list: async (args) => {
+          listCalls.push(args);
+          return {
+            data: [{ number: 55, html_url: 'https://github.com/org/repo/pull/55' }],
+          };
+        },
         update: async (args) => {
           updateCalls.push(args);
           return { data: {} };
@@ -164,31 +171,41 @@ test('refreshReleasePR: prNumber present → calls pulls.update with correct bod
     core,
     owner: 'org',
     repo: 'repo',
-    prNumber: 55,
-    compareRange: 'v1.0.0...v2.0.0',
+    targetBranch: 'prep-release-2.0.0',
+    compareRange: 'v1.0.0..HEAD',
     targetVersion: '2.0.0',
+  });
+
+  assert.equal(listCalls.length, 1, 'pulls.list should be called once');
+  assert.deepEqual(listCalls[0], {
+    owner: 'org',
+    repo: 'repo',
+    state: 'open',
+    head: 'org:prep-release-2.0.0',
+    base: 'main',
   });
 
   assert.equal(updateCalls.length, 1, 'pulls.update should be called once');
   assert.equal(updateCalls[0].pull_number, 55);
   assert.ok(updateCalls[0].body.includes('**Version:** `2.0.0`'), 'body should include version');
-  assert.ok(updateCalls[0].body.includes('**Compare range:** `v1.0.0...v2.0.0`'), 'body should include compare range');
+  assert.ok(updateCalls[0].body.includes('**Compare range:** `v1.0.0..HEAD`'), 'body should include compare range');
   assert.match(updateCalls[0].body, /\*\*Generated:\*\* \d{4}-\d{2}-\d{2}/);
 
   assert.equal(warnings.length, 0, 'no warnings should be emitted');
 });
 
 // ---------------------------------------------------------------------------
-// refreshReleasePR: prNumber absent → core.warning called, no API call
+// refreshReleasePR: release PR missing → core.warning called, no update call
 // ---------------------------------------------------------------------------
 
-test('refreshReleasePR: prNumber absent → emits warning, does not call pulls.update', async () => {
+test('refreshReleasePR: release PR missing → emits warning, does not call pulls.update', async () => {
   const updateCalls = [];
   const warnings = [];
 
   const github = {
     rest: {
       pulls: {
+        list: async () => ({ data: [] }),
         update: async (args) => {
           updateCalls.push(args);
           return { data: {} };
@@ -207,12 +224,12 @@ test('refreshReleasePR: prNumber absent → emits warning, does not call pulls.u
     core,
     owner: 'org',
     repo: 'repo',
-    prNumber: null,
-    compareRange: 'v1.0.0...v2.0.0',
+    targetBranch: 'prep-release-2.0.0',
+    compareRange: 'v1.0.0..HEAD',
     targetVersion: '2.0.0',
   });
 
   assert.equal(updateCalls.length, 0, 'pulls.update should not be called');
   assert.equal(warnings.length, 1, 'one warning should be emitted');
-  assert.ok(warnings[0].includes('skipping PR metadata refresh'), 'warning message should mention skipping');
+  assert.ok(warnings[0].includes('No open release PR found for branch prep-release-2.0.0'), 'warning message should mention missing release PR');
 });

--- a/.github/workflows-src/lib/changelog-release-context.js
+++ b/.github/workflows-src/lib/changelog-release-context.js
@@ -1,21 +1,38 @@
 const RELEASE_BRANCH_PATTERN = /^prep-release-(.+)$/;
 const SEMVER_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
 
-function resolveReleaseMode({ eventName, headBranch = '' }) {
+function resolveReleaseMode({ eventName, headBranch = '', dispatchMode = '', targetVersion = '' }) {
+  if (eventName === 'workflow_dispatch') {
+    if (dispatchMode === 'release') {
+      const normalizedVersion = targetVersion.trim();
+      return {
+        mode: 'release',
+        targetVersion: normalizedVersion,
+        targetBranch: normalizedVersion ? `prep-release-${normalizedVersion}` : '',
+      };
+    }
+
+    return {
+      mode: 'unreleased',
+      targetVersion: '',
+      targetBranch: 'generated-changelog',
+    };
+  }
+
   let mode = 'unreleased';
-  let targetVersion = '';
+  let resolvedTargetVersion = '';
   let targetBranch = 'generated-changelog';
 
   if (eventName === 'pull_request' || eventName === 'pull_request_target') {
     const match = headBranch.match(RELEASE_BRANCH_PATTERN);
     if (match) {
       mode = 'release';
-      targetVersion = match[1];
+      resolvedTargetVersion = match[1];
       targetBranch = headBranch;
     }
   }
 
-  return { mode, targetVersion, targetBranch };
+  return { mode, targetVersion: resolvedTargetVersion, targetBranch };
 }
 
 function parseSemverTags(tagsRaw = '') {
@@ -40,8 +57,14 @@ function buildCompareRange(previousTag) {
   return previousTag ? `${previousTag}..HEAD` : 'HEAD';
 }
 
-function buildReleaseContext({ eventName, headBranch = '', tags = [] }) {
-  const modeResult = resolveReleaseMode({ eventName, headBranch });
+function buildReleaseContext({
+  eventName,
+  headBranch = '',
+  dispatchMode = '',
+  targetVersion = '',
+  tags = [],
+}) {
+  const modeResult = resolveReleaseMode({ eventName, headBranch, dispatchMode, targetVersion });
   const previousTagResult = selectPreviousTag({
     tags,
     mode: modeResult.mode,

--- a/.github/workflows-src/lib/changelog-release-context.js
+++ b/.github/workflows-src/lib/changelog-release-context.js
@@ -1,38 +1,21 @@
 const RELEASE_BRANCH_PATTERN = /^prep-release-(.+)$/;
 const SEMVER_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
 
-function resolveReleaseMode({ eventName, headBranch = '', dispatchMode = '', targetVersion = '' }) {
-  if (eventName === 'workflow_dispatch') {
-    if (dispatchMode === 'release') {
-      const normalizedVersion = targetVersion.trim();
-      return {
-        mode: 'release',
-        targetVersion: normalizedVersion,
-        targetBranch: normalizedVersion ? `prep-release-${normalizedVersion}` : '',
-      };
-    }
-
+function resolveReleaseMode({ eventName, dispatchMode = '', targetVersion = '' }) {
+  if (eventName === 'workflow_dispatch' && dispatchMode === 'release') {
+    const normalizedVersion = targetVersion.trim();
     return {
-      mode: 'unreleased',
-      targetVersion: '',
-      targetBranch: 'generated-changelog',
+      mode: 'release',
+      targetVersion: normalizedVersion,
+      targetBranch: normalizedVersion ? `prep-release-${normalizedVersion}` : '',
     };
   }
 
-  let mode = 'unreleased';
-  let resolvedTargetVersion = '';
-  let targetBranch = 'generated-changelog';
-
-  if (eventName === 'pull_request' || eventName === 'pull_request_target') {
-    const match = headBranch.match(RELEASE_BRANCH_PATTERN);
-    if (match) {
-      mode = 'release';
-      resolvedTargetVersion = match[1];
-      targetBranch = headBranch;
-    }
-  }
-
-  return { mode, targetVersion: resolvedTargetVersion, targetBranch };
+  return {
+    mode: 'unreleased',
+    targetVersion: '',
+    targetBranch: 'generated-changelog',
+  };
 }
 
 function parseSemverTags(tagsRaw = '') {
@@ -59,12 +42,11 @@ function buildCompareRange(previousTag) {
 
 function buildReleaseContext({
   eventName,
-  headBranch = '',
   dispatchMode = '',
   targetVersion = '',
   tags = [],
 }) {
-  const modeResult = resolveReleaseMode({ eventName, headBranch, dispatchMode, targetVersion });
+  const modeResult = resolveReleaseMode({ eventName, dispatchMode, targetVersion });
   const previousTagResult = selectPreviousTag({
     tags,
     mode: modeResult.mode,

--- a/.github/workflows-src/lib/changelog-release-context.test.mjs
+++ b/.github/workflows-src/lib/changelog-release-context.test.mjs
@@ -11,16 +11,15 @@ const {
   selectPreviousTag,
 } = require('./changelog-release-context.js');
 
-test('resolveReleaseMode detects prep-release pull request branches', () => {
+test('resolveReleaseMode defaults non-dispatch events to unreleased', () => {
   assert.deepEqual(
     resolveReleaseMode({
-      eventName: 'pull_request',
-      headBranch: 'prep-release-1.2.3',
+      eventName: 'schedule',
     }),
     {
-      mode: 'release',
-      targetVersion: '1.2.3',
-      targetBranch: 'prep-release-1.2.3',
+      mode: 'unreleased',
+      targetVersion: '',
+      targetBranch: 'generated-changelog',
     }
   );
 });
@@ -81,25 +80,6 @@ test('buildCompareRange falls back to HEAD when no previous tag exists', () => {
   assert.equal(buildCompareRange('v1.2.2'), 'v1.2.2..HEAD');
 });
 
-test('buildReleaseContext combines pull request release mode and previous tag selection', () => {
-  assert.deepEqual(
-    buildReleaseContext({
-      eventName: 'pull_request_target',
-      headBranch: 'prep-release-2.0.0',
-      tags: ['v2.0.0', 'v1.9.0'],
-    }),
-    {
-      mode: 'release',
-      targetVersion: '2.0.0',
-      targetBranch: 'prep-release-2.0.0',
-      previousTag: 'v1.9.0',
-      excludedTag: 'v2.0.0',
-      excludedCurrentTag: true,
-      compareRange: 'v1.9.0..HEAD',
-    }
-  );
-});
-
 test('buildReleaseContext combines workflow_dispatch release mode and previous tag selection', () => {
   assert.deepEqual(
     buildReleaseContext({
@@ -115,6 +95,26 @@ test('buildReleaseContext combines workflow_dispatch release mode and previous t
       previousTag: 'v1.9.0',
       excludedTag: 'v2.0.0',
       excludedCurrentTag: true,
+      compareRange: 'v1.9.0..HEAD',
+    }
+  );
+});
+
+test('buildReleaseContext keeps current release tag when it is not present locally', () => {
+  assert.deepEqual(
+    buildReleaseContext({
+      eventName: 'workflow_dispatch',
+      dispatchMode: 'release',
+      targetVersion: '2.0.0',
+      tags: ['v1.9.0', 'v1.8.0'],
+    }),
+    {
+      mode: 'release',
+      targetVersion: '2.0.0',
+      targetBranch: 'prep-release-2.0.0',
+      previousTag: 'v1.9.0',
+      excludedTag: 'v2.0.0',
+      excludedCurrentTag: false,
       compareRange: 'v1.9.0..HEAD',
     }
   );

--- a/.github/workflows-src/lib/changelog-release-context.test.mjs
+++ b/.github/workflows-src/lib/changelog-release-context.test.mjs
@@ -25,7 +25,7 @@ test('resolveReleaseMode detects prep-release pull request branches', () => {
   );
 });
 
-test('resolveReleaseMode defaults to unreleased for non-release branches', () => {
+test('resolveReleaseMode defaults workflow_dispatch to unreleased', () => {
   assert.deepEqual(
     resolveReleaseMode({
       eventName: 'workflow_dispatch',
@@ -35,6 +35,21 @@ test('resolveReleaseMode defaults to unreleased for non-release branches', () =>
       mode: 'unreleased',
       targetVersion: '',
       targetBranch: 'generated-changelog',
+    }
+  );
+});
+
+test('resolveReleaseMode uses explicit workflow_dispatch release inputs', () => {
+  assert.deepEqual(
+    resolveReleaseMode({
+      eventName: 'workflow_dispatch',
+      dispatchMode: 'release',
+      targetVersion: '2.0.0',
+    }),
+    {
+      mode: 'release',
+      targetVersion: '2.0.0',
+      targetBranch: 'prep-release-2.0.0',
     }
   );
 });
@@ -66,11 +81,31 @@ test('buildCompareRange falls back to HEAD when no previous tag exists', () => {
   assert.equal(buildCompareRange('v1.2.2'), 'v1.2.2..HEAD');
 });
 
-test('buildReleaseContext combines mode and previous tag selection', () => {
+test('buildReleaseContext combines pull request release mode and previous tag selection', () => {
   assert.deepEqual(
     buildReleaseContext({
       eventName: 'pull_request_target',
       headBranch: 'prep-release-2.0.0',
+      tags: ['v2.0.0', 'v1.9.0'],
+    }),
+    {
+      mode: 'release',
+      targetVersion: '2.0.0',
+      targetBranch: 'prep-release-2.0.0',
+      previousTag: 'v1.9.0',
+      excludedTag: 'v2.0.0',
+      excludedCurrentTag: true,
+      compareRange: 'v1.9.0..HEAD',
+    }
+  );
+});
+
+test('buildReleaseContext combines workflow_dispatch release mode and previous tag selection', () => {
+  assert.deepEqual(
+    buildReleaseContext({
+      eventName: 'workflow_dispatch',
+      dispatchMode: 'release',
+      targetVersion: '2.0.0',
       tags: ['v2.0.0', 'v1.9.0'],
     }),
     {

--- a/.github/workflows-src/lib/changelog-workflow-contract.test.mjs
+++ b/.github/workflows-src/lib/changelog-workflow-contract.test.mjs
@@ -24,7 +24,15 @@ test('compiled changelog workflow matches source expectations', () => {
   assert.doesNotMatch(compiled, /^\s*pull_request_target:/m);
   assert.match(compiled, /^\s*workflow_dispatch:\s*$/m);
   assert.match(compiled, /^\s+mode:\s*$/m);
+  assert.match(compiled, /^\s+options:\s*$/m);
+  assert.match(compiled, /^\s+- unreleased\s*$/m);
+  assert.match(compiled, /^\s+- release\s*$/m);
   assert.match(compiled, /^\s+target_version:\s*$/m);
+  assert.match(compiled, /target_version: \$\{\{ github\.event\.inputs\.target_version \|\| '' \}\}/);
+  assert.match(compiled, /format\('refs\/heads\/prep-release-\{0\}', github\.event\.inputs\.target_version\)/);
+  assert.match(compiled, /- name: Push to generated-changelog branch \(unreleased mode\)/);
+  assert.match(compiled, /steps\.resolve_release_context\.outputs\.mode == 'unreleased' &&/);
+  assert.doesNotMatch(compiled, /Push to generated-changelog branch \(release mode\)/);
   assert.match(compiled, /python - <<'PY'/);
   assert.match(compiled, /json\.loads\(output_path\.read_text\(\)\)/);
 });

--- a/.github/workflows-src/lib/changelog-workflow-contract.test.mjs
+++ b/.github/workflows-src/lib/changelog-workflow-contract.test.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const sourcePath = '.github/workflows-src/changelog-generation/workflow.yml.tmpl';
+const compiledPath = '.github/workflows/changelog-generation.yml';
+
+function read(path) {
+  return readFileSync(path, 'utf8');
+}
+
+test('changelog workflow source removes pull_request_target and exposes explicit workflow_dispatch inputs', () => {
+  const source = read(sourcePath);
+
+  assert.doesNotMatch(source, /^\s*pull_request_target:/m);
+  assert.match(source, /^\s*workflow_dispatch:\s*$/m);
+  assert.match(source, /^\s+mode:\s*$/m);
+  assert.match(source, /^\s+target_version:\s*$/m);
+});
+
+test('compiled changelog workflow matches source expectations', () => {
+  const compiled = read(compiledPath);
+
+  assert.doesNotMatch(compiled, /^\s*pull_request_target:/m);
+  assert.match(compiled, /^\s*workflow_dispatch:\s*$/m);
+  assert.match(compiled, /^\s+mode:\s*$/m);
+  assert.match(compiled, /^\s+target_version:\s*$/m);
+  assert.match(compiled, /python - <<'PY'/);
+  assert.match(compiled, /json\.loads\(output_path\.read_text\(\)\)/);
+});

--- a/.github/workflows-src/lib/changelog-workflow-contract.test.mjs
+++ b/.github/workflows-src/lib/changelog-workflow-contract.test.mjs
@@ -33,6 +33,8 @@ test('compiled changelog workflow matches source expectations', () => {
   assert.match(compiled, /- name: Push to generated-changelog branch \(unreleased mode\)/);
   assert.match(compiled, /steps\.resolve_release_context\.outputs\.mode == 'unreleased' &&/);
   assert.doesNotMatch(compiled, /Push to generated-changelog branch \(release mode\)/);
-  assert.match(compiled, /python - <<'PY'/);
-  assert.match(compiled, /json\.loads\(output_path\.read_text\(\)\)/);
+  assert.match(compiled, /id: changelog_engine/);
+  assert.match(compiled, /run \.\/scripts\/changelog-engine\/cmd\/changelog-engine/);
+  assert.doesNotMatch(compiled, /-previous-tag/);
+  assert.doesNotMatch(compiled, /Load changelog engine outputs/);
 });

--- a/.github/workflows-src/lib/prep-release-workflow-contract.test.mjs
+++ b/.github/workflows-src/lib/prep-release-workflow-contract.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+
+const workflowPath = '.github/workflows/prep-release.yml';
+
+function read(path) {
+  return readFileSync(path, 'utf8');
+}
+
+test('prep-release runs release-mode changelog generation before PR management and without unused engine output file', () => {
+  const workflow = read(workflowPath);
+
+  const engineStep = workflow.indexOf('- name: Run shared changelog engine in release mode');
+  const prCheckStep = workflow.indexOf('- name: Check if release PR already exists');
+  const createPrStep = workflow.indexOf('- name: Create release PR');
+
+  assert.notEqual(engineStep, -1, 'workflow should invoke the shared changelog engine');
+  assert.notEqual(prCheckStep, -1, 'workflow should check for an existing release PR');
+  assert.notEqual(createPrStep, -1, 'workflow should create a release PR when needed');
+  assert.ok(engineStep < prCheckStep, 'release-mode changelog generation should occur before PR reuse checks');
+  assert.ok(engineStep < createPrStep, 'release-mode changelog generation should occur before PR creation');
+  assert.doesNotMatch(workflow, /-output\s+"\$RUNNER_TEMP\/changelog-engine-outputs"/, 'prep-release should not pass an unused engine output file');
+});
+
+test('prep-release keeps deterministic single-commit intent and stable reuse contract', () => {
+  const workflow = read(workflowPath);
+
+  assert.match(workflow, /BRANCH="prep-release-\$\{TARGET_VERSION\}"/, 'workflow should derive a deterministic prep-release branch name');
+  assert.match(workflow, /git checkout -B "\$\{BRANCH\}" "origin\/\$\{BRANCH\}"/, 'workflow should reset the local branch from the remote branch on rerun');
+  assert.match(workflow, /git commit -m "chore\(release\): prepare \$\{TARGET_VERSION\} release"/, 'workflow should create the single deterministic release-preparation commit');
+  assert.match(workflow, /gh pr list --head "\$\{BRANCH\}" --state open --json url --jq '\.\[0\]\.url'/, 'workflow should reuse an existing PR for the branch');
+  assert.match(workflow, /--label no-changelog/, 'workflow should apply the no-changelog label on PR creation');
+  assert.match(workflow, /gh pr edit "\$\{\{ steps\.pr-check\.outputs\.PR_URL \}\}" --add-label no-changelog/, 'workflow should reapply the no-changelog label when reusing a PR');
+});

--- a/.github/workflows/changelog-generation.yml
+++ b/.github/workflows/changelog-generation.yml
@@ -49,38 +49,21 @@ jobs:
             const RELEASE_BRANCH_PATTERN = /^prep-release-(.+)$/;
             const SEMVER_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
             
-            function resolveReleaseMode({ eventName, headBranch = '', dispatchMode = '', targetVersion = '' }) {
-              if (eventName === 'workflow_dispatch') {
-                if (dispatchMode === 'release') {
-                  const normalizedVersion = targetVersion.trim();
-                  return {
-                    mode: 'release',
-                    targetVersion: normalizedVersion,
-                    targetBranch: normalizedVersion ? `prep-release-${normalizedVersion}` : '',
-                  };
-                }
-            
+            function resolveReleaseMode({ eventName, dispatchMode = '', targetVersion = '' }) {
+              if (eventName === 'workflow_dispatch' && dispatchMode === 'release') {
+                const normalizedVersion = targetVersion.trim();
                 return {
-                  mode: 'unreleased',
-                  targetVersion: '',
-                  targetBranch: 'generated-changelog',
+                  mode: 'release',
+                  targetVersion: normalizedVersion,
+                  targetBranch: normalizedVersion ? `prep-release-${normalizedVersion}` : '',
                 };
               }
             
-              let mode = 'unreleased';
-              let resolvedTargetVersion = '';
-              let targetBranch = 'generated-changelog';
-            
-              if (eventName === 'pull_request' || eventName === 'pull_request_target') {
-                const match = headBranch.match(RELEASE_BRANCH_PATTERN);
-                if (match) {
-                  mode = 'release';
-                  resolvedTargetVersion = match[1];
-                  targetBranch = headBranch;
-                }
-              }
-            
-              return { mode, targetVersion: resolvedTargetVersion, targetBranch };
+              return {
+                mode: 'unreleased',
+                targetVersion: '',
+                targetBranch: 'generated-changelog',
+              };
             }
             
             function parseSemverTags(tagsRaw = '') {
@@ -107,12 +90,11 @@ jobs:
             
             function buildReleaseContext({
               eventName,
-              headBranch = '',
               dispatchMode = '',
               targetVersion = '',
               tags = [],
             }) {
-              const modeResult = resolveReleaseMode({ eventName, headBranch, dispatchMode, targetVersion });
+              const modeResult = resolveReleaseMode({ eventName, dispatchMode, targetVersion });
               const previousTagResult = selectPreviousTag({
                 tags,
                 mode: modeResult.mode,
@@ -226,9 +208,19 @@ jobs:
       - name: Load changelog engine outputs
         id: changelog_engine
         run: |
-          while IFS='=' read -r key value; do
-            echo "${key}=${value}" >> "$GITHUB_OUTPUT"
-          done < "$RUNNER_TEMP/changelog-engine-outputs"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          output_path = Path(os.environ['RUNNER_TEMP']) / 'changelog-engine-outputs'
+          github_output = Path(os.environ['GITHUB_OUTPUT'])
+          data = json.loads(output_path.read_text())
+
+          with github_output.open('a', encoding='utf-8') as fh:
+            for key, value in data.get('outputs', {}).items():
+              fh.write(f"{key}={str(value).lower() if isinstance(value, bool) else value}\n")
+          PY
 
       - name: Commit changelog (release mode)
         id: commit_release
@@ -259,8 +251,9 @@ jobs:
           steps.commit_release.outputs.ran == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          COMPARE_RANGE: ${{ steps.resolve_release_context.outputs.compare_range }}
-          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
+          COMPARE_RANGE: ${{ steps.changelog_engine.outputs.compare_range }}
+          TARGET_VERSION: ${{ steps.changelog_engine.outputs.target_version }}
+          TARGET_BRANCH: ${{ steps.changelog_engine.outputs.target_branch }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -364,17 +357,32 @@ jobs:
             /**
              * Refresh the release prep PR body with generated metadata.
              *
-             * If prNumber is null/undefined, emits a warning and returns without failing.
+             * Finds the release PR by its `prep-release-*` head branch and updates its body.
+             * If no open release PR exists, emits a warning and returns without failing.
              *
-             * @param {{ github: object, core: object, owner: string, repo: string, prNumber: number|null, compareRange: string, targetVersion: string }} opts
+             * @param {{ github: object, core: object, owner: string, repo: string, targetBranch: string, compareRange: string, targetVersion: string }} opts
              * @returns {Promise<void>}
              */
-            async function refreshReleasePR({ github, core, owner, repo, prNumber, compareRange, targetVersion }) {
-              if (!prNumber) {
-                core.warning('No pull_request.number in event metadata; skipping PR metadata refresh');
+            async function refreshReleasePR({ github, core, owner, repo, targetBranch, compareRange, targetVersion }) {
+              if (!targetBranch) {
+                core.warning('No target release branch provided; skipping PR metadata refresh');
                 return;
               }
             
+              const { data: releasePRs } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${owner}:${targetBranch}`,
+                base: 'main',
+              });
+            
+              if (releasePRs.length === 0) {
+                core.warning(`No open release PR found for branch ${targetBranch}; skipping PR metadata refresh`);
+                return;
+              }
+            
+              const prNumber = releasePRs[0].number;
               const prBody = buildReleasePRBody({ targetVersion, compareRange });
             
               core.info(`Refreshing release PR #${prNumber} metadata`);
@@ -397,11 +405,11 @@ jobs:
             }
             
             const { owner, repo } = context.repo;
-            const prNumber = context.payload.pull_request?.number ?? null;
             const compareRange = process.env.COMPARE_RANGE;
             const targetVersion = process.env.TARGET_VERSION;
+            const targetBranch = process.env.TARGET_BRANCH;
             
-            await refreshReleasePR({ github, core, owner, repo, prNumber, compareRange, targetVersion });
+            await refreshReleasePR({ github, core, owner, repo, targetBranch, compareRange, targetVersion });
             
       - name: Push to generated-changelog branch (unreleased mode)
         id: push_unreleased
@@ -531,17 +539,32 @@ jobs:
             /**
              * Refresh the release prep PR body with generated metadata.
              *
-             * If prNumber is null/undefined, emits a warning and returns without failing.
+             * Finds the release PR by its `prep-release-*` head branch and updates its body.
+             * If no open release PR exists, emits a warning and returns without failing.
              *
-             * @param {{ github: object, core: object, owner: string, repo: string, prNumber: number|null, compareRange: string, targetVersion: string }} opts
+             * @param {{ github: object, core: object, owner: string, repo: string, targetBranch: string, compareRange: string, targetVersion: string }} opts
              * @returns {Promise<void>}
              */
-            async function refreshReleasePR({ github, core, owner, repo, prNumber, compareRange, targetVersion }) {
-              if (!prNumber) {
-                core.warning('No pull_request.number in event metadata; skipping PR metadata refresh');
+            async function refreshReleasePR({ github, core, owner, repo, targetBranch, compareRange, targetVersion }) {
+              if (!targetBranch) {
+                core.warning('No target release branch provided; skipping PR metadata refresh');
                 return;
               }
             
+              const { data: releasePRs } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                head: `${owner}:${targetBranch}`,
+                base: 'main',
+              });
+            
+              if (releasePRs.length === 0) {
+                core.warning(`No open release PR found for branch ${targetBranch}; skipping PR metadata refresh`);
+                return;
+              }
+            
+              const prNumber = releasePRs[0].number;
               const prBody = buildReleasePRBody({ targetVersion, compareRange });
             
               core.info(`Refreshing release PR #${prNumber} metadata`);

--- a/.github/workflows/changelog-generation.yml
+++ b/.github/workflows/changelog-generation.yml
@@ -186,6 +186,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
         run: |
           set -euo pipefail
           args=(
@@ -194,8 +195,8 @@ jobs:
             -changelog CHANGELOG.md
           )
 
-          if [[ -n "${{ steps.resolve_release_context.outputs.target_version }}" ]]; then
-            args+=(-target-version "${{ steps.resolve_release_context.outputs.target_version }}")
+          if [[ -n "${TARGET_VERSION}" ]]; then
+            args+=(-target-version "${TARGET_VERSION}")
           fi
 
           go "${args[@]}"

--- a/.github/workflows/changelog-generation.yml
+++ b/.github/workflows/changelog-generation.yml
@@ -4,10 +4,19 @@ on:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
-  pull_request_target:
-    branches:
-      - main
-    types: [opened, synchronize, reopened]
+    inputs:
+      mode:
+        description: Changelog generation mode
+        required: true
+        default: unreleased
+        type: choice
+        options:
+          - unreleased
+          - release
+      target_version:
+        description: Release target version (required when mode=release)
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -17,10 +26,6 @@ jobs:
   generate-changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request_target' ||
-      (startsWith(github.head_ref, 'prep-release-') &&
-       github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -28,33 +33,54 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          ref: >-
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'release' &&
+                format('refs/heads/prep-release-{0}', github.event.inputs.target_version) || '' }}
 
       - name: Resolve release context
         id: resolve_release_context
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          mode: ${{ github.event.inputs.mode || 'unreleased' }}
+          target_version: ${{ github.event.inputs.target_version || '' }}
           script: |
             const { execSync } = require('child_process');
             const RELEASE_BRANCH_PATTERN = /^prep-release-(.+)$/;
             const SEMVER_TAG_PATTERN = /^v\d+\.\d+\.\d+$/;
             
-            function resolveReleaseMode({ eventName, headBranch = '' }) {
+            function resolveReleaseMode({ eventName, headBranch = '', dispatchMode = '', targetVersion = '' }) {
+              if (eventName === 'workflow_dispatch') {
+                if (dispatchMode === 'release') {
+                  const normalizedVersion = targetVersion.trim();
+                  return {
+                    mode: 'release',
+                    targetVersion: normalizedVersion,
+                    targetBranch: normalizedVersion ? `prep-release-${normalizedVersion}` : '',
+                  };
+                }
+            
+                return {
+                  mode: 'unreleased',
+                  targetVersion: '',
+                  targetBranch: 'generated-changelog',
+                };
+              }
+            
               let mode = 'unreleased';
-              let targetVersion = '';
+              let resolvedTargetVersion = '';
               let targetBranch = 'generated-changelog';
             
               if (eventName === 'pull_request' || eventName === 'pull_request_target') {
                 const match = headBranch.match(RELEASE_BRANCH_PATTERN);
                 if (match) {
                   mode = 'release';
-                  targetVersion = match[1];
+                  resolvedTargetVersion = match[1];
                   targetBranch = headBranch;
                 }
               }
             
-              return { mode, targetVersion, targetBranch };
+              return { mode, targetVersion: resolvedTargetVersion, targetBranch };
             }
             
             function parseSemverTags(tagsRaw = '') {
@@ -79,8 +105,14 @@ jobs:
               return previousTag ? `${previousTag}..HEAD` : 'HEAD';
             }
             
-            function buildReleaseContext({ eventName, headBranch = '', tags = [] }) {
-              const modeResult = resolveReleaseMode({ eventName, headBranch });
+            function buildReleaseContext({
+              eventName,
+              headBranch = '',
+              dispatchMode = '',
+              targetVersion = '',
+              tags = [],
+            }) {
+              const modeResult = resolveReleaseMode({ eventName, headBranch, dispatchMode, targetVersion });
               const previousTagResult = selectPreviousTag({
                 tags,
                 mode: modeResult.mode,
@@ -106,7 +138,7 @@ jobs:
               };
             }
             
-            // Determine mode from event
+            // Determine mode from event or explicit workflow_dispatch inputs
             const eventName = context.eventName;
             const headBranch =
               context.payload.pull_request?.head?.ref ??
@@ -114,6 +146,13 @@ jobs:
               process.env.GITHUB_HEAD_REF ??
               process.env.GITHUB_REF_NAME ??
               '';
+            const dispatchMode = core.getInput('mode') || 'unreleased';
+            const targetVersionInput = core.getInput('target_version') || '';
+            
+            if (eventName === 'workflow_dispatch' && dispatchMode === 'release' && !targetVersionInput.trim()) {
+              core.setFailed('workflow_dispatch release mode requires a target_version input');
+              process.exit(1);
+            }
             
             let tags = [];
             try {
@@ -128,7 +167,13 @@ jobs:
               core.warning(`Failed to list git tags: ${err.message}`);
             }
             
-            const releaseContext = buildReleaseContext({ eventName, headBranch, tags });
+            const releaseContext = buildReleaseContext({
+              eventName,
+              headBranch,
+              dispatchMode,
+              targetVersion: targetVersionInput,
+              tags,
+            });
             
             if (releaseContext.mode === 'release') {
               core.info(`Release mode: branch=${headBranch}, version=${releaseContext.targetVersion}`);
@@ -154,785 +199,42 @@ jobs:
             core.info(`Compare range: ${releaseContext.compareRange}`);
             core.info(`Target branch: ${releaseContext.targetBranch}`);
             
-      - name: Gather merged PRs
-        id: gather_merged_prs
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+      - name: Run shared changelog engine
+        id: run_changelog_engine
         env:
-          PREVIOUS_TAG: ${{ steps.resolve_release_context.outputs.previous_tag }}
-          COMPARE_RANGE: ${{ steps.resolve_release_context.outputs.compare_range }}
-          MODE: ${{ steps.resolve_release_context.outputs.mode }}
-          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const { execSync } = require('child_process');
-            
-            const previousTag = process.env.PREVIOUS_TAG || '';
-            const compareRange = process.env.COMPARE_RANGE || 'HEAD';
-            const mode = process.env.MODE || 'unreleased';
-            const targetVersion = process.env.TARGET_VERSION || '';
-            
-            const { owner, repo } = context.repo;
-            
-            function parseCommitShas(raw = '') {
-              return raw
-                .split('\n')
-                .map((sha) => sha.trim())
-                .filter(Boolean);
-            }
-            
-            function getLabelNames(pr) {
-              return (pr.labels ?? []).map((label) => label.name);
-            }
-            
-            // Collect commits in range
-            let commitSHAs = [];
-            try {
-              const range = compareRange || 'HEAD';
-              const raw = execSync(`git log --format=%H ${range}`, {
-                encoding: 'utf8',
-                stdio: ['pipe', 'pipe', 'pipe'],
-              }).trim();
-              commitSHAs = parseCommitShas(raw);
-              core.info(`Found ${commitSHAs.length} commit(s) in range ${range}`);
-            } catch (err) {
-              core.warning(`Failed to list commits in range: ${err.message}`);
-            }
-            
-            // Find PRs associated with these commits and dedupe merged PRs as we go.
-            const mergedPullRequestsByNumber = new Map();
-            
-            for (const sha of commitSHAs) {
-              try {
-                const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  owner,
-                  repo,
-                  commit_sha: sha,
-                });
-                for (const pr of prs) {
-                  if (pr.state === 'closed' && pr.merged_at && !mergedPullRequestsByNumber.has(pr.number)) {
-                    mergedPullRequestsByNumber.set(pr.number, pr);
-                  }
-                }
-              } catch (err) {
-                core.warning(`Failed to list PRs for commit ${sha}: ${err.message}`);
-              }
-            }
-            
-            const mergedPullRequests = Array.from(mergedPullRequestsByNumber.values());
-            core.info(`Found ${mergedPullRequests.length} unique merged PR(s) in compare range`);
-            
-            // Build the PR metadata records for the renderer.
-            // We capture: number, url, merge_commit_sha, labels, body.
-            // We do NOT need per-file classification here — deterministic rendering uses the
-            // PR-body changelog contract and the no-changelog label instead.
-            const prRecords = mergedPullRequests.map((pr) => ({
-              number: pr.number,
-              title: pr.title,
-              url: pr.html_url,
-              merge_commit_sha: pr.merge_commit_sha,
-              author: pr.user?.login ?? 'unknown',
-              labels: getLabelNames(pr),
-              body: pr.body || '',
-            }));
-            
-            const manifest = {
-              generated_at: new Date().toISOString(),
-              mode,
-              target_version: targetVersion,
-              previous_tag: previousTag,
-              compare_range: compareRange,
-              pr_count: prRecords.length,
-              pull_requests: prRecords,
-            };
-            
-            const artifactDir = '/tmp/changelog-assembly';
-            const artifactPath = `${artifactDir}/merged-prs.json`;
-            fs.mkdirSync(artifactDir, { recursive: true });
-            fs.writeFileSync(artifactPath, JSON.stringify(manifest, null, 2), 'utf8');
-            
-            core.setOutput('merged_prs_path', artifactPath);
-            const hasPRs = prRecords.length > 0;
-            core.setOutput('has_prs', hasPRs ? 'true' : 'false');
-            core.info(`Merged PR manifest written to ${artifactPath} (${prRecords.length} PRs)`);
-            
-      - name: Render changelog section
-        id: render_changelog
-        if: steps.gather_merged_prs.outputs.has_prs == 'true'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          MERGED_PRS_PATH: ${{ steps.gather_merged_prs.outputs.merged_prs_path }}
-          MODE: ${{ steps.resolve_release_context.outputs.mode }}
-          TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
-          CHANGELOG_PATH: CHANGELOG.md
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            /**
-             * Deterministic changelog renderer.
-             *
-             * Converts an array of merged PR metadata records (each with a parsed
-             * `## Changelog` section) into a rendered changelog section body.
-             *
-             * Rendering rules:
-             * - PRs with the `no-changelog` label are silently excluded.
-             * - PRs with `Customer impact: none` produce no change bullet (but may
-             *   still contribute breaking-change blocks).
-             * - PRs that have neither the `no-changelog` label nor a parseable
-             *   `## Changelog` section cause a hard assembly failure.
-             * - Breaking-change blocks from included PRs are collected and placed
-             *   under a `### Breaking changes` subsection.
-             * - Regular change bullets are placed under `### Changes`.
-             * - Normalization is minimal: standard `- ` bullet prefix, citation
-             *   shape `([#NNN](url))`, and consistent whitespace. Author-provided
-             *   summary text is preserved verbatim.
-             */
-            
-            /**
-             * Helpers to parse and validate the PR-body `## Changelog` contract.
-             *
-             * Contract:
-             *   ## Changelog
-             *   Customer impact: <none|fix|enhancement|breaking>
-             *   Summary: <text>          (required when Customer impact is not "none")
-             *
-             *   ### Breaking changes
-             *   <free-form markdown>     (optional subsection)
-             */
-            
-            const VALID_CUSTOMER_IMPACTS = new Set(['none', 'fix', 'enhancement', 'breaking']);
-            
-            /**
-             * Extract the raw text of the `## Changelog` section from a PR body.
-             * Returns the content between `## Changelog` and the next `##`-level heading
-             * (or the end of the string).
-             *
-             * @param {string} body
-             * @returns {string|null}
-             */
-            function extractChangelogSection(body) {
-              if (!body) return null;
-            
-              const lines = body.split('\n');
-              let inChangelog = false;
-              /** @type {null | '`' | '~'} */
-              let fenceType = null;
-              const content = [];
-            
-              for (const line of lines) {
-                if (/^##\s+Changelog/.test(line)) {
-                  inChangelog = true;
-                  continue;
-                }
-                if (inChangelog) {
-                  if (fenceType === null && /^```/.test(line)) {
-                    fenceType = '`';
-                  } else if (fenceType === null && /^~~~/.test(line)) {
-                    fenceType = '~';
-                  } else if (fenceType === '`' && /^```/.test(line)) {
-                    fenceType = null;
-                  } else if (fenceType === '~' && /^~~~/.test(line)) {
-                    fenceType = null;
-                  }
-                  if (fenceType === null && /^##\s/.test(line)) {
-                    break;
-                  }
-                  content.push(line);
-                }
-              }
-            
-              if (!inChangelog) return null;
-            
-              return content.join('\n');
-            }
-            
-            /**
-             * Extract the raw markdown content of the `### Breaking changes` subsection
-             * from a PR body string. Returns everything from the heading line (exclusive)
-             * up to the next `##` or `###` heading, or the end of the string.
-             *
-             * @param {string} body
-             * @returns {string|null} Trimmed markdown content, or null if not present or empty.
-             */
-            function extractBreakingChanges(changelogSection) {
-              if (!changelogSection) return null;
-            
-              const lines = changelogSection.split('\n');
-              let inBreaking = false;
-              /** @type {null | '`' | '~'} */
-              let fenceType = null;
-              const content = [];
-            
-              for (const line of lines) {
-                if (/^###\s+Breaking changes/.test(line)) {
-                  inBreaking = true;
-                  continue;
-                }
-                if (inBreaking) {
-                  if (fenceType === null && /^```/.test(line)) {
-                    fenceType = '`';
-                  } else if (fenceType === null && /^~~~/.test(line)) {
-                    fenceType = '~';
-                  } else if (fenceType === '`' && /^```/.test(line)) {
-                    fenceType = null;
-                  } else if (fenceType === '~' && /^~~~/.test(line)) {
-                    fenceType = null;
-                  }
-                  if (fenceType === null && /^#{2,3}\s/.test(line)) {
-                    break;
-                  }
-                  content.push(line);
-                }
-              }
-            
-              if (!inBreaking) return null;
-            
-              const trimmed = content.join('\n').trimEnd();
-              return trimmed.length > 0 ? trimmed : null;
-            }
-            
-            /**
-             * Parse the `## Changelog` section from a PR body string.
-             *
-             * @param {string} body - Full PR body text.
-             * @returns {{ customerImpact: string|null, summary: string|null, breakingChanges: string|null }|null}
-             *   Returns null when no `## Changelog` section is found.
-             */
-            function parseChangelogSection(body) {
-              const section = extractChangelogSection(body);
-              if (section === null) return null;
-            
-              // Parse `Customer impact: <value>`
-              const customerImpactMatch = section.match(/^Customer impact:\s*(.+)$/m);
-              const customerImpact = customerImpactMatch ? customerImpactMatch[1].trim() : null;
-            
-              // Parse `Summary: <text>`
-              const summaryMatch = section.match(/^Summary:\s*(.+)$/m);
-              const summary = summaryMatch ? summaryMatch[1].trim() : null;
-            
-              // Extract breaking changes from the changelog section only
-              const breakingChanges = extractBreakingChanges(section);
-            
-              return {
-                customerImpact,
-                summary: summary || null,
-                breakingChanges,
-              };
-            }
-            
-            /**
-             * Validate a parsed changelog section.
-             *
-             * @param {{ customerImpact: string|null, summary: string|null, breakingChanges: string|null }|null} parsed
-             * @returns {{ valid: boolean, errors: string[] }}
-             */
-            function validateChangelogSection(parsed) {
-              const errors = [];
-            
-              if (parsed === null) {
-                errors.push('No ## Changelog section found in PR body');
-                return { valid: false, errors };
-              }
-            
-              const { customerImpact, summary } = parsed;
-            
-              // Validate Customer impact
-              if (!customerImpact) {
-                errors.push('Missing required field: Customer impact');
-              } else if (!VALID_CUSTOMER_IMPACTS.has(customerImpact)) {
-                errors.push(
-                  `Invalid Customer impact value: "${customerImpact}". Must be one of: ${[...VALID_CUSTOMER_IMPACTS].join(', ')}`
-                );
-              }
-            
-              // Summary is required unless Customer impact is "none"
-              if (customerImpact && customerImpact !== 'none' && VALID_CUSTOMER_IMPACTS.has(customerImpact)) {
-                if (!summary) {
-                  errors.push('Missing required field: Summary (required when Customer impact is not "none")');
-                }
-              }
-            
-              return {
-                valid: errors.length === 0,
-                errors,
-              };
-            }
-            
-            /**
-             * Internal variant that also detects whether a `### Breaking changes` heading
-             * was present but had no content.
-             *
-             * @param {string} body
-             * @returns {{ customerImpact: string|null, summary: string|null, breakingChanges: string|null, breakingChangesHeadingPresent: boolean }|null}
-             */
-            function parseChangelogSectionFull(body) {
-              const section = extractChangelogSection(body);
-              if (section === null) return null;
-            
-              const customerImpactMatch = section.match(/^Customer impact:\s*(.+)$/m);
-              const customerImpact = customerImpactMatch ? customerImpactMatch[1].trim() : null;
-            
-              const summaryMatch = section.match(/^Summary:\s*(.+)$/m);
-              const summary = summaryMatch ? summaryMatch[1].trim() : null;
-            
-              // Detect whether the heading exists within the changelog section (not the full body)
-              const lines = section.split('\n');
-              const breakingChangesHeadingPresent = lines.some((line) => /^###\s+Breaking changes/.test(line));
-              const breakingChanges = extractBreakingChanges(section);
-            
-              return {
-                customerImpact,
-                summary: summary || null,
-                breakingChanges,
-                breakingChangesHeadingPresent,
-              };
-            }
-            
-            /**
-             * Validate a full parsed changelog section (including empty breaking-changes detection).
-             *
-             * @param {ReturnType<typeof parseChangelogSectionFull>|null} parsed
-             * @returns {{ valid: boolean, errors: string[] }}
-             */
-            function validateChangelogSectionFull(parsed) {
-              const base = validateChangelogSection(parsed);
-              if (!parsed) return base;
-            
-              const errors = [...base.errors];
-            
-              if (parsed.breakingChangesHeadingPresent && parsed.breakingChanges === null) {
-                errors.push('### Breaking changes section is present but contains no content');
-              }
-            
-              if (parsed.customerImpact === 'breaking' && !parsed.breakingChangesHeadingPresent) {
-                errors.push('Customer impact: breaking requires a ### Breaking changes subsection');
-              }
-            
-              return { valid: errors.length === 0, errors };
-            }
-            
-            if (typeof module !== 'undefined') {
-              module.exports = {
-                VALID_CUSTOMER_IMPACTS,
-                extractBreakingChanges,
-                extractChangelogSection,
-                parseChangelogSection,
-                parseChangelogSectionFull,
-                validateChangelogSection,
-                validateChangelogSectionFull,
-              };
-            }
-            
-            /* global parseChangelogSectionFull, validateChangelogSectionFull */
-            
-            const NO_CHANGELOG_LABEL = 'no-changelog';
-            
-            /**
-             * Result from assembling PR changelog data.
-             *
-             * @typedef {Object} RenderResult
-             * @property {boolean} success
-             * @property {string|null} sectionBody - Rendered markdown body (without section header line), or null on failure.
-             * @property {AssemblyError[]} errors - Assembly errors (non-empty only when success is false).
-             * @property {IncludedPR[]} included - PRs that contributed at least one bullet or breaking-change block.
-             * @property {ExcludedPR[]} excluded - PRs that were explicitly excluded (no-changelog or Customer impact: none).
-             */
-            
-            /**
-             * @typedef {Object} AssemblyError
-             * @property {number} prNumber
-             * @property {string} prUrl
-             * @property {string} reason
-             */
-            
-            /**
-             * @typedef {Object} IncludedPR
-             * @property {number} prNumber
-             * @property {string} prUrl
-             * @property {string} summary
-             * @property {string|null} breakingChanges
-             */
-            
-            /**
-             * @typedef {Object} ExcludedPR
-             * @property {number} prNumber
-             * @property {string} prUrl
-             * @property {string} reason
-             * @property {string|null} [breakingChanges] - Present when a `Customer impact: none` PR also had a ### Breaking changes block.
-             */
-            
-            /**
-             * Normalize a bullet line: ensure it starts with `- ` (strip leading `-`, `*`, `+` and spaces).
-             *
-             * @param {string} line
-             * @returns {string}
-             */
-            function normalizeBulletPrefix(line) {
-              return '- ' + line.replace(/^[-*+]\s*/, '').replace(/^\s+/, '');
-            }
-            
-            /**
-             * Build a citation string for a PR.
-             *
-             * @param {number} prNumber
-             * @param {string} prUrl
-             * @returns {string} e.g. `([#123](https://github.com/.../pull/123))`
-             */
-            function buildCitation(prNumber, prUrl) {
-              return `([#${prNumber}](${prUrl}))`;
-            }
-            
-            /**
-             * Build a normalized change bullet from a PR summary and citation.
-             *
-             * @param {string} summary - Author-provided summary text (preserved verbatim).
-             * @param {number} prNumber
-             * @param {string} prUrl
-             * @returns {string}
-             */
-            function buildChangeBullet(summary, prNumber, prUrl) {
-              // Normalize the bullet prefix on the summary line, then append the citation.
-              const normalizedSummary = normalizeBulletPrefix(summary.trim());
-              const citation = buildCitation(prNumber, prUrl);
-              return `${normalizedSummary} ${citation}`;
-            }
-            
-            /**
-             * Render a changelog section body from an array of merged PR records.
-             *
-             * Each PR record must have:
-             *   - `number` {number}
-             *   - `url` {string}
-             *   - `labels` {string[]}
-             *   - `body` {string|null}
-             *
-             * @param {Array<{number: number, url: string, labels: string[], body: string|null}>} mergedPRs
-             * @returns {RenderResult}
-             */
-            function renderChangelogSection(mergedPRs) {
-              const errors = [];
-              const included = [];
-              const excluded = [];
-            
-              const changeBullets = [];
-              const breakingChangeBlocks = [];
-            
-              for (const pr of mergedPRs) {
-                const { number: prNumber, url: prUrl, labels, body } = pr;
-                const labelNames = Array.isArray(labels) ? labels : [];
-            
-                // Exclude PRs with the no-changelog label
-                if (labelNames.includes(NO_CHANGELOG_LABEL)) {
-                  excluded.push({ prNumber, prUrl, reason: 'no-changelog label' });
-                  continue;
-                }
-            
-                // Parse and validate the changelog section from the PR body
-                const parsed = parseChangelogSectionFull(body || '');
-            
-                if (parsed === null) {
-                  // No parseable ## Changelog section and no no-changelog label — hard fail
-                  errors.push({
-                    prNumber,
-                    prUrl,
-                    reason:
-                      `PR #${prNumber} (${prUrl}) has no parseable ## Changelog section and is not labeled 'no-changelog'. ` +
-                      'Add a ## Changelog section to the PR body or apply the no-changelog label.',
-                  });
-                  continue;
-                }
-            
-                // Validate structural correctness (invalid customerImpact, empty breaking-changes heading, etc.)
-                const { valid, errors: validationErrors } = validateChangelogSectionFull(parsed);
-                if (!valid) {
-                  if (parsed.customerImpact === null) {
-                    errors.push({
-                      prNumber,
-                      prUrl,
-                      reason: `PR #${prNumber}: ## Changelog section is missing the required Customer impact field`,
-                    });
-                  } else {
-                    errors.push({
-                      prNumber,
-                      prUrl,
-                      reason: `PR #${prNumber}: ## Changelog section failed validation: ${validationErrors.join('; ')}`,
-                    });
-                  }
-                  continue;
-                }
-            
-                const { customerImpact, summary, breakingChanges } = parsed;
-            
-                // Collect breaking-change block regardless of customerImpact
-                if (breakingChanges) {
-                  breakingChangeBlocks.push({ prNumber, prUrl, breakingChanges });
-                }
-            
-                // customerImpact === null case is already caught by validateChangelogSectionFull above
-                if (customerImpact.trim().toLowerCase() === 'none') {
-                  const excludedEntry = { prNumber, prUrl, reason: 'Customer impact: none' };
-                  if (breakingChanges !== null) {
-                    excludedEntry.breakingChanges = breakingChanges;
-                  }
-                  excluded.push(excludedEntry);
-                  continue;
-                }
-            
-                if (!summary) {
-                  // Missing summary for a non-none impact — treat as assembly error
-                  errors.push({
-                    prNumber,
-                    prUrl,
-                    reason:
-                      `PR #${prNumber} (${prUrl}) has Customer impact: ${customerImpact} but is missing the required Summary field.`,
-                  });
-                  continue;
-                }
-            
-                const bullet = buildChangeBullet(summary, prNumber, prUrl);
-                changeBullets.push(bullet);
-                included.push({ prNumber, prUrl, summary, breakingChanges: breakingChanges || null });
-              }
-            
-              if (errors.length > 0) {
-                return { success: false, sectionBody: null, errors, included, excluded };
-              }
-            
-              // Render the section body
-              const sectionParts = [];
-            
-              if (breakingChangeBlocks.length > 0) {
-                sectionParts.push('### Breaking changes');
-                sectionParts.push('');
-                for (const { breakingChanges } of breakingChangeBlocks) {
-                  // Preserve the author-provided breaking-change prose verbatim, trimming
-                  // only trailing whitespace from the block as a whole.
-                  sectionParts.push(breakingChanges.trimEnd());
-                  sectionParts.push('');
-                }
-              }
-            
-              if (changeBullets.length > 0) {
-                sectionParts.push('### Changes');
-                sectionParts.push('');
-                for (const bullet of changeBullets) {
-                  sectionParts.push(bullet);
-                }
-                sectionParts.push('');
-              }
-            
-              // Trim trailing blank lines
-              while (sectionParts.length > 0 && sectionParts[sectionParts.length - 1] === '') {
-                sectionParts.pop();
-              }
-            
-              const sectionBody = sectionParts.length > 0 ? sectionParts.join('\n') : '';
-            
-              return { success: true, sectionBody, errors: [], included, excluded };
-            }
-            
-            if (typeof module !== 'undefined') {
-              module.exports = {
-                NO_CHANGELOG_LABEL,
-                buildChangeBullet,
-                buildCitation,
-                normalizeBulletPrefix,
-                renderChangelogSection,
-              };
-            }
-            
-            /**
-             * Find the index of the next `##`-level section header after startIndex,
-             * returning it as the exclusive end of the current section.
-             * If no next section is found, returns the index of the last non-blank line + 1.
-             *
-             * @param {string[]} lines
-             * @param {number} startIndex - Index of the current section header.
-             * @returns {number}
-             */
-            function findSectionEnd(lines, startIndex) {
-              for (let i = startIndex + 1; i < lines.length; i++) {
-                if (/^## /.test(lines[i])) {
-                  return i;
-                }
-              }
-              // No next section — return end of file
-              return lines.length;
-            }
-            
-            /**
-             * Rewrite only the target section of CHANGELOG.md.
-             * Preserves all other sections and the link footer exactly.
-             *
-             * @param {string} content - Current CHANGELOG.md content.
-             * @param {string} sectionHeader - The target section header line.
-             * @param {string} newSectionContent - The full replacement (header + body).
-             * @param {string} mode - 'unreleased' | 'release'
-             * @param {string} targetVersion - Version string (release mode only).
-             * @returns {string}
-             */
-            function rewriteChangelogSection(content, sectionHeader, newSectionContent, mode, targetVersion) {
-              const lines = content.split('\n');
-            
-              // Find the start of the target section
-              let targetStart = -1;
-            
-              if (mode === 'unreleased') {
-                targetStart = lines.findIndex((line) => /^## \[Unreleased\]/.test(line));
-              } else {
-                // For release mode, look for the exact version header or the Unreleased section
-                // (we insert after Unreleased when no existing release section is found)
-                targetStart = lines.findIndex((line) =>
-                  line.startsWith(`## [${targetVersion}]`)
-                );
-              }
-            
-              if (targetStart === -1) {
-                // Section not found — insert appropriately
-                if (mode === 'release') {
-                  // Insert after ## [Unreleased] section if present, otherwise at the top
-                  const unreleasedStart = lines.findIndex((line) => /^## \[Unreleased\]/.test(line));
-                  if (unreleasedStart !== -1) {
-                    // Find the end of the Unreleased section
-                    const insertAfter = findSectionEnd(lines, unreleasedStart);
-                    const before = lines.slice(0, insertAfter);
-                    const after = lines.slice(insertAfter);
-                    return [...before, '', newSectionContent, ...after].join('\n');
-                  } else {
-                    // No Unreleased section — prepend after any top-level heading
-                    return newSectionContent + '\n\n' + content;
-                  }
-                } else {
-                  // unreleased: prepend after any top-level heading
-                  return newSectionContent + '\n\n' + content;
-                }
-              }
-            
-              // Find the end of the target section (start of the next ## section)
-              const sectionEnd = findSectionEnd(lines, targetStart);
-            
-              const before = lines.slice(0, targetStart);
-              const after = lines.slice(sectionEnd);
-            
-              // Remove trailing blank lines from 'before' that were padding before the old section
-              while (before.length > 0 && before[before.length - 1] === '') {
-                before.pop();
-              }
-            
-              // Rebuild: before content, blank separator, new section, blank separator, after content
-              const parts = [...before];
-              if (parts.length > 0) parts.push('');
-              parts.push(newSectionContent);
-            
-              // Normalize leading blank lines in 'after'
-              let afterStart = 0;
-              while (afterStart < after.length && after[afterStart] === '') {
-                afterStart++;
-              }
-            
-              if (afterStart < after.length) {
-                parts.push('');
-                parts.push(...after.slice(afterStart));
-              }
-            
-              return parts.join('\n');
-            }
-            
-            const mergedPRsPath = process.env.MERGED_PRS_PATH || '';
-            const mode = process.env.MODE || 'unreleased';
-            const targetVersion = process.env.TARGET_VERSION || '';
-            const changelogPath = process.env.CHANGELOG_PATH || 'CHANGELOG.md';
-            
-            if (!mergedPRsPath) {
-              core.setFailed('MERGED_PRS_PATH environment variable is required');
-              process.exit(1);
-            }
-            
-            if (mode === 'release' && !targetVersion) {
-              core.setFailed('Release mode requires target_version from resolve_release_context');
-              process.exit(1);
-            }
-            
-            // Read the merged PR manifest
-            let manifest;
-            try {
-              manifest = JSON.parse(fs.readFileSync(mergedPRsPath, 'utf8'));
-            } catch (err) {
-              core.setFailed(`Failed to read merged PR manifest from ${mergedPRsPath}: ${err.message}`);
-              process.exit(1);
-            }
-            
-            const prRecords = manifest.pull_requests || [];
-            core.info(`Rendering changelog from ${prRecords.length} merged PR(s)`);
-            
-            // Run deterministic rendering
-            const result = renderChangelogSection(prRecords);
-            
-            if (!result.success) {
-              // Hard fail: report all assembly errors clearly
-              const errorMessages = result.errors.map((e) => `  - ${e.reason}`).join('\n');
-              core.setFailed(
-                `Changelog assembly failed. The following pull requests are missing a required ## Changelog section or Summary field:\n${errorMessages}\n\n` +
-                'Each merged PR must either:\n' +
-                "  1. Have a '## Changelog' section with 'Customer impact' and (when not 'none') a 'Summary' field, OR\n" +
-                "  2. Be labeled 'no-changelog'"
-              );
-              process.exit(1);
-            }
-            
-            // Log what was included/excluded
-            core.info(`Included ${result.included.length} PR(s) with change bullets or breaking changes`);
-            core.info(`Excluded ${result.excluded.length} PR(s) (no-changelog or Customer impact: none)`);
-            for (const ex of result.excluded) {
-              core.info(`  Excluded PR #${ex.prNumber}: ${ex.reason}`);
-            }
-            
-            // Read current CHANGELOG.md
-            let currentChangelog = '';
-            try {
-              currentChangelog = fs.readFileSync(changelogPath, 'utf8');
-            } catch (err) {
-              core.warning(`Could not read ${changelogPath}: ${err.message}. Will create a new file.`);
-            }
-            
-            // Rewrite the target section in CHANGELOG.md
-            const today = new Date().toISOString().split('T')[0];
-            let sectionHeader;
-            if (mode === 'release' && targetVersion) {
-              sectionHeader = `## [${targetVersion}] - ${today}`;
-            } else {
-              sectionHeader = '## [Unreleased]';
-            }
-            
-            const sectionBody = result.sectionBody;
-            const newSectionContent = sectionBody
-              ? `${sectionHeader}\n\n${sectionBody}`
-              : `${sectionHeader}`;
-            
-            const updatedChangelog = rewriteChangelogSection(currentChangelog, sectionHeader, newSectionContent, mode, targetVersion);
-            
-            // Write updated CHANGELOG.md
-            try {
-              fs.writeFileSync(changelogPath, updatedChangelog, 'utf8');
-              core.info(`CHANGELOG.md updated with section: ${sectionHeader}`);
-            } catch (err) {
-              core.setFailed(`Failed to write ${changelogPath}: ${err.message}`);
-              process.exit(1);
-            }
-            
-            core.setOutput('section_header', sectionHeader);
-            core.setOutput('has_changes', result.included.length > 0 || result.excluded.length > 0 ? 'true' : 'false');
-            core.setOutput('has_user_facing_changes', result.included.length > 0 ? 'true' : 'false');
-            core.info(`Changelog section rendered: ${sectionHeader}`);
-            
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          args=(
+            run ./scripts/changelog-engine
+            -mode "${{ steps.resolve_release_context.outputs.mode }}"
+            -changelog CHANGELOG.md
+            -output "$RUNNER_TEMP/changelog-engine-outputs"
+          )
+
+          if [[ -n "${{ steps.resolve_release_context.outputs.target_version }}" ]]; then
+            args+=(-target-version "${{ steps.resolve_release_context.outputs.target_version }}")
+          fi
+
+          if [[ -n "${{ steps.resolve_release_context.outputs.previous_tag }}" ]]; then
+            args+=(-previous-tag "${{ steps.resolve_release_context.outputs.previous_tag }}")
+          fi
+
+          go "${args[@]}"
+
+      - name: Load changelog engine outputs
+        id: changelog_engine
+        run: |
+          while IFS='=' read -r key value; do
+            echo "${key}=${value}" >> "$GITHUB_OUTPUT"
+          done < "$RUNNER_TEMP/changelog-engine-outputs"
+
       - name: Commit changelog (release mode)
         id: commit_release
         if: >-
           steps.resolve_release_context.outputs.mode == 'release' &&
-          steps.gather_merged_prs.outputs.has_prs == 'true' &&
-          steps.render_changelog.outputs.has_user_facing_changes == 'true'
+          steps.changelog_engine.outputs.has_user_facing_changes == 'true'
         env:
           TARGET_VERSION: ${{ steps.resolve_release_context.outputs.target_version }}
           TARGET_BRANCH: ${{ steps.resolve_release_context.outputs.target_branch }}
@@ -1105,8 +407,7 @@ jobs:
         id: push_unreleased
         if: >-
           steps.resolve_release_context.outputs.mode == 'unreleased' &&
-          steps.gather_merged_prs.outputs.has_prs == 'true' &&
-          steps.render_changelog.outputs.has_user_facing_changes == 'true'
+          steps.changelog_engine.outputs.has_user_facing_changes == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/changelog-generation.yml
+++ b/.github/workflows/changelog-generation.yml
@@ -182,45 +182,23 @@ jobs:
             core.info(`Target branch: ${releaseContext.targetBranch}`);
             
       - name: Run shared changelog engine
-        id: run_changelog_engine
+        id: changelog_engine
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           args=(
-            run ./scripts/changelog-engine
+            run ./scripts/changelog-engine/cmd/changelog-engine
             -mode "${{ steps.resolve_release_context.outputs.mode }}"
             -changelog CHANGELOG.md
-            -output "$RUNNER_TEMP/changelog-engine-outputs"
           )
 
           if [[ -n "${{ steps.resolve_release_context.outputs.target_version }}" ]]; then
             args+=(-target-version "${{ steps.resolve_release_context.outputs.target_version }}")
           fi
 
-          if [[ -n "${{ steps.resolve_release_context.outputs.previous_tag }}" ]]; then
-            args+=(-previous-tag "${{ steps.resolve_release_context.outputs.previous_tag }}")
-          fi
-
           go "${args[@]}"
-
-      - name: Load changelog engine outputs
-        id: changelog_engine
-        run: |
-          python - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          output_path = Path(os.environ['RUNNER_TEMP']) / 'changelog-engine-outputs'
-          github_output = Path(os.environ['GITHUB_OUTPUT'])
-          data = json.loads(output_path.read_text())
-
-          with github_output.open('a', encoding='utf-8') as fh:
-            for key, value in data.get('outputs', {}).items():
-              fh.write(f"{key}={str(value).lower() if isinstance(value, bool) else value}\n")
-          PY
 
       - name: Commit changelog (release mode)
         id: commit_release

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -94,7 +94,7 @@ jobs:
           EXISTS="${{ steps.branch-check.outputs.EXISTS }}"
           if [ "$EXISTS" = "true" ]; then
             git fetch origin "${BRANCH}"
-            git checkout "${BRANCH}"
+            git checkout -B "${BRANCH}" "origin/${BRANCH}"
             git merge --no-edit origin/main || { git merge --abort; exit 1; }
           else
             git checkout main
@@ -118,8 +118,7 @@ jobs:
           go run ./scripts/changelog-engine \
             -mode release \
             -target-version "${{ steps.version.outputs.TARGET_VERSION }}" \
-            -changelog CHANGELOG.md \
-            -output "$RUNNER_TEMP/changelog-engine-outputs"
+            -changelog CHANGELOG.md
 
       - name: Commit release preparation changes
         id: commit_release_prep

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -113,11 +113,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_VERSION: ${{ steps.version.outputs.TARGET_VERSION }}
         run: |
           set -euo pipefail
-          go run ./scripts/changelog-engine \
+          go run ./scripts/changelog-engine/cmd/changelog-engine \
             -mode release \
-            -target-version "${{ steps.version.outputs.TARGET_VERSION }}" \
+            -target-version "${TARGET_VERSION}" \
             -changelog CHANGELOG.md
 
       - name: Commit release preparation changes

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -103,21 +103,26 @@ jobs:
           fi
 
       - name: Apply version bump to Makefile
-        id: version-bump
         run: |
           TARGET_VERSION="${{ steps.version.outputs.TARGET_VERSION }}"
           # Replace the VERSION line in the Makefile
           sed -i "s/^VERSION ?= .*/VERSION ?= ${TARGET_VERSION}/" Makefile
-          if git diff --quiet Makefile; then
-            echo "No changes to Makefile (VERSION already set to ${TARGET_VERSION})"
-            echo "CHANGED=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Makefile updated: VERSION set to ${TARGET_VERSION}"
-            echo "CHANGED=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Commit version bump
-        if: steps.version-bump.outputs.CHANGED == 'true'
+      - name: Run shared changelog engine in release mode
+        id: changelog_engine
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          go run ./scripts/changelog-engine \
+            -mode release \
+            -target-version "${{ steps.version.outputs.TARGET_VERSION }}" \
+            -changelog CHANGELOG.md \
+            -output "$RUNNER_TEMP/changelog-engine-outputs"
+
+      - name: Commit release preparation changes
+        id: commit_release_prep
         env:
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
@@ -125,8 +130,14 @@ jobs:
           GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
         run: |
           TARGET_VERSION="${{ steps.version.outputs.TARGET_VERSION }}"
-          git add Makefile
-          git commit -m "chore(release): bump version to ${TARGET_VERSION}"
+          git add Makefile CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No release preparation changes to commit"
+            echo "CHANGED=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git commit -m "chore(release): prepare ${TARGET_VERSION} release"
+          echo "CHANGED=true" >> "$GITHUB_OUTPUT"
 
       - name: Push release branch
         run: |
@@ -163,7 +174,7 @@ jobs:
             "## Changes" \
             "" \
             "- Bumps \`VERSION\` in \`Makefile\` to \`${TARGET_VERSION}\`" \
-            "- Changelog section for this release will be populated automatically by the changelog generator workflow" \
+            "- Regenerates the final \`CHANGELOG.md\` release section for \`${TARGET_VERSION}\`" \
             "" \
             "## Checklist" \
             "" \
@@ -176,6 +187,13 @@ jobs:
             --title "${PR_TITLE}" \
             --body-file /tmp/pr-body.txt \
             --label no-changelog
+
+      - name: Ensure no-changelog label on reused PR
+        if: steps.pr-check.outputs.EXISTS == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ steps.pr-check.outputs.PR_URL }}" --add-label no-changelog
 
       - name: Report outcome
         run: |

--- a/dev-docs/high-level/contributing.md
+++ b/dev-docs/high-level/contributing.md
@@ -86,13 +86,14 @@ To release a new provider version:
 
    This dispatches the `prep-release.yml` GitHub Actions workflow, which:
    - Computes the target version by finding the latest semver release tag (`v*.*.*`) on `main` and applying the requested bump.
-   - Creates (or reuses) a `prep-release-x.y.z` branch and opens a pull request with the `VERSION` variable in `Makefile` updated to the target version.
+   - Creates (or reuses) a `prep-release-x.y.z` branch.
+   - Updates the `VERSION` variable in `Makefile` to the target version.
+   - Regenerates the concrete `## [x.y.z] - YYYY-MM-DD` section in `CHANGELOG.md` using the shared changelog engine in release mode.
+   - Pushes a single deterministic release-preparation commit and creates or reuses the release pull request.
 
-2. **Await the changelog update**. The `changelog-generation` workflow automatically detects the new `prep-release-*` PR and regenerates the concrete `## [x.y.z] - YYYY-MM-DD` section in `CHANGELOG.md`, pushing the result to the `prep-release-*` branch.
+2. **Review and merge the release PR**. Once the final changelog section looks correct and all checks pass, merge the `prep-release-x.y.z` PR.
 
-3. **Review and merge the release PR**. Once the changelog section is populated and all checks pass, merge the `prep-release-x.y.z` PR.
-
-4. **Tag and release**. After the PR is merged, start the release by pushing the version tag to `main`:
+3. **Tag and release**. After the PR is merged, start the release by pushing the version tag to `main`:
 
    ```
    git tag v0.14.4 && git push origin v0.14.4

--- a/openspec/changes/shared-changelog-engine/design.md
+++ b/openspec/changes/shared-changelog-engine/design.md
@@ -2,12 +2,12 @@
 
 The current changelog automation mixes two concerns in one workflow: scheduled maintenance of the `## [Unreleased]` section and release-specific regeneration of a concrete `## [x.y.z] - <date>` section. Release mode is currently activated from `pull_request_target` events on `prep-release-*` branches, which makes final release changelog generation depend on PR event delivery and timing rather than on the release-preparation workflow that actually owns the release branch contents.
 
-The repository already contains deterministic changelog parsing and rendering logic spread across inline `actions/github-script` steps, small shared JavaScript helpers under `.github/workflows-src/lib/`, and a small `scripts/changelog-generation` Go entrypoint. The target design should preserve deterministic assembly and existing PR-body changelog-contract rules, while moving release-mode invocation to an explicit synchronous step in release preparation.
+The repository already contains deterministic changelog parsing and rendering logic spread across inline `actions/github-script` steps, small shared JavaScript helpers under `.github/workflows-src/lib/`, and a small `scripts/changelog-generation` Go entrypoint. The target design should preserve deterministic assembly and existing PR-body changelog-contract rules, while moving the workflow engine fully into a Go implementation under `/scripts` and moving release-mode invocation to an explicit synchronous step in release preparation.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- Introduce a shared repository-authored changelog engine that can be invoked from multiple workflows with explicit mode inputs.
+- Introduce a shared repository-authored changelog engine implemented in Go under `/scripts` that can be invoked from multiple workflows with explicit mode inputs.
 - Make `prep-release.yml` responsible for invoking release-mode changelog generation before it creates or updates the release PR.
 - Keep scheduled unreleased generation in `changelog-generation.yml` and add an explicit manual `workflow_dispatch` release-mode fallback in the same workflow.
 - Keep changelog assembly fail-fast: invalid or missing PR changelog contracts in the authoritative range must fail release preparation and manual release regeneration.
@@ -21,8 +21,8 @@ The repository already contains deterministic changelog parsing and rendering lo
 
 ## Decisions
 
-### Use an explicit shared changelog engine instead of event-inferred release mode
-The changelog engine will be invoked with explicit workflow inputs that select `release` or `unreleased` mode. Release-mode behavior will no longer be inferred from `pull_request_target` event metadata.
+### Use an explicit shared Go changelog engine under `/scripts` instead of event-inferred release mode
+The changelog engine must be rewritten in Go under `/scripts` and will be invoked with explicit workflow inputs that select `release` or `unreleased` mode. Release-mode behavior will no longer be inferred from `pull_request_target` event metadata.
 
 This makes release preparation deterministic and enables a manual release fallback without needing synthetic PR events. It also removes the need for the changelog engine to interpret GitHub event shape as its primary control surface.
 
@@ -30,7 +30,7 @@ This makes release preparation deterministic and enables a manual release fallba
 - Keep `pull_request_target` as the release trigger: rejected because release preparation should not depend on downstream PR-event timing.
 - Use `workflow_run` or dispatch from `prep-release.yml`: rejected because explicit synchronous invocation inside release preparation is simpler and provides fail-fast semantics.
 
-### The shared engine resolves merged PRs through the GitHub API using the workflow token
+### The shared Go engine under `/scripts` resolves merged PRs through the GitHub API using the workflow token
 The engine will own authoritative-range discovery and merged-PR resolution, including GitHub API lookups needed to map commits in the compare range to merged pull requests and to retrieve their bodies, labels, and other required metadata. Workflows will provide authenticated environment context through the built-in workflow token.
 
 This keeps the core changelog assembly path self-contained and reusable across release and unreleased modes. It also avoids splitting the authoritative changelog assembly pipeline between workflow glue and engine internals.
@@ -72,7 +72,7 @@ This preserves a single operational place for changelog regeneration without kee
 
 ## Migration Plan
 
-1. Extract or consolidate the deterministic changelog engine behind a reusable repository-authored script interface.
+1. Extract or consolidate the deterministic changelog engine into a reusable Go-based repository-authored script interface under `/scripts`.
 2. Update `prep-release.yml` to invoke the engine in release mode after applying the version bump and before creating/updating the PR.
 3. Update `changelog-generation.yml` and its template to remove `pull_request_target`, add explicit `workflow_dispatch` inputs for release mode, and invoke the shared engine in unreleased or release mode accordingly.
 4. Preserve or adapt PR-management helper logic so unreleased mode still maintains the singleton `generated-changelog` PR and release mode can refresh release PR metadata when manually dispatched.

--- a/openspec/changes/shared-changelog-engine/proposal.md
+++ b/openspec/changes/shared-changelog-engine/proposal.md
@@ -4,7 +4,7 @@ The final release changelog update currently depends on `ci-changelog-generation
 
 ## What Changes
 
-- Refactor changelog-generation logic into a shared repository-authored script/engine that resolves merged PRs via the GitHub API using the workflow token, parses PR-body changelog contracts, and rewrites `CHANGELOG.md` deterministically.
+- Refactor changelog-generation logic into a shared repository-authored script/engine implemented in Go under `/scripts` that resolves merged PRs via the GitHub API using the workflow token, parses PR-body changelog contracts, and rewrites `CHANGELOG.md` deterministically.
 - Update `prep-release.yml` to invoke the shared changelog engine directly in release mode during release preparation, so release preparation fails immediately when changelog assembly fails.
 - Simplify `changelog-generation.yml` so its automatic triggers only cover scheduled unreleased maintenance, while `workflow_dispatch` also supports an explicit release mode via inputs.
 - Remove the `pull_request_target` release trigger path from the changelog-generation workflow and replace event-inferred release mode with explicit workflow inputs.
@@ -16,13 +16,13 @@ The final release changelog update currently depends on `ci-changelog-generation
 <!-- None -->
 
 ### Modified Capabilities
-- `ci-changelog-generation`: Change workflow triggering and operating-mode selection so scheduled automation maintains the unreleased changelog, while release-mode execution is invoked explicitly and uses a shared repository-authored engine.
-- `ci-release-pr-preparation`: Change release preparation so the workflow deterministically generates the final release changelog section during preparation and creates a single ready-to-review release-preparation commit/PR.
+- `ci-changelog-generation`: Change workflow triggering and operating-mode selection so scheduled automation maintains the unreleased changelog, while release-mode execution is invoked explicitly and uses a shared repository-authored Go engine under `/scripts`.
+- `ci-release-pr-preparation`: Change release preparation so the workflow deterministically generates the final release changelog section during preparation using the same Go engine under `/scripts` and creates a single ready-to-review release-preparation commit/PR.
 
 ## Impact
 
 - `.github/workflows/prep-release.yml`
 - `.github/workflows/changelog-generation.yml`
 - `.github/workflows-src/changelog-generation/workflow.yml.tmpl`
-- changelog-generation helper code under `.github/workflows-src/lib/` and/or `scripts/changelog-generation/`
+- changelog-generation helper code migrated into a Go-based engine under `scripts/`
 - OpenSpec specs for `ci-changelog-generation` and `ci-release-pr-preparation`

--- a/openspec/changes/shared-changelog-engine/proposal.md
+++ b/openspec/changes/shared-changelog-engine/proposal.md
@@ -8,6 +8,7 @@ The final release changelog update currently depends on `ci-changelog-generation
 - Update `prep-release.yml` to invoke the shared changelog engine directly in release mode during release preparation, so release preparation fails immediately when changelog assembly fails.
 - Simplify `changelog-generation.yml` so its automatic triggers only cover scheduled unreleased maintenance, while `workflow_dispatch` also supports an explicit release mode via inputs.
 - Remove the `pull_request_target` release trigger path from the changelog-generation workflow and replace event-inferred release mode with explicit workflow inputs.
+- Update the workflow-source release-context and release-PR-refresh inline scripts, plus the authored workflow markdown template, so the compiled workflow, helper glue, and human-facing workflow documentation all describe and implement the same explicit release-mode contract.
 - Keep workflow responsibilities limited to checkout, commit/push, PR create/reuse/labeling, and PR metadata updates around the shared engine.
 
 ## Capabilities
@@ -24,5 +25,8 @@ The final release changelog update currently depends on `ci-changelog-generation
 - `.github/workflows/prep-release.yml`
 - `.github/workflows/changelog-generation.yml`
 - `.github/workflows-src/changelog-generation/workflow.yml.tmpl`
+- `.github/workflows-src/changelog-generation/workflow.md.tmpl`
+- `.github/workflows-src/changelog-generation/scripts/resolve-release-context.inline.js`
+- `.github/workflows-src/changelog-generation/scripts/refresh-release-pr.inline.js`
 - changelog-generation helper code migrated into a Go-based engine under `scripts/`
 - OpenSpec specs for `ci-changelog-generation` and `ci-release-pr-preparation`

--- a/openspec/changes/shared-changelog-engine/tasks.md
+++ b/openspec/changes/shared-changelog-engine/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Extract the shared changelog engine
 
-- [ ] 1.1 Identify the current changelog-generation logic that must move behind a shared repository-authored script interface, including release-context resolution, merged-PR discovery, changelog parsing/validation, rendering, and `CHANGELOG.md` rewriting
-- [ ] 1.2 Implement the shared engine so it accepts explicit mode inputs (`unreleased` or `release`, with explicit target version for release mode), resolves merged PRs through the GitHub API using the workflow token, and emits structured outputs needed by workflows
+- [ ] 1.1 Identify the current changelog-generation logic that must be rewritten into a shared Go repository-authored engine under `/scripts`, including release-context resolution, merged-PR discovery, changelog parsing/validation, rendering, and `CHANGELOG.md` rewriting
+- [ ] 1.2 Implement the shared Go engine under `/scripts` so it accepts explicit mode inputs (`unreleased` or `release`, with explicit target version for release mode), resolves merged PRs through the GitHub API using the workflow token, and emits structured outputs needed by workflows
 - [ ] 1.3 Preserve or add automated tests covering deterministic assembly, release/unreleased mode selection, GitHub-backed merged-PR resolution, and changelog-section rewriting behavior
 
 ## 2. Update changelog-generation workflow behavior

--- a/openspec/changes/shared-changelog-engine/tasks.md
+++ b/openspec/changes/shared-changelog-engine/tasks.md
@@ -12,6 +12,6 @@
 
 ## 3. Update release preparation workflow
 
-- [ ] 3.1 Refactor `.github/workflows/prep-release.yml` to invoke the shared changelog engine in release mode after applying the version bump and before PR creation/reuse
-- [ ] 3.2 Update release preparation to produce a single deterministic commit containing both the version bump and final release changelog update, while retaining deterministic branch naming, PR reuse, and `no-changelog` labeling
-- [ ] 3.3 Verify the updated workflow behavior and sync the canonical specs affected by release preparation and changelog generation
+- [x] 3.1 Refactor `.github/workflows/prep-release.yml` to invoke the shared changelog engine in release mode after applying the version bump and before PR creation/reuse
+- [x] 3.2 Update release preparation to produce a single deterministic commit containing both the version bump and final release changelog update, while retaining deterministic branch naming, PR reuse, and `no-changelog` labeling
+- [x] 3.3 Verify the updated workflow behavior and sync the canonical specs affected by release preparation and changelog generation

--- a/openspec/changes/shared-changelog-engine/tasks.md
+++ b/openspec/changes/shared-changelog-engine/tasks.md
@@ -6,9 +6,9 @@
 
 ## 2. Update changelog-generation workflow behavior
 
-- [ ] 2.1 Refactor `.github/workflows-src/changelog-generation/workflow.yml.tmpl` and generated workflow output to remove `pull_request_target`, add explicit `workflow_dispatch` inputs for release mode, and invoke the shared engine in both scheduled unreleased mode and manual release mode
-- [ ] 2.2 Keep unreleased-mode branch/PR management in workflow orchestration, ensuring scheduled or manually dispatched unreleased runs still maintain the singleton `generated-changelog` PR
-- [ ] 2.3 Preserve or update workflow-source helper tests/fixtures so compiled workflow behavior and manual release-mode dispatch semantics are covered
+- [x] 2.1 Refactor `.github/workflows-src/changelog-generation/workflow.yml.tmpl` and generated workflow output to remove `pull_request_target`, add explicit `workflow_dispatch` inputs for release mode, and invoke the shared engine in both scheduled unreleased mode and manual release mode
+- [x] 2.2 Keep unreleased-mode branch/PR management in workflow orchestration, ensuring scheduled or manually dispatched unreleased runs still maintain the singleton `generated-changelog` PR
+- [x] 2.3 Preserve or update workflow-source helper tests/fixtures so compiled workflow behavior and manual release-mode dispatch semantics are covered
 
 ## 3. Update release preparation workflow
 

--- a/openspec/changes/shared-changelog-engine/tasks.md
+++ b/openspec/changes/shared-changelog-engine/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Extract the shared changelog engine
 
-- [ ] 1.1 Identify the current changelog-generation logic that must be rewritten into a shared Go repository-authored engine under `/scripts`, including release-context resolution, merged-PR discovery, changelog parsing/validation, rendering, and `CHANGELOG.md` rewriting
-- [ ] 1.2 Implement the shared Go engine under `/scripts` so it accepts explicit mode inputs (`unreleased` or `release`, with explicit target version for release mode), resolves merged PRs through the GitHub API using the workflow token, and emits structured outputs needed by workflows
-- [ ] 1.3 Preserve or add automated tests covering deterministic assembly, release/unreleased mode selection, GitHub-backed merged-PR resolution, and changelog-section rewriting behavior
+- [x] 1.1 Identify the current changelog-generation logic that must be rewritten into a shared Go repository-authored engine under `/scripts`, including release-context resolution, merged-PR discovery, changelog parsing/validation, rendering, and `CHANGELOG.md` rewriting
+- [x] 1.2 Implement the shared Go engine under `/scripts` so it accepts explicit mode inputs (`unreleased` or `release`, with explicit target version for release mode), resolves merged PRs through the GitHub API using the workflow token, and emits structured outputs needed by workflows
+- [x] 1.3 Preserve or add automated tests covering deterministic assembly, release/unreleased mode selection, GitHub-backed merged-PR resolution, and changelog-section rewriting behavior
 
 ## 2. Update changelog-generation workflow behavior
 

--- a/openspec/specs/ci-changelog-generation/spec.md
+++ b/openspec/specs/ci-changelog-generation/spec.md
@@ -3,37 +3,36 @@
 Workflow implementation: authored GH AW source under `.github/workflows/`, backed by repository-authored template/source under `.github/workflows-src/`, with compiled `.lock.yml` committed from `gh aw compile`.
 
 ## Purpose
-Define a GitHub Agentic Workflow that maintains `CHANGELOG.md` from merged pull-request history. The workflow has one agentic changelog engine and two operating modes: maintaining the full `## [Unreleased]` section on branch `generated-changelog`, and regenerating a concrete release section for release-preparation pull requests.
+Define a GitHub Agentic Workflow that maintains `CHANGELOG.md` from merged pull-request history. The workflow has one agentic changelog engine and two operating modes: maintaining the full `## [Unreleased]` section on branch `generated-changelog`, and regenerating a concrete release section for an explicitly selected release-preparation branch.
 ## Requirements
 ### Requirement: Workflow artifacts and operating modes
 The changelog generator SHALL be authored as a deterministic workflow template under `.github/workflows-src/` and SHALL generate a checked-in workflow YAML artifact under `.github/workflows/` via `scripts/compile-workflow-sources/main.go`. The workflow SHALL NOT require a GH AW markdown source or a compiled `.lock.yml`. The workflow SHALL support:
 
 - a scheduled mode
 - a manual `workflow_dispatch` mode
-- a `pull_request_target` mode for same-repository release-preparation branches matching the repository's `prep-release-*` naming contract
+- explicit workflow-dispatch inputs that allow maintainers to select `unreleased` or `release` execution mode
 
 #### Scenario: Source and compiled workflow stay paired
 - **WHEN** maintainers change changelog generator behavior
 - **THEN** the `.github/workflows-src/` template and generated `.github/workflows/changelog-generation.yml` SHALL match the current repository compiler output
 
-#### Scenario: Release-preparation pull request activates release mode
-- **GIVEN** a same-repository pull request whose head branch matches the configured `prep-release-*` pattern
-- **WHEN** the changelog generator runs for that pull request through `pull_request_target`
-- **THEN** it SHALL enter release-section generation mode for the triggering pull request branch
+#### Scenario: Manual dispatch can enter release mode explicitly
+- **WHEN** a maintainer dispatches the changelog generator with inputs selecting `release` mode and a target version
+- **THEN** the workflow SHALL enter release-section generation mode for the checked out target branch without relying on pull-request event metadata
 
 ### Requirement: Full-section regeneration uses authoritative ranges
 The changelog generator SHALL regenerate the full target section on each run from an authoritative range rather than appending only “since last run” changes.
 
-- In scheduled/manual mode, it SHALL regenerate the full `## [Unreleased]` section from the previous semver release tag to `main`.
-- In release-pull-request mode, it SHALL regenerate the full concrete `## [x.y.z] - <date>` section for the triggering release branch from the previous semver release tag to that branch head.
+- In scheduled/manual unreleased mode, it SHALL regenerate the full `## [Unreleased]` section from the previous semver release tag to `main`.
+- In explicit release mode, it SHALL regenerate the full concrete `## [x.y.z] - <date>` section for the checked out release branch from the previous semver release tag to that branch head.
 - In both modes, release-note content SHALL be assembled from merged pull requests in that authoritative range by parsing their PR-body changelog contract and labels.
 
 #### Scenario: Scheduled run rebuilds full Unreleased
-- **WHEN** the changelog generator runs in scheduled or manual mode
+- **WHEN** the changelog generator runs in scheduled mode
 - **THEN** it SHALL regenerate the entire `## [Unreleased]` section from the authoritative release range instead of incrementally appending entries
 
-#### Scenario: Release PR run rebuilds full release section
-- **WHEN** the changelog generator runs for a `prep-release-*` pull request
+#### Scenario: Manual release run rebuilds full release section
+- **WHEN** the changelog generator runs in explicit release mode for a checked out `prep-release-*` branch
 - **THEN** it SHALL regenerate the full `## [x.y.z] - <date>` section for that branch from the authoritative release range instead of incrementally appending entries
 
 ### Requirement: Deterministic validation gates changelog mutation
@@ -48,7 +47,7 @@ Before updating `CHANGELOG.md`, deterministic repository-authored validation SHA
 - **THEN** changelog mutation SHALL fail before `CHANGELOG.md` is updated
 
 ### Requirement: Scheduled/manual mode updates the singleton generated changelog PR
-In scheduled/manual mode, after deterministic validation succeeds, the workflow SHALL rewrite only the `## [Unreleased]` section of `CHANGELOG.md` and SHALL push the result to the singleton branch named `generated-changelog`. The workflow SHALL use repository-authored GitHub Actions logic to look up an existing pull request from `generated-changelog` to `main`, create that pull request when none exists, and update the existing PR body when one already exists.
+In scheduled or manually dispatched unreleased mode, after deterministic validation succeeds, the workflow SHALL rewrite only the `## [Unreleased]` section of `CHANGELOG.md` and SHALL push the result to the singleton branch named `generated-changelog`. The workflow SHALL use repository-authored GitHub Actions logic to look up an existing pull request from `generated-changelog` to `main`, create that pull request when none exists, and update the existing PR body when one already exists.
 
 #### Scenario: Generated changelog branch PR is reused
 - **GIVEN** the singleton branch `generated-changelog` already has an open pull request to `main`
@@ -60,15 +59,15 @@ In scheduled/manual mode, after deterministic validation succeeds, the workflow 
 - **WHEN** the scheduled/manual changelog generator produces an updated `CHANGELOG.md`
 - **THEN** the workflow SHALL create the pull request after pushing the branch update
 
-### Requirement: Release-pull-request mode updates only the triggering release section
-In release-pull-request mode, after deterministic validation succeeds, repository-authored helper logic SHALL update only the concrete `## [x.y.z] - <date>` section for the triggering release branch and SHALL push that change only to the triggering release pull request branch. When the workflow refreshes release PR metadata, it SHALL use the pull request number from event metadata rather than performing branch-based PR discovery.
+### Requirement: Explicit release mode updates only the targeted release section
+In explicit release mode, after deterministic validation succeeds, repository-authored helper logic SHALL update only the concrete `## [x.y.z] - <date>` section for the checked out release branch and SHALL push that change only to the targeted release branch. Manual release-mode execution MAY refresh release PR metadata when the corresponding pull request is known, but release-mode changelog generation SHALL NOT depend on `pull_request_target` event metadata or automatic pull-request triggers.
 
-#### Scenario: Release mode updates only the triggering branch
-- **WHEN** the changelog generator runs for a `prep-release-*` pull request
-- **THEN** it SHALL push changelog updates only to the triggering release pull request branch
+#### Scenario: Release mode updates only the targeted branch
+- **WHEN** the changelog generator runs in explicit release mode for a release-preparation branch
+- **THEN** it SHALL push changelog updates only to that targeted release branch
 
 #### Scenario: Release mode does not rewrite Unreleased on the release branch
-- **WHEN** the changelog generator runs for a release-preparation pull request
+- **WHEN** the changelog generator runs in explicit release mode
 - **THEN** it SHALL regenerate the concrete release section needed for that branch without treating the branch as the singleton `Unreleased` maintenance branch
 
 ### Requirement: Merged PR changelog metadata is gathered for deterministic assembly

--- a/openspec/specs/ci-release-pr-preparation/spec.md
+++ b/openspec/specs/ci-release-pr-preparation/spec.md
@@ -5,7 +5,7 @@ Workflow implementation: repository-authored GitHub Actions workflow under `.git
 "Repository-authored" means the workflow uses standard GitHub Actions tooling - shell scripts, `git`, and the `gh` CLI - rather than agentic (LLM-driven) execution. Using `gh pr create`/`gh pr list` for PR management and configuring a bot git identity (`github-actions[bot]`) for commits are the expected implementation patterns in this context.
 
 ## Purpose
-Define a deterministic workflow that prepares provider release pull requests by computing the target version, creating or updating a release branch, applying the simple version bump changes, and creating or reusing the release PR. Changelog generation is handled separately by `ci-changelog-generation`.
+Define a deterministic workflow that prepares provider release pull requests by computing the target version, creating or updating a release branch, applying the release-preparation changes, and creating or reusing the release PR.
 ## Requirements
 ### Requirement: Workflow trigger and inputs
 The release preparation workflow SHALL run only from `workflow_dispatch` and SHALL accept a bump-mode input that supports `patch`, `minor`, and `major`, defaulting to `patch`.
@@ -29,12 +29,12 @@ Before mutating repository state, deterministic repository-authored steps SHALL 
 - **AND** it SHALL derive a stable pull-request title such as `Prepare 0.14.4 release`
 
 ### Requirement: Release preparation changes are limited to deterministic version bump plumbing
-The release preparation workflow SHALL apply only the deterministic release-preparation changes owned by that workflow. It SHALL update the top-level provider `VERSION` in `Makefile` to the target version, and it SHALL NOT perform agentic changelog synthesis itself.
+The release preparation workflow SHALL apply only the deterministic release-preparation changes owned by that workflow. It SHALL update the top-level provider `VERSION` in `Makefile` to the target version, and it SHALL invoke the shared deterministic changelog engine in release mode to regenerate the concrete release section in `CHANGELOG.md` before opening or reusing the release pull request. The workflow SHALL NOT perform agentic changelog synthesis.
 
-#### Scenario: Release-preparation branch starts with version bump changes
+#### Scenario: Release-preparation branch includes version bump and final changelog update
 - **WHEN** the workflow prepares a release branch for version `X`
 - **THEN** the branch SHALL contain the deterministic version bump changes owned by the workflow
-- **AND** changelog content generation SHALL remain delegated to `ci-changelog-generation`
+- **AND** it SHALL contain the regenerated concrete changelog section for version `X` before the release PR is created or reused
 
 ### Requirement: Release branch and pull request are managed deterministically
 After applying its deterministic changes, the workflow SHALL create or update a deterministic release branch named from the target version, SHALL commit the release-preparation changes with a stable release-preparation commit message, SHALL push that branch, and SHALL create or reuse a pull request targeting `main` with a stable release-preparation title.
@@ -47,6 +47,10 @@ After applying its deterministic changes, the workflow SHALL create or update a 
 - **GIVEN** a release pull request for the target version already exists
 - **WHEN** the workflow is rerun for the same version
 - **THEN** the workflow SHALL update or reuse that release branch and pull request rather than opening a duplicate
+
+#### Scenario: Release preparation uses a single deterministic commit
+- **WHEN** the workflow prepares a release branch for version `X`
+- **THEN** it SHALL combine the deterministic version bump and release changelog update into a single release-preparation commit before pushing the branch
 
 ### Requirement: Release PR carries the no-changelog label
 The release preparation workflow SHALL apply the `no-changelog` label to the release PR. This label SHALL be present whether the PR is newly created or already exists (reused on a rerun). The `no-changelog` label is assumed to exist in the repository as a pre-condition.
@@ -61,10 +65,11 @@ The release preparation workflow SHALL apply the `no-changelog` label to the rel
 - **THEN** the workflow SHALL apply the `no-changelog` label to the existing PR
 - **AND** the label application SHALL be idempotent (re-applying an already-present label SHALL NOT cause an error)
 
-### Requirement: Release PR triggers changelog regeneration for the release section
-The release preparation workflow SHALL create the release branch and pull request in a way that allows `ci-changelog-generation` to recognize the branch as a release-preparation PR and regenerate the concrete `## [x.y.z] - <date>` changelog section on that branch.
+### Requirement: Release PR can be regenerated manually without pull-request-triggered automation
+The release preparation workflow SHALL prepare release branches so that the changelog-generation workflow can be rerun manually in explicit release mode for the same target version, without requiring `pull_request_target` or other pull-request-triggered changelog automation.
 
-#### Scenario: Release PR branch matches changelog generator contract
-- **WHEN** the release preparation workflow creates a release branch
-- **THEN** that branch name SHALL match the naming pattern expected by the changelog generator's pull-request mode
+#### Scenario: Manual release regeneration targets an existing prep-release branch
+- **GIVEN** a release-preparation branch for version `X` already exists
+- **WHEN** a maintainer manually dispatches the changelog-generation workflow in release mode for version `X`
+- **THEN** the workflow SHALL be able to regenerate the concrete release changelog section for that branch without requiring a new pull-request event
 

--- a/scripts/changelog-engine/cmd/changelog-engine/main.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package main
 
 import (
@@ -10,6 +27,14 @@ import (
 
 	changelogengine "github.com/elastic/terraform-provider-elasticstack/scripts/changelog-engine"
 )
+
+var runEngine = func(ctx context.Context, cfg changelogengine.Config) (*changelogengine.RunResult, error) {
+	engine, err := changelogengine.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return engine.Run(ctx)
+}
 
 func main() {
 	var mode string
@@ -33,55 +58,64 @@ func main() {
 	flag.StringVar(&repo, "repo", repoDefault, "GitHub repo")
 	flag.StringVar(&token, "token", os.Getenv("GITHUB_TOKEN"), "GitHub token")
 	flag.StringVar(&changelogPath, "changelog", envOrDefault("CHANGELOG_PATH", "CHANGELOG.md"), "path to changelog")
-	flag.StringVar(&outputPath, "output", os.Getenv("GITHUB_OUTPUT"), "optional JSON output file")
+	flag.StringVar(&outputPath, "output", "", "optional JSON output file")
 	flag.Parse()
 
-	engine, err := changelogengine.New(changelogengine.Config{
+	if _, err := run(context.Background(), changelogengine.Config{
 		Mode:          changelogengine.Mode(mode),
 		TargetVersion: targetVersion,
 		Owner:         owner,
 		Repo:          repo,
 		Token:         token,
 		ChangelogPath: changelogPath,
-	})
-	if err != nil {
+	}, outputPath); err != nil {
 		fatal(err)
 	}
+}
 
-	result, err := engine.Run(context.Background())
+func run(ctx context.Context, cfg changelogengine.Config, outputPath string) (*changelogengine.RunResult, error) {
+	result, err := runEngine(ctx, cfg)
 	if err != nil {
-		fatal(err)
+		return nil, err
 	}
 
 	if outputPath != "" {
 		payload, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {
-			fatal(err)
+			return nil, err
 		}
 		if err := os.WriteFile(outputPath, payload, 0o644); err != nil {
-			fatal(err)
+			return nil, err
 		}
 	}
 
-	printGitHubOutput(result.Outputs)
+	if err := printGitHubOutput(result.Outputs); err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
-func printGitHubOutput(outputs changelogengine.Outputs) {
-	if path := os.Getenv("GITHUB_OUTPUT"); path != "" {
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-		if err != nil {
-			fatal(err)
-		}
-		defer f.Close()
-		fmt.Fprintf(f, "mode=%s\n", outputs.Mode)
-		fmt.Fprintf(f, "target_version=%s\n", outputs.TargetVersion)
-		fmt.Fprintf(f, "target_branch=%s\n", outputs.TargetBranch)
-		fmt.Fprintf(f, "previous_tag=%s\n", outputs.PreviousTag)
-		fmt.Fprintf(f, "compare_range=%s\n", outputs.CompareRange)
-		fmt.Fprintf(f, "section_header=%s\n", outputs.SectionHeader)
-		fmt.Fprintf(f, "has_changes=%t\n", outputs.HasChanges)
-		fmt.Fprintf(f, "has_user_facing_changes=%t\n", outputs.HasUserFacingChanges)
+func printGitHubOutput(outputs changelogengine.Outputs) error {
+	path := os.Getenv("GITHUB_OUTPUT")
+	if path == "" {
+		return nil
 	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "mode=%s\n", outputs.Mode)
+	fmt.Fprintf(f, "target_version=%s\n", outputs.TargetVersion)
+	fmt.Fprintf(f, "target_branch=%s\n", outputs.TargetBranch)
+	fmt.Fprintf(f, "previous_tag=%s\n", outputs.PreviousTag)
+	fmt.Fprintf(f, "compare_range=%s\n", outputs.CompareRange)
+	fmt.Fprintf(f, "section_header=%s\n", outputs.SectionHeader)
+	fmt.Fprintf(f, "has_changes=%t\n", outputs.HasChanges)
+	fmt.Fprintf(f, "has_user_facing_changes=%t\n", outputs.HasUserFacingChanges)
+	return nil
 }
 
 func envOrDefault(key, fallback string) string {

--- a/scripts/changelog-engine/cmd/changelog-engine/main.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main.go
@@ -89,14 +89,15 @@ func run(ctx context.Context, cfg changelogengine.Config, outputPath string) (*c
 		}
 	}
 
-	if err := printGitHubOutput(result.Outputs); err != nil {
+	if err := printGitHubOutput(result); err != nil {
 		return nil, err
 	}
 
 	return result, nil
 }
 
-func printGitHubOutput(outputs changelogengine.Outputs) error {
+func printGitHubOutput(result *changelogengine.RunResult) error {
+	outputs := result.Outputs
 	path := os.Getenv("GITHUB_OUTPUT")
 	if path == "" {
 		return nil
@@ -139,6 +140,23 @@ func printGitHubOutput(outputs changelogengine.Outputs) error {
 		return err
 	}
 	if _, err := fmt.Fprintf(f, "pr_count=%d\n", outputs.PRCount); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintln(f, "pull_requests<<EOF"); err != nil {
+		_ = f.Close()
+		return err
+	}
+	payload, err := json.Marshal(result.PullRequests)
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "%s\n", payload); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintln(f, "EOF"); err != nil {
 		_ = f.Close()
 		return err
 	}

--- a/scripts/changelog-engine/cmd/changelog-engine/main.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	changelogengine "github.com/elastic/terraform-provider-elasticstack/scripts/changelog-engine"
+)
+
+func main() {
+	var mode string
+	var targetVersion string
+	var owner string
+	var repo string
+	var token string
+	var changelogPath string
+	var outputPath string
+
+	flag.StringVar(&mode, "mode", envOrDefault("CHANGELOG_MODE", "unreleased"), "unreleased or release")
+	flag.StringVar(&targetVersion, "target-version", os.Getenv("CHANGELOG_TARGET_VERSION"), "target version for release mode")
+	flag.StringVar(&owner, "owner", os.Getenv("GITHUB_REPOSITORY_OWNER"), "GitHub owner")
+	repoDefault := ""
+	if repository := os.Getenv("GITHUB_REPOSITORY"); repository != "" {
+		parts := strings.SplitN(repository, "/", 2)
+		if len(parts) == 2 {
+			repoDefault = parts[1]
+		}
+	}
+	flag.StringVar(&repo, "repo", repoDefault, "GitHub repo")
+	flag.StringVar(&token, "token", os.Getenv("GITHUB_TOKEN"), "GitHub token")
+	flag.StringVar(&changelogPath, "changelog", envOrDefault("CHANGELOG_PATH", "CHANGELOG.md"), "path to changelog")
+	flag.StringVar(&outputPath, "output", os.Getenv("GITHUB_OUTPUT"), "optional JSON output file")
+	flag.Parse()
+
+	engine, err := changelogengine.New(changelogengine.Config{
+		Mode:          changelogengine.Mode(mode),
+		TargetVersion: targetVersion,
+		Owner:         owner,
+		Repo:          repo,
+		Token:         token,
+		ChangelogPath: changelogPath,
+	})
+	if err != nil {
+		fatal(err)
+	}
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		fatal(err)
+	}
+
+	if outputPath != "" {
+		payload, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			fatal(err)
+		}
+		if err := os.WriteFile(outputPath, payload, 0o644); err != nil {
+			fatal(err)
+		}
+	}
+
+	printGitHubOutput(result.Outputs)
+}
+
+func printGitHubOutput(outputs changelogengine.Outputs) {
+	if path := os.Getenv("GITHUB_OUTPUT"); path != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			fatal(err)
+		}
+		defer f.Close()
+		fmt.Fprintf(f, "mode=%s\n", outputs.Mode)
+		fmt.Fprintf(f, "target_version=%s\n", outputs.TargetVersion)
+		fmt.Fprintf(f, "target_branch=%s\n", outputs.TargetBranch)
+		fmt.Fprintf(f, "previous_tag=%s\n", outputs.PreviousTag)
+		fmt.Fprintf(f, "compare_range=%s\n", outputs.CompareRange)
+		fmt.Fprintf(f, "section_header=%s\n", outputs.SectionHeader)
+		fmt.Fprintf(f, "has_changes=%t\n", outputs.HasChanges)
+		fmt.Fprintf(f, "has_user_facing_changes=%t\n", outputs.HasUserFacingChanges)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/scripts/changelog-engine/cmd/changelog-engine/main.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main.go
@@ -138,6 +138,10 @@ func printGitHubOutput(outputs changelogengine.Outputs) error {
 		_ = f.Close()
 		return err
 	}
+	if _, err := fmt.Fprintf(f, "pr_count=%d\n", outputs.PRCount); err != nil {
+		_ = f.Close()
+		return err
+	}
 	if err := f.Close(); err != nil {
 		return err
 	}

--- a/scripts/changelog-engine/cmd/changelog-engine/main.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main.go
@@ -106,15 +106,41 @@ func printGitHubOutput(outputs changelogengine.Outputs) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	fmt.Fprintf(f, "mode=%s\n", outputs.Mode)
-	fmt.Fprintf(f, "target_version=%s\n", outputs.TargetVersion)
-	fmt.Fprintf(f, "target_branch=%s\n", outputs.TargetBranch)
-	fmt.Fprintf(f, "previous_tag=%s\n", outputs.PreviousTag)
-	fmt.Fprintf(f, "compare_range=%s\n", outputs.CompareRange)
-	fmt.Fprintf(f, "section_header=%s\n", outputs.SectionHeader)
-	fmt.Fprintf(f, "has_changes=%t\n", outputs.HasChanges)
-	fmt.Fprintf(f, "has_user_facing_changes=%t\n", outputs.HasUserFacingChanges)
+	if _, err := fmt.Fprintf(f, "mode=%s\n", outputs.Mode); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "target_version=%s\n", outputs.TargetVersion); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "target_branch=%s\n", outputs.TargetBranch); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "previous_tag=%s\n", outputs.PreviousTag); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "compare_range=%s\n", outputs.CompareRange); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "section_header=%s\n", outputs.SectionHeader); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "has_changes=%t\n", outputs.HasChanges); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "has_user_facing_changes=%t\n", outputs.HasUserFacingChanges); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/scripts/changelog-engine/cmd/changelog-engine/main_test.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main_test.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	changelogengine "github.com/elastic/terraform-provider-elasticstack/scripts/changelog-engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWritesJSONOutputAndGitHubOutputsSeparately(t *testing.T) {
+	oldRunEngine := runEngine
+	t.Cleanup(func() {
+		runEngine = oldRunEngine
+	})
+
+	runEngine = func(_ context.Context, cfg changelogengine.Config) (*changelogengine.RunResult, error) {
+		return &changelogengine.RunResult{
+			Outputs: changelogengine.Outputs{
+				Mode:                 string(cfg.Mode),
+				TargetVersion:        cfg.TargetVersion,
+				TargetBranch:         "generated-changelog",
+				PreviousTag:          "v1.0.0",
+				CompareRange:         "v1.0.0..HEAD",
+				SectionHeader:        "## [Unreleased]",
+				HasChanges:           true,
+				HasUserFacingChanges: true,
+				PRCount:              1,
+			},
+			PullRequests: []changelogengine.PullRequestRecord{{Number: 11}},
+			UpdatedBody:  "# Changelog",
+		}, nil
+	}
+
+	dir := t.TempDir()
+	jsonOutputPath := filepath.Join(dir, "result.json")
+	githubOutputPath := filepath.Join(dir, "github-output.txt")
+	t.Setenv("GITHUB_OUTPUT", githubOutputPath)
+
+	result, err := run(context.Background(), changelogengine.Config{
+		Mode:          changelogengine.ModeUnreleased,
+		Owner:         "elastic",
+		Repo:          "repo",
+		Token:         "token",
+		ChangelogPath: filepath.Join(dir, "CHANGELOG.md"),
+	}, jsonOutputPath)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	payload, err := os.ReadFile(jsonOutputPath)
+	require.NoError(t, err)
+	var persisted changelogengine.RunResult
+	require.NoError(t, json.Unmarshal(payload, &persisted))
+	assert.Equal(t, "generated-changelog", persisted.Outputs.TargetBranch)
+	assert.Equal(t, 1, persisted.Outputs.PRCount)
+
+	githubOutput, err := os.ReadFile(githubOutputPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(githubOutput), "mode=unreleased")
+	assert.Contains(t, string(githubOutput), "target_branch=generated-changelog")
+	assert.NotContains(t, string(githubOutput), "\"outputs\"")
+}

--- a/scripts/changelog-engine/cmd/changelog-engine/main_test.go
+++ b/scripts/changelog-engine/cmd/changelog-engine/main_test.go
@@ -79,5 +79,7 @@ func TestRunWritesJSONOutputAndGitHubOutputsSeparately(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(githubOutput), "mode=unreleased")
 	assert.Contains(t, string(githubOutput), "target_branch=generated-changelog")
+	assert.Contains(t, string(githubOutput), "pull_requests<<EOF")
+	assert.Contains(t, string(githubOutput), "[{\"number\":11")
 	assert.NotContains(t, string(githubOutput), "\"outputs\"")
 }

--- a/scripts/changelog-engine/engine.go
+++ b/scripts/changelog-engine/engine.go
@@ -258,11 +258,15 @@ func (e *Engine) ResolveReleaseContext() (ReleaseContext, error) {
 			candidates = append(candidates, tag)
 		}
 	}
+	compareTarget := "HEAD"
+	if ctx.Mode == ModeRelease && ctx.ExcludedCurrentTag {
+		compareTarget = ctx.ExcludedTag
+	}
 	if len(candidates) > 0 {
 		ctx.PreviousTag = candidates[0]
-		ctx.CompareRange = ctx.PreviousTag + "..HEAD"
+		ctx.CompareRange = ctx.PreviousTag + ".." + compareTarget
 	} else {
-		ctx.CompareRange = "HEAD"
+		ctx.CompareRange = compareTarget
 	}
 
 	return ctx, nil

--- a/scripts/changelog-engine/engine.go
+++ b/scripts/changelog-engine/engine.go
@@ -1,0 +1,580 @@
+package changelogengine
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	github "github.com/google/go-github/v85/github"
+	"golang.org/x/oauth2"
+)
+
+type Mode string
+
+const (
+	ModeUnreleased Mode = "unreleased"
+	ModeRelease    Mode = "release"
+)
+
+var (
+	semverTagPattern      = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+	releaseBranchPattern  = regexp.MustCompile(`^prep-release-(.+)$`)
+	changelogHeaderRegexp = regexp.MustCompile(`^##\s+Changelog`)
+	topSectionRegexp      = regexp.MustCompile(`^##\s`)
+	subSectionRegexp      = regexp.MustCompile(`^#{2,3}\s`)
+	breakingHeaderRegexp  = regexp.MustCompile(`^###\s+Breaking changes`)
+)
+
+type Config struct {
+	Mode          Mode
+	TargetVersion string
+	Owner         string
+	Repo          string
+	Token         string
+	ChangelogPath string
+	Now           time.Time
+}
+
+type Engine struct {
+	client               *github.Client
+	config               Config
+	gitExec              func(args ...string) ([]byte, error)
+	listPRsForCommitFunc func(ctx context.Context, owner, repo, sha string) ([]*github.PullRequest, error)
+}
+
+type ReleaseContext struct {
+	Mode               Mode
+	TargetVersion      string
+	TargetBranch       string
+	PreviousTag        string
+	CompareRange       string
+	ExcludedTag        string
+	ExcludedCurrentTag bool
+}
+
+type PullRequestRecord struct {
+	Number         int      `json:"number"`
+	Title          string   `json:"title"`
+	URL            string   `json:"url"`
+	MergeCommitSHA string   `json:"merge_commit_sha"`
+	Author         string   `json:"author"`
+	Labels         []string `json:"labels"`
+	Body           string   `json:"body"`
+}
+
+type Outputs struct {
+	Mode                 string `json:"mode"`
+	TargetVersion        string `json:"target_version"`
+	TargetBranch         string `json:"target_branch"`
+	PreviousTag          string `json:"previous_tag"`
+	CompareRange         string `json:"compare_range"`
+	SectionHeader        string `json:"section_header"`
+	HasChanges           bool   `json:"has_changes"`
+	HasUserFacingChanges bool   `json:"has_user_facing_changes"`
+	PRCount              int    `json:"pr_count"`
+}
+
+type RunResult struct {
+	Outputs      Outputs
+	PullRequests []PullRequestRecord
+	UpdatedBody  string
+}
+
+type RenderResult struct {
+	Success     bool
+	SectionBody string
+	Errors      []AssemblyError
+	Included    []IncludedPR
+	Excluded    []ExcludedPR
+}
+
+type AssemblyError struct {
+	PRNumber int
+	PRURL    string
+	Reason   string
+}
+
+type IncludedPR struct {
+	PRNumber        int
+	PRURL           string
+	Summary         string
+	BreakingChanges string
+}
+
+type ExcludedPR struct {
+	PRNumber        int
+	PRURL           string
+	Reason          string
+	BreakingChanges string
+}
+
+type ParsedChangelog struct {
+	CustomerImpact              string
+	Summary                     string
+	BreakingChanges             string
+	BreakingChangesHeadingFound bool
+}
+
+func New(config Config) (*Engine, error) {
+	if config.Mode != ModeUnreleased && config.Mode != ModeRelease {
+		return nil, fmt.Errorf("unsupported mode %q", config.Mode)
+	}
+	if config.Mode == ModeRelease && config.TargetVersion == "" {
+		return nil, errors.New("release mode requires target version")
+	}
+	if config.Owner == "" || config.Repo == "" {
+		return nil, errors.New("owner and repo are required")
+	}
+	if config.Token == "" {
+		return nil, errors.New("token is required")
+	}
+	if config.ChangelogPath == "" {
+		config.ChangelogPath = "CHANGELOG.md"
+	}
+	if config.Now.IsZero() {
+		config.Now = time.Now().UTC()
+	}
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.Token})
+	client := github.NewClient(oauth2.NewClient(context.Background(), ts))
+
+	engine := &Engine{
+		client: client,
+		config: config,
+		gitExec: func(args ...string) ([]byte, error) {
+			cmd := exec.Command("git", args...)
+			return cmd.CombinedOutput()
+		},
+	}
+	engine.listPRsForCommitFunc = func(ctx context.Context, owner, repo, sha string) ([]*github.PullRequest, error) {
+		prs, _, err := engine.client.PullRequests.ListPullRequestsWithCommit(ctx, owner, repo, sha, nil)
+		return prs, err
+	}
+	return engine, nil
+}
+
+func (e *Engine) Run(ctx context.Context) (*RunResult, error) {
+	releaseContext, err := e.ResolveReleaseContext()
+	if err != nil {
+		return nil, err
+	}
+
+	prs, err := e.ResolveMergedPullRequests(ctx, releaseContext.CompareRange)
+	if err != nil {
+		return nil, err
+	}
+
+	rendered := RenderChangelogSection(prs)
+	if !rendered.Success {
+		var reasons []string
+		for _, item := range rendered.Errors {
+			reasons = append(reasons, item.Reason)
+		}
+		return nil, fmt.Errorf("changelog assembly failed:\n%s", strings.Join(reasons, "\n"))
+	}
+
+	current, err := os.ReadFile(e.config.ChangelogPath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("read changelog: %w", err)
+	}
+
+	sectionHeader := buildSectionHeader(releaseContext.Mode, releaseContext.TargetVersion, e.config.Now)
+	newSectionContent := sectionHeader
+	if rendered.SectionBody != "" {
+		newSectionContent += "\n\n" + rendered.SectionBody
+	}
+
+	updated := RewriteChangelogSection(string(current), newSectionContent, releaseContext.Mode, releaseContext.TargetVersion)
+	if err := os.WriteFile(e.config.ChangelogPath, []byte(updated), 0o644); err != nil {
+		return nil, fmt.Errorf("write changelog: %w", err)
+	}
+
+	return &RunResult{
+		Outputs: Outputs{
+			Mode:                 string(releaseContext.Mode),
+			TargetVersion:        releaseContext.TargetVersion,
+			TargetBranch:         releaseContext.TargetBranch,
+			PreviousTag:          releaseContext.PreviousTag,
+			CompareRange:         releaseContext.CompareRange,
+			SectionHeader:        sectionHeader,
+			HasChanges:           len(rendered.Included) > 0 || len(rendered.Excluded) > 0,
+			HasUserFacingChanges: len(rendered.Included) > 0,
+			PRCount:              len(prs),
+		},
+		PullRequests: prs,
+		UpdatedBody:  updated,
+	}, nil
+}
+
+func (e *Engine) ResolveReleaseContext() (ReleaseContext, error) {
+	tags, err := e.semverTags()
+	if err != nil {
+		return ReleaseContext{}, err
+	}
+
+	ctx := ReleaseContext{
+		Mode:          e.config.Mode,
+		TargetVersion: e.config.TargetVersion,
+		TargetBranch:  "generated-changelog",
+	}
+	if ctx.Mode == ModeRelease {
+		ctx.TargetBranch = fmt.Sprintf("prep-release-%s", ctx.TargetVersion)
+		ctx.ExcludedTag = "v" + ctx.TargetVersion
+	}
+
+	candidates := tags
+	if ctx.ExcludedTag != "" {
+		candidates = nil
+		for _, tag := range tags {
+			if tag == ctx.ExcludedTag {
+				ctx.ExcludedCurrentTag = true
+				continue
+			}
+			candidates = append(candidates, tag)
+		}
+	}
+	if len(candidates) > 0 {
+		ctx.PreviousTag = candidates[0]
+		ctx.CompareRange = ctx.PreviousTag + "..HEAD"
+	} else {
+		ctx.CompareRange = "HEAD"
+	}
+
+	return ctx, nil
+}
+
+func (e *Engine) ResolveMergedPullRequests(ctx context.Context, compareRange string) ([]PullRequestRecord, error) {
+	shas, err := e.commitSHAs(compareRange)
+	if err != nil {
+		return nil, err
+	}
+
+	byNumber := map[int]PullRequestRecord{}
+	for _, sha := range shas {
+		prs, err := e.listPRsForCommitFunc(ctx, e.config.Owner, e.config.Repo, sha)
+		if err != nil {
+			return nil, fmt.Errorf("list pull requests for commit %s: %w", sha, err)
+		}
+		for _, pr := range prs {
+			if pr.GetState() != "closed" || pr.GetMergedAt().IsZero() {
+				continue
+			}
+			if _, exists := byNumber[pr.GetNumber()]; exists {
+				continue
+			}
+			byNumber[pr.GetNumber()] = PullRequestRecord{
+				Number:         pr.GetNumber(),
+				Title:          pr.GetTitle(),
+				URL:            pr.GetHTMLURL(),
+				MergeCommitSHA: pr.GetMergeCommitSHA(),
+				Author:         pr.GetUser().GetLogin(),
+				Labels:         labelNames(pr.Labels),
+				Body:           pr.GetBody(),
+			}
+		}
+	}
+
+	result := make([]PullRequestRecord, 0, len(byNumber))
+	for _, pr := range byNumber {
+		result = append(result, pr)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Number < result[j].Number })
+	return result, nil
+}
+
+func labelNames(labels []*github.Label) []string {
+	result := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if name := label.GetName(); name != "" {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
+func (e *Engine) semverTags() ([]string, error) {
+	output, err := e.gitExec("tag", "--list", "v[0-9]*.[0-9]*.[0-9]*", "--sort=-version:refname")
+	if err != nil {
+		return nil, fmt.Errorf("list git tags: %w (%s)", err, strings.TrimSpace(string(output)))
+	}
+	var tags []string
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		tag := strings.TrimSpace(scanner.Text())
+		if semverTagPattern.MatchString(tag) {
+			tags = append(tags, tag)
+		}
+	}
+	return tags, scanner.Err()
+}
+
+func (e *Engine) commitSHAs(compareRange string) ([]string, error) {
+	args := []string{"log", "--format=%H"}
+	if compareRange != "" {
+		args = append(args, compareRange)
+	}
+	output, err := e.gitExec(args...)
+	if err != nil {
+		return nil, fmt.Errorf("git log %s: %w (%s)", compareRange, err, strings.TrimSpace(string(output)))
+	}
+	var shas []string
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		sha := strings.TrimSpace(scanner.Text())
+		if sha != "" {
+			shas = append(shas, sha)
+		}
+	}
+	return shas, scanner.Err()
+}
+
+func RenderChangelogSection(mergedPRs []PullRequestRecord) RenderResult {
+	var result RenderResult
+	var changeBullets []string
+	var breakingBlocks []string
+
+	for _, pr := range mergedPRs {
+		if slices.Contains(pr.Labels, "no-changelog") {
+			result.Excluded = append(result.Excluded, ExcludedPR{PRNumber: pr.Number, PRURL: pr.URL, Reason: "no-changelog label"})
+			continue
+		}
+
+		parsed := ParseChangelogSection(pr.Body)
+		if parsed == nil {
+			result.Errors = append(result.Errors, AssemblyError{PRNumber: pr.Number, PRURL: pr.URL, Reason: fmt.Sprintf("PR #%d (%s) has no parseable ## Changelog section and is not labeled 'no-changelog'. Add a ## Changelog section to the PR body or apply the no-changelog label.", pr.Number, pr.URL)})
+			continue
+		}
+
+		validationErrors := ValidateChangelogSection(parsed)
+		if len(validationErrors) > 0 {
+			reason := strings.Join(validationErrors, "; ")
+			if parsed.CustomerImpact == "" {
+				reason = fmt.Sprintf("PR #%d: ## Changelog section is missing the required Customer impact field", pr.Number)
+			} else {
+				reason = fmt.Sprintf("PR #%d: ## Changelog section failed validation: %s", pr.Number, reason)
+			}
+			result.Errors = append(result.Errors, AssemblyError{PRNumber: pr.Number, PRURL: pr.URL, Reason: reason})
+			continue
+		}
+
+		if parsed.BreakingChanges != "" {
+			breakingBlocks = append(breakingBlocks, strings.TrimRight(parsed.BreakingChanges, "\n"))
+		}
+
+		if strings.EqualFold(parsed.CustomerImpact, "none") {
+			excluded := ExcludedPR{PRNumber: pr.Number, PRURL: pr.URL, Reason: "Customer impact: none"}
+			if parsed.BreakingChanges != "" {
+				excluded.BreakingChanges = parsed.BreakingChanges
+			}
+			result.Excluded = append(result.Excluded, excluded)
+			continue
+		}
+
+		bullet := buildChangeBullet(parsed.Summary, pr.Number, pr.URL)
+		changeBullets = append(changeBullets, bullet)
+		result.Included = append(result.Included, IncludedPR{PRNumber: pr.Number, PRURL: pr.URL, Summary: parsed.Summary, BreakingChanges: parsed.BreakingChanges})
+	}
+
+	if len(result.Errors) > 0 {
+		return result
+	}
+
+	var parts []string
+	if len(breakingBlocks) > 0 {
+		parts = append(parts, "### Breaking changes", "")
+		for _, block := range breakingBlocks {
+			parts = append(parts, block, "")
+		}
+	}
+	if len(changeBullets) > 0 {
+		parts = append(parts, "### Changes", "")
+		parts = append(parts, changeBullets...)
+	}
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	result.Success = true
+	result.SectionBody = strings.Join(parts, "\n")
+	return result
+}
+
+func buildChangeBullet(summary string, prNumber int, prURL string) string {
+	return fmt.Sprintf("%s ([#%d](%s))", normalizeBulletPrefix(strings.TrimSpace(summary)), prNumber, prURL)
+}
+
+func normalizeBulletPrefix(line string) string {
+	line = strings.TrimLeft(line, " \t")
+	line = strings.TrimPrefix(line, "-")
+	line = strings.TrimPrefix(line, "*")
+	line = strings.TrimPrefix(line, "+")
+	line = strings.TrimLeft(line, " \t")
+	return "- " + line
+}
+
+func ParseChangelogSection(body string) *ParsedChangelog {
+	section := extractSection(body, changelogHeaderRegexp, topSectionRegexp)
+	if section == "" && !changelogHeaderRegexp.MatchString(body) {
+		return nil
+	}
+
+	parsed := &ParsedChangelog{}
+	for _, line := range strings.Split(section, "\n") {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "Customer impact:"):
+			parsed.CustomerImpact = strings.TrimSpace(strings.TrimPrefix(trimmed, "Customer impact:"))
+		case strings.HasPrefix(trimmed, "Summary:"):
+			parsed.Summary = strings.TrimSpace(strings.TrimPrefix(trimmed, "Summary:"))
+		case breakingHeaderRegexp.MatchString(trimmed):
+			parsed.BreakingChangesHeadingFound = true
+		}
+	}
+	parsed.BreakingChanges = extractSection(section, breakingHeaderRegexp, subSectionRegexp)
+	return parsed
+}
+
+func ValidateChangelogSection(parsed *ParsedChangelog) []string {
+	if parsed == nil {
+		return []string{"No ## Changelog section found in PR body"}
+	}
+
+	var errs []string
+	switch parsed.CustomerImpact {
+	case "":
+		errs = append(errs, "Missing required field: Customer impact")
+	case "none", "fix", "enhancement", "breaking":
+	default:
+		errs = append(errs, fmt.Sprintf("Invalid Customer impact value: %q. Must be one of: none, fix, enhancement, breaking", parsed.CustomerImpact))
+	}
+
+	if parsed.CustomerImpact != "" && !strings.EqualFold(parsed.CustomerImpact, "none") && parsed.Summary == "" {
+		errs = append(errs, "Missing required field: Summary (required when Customer impact is not \"none\")")
+	}
+	if parsed.BreakingChangesHeadingFound && parsed.BreakingChanges == "" {
+		errs = append(errs, "### Breaking changes section is present but contains no content")
+	}
+	if strings.EqualFold(parsed.CustomerImpact, "breaking") && !parsed.BreakingChangesHeadingFound {
+		errs = append(errs, "Customer impact: breaking requires a ### Breaking changes subsection")
+	}
+	return errs
+}
+
+func extractSection(body string, start *regexp.Regexp, end *regexp.Regexp) string {
+	var lines []string
+	inSection := false
+	var fence string
+	for _, line := range strings.Split(body, "\n") {
+		if !inSection && start.MatchString(line) {
+			inSection = true
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		if fence == "" {
+			switch {
+			case strings.HasPrefix(line, "```"):
+				fence = "```"
+			case strings.HasPrefix(line, "~~~"):
+				fence = "~~~"
+			case end.MatchString(line):
+				return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+			}
+		} else if strings.HasPrefix(line, fence) {
+			fence = ""
+		}
+		lines = append(lines, line)
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+}
+
+func RewriteChangelogSection(content, newSectionContent string, mode Mode, targetVersion string) string {
+	lines := strings.Split(content, "\n")
+	targetStart := -1
+	if mode == ModeUnreleased {
+		for i, line := range lines {
+			if strings.HasPrefix(line, "## [Unreleased]") {
+				targetStart = i
+				break
+			}
+		}
+	} else {
+		header := fmt.Sprintf("## [%s]", targetVersion)
+		for i, line := range lines {
+			if strings.HasPrefix(line, header) {
+				targetStart = i
+				break
+			}
+		}
+	}
+
+	if targetStart == -1 {
+		if mode == ModeRelease {
+			for i, line := range lines {
+				if strings.HasPrefix(line, "## [Unreleased]") {
+					end := findSectionEnd(lines, i)
+					before := append([]string{}, lines[:end]...)
+					after := lines[end:]
+					return strings.Join(append(append(before, "", newSectionContent), after...), "\n")
+				}
+			}
+		}
+		if strings.TrimSpace(content) == "" {
+			return newSectionContent
+		}
+		return newSectionContent + "\n\n" + content
+	}
+
+	end := findSectionEnd(lines, targetStart)
+	before := append([]string{}, lines[:targetStart]...)
+	after := lines[end:]
+	for len(before) > 0 && before[len(before)-1] == "" {
+		before = before[:len(before)-1]
+	}
+	for len(after) > 0 && after[0] == "" {
+		after = after[1:]
+	}
+	parts := append([]string{}, before...)
+	if len(parts) > 0 {
+		parts = append(parts, "")
+	}
+	parts = append(parts, newSectionContent)
+	if len(after) > 0 {
+		parts = append(parts, "")
+		parts = append(parts, after...)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func findSectionEnd(lines []string, start int) int {
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			return i
+		}
+	}
+	return len(lines)
+}
+
+func buildSectionHeader(mode Mode, targetVersion string, now time.Time) string {
+	if mode == ModeRelease {
+		return fmt.Sprintf("## [%s] - %s", targetVersion, now.UTC().Format("2006-01-02"))
+	}
+	return "## [Unreleased]"
+}
+
+func ResolveReleaseMode(eventName, headBranch string) (Mode, string, string) {
+	if (eventName == "pull_request" || eventName == "pull_request_target") && releaseBranchPattern.MatchString(headBranch) {
+		match := releaseBranchPattern.FindStringSubmatch(headBranch)
+		return ModeRelease, match[1], headBranch
+	}
+	return ModeUnreleased, "", "generated-changelog"
+}

--- a/scripts/changelog-engine/engine.go
+++ b/scripts/changelog-engine/engine.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package changelogengine
 
 import (
@@ -27,7 +44,6 @@ const (
 
 var (
 	semverTagPattern      = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
-	releaseBranchPattern  = regexp.MustCompile(`^prep-release-(.+)$`)
 	changelogHeaderRegexp = regexp.MustCompile(`^##\s+Changelog`)
 	topSectionRegexp      = regexp.MustCompile(`^##\s`)
 	subSectionRegexp      = regexp.MustCompile(`^#{2,3}\s`)
@@ -350,7 +366,12 @@ func RenderChangelogSection(mergedPRs []PullRequestRecord) RenderResult {
 
 		parsed := ParseChangelogSection(pr.Body)
 		if parsed == nil {
-			result.Errors = append(result.Errors, AssemblyError{PRNumber: pr.Number, PRURL: pr.URL, Reason: fmt.Sprintf("PR #%d (%s) has no parseable ## Changelog section and is not labeled 'no-changelog'. Add a ## Changelog section to the PR body or apply the no-changelog label.", pr.Number, pr.URL)})
+			reason := fmt.Sprintf(
+				"PR #%d (%s) has no parseable ## Changelog section and is not labeled 'no-changelog'. Add a ## Changelog section to the PR body or apply the no-changelog label.",
+				pr.Number,
+				pr.URL,
+			)
+			result.Errors = append(result.Errors, AssemblyError{PRNumber: pr.Number, PRURL: pr.URL, Reason: reason})
 			continue
 		}
 
@@ -381,7 +402,12 @@ func RenderChangelogSection(mergedPRs []PullRequestRecord) RenderResult {
 
 		bullet := buildChangeBullet(parsed.Summary, pr.Number, pr.URL)
 		changeBullets = append(changeBullets, bullet)
-		result.Included = append(result.Included, IncludedPR{PRNumber: pr.Number, PRURL: pr.URL, Summary: parsed.Summary, BreakingChanges: parsed.BreakingChanges})
+		result.Included = append(result.Included, IncludedPR{
+			PRNumber:        pr.Number,
+			PRURL:           pr.URL,
+			Summary:         parsed.Summary,
+			BreakingChanges: parsed.BreakingChanges,
+		})
 	}
 
 	if len(result.Errors) > 0 {
@@ -427,7 +453,7 @@ func ParseChangelogSection(body string) *ParsedChangelog {
 	}
 
 	parsed := &ParsedChangelog{}
-	for _, line := range strings.Split(section, "\n") {
+	for line := range strings.SplitSeq(section, "\n") {
 		trimmed := strings.TrimSpace(line)
 		switch {
 		case strings.HasPrefix(trimmed, "Customer impact:"):
@@ -453,10 +479,18 @@ func ValidateChangelogSection(parsed *ParsedChangelog) []string {
 		errs = append(errs, "Missing required field: Customer impact")
 	case "none", "fix", "enhancement", "breaking":
 	default:
-		errs = append(errs, fmt.Sprintf("Invalid Customer impact value: %q. Must be one of: none, fix, enhancement, breaking", parsed.CustomerImpact))
+		errs = append(
+			errs,
+			fmt.Sprintf(
+				"Invalid Customer impact value: %q. Must be one of: none, fix, enhancement, breaking",
+				parsed.CustomerImpact,
+			),
+		)
 	}
 
-	if parsed.CustomerImpact != "" && !strings.EqualFold(parsed.CustomerImpact, "none") && parsed.Summary == "" {
+	if parsed.CustomerImpact != "" &&
+		!strings.EqualFold(parsed.CustomerImpact, "none") &&
+		parsed.Summary == "" {
 		errs = append(errs, "Missing required field: Summary (required when Customer impact is not \"none\")")
 	}
 	if parsed.BreakingChangesHeadingFound && parsed.BreakingChanges == "" {
@@ -472,7 +506,7 @@ func extractSection(body string, start *regexp.Regexp, end *regexp.Regexp) strin
 	var lines []string
 	inSection := false
 	var fence string
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if !inSection && start.MatchString(line) {
 			inSection = true
 			continue
@@ -569,12 +603,4 @@ func buildSectionHeader(mode Mode, targetVersion string, now time.Time) string {
 		return fmt.Sprintf("## [%s] - %s", targetVersion, now.UTC().Format("2006-01-02"))
 	}
 	return "## [Unreleased]"
-}
-
-func ResolveReleaseMode(eventName, headBranch string) (Mode, string, string) {
-	if (eventName == "pull_request" || eventName == "pull_request_target") && releaseBranchPattern.MatchString(headBranch) {
-		match := releaseBranchPattern.FindStringSubmatch(headBranch)
-		return ModeRelease, match[1], headBranch
-	}
-	return ModeUnreleased, "", "generated-changelog"
 }

--- a/scripts/changelog-engine/engine.go
+++ b/scripts/changelog-engine/engine.go
@@ -100,9 +100,9 @@ type Outputs struct {
 }
 
 type RunResult struct {
-	Outputs      Outputs
-	PullRequests []PullRequestRecord
-	UpdatedBody  string
+	Outputs      Outputs             `json:"outputs"`
+	PullRequests []PullRequestRecord `json:"pull_requests"`
+	UpdatedBody  string              `json:"updated_body"`
 }
 
 type RenderResult struct {

--- a/scripts/changelog-engine/engine_test.go
+++ b/scripts/changelog-engine/engine_test.go
@@ -1,0 +1,106 @@
+package changelogengine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	github "github.com/google/go-github/v85/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveReleaseContext(t *testing.T) {
+	engine := testEngine(t)
+	engine.gitExec = func(args ...string) ([]byte, error) {
+		return []byte("v2.0.0\nv1.9.0\n"), nil
+	}
+	engine.config.Mode = ModeRelease
+	engine.config.TargetVersion = "2.0.0"
+
+	ctx, err := engine.ResolveReleaseContext()
+	require.NoError(t, err)
+	assert.Equal(t, ModeRelease, ctx.Mode)
+	assert.Equal(t, "2.0.0", ctx.TargetVersion)
+	assert.Equal(t, "prep-release-2.0.0", ctx.TargetBranch)
+	assert.Equal(t, "v1.9.0", ctx.PreviousTag)
+	assert.Equal(t, "v1.9.0..HEAD", ctx.CompareRange)
+	assert.True(t, ctx.ExcludedCurrentTag)
+}
+
+func TestRenderChangelogSection(t *testing.T) {
+	result := RenderChangelogSection([]PullRequestRecord{
+		{Number: 1, URL: "https://example.test/pr/1", Body: "## Changelog\nCustomer impact: fix\nSummary: Fix a bug"},
+		{Number: 2, URL: "https://example.test/pr/2", Labels: []string{"no-changelog"}},
+		{Number: 3, URL: "https://example.test/pr/3", Body: "## Changelog\nCustomer impact: breaking\nSummary: Remove an API\n\n### Breaking changes\nMigration required"},
+	})
+
+	require.True(t, result.Success)
+	assert.Contains(t, result.SectionBody, "### Breaking changes")
+	assert.Contains(t, result.SectionBody, "### Changes")
+	assert.Contains(t, result.SectionBody, "- Fix a bug ([#1](https://example.test/pr/1))")
+	assert.Contains(t, result.SectionBody, "- Remove an API ([#3](https://example.test/pr/3))")
+	assert.Len(t, result.Excluded, 1)
+}
+
+func TestRenderChangelogSectionValidationFailure(t *testing.T) {
+	result := RenderChangelogSection([]PullRequestRecord{{Number: 1, URL: "https://example.test/pr/1", Body: "## Changelog\nSummary: Missing impact"}})
+	require.False(t, result.Success)
+	assert.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Reason, "Customer impact")
+}
+
+func TestRewriteChangelogSection(t *testing.T) {
+	content := "# Changelog\n\n## [Unreleased]\n\nOld unreleased\n\n## [1.0.0] - 2026-01-01\n\nPrevious"
+	updated := RewriteChangelogSection(content, "## [Unreleased]\n\n### Changes\n\n- New entry", ModeUnreleased, "")
+	assert.Contains(t, updated, "- New entry")
+	assert.NotContains(t, updated, "Old unreleased")
+	assert.Contains(t, updated, "## [1.0.0] - 2026-01-01")
+}
+
+func TestRunWritesChangelogAndOutputs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CHANGELOG.md")
+	require.NoError(t, os.WriteFile(path, []byte("# Changelog\n\n## [Unreleased]\n"), 0o644))
+
+	engine := testEngine(t)
+	engine.config.ChangelogPath = path
+	engine.config.Now = time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)
+	engine.gitExec = func(args ...string) ([]byte, error) {
+		switch args[0] {
+		case "tag":
+			return []byte("v1.0.0\n"), nil
+		case "log":
+			return []byte("abc123\n"), nil
+		default:
+			return nil, nil
+		}
+	}
+	engine.listPRsForCommitFunc = func(ctx context.Context, owner, repo, sha string) ([]*github.PullRequest, error) {
+		return []*github.PullRequest{{
+			Number:         github.Ptr(11),
+			HTMLURL:        github.Ptr("https://example.test/pr/11"),
+			State:          github.Ptr("closed"),
+			MergedAt:       &github.Timestamp{Time: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
+			MergeCommitSHA: github.Ptr("abc123"),
+			Body:           github.Ptr("## Changelog\nCustomer impact: fix\nSummary: Add a new thing"),
+			User:           &github.User{Login: github.Ptr("octocat")},
+		}}, nil
+	}
+
+	result, err := engine.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "## [Unreleased]", result.Outputs.SectionHeader)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "- Add a new thing ([#11](https://example.test/pr/11))")
+}
+
+func testEngine(t *testing.T) *Engine {
+	t.Helper()
+	engine, err := New(Config{Mode: ModeUnreleased, Owner: "elastic", Repo: "repo", Token: "token", ChangelogPath: "CHANGELOG.md"})
+	require.NoError(t, err)
+	return engine
+}

--- a/scripts/changelog-engine/engine_test.go
+++ b/scripts/changelog-engine/engine_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package changelogengine
 
 import (
@@ -78,15 +95,15 @@ func TestRunWritesChangelogAndOutputs(t *testing.T) {
 			return nil, nil
 		}
 	}
-	engine.listPRsForCommitFunc = func(ctx context.Context, owner, repo, sha string) ([]*github.PullRequest, error) {
+	engine.listPRsForCommitFunc = func(_ context.Context, _, _, _ string) ([]*github.PullRequest, error) {
 		return []*github.PullRequest{{
-			Number:         github.Ptr(11),
-			HTMLURL:        github.Ptr("https://example.test/pr/11"),
-			State:          github.Ptr("closed"),
+			Number:         new(11),
+			HTMLURL:        new("https://example.test/pr/11"),
+			State:          new("closed"),
 			MergedAt:       &github.Timestamp{Time: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
-			MergeCommitSHA: github.Ptr("abc123"),
-			Body:           github.Ptr("## Changelog\nCustomer impact: fix\nSummary: Add a new thing"),
-			User:           &github.User{Login: github.Ptr("octocat")},
+			MergeCommitSHA: new("abc123"),
+			Body:           new("## Changelog\nCustomer impact: fix\nSummary: Add a new thing"),
+			User:           &github.User{Login: new("octocat")},
 		}}, nil
 	}
 
@@ -96,6 +113,58 @@ func TestRunWritesChangelogAndOutputs(t *testing.T) {
 	content, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "- Add a new thing ([#11](https://example.test/pr/11))")
+}
+
+func TestResolveMergedPullRequestsDeduplicatesAndFiltersMergedPRs(t *testing.T) {
+	engine := testEngine(t)
+	engine.gitExec = func(args ...string) ([]byte, error) {
+		require.Equal(t, []string{"log", "--format=%H", "v1.0.0..HEAD"}, args)
+		return []byte("sha1\nsha2\nsha3\n"), nil
+	}
+	engine.listPRsForCommitFunc = func(_ context.Context, _, _, sha string) ([]*github.PullRequest, error) {
+		switch sha {
+		case "sha1":
+			return []*github.PullRequest{{
+				Number:         github.Ptr(10),
+				Title:          github.Ptr("merged"),
+				HTMLURL:        github.Ptr("https://example.test/pr/10"),
+				State:          github.Ptr("closed"),
+				MergedAt:       &github.Timestamp{Time: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
+				MergeCommitSHA: github.Ptr("merge-sha-10"),
+				Body:           github.Ptr("## Changelog\nCustomer impact: fix\nSummary: merged"),
+				Labels:         []*github.Label{{Name: github.Ptr("enhancement")}},
+				User:           &github.User{Login: github.Ptr("octocat")},
+			}}, nil
+		case "sha2":
+			return []*github.PullRequest{{
+				Number:   github.Ptr(10),
+				State:    github.Ptr("closed"),
+				MergedAt: &github.Timestamp{Time: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
+			}, {
+				Number: github.Ptr(11),
+				State:  github.Ptr("open"),
+			}}, nil
+		case "sha3":
+			return []*github.PullRequest{{
+				Number: github.Ptr(12),
+				State:  github.Ptr("closed"),
+			}}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	prs, err := engine.ResolveMergedPullRequests(context.Background(), "v1.0.0..HEAD")
+	require.NoError(t, err)
+	require.Len(t, prs, 1)
+	assert.Equal(t, 10, prs[0].Number)
+	assert.Equal(t, "merge-sha-10", prs[0].MergeCommitSHA)
+	assert.Equal(t, []string{"enhancement"}, prs[0].Labels)
+}
+
+func TestNewRequiresExplicitReleaseTargetVersion(t *testing.T) {
+	_, err := New(Config{Mode: ModeRelease, Owner: "elastic", Repo: "repo", Token: "token"})
+	require.EqualError(t, err, "release mode requires target version")
 }
 
 func testEngine(t *testing.T) *Engine {

--- a/scripts/changelog-engine/engine_test.go
+++ b/scripts/changelog-engine/engine_test.go
@@ -30,21 +30,48 @@ import (
 )
 
 func TestResolveReleaseContext(t *testing.T) {
-	engine := testEngine(t)
-	engine.gitExec = func(_ ...string) ([]byte, error) {
-		return []byte("v2.0.0\nv1.9.0\n"), nil
+	tests := []struct {
+		name                string
+		tags                string
+		wantPreviousTag     string
+		wantCompareRange    string
+		wantExcludedCurrent bool
+	}{
+		{
+			name:                "bounds release range to target tag when present",
+			tags:                "v2.0.0\nv1.9.0\n",
+			wantPreviousTag:     "v1.9.0",
+			wantCompareRange:    "v1.9.0..v2.0.0",
+			wantExcludedCurrent: true,
+		},
+		{
+			name:                "uses head when target tag is absent",
+			tags:                "v1.9.0\n",
+			wantPreviousTag:     "v1.9.0",
+			wantCompareRange:    "v1.9.0..HEAD",
+			wantExcludedCurrent: false,
+		},
 	}
-	engine.config.Mode = ModeRelease
-	engine.config.TargetVersion = "2.0.0"
 
-	ctx, err := engine.ResolveReleaseContext()
-	require.NoError(t, err)
-	assert.Equal(t, ModeRelease, ctx.Mode)
-	assert.Equal(t, "2.0.0", ctx.TargetVersion)
-	assert.Equal(t, "prep-release-2.0.0", ctx.TargetBranch)
-	assert.Equal(t, "v1.9.0", ctx.PreviousTag)
-	assert.Equal(t, "v1.9.0..HEAD", ctx.CompareRange)
-	assert.True(t, ctx.ExcludedCurrentTag)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := testEngine(t)
+			engine.gitExec = func(_ ...string) ([]byte, error) {
+				return []byte(tt.tags), nil
+			}
+			engine.config.Mode = ModeRelease
+			engine.config.TargetVersion = "2.0.0"
+
+			ctx, err := engine.ResolveReleaseContext()
+			require.NoError(t, err)
+			assert.Equal(t, ModeRelease, ctx.Mode)
+			assert.Equal(t, "2.0.0", ctx.TargetVersion)
+			assert.Equal(t, "prep-release-2.0.0", ctx.TargetBranch)
+			assert.Equal(t, tt.wantPreviousTag, ctx.PreviousTag)
+			assert.Equal(t, tt.wantCompareRange, ctx.CompareRange)
+			assert.Equal(t, tt.wantExcludedCurrent, ctx.ExcludedCurrentTag)
+		})
+	}
 }
 
 func TestRenderChangelogSection(t *testing.T) {

--- a/scripts/changelog-engine/engine_test.go
+++ b/scripts/changelog-engine/engine_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestResolveReleaseContext(t *testing.T) {
 	engine := testEngine(t)
-	engine.gitExec = func(args ...string) ([]byte, error) {
+	engine.gitExec = func(_ ...string) ([]byte, error) {
 		return []byte("v2.0.0\nv1.9.0\n"), nil
 	}
 	engine.config.Mode = ModeRelease
@@ -125,29 +125,29 @@ func TestResolveMergedPullRequestsDeduplicatesAndFiltersMergedPRs(t *testing.T) 
 		switch sha {
 		case "sha1":
 			return []*github.PullRequest{{
-				Number:         github.Ptr(10),
-				Title:          github.Ptr("merged"),
-				HTMLURL:        github.Ptr("https://example.test/pr/10"),
-				State:          github.Ptr("closed"),
+				Number:         new(10),
+				Title:          new("merged"),
+				HTMLURL:        new("https://example.test/pr/10"),
+				State:          new("closed"),
 				MergedAt:       &github.Timestamp{Time: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
-				MergeCommitSHA: github.Ptr("merge-sha-10"),
-				Body:           github.Ptr("## Changelog\nCustomer impact: fix\nSummary: merged"),
-				Labels:         []*github.Label{{Name: github.Ptr("enhancement")}},
-				User:           &github.User{Login: github.Ptr("octocat")},
+				MergeCommitSHA: new("merge-sha-10"),
+				Body:           new("## Changelog\nCustomer impact: fix\nSummary: merged"),
+				Labels:         []*github.Label{{Name: new("enhancement")}},
+				User:           &github.User{Login: new("octocat")},
 			}}, nil
 		case "sha2":
 			return []*github.PullRequest{{
-				Number:   github.Ptr(10),
-				State:    github.Ptr("closed"),
+				Number:   new(10),
+				State:    new("closed"),
 				MergedAt: &github.Timestamp{Time: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
 			}, {
-				Number: github.Ptr(11),
-				State:  github.Ptr("open"),
+				Number: new(11),
+				State:  new("open"),
 			}}, nil
 		case "sha3":
 			return []*github.PullRequest{{
-				Number: github.Ptr(12),
-				State:  github.Ptr("closed"),
+				Number: new(12),
+				State:  new("closed"),
 			}}, nil
 		default:
 			return nil, nil


### PR DESCRIPTION
## Summary
- extract changelog generation into a shared Go engine under `scripts/changelog-engine`
- switch changelog-generation to explicit dispatch release mode and remove `pull_request_target`
- update prep-release to generate the final release changelog in a single deterministic commit

## Changelog
Customer impact: enhancement
Summary: Refactor changelog automation to use a shared Go engine with explicit release-mode workflow inputs and deterministic release preparation.

## Validation
- make lint
- make build
- make check-openspec
- go test -v ./scripts/changelog-engine/...
- go test ./scripts/compile-workflow-sources/...
- node --test .github/workflows-src/lib/changelog-release-context.test.mjs .github/workflows-src/lib/changelog-pr-management.test.mjs .github/workflows-src/lib/changelog-workflow-contract.test.mjs .github/workflows-src/lib/prep-release-workflow-contract.test.mjs

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace inline changelog scripts with a shared Go engine for changelog generation
> - Introduces a Go-based changelog engine at [`scripts/changelog-engine/`](https://github.com/elastic/terraform-provider-elasticstack/pull/2431/files#diff-9272fb015c29b944b3f06417b8473c0d9d311eaa2c50e999914f23c53b7cb61d) that queries merged PRs via GitHub API, parses PR changelog sections, renders markdown, and rewrites `CHANGELOG.md` in either `unreleased` or `release` mode.
> - Replaces the inline `github-script` gather/render steps in the changelog generation workflow with a single shell step invoking the Go binary; downstream steps consume structured outputs (`has_user_facing_changes`, `compare_range`, `target_branch`, etc.).
> - Removes `pull_request_target` trigger from the changelog workflow and replaces it with explicit `workflow_dispatch` inputs (`mode` and `target_version`); release mode requires a non-empty `target_version` or the workflow fails.
> - Updates `prep-release.yml` to invoke the Go engine in release mode as a synchronous step, then commits both `Makefile` and `CHANGELOG.md` in a single deterministic `chore(release): prepare <version> release` commit.
> - Changes `refreshReleasePR` to locate the release PR by head branch (`prep-release-<version>`) instead of event payload PR number.
> - Behavioral Change: changelog regeneration on release PRs is no longer automatic on PR open/update — it requires a manual `workflow_dispatch` or a rerun of `prep-release`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1f7596.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->