### PR TITLE
Persist kibana connection in agent builder workflow ds

### DIFF
--- a/internal/kibana/agentbuilderworkflow/data_source_read.go
+++ b/internal/kibana/agentbuilderworkflow/data_source_read.go
@@ -88,12 +88,11 @@ func (d *WorkflowDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	compositeID := &clients.CompositeID{ClusterID: spaceID, ResourceID: workflowID}
 
-	var state workflowDataSourceModel
-	state.ID = types.StringValue(compositeID.String())
-	state.SpaceID = types.StringValue(spaceID)
-	state.WorkflowID = types.StringValue(workflow.ID)
-	state.ConfigurationYaml = customtypes.NewNormalizedYamlValue(workflow.Yaml)
+	config.ID = types.StringValue(compositeID.String())
+	config.SpaceID = types.StringValue(spaceID)
+	config.WorkflowID = types.StringValue(workflow.ID)
+	config.ConfigurationYaml = customtypes.NewNormalizedYamlValue(workflow.Yaml)
 
-	diags = resp.State.Set(ctx, &state)
+	diags = resp.State.Set(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Persist Kibana connection state in agent builder workflow data source
In [data_source_read.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2438/files#diff-fdce2ce4fb750a6fe01f7f34d946908f3226a00c3039aacbf8623332f73f6162), the `Read` method now writes state by setting fields directly on the existing `config` struct and passing it to `resp.State.Set`, rather than copying values into a separate `state` struct. This ensures the persisted state reflects the full config, including the Kibana connection.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c2b649.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->