### PR TITLE
Shared core resource behaviour

### DIFF
--- a/openspec/changes/refactor-resource-boilerplate-core/.openspec.yaml
+++ b/openspec/changes/refactor-resource-boilerplate-core/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/refactor-resource-boilerplate-core/design.md
+++ b/openspec/changes/refactor-resource-boilerplate-core/design.md
@@ -1,0 +1,107 @@
+## Context
+
+Many Plugin Framework resources in this repository repeat the same three pieces of wiring in `resource.go`: a `*clients.ProviderClientFactory` field, a `Configure` method that converts provider data into that factory, and a `Metadata` method that constructs the Terraform type name from a hard-coded suffix. The duplication is spread across Elasticsearch, Kibana, Fleet, and APM packages, even though the pattern is substantially the same.
+
+The refactor needs to stay narrow. `ImportState` is not uniform: some resources use passthrough import, some parse composite IDs, and some do not implement import at all. The refactor also needs to respect existing type names exactly during rollout, including legacy suffix spellings such as `agentbuilder_tool`. Although APM resources use Kibana-backed APIs, their Terraform type names live under the `apm_*` namespace, so naming concerns and client-resolution concerns cannot be treated as the same axis.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a shared embedded core for Plugin Framework resources that centralizes canonical `Configure`, client storage, and `Metadata`.
+- Introduce a typed component namespace for type-name generation, including `elasticsearch`, `kibana`, `fleet`, and `apm`.
+- Standardize the default `Configure` behavior on early return after appended diagnostics.
+- Trial the embedded core on four representative resources:
+  - `internal/elasticsearch/ml/jobstate`
+  - `internal/kibana/agentbuildertool`
+  - `internal/fleet/integration`
+  - `internal/apm/agent_configuration`
+- Add guardrails that detect accidental interface drift when methods are promoted through embedding.
+
+**Non-Goals:**
+- Unifying `ImportState` behind the embedded core.
+- Renaming existing Terraform resource type names as part of this change.
+- Extending the abstraction to data sources in the initial rollout.
+- Moving CRUD, schema, validation, or state-upgrade logic into the shared core.
+
+## Decisions
+
+### Introduce a provider-wide `internal/resourcecore` package
+
+The shared logic will live in a provider-wide package dedicated to Plugin Framework resource wiring, tentatively `internal/resourcecore`. This keeps the code grouped by logical concept, matches the repository guidance for provider-wide shared helpers, and avoids adding another generic `utils` surface.
+
+**Alternative considered:** keep the logic as free functions only. Rejected for this change because the primary goal is to reduce repeated receiver boilerplate in `resource.go`, and an embedded core gives a cleaner end state for the pilot resources.
+
+### The core will own only client wiring and type-name construction
+
+The core will carry:
+- a typed `Component` value
+- a literal `resourceName` suffix segment
+- the configured `*clients.ProviderClientFactory`
+
+The core will expose:
+- `Configure(...)`
+- `Metadata(...)`
+- `Client() *clients.ProviderClientFactory`
+
+The `Client()` accessor keeps concrete resources from depending on a mutable exported field while still allowing embedded use across packages.
+
+**Alternative considered:** export the client field directly. Rejected because it weakens encapsulation and makes later evolution of the core more difficult.
+
+### Type names will be constructed from literal namespace parts, without normalization
+
+`Metadata` will build the Terraform type name as:
+
+`<provider_type_name>_<component>_<resource_name>`
+
+The `component` value will come from well-known typed constants such as `ComponentElasticsearch`, `ComponentKibana`, `ComponentFleet`, and `ComponentAPM`. The `resourceName` value will be passed in as the final suffix segment to preserve current compatibility, rather than being derived from package names or transformed automatically.
+
+This allows future resources to use names like `agent_builder_tool` if desired, while allowing the initial pilot to preserve current spellings such as `agentbuilder_tool`.
+
+**Alternative considered:** derive the resource suffix from the Go package name or auto-convert identifiers to snake case. Rejected because current resource type names are not uniform enough for safe derivation.
+
+### `ImportState` remains explicit on concrete resources
+
+The embedded core will not define `ImportState`. Resources that already implement import will continue to do so explicitly, and resources that do not support import will remain non-importable. This avoids accidental satisfaction of `resource.ResourceWithImportState` through promoted methods.
+
+**Alternative considered:** add a default passthrough import implementation to the core. Rejected because it would blur intentional differences between passthrough, composite-ID, and no-import resources.
+
+### The pilot rollout will be staged to maximize shape coverage
+
+The initial rollout sequence will be:
+1. `internal/elasticsearch/ml/jobstate` — simple Elasticsearch resource with passthrough import.
+2. `internal/kibana/agentbuildertool` — Kibana resource with passthrough import and a legacy type-name suffix spelling.
+3. `internal/fleet/integration` — resource with canonical `Configure` and `Metadata`, but no import and additional upgrade-state behavior.
+4. `internal/apm/agent_configuration` — resource that uses Kibana-backed APIs while needing the new `apm` naming component.
+
+This order exercises the core across the main namespace and behavior combinations before any broader adoption.
+
+### Add a conformance harness for promoted-method safety
+
+The change will include a small conformance test surface that asserts the intended interface shape of representative resource forms. At minimum, the harness will verify that:
+- an embedded-core resource satisfies `resource.ResourceWithConfigure`
+- a no-import resource does not accidentally satisfy `resource.ResourceWithImportState`
+- a custom-import resource continues to own its explicit import behavior
+
+**Alternative considered:** rely only on existing concrete resource interface assertions. Rejected because those assertions do not protect against architectural drift in the abstraction itself.
+
+## Risks / Trade-offs
+
+- [Promoted methods make behavior ownership less obvious in review] → Keep the core small, preserve explicit interface assertions on each concrete resource, and add the conformance harness.
+- [Canonical early-return `Configure` could subtly change resources that currently assign `client` despite diagnostics] → Limit the pilot to resources already matching or compatible with the canonical behavior, and audit outliers separately.
+- [Component naming could be confused with client-resolution kind] → Document `Component` as a Terraform type-name namespace, not as a client selector.
+- [The embedded pattern may still feel less readable than helper-only wrappers] → Use the four-resource pilot to compare review clarity before wider rollout.
+
+## Migration Plan
+
+1. Add `internal/resourcecore` with the typed component constants, constructor, `Configure`, `Metadata`, and `Client()` accessor.
+2. Add unit and conformance tests for type-name generation and promoted-method/interface behavior.
+3. Convert the four pilot resources one at a time, preserving existing type names and import behavior.
+4. Run targeted tests for the shared package and each converted resource package after each step.
+5. If the pilot shows reduced readability or unexpected interface coupling, stop rollout and retain the package only as a helper surface for later reconsideration.
+
+Rollback is straightforward because the change is internal to resource wiring: each pilot resource can be reverted to explicit `client`, `Configure`, and `Metadata` methods without user state migration.
+
+## Open Questions
+
+- Whether a sibling abstraction for data sources should be proposed later, after the resource pilot has proven readable.
+- Whether `internal/resourcecore` is the best final package name, or whether another provider-wide logical name would better match existing conventions.

--- a/openspec/changes/refactor-resource-boilerplate-core/proposal.md
+++ b/openspec/changes/refactor-resource-boilerplate-core/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Plugin Framework resources in this repository repeat the same `client *clients.ProviderClientFactory`, `Configure`, and `Metadata` wiring with only a component-prefixed resource name changing between packages. That duplication makes consistency harder to maintain, obscures the intended canonical `Configure` behavior, and slows down reviews when boilerplate changes need to be applied across many resources.
+
+## What Changes
+
+- Add a provider-wide Plugin Framework resource core that owns canonical client-factory wiring and resource type-name construction from a typed component plus resource name.
+- Define a typed component namespace for well-known values, including `elasticsearch`, `kibana`, `fleet`, and `apm`.
+- Restrict the shared core to `Configure` and `Metadata`; keep `ImportState` explicit on each resource.
+- Trial the embedded-core rollout on `elasticstack_elasticsearch_ml_job_state`, `elasticstack_kibana_agentbuilder_tool`, `elasticstack_fleet_integration`, and `elasticstack_apm_agent_configuration`.
+- Add compile-time and targeted test coverage that protects against accidental interface drift from promoted methods during the rollout.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-framework-resource-core`: Define the shared Plugin Framework resource-core contract for provider client handling, typed component-based type-name generation, and rollout safety rules for embedded usage.
+
+### Modified Capabilities
+
+<!-- None -->
+
+## Impact
+
+- New provider-wide logical package under `internal/` for the shared resource core and typed component constants.
+- Pilot resource wiring updates in:
+  - `internal/elasticsearch/ml/jobstate`
+  - `internal/kibana/agentbuildertool`
+  - `internal/fleet/integration`
+  - `internal/apm/agent_configuration`
+- New or updated tests covering embedded-core conformance and pilot resource behavior.
+- New OpenSpec capability at `openspec/changes/refactor-resource-boilerplate-core/specs/provider-framework-resource-core/spec.md`

--- a/openspec/changes/refactor-resource-boilerplate-core/specs/provider-framework-resource-core/spec.md
+++ b/openspec/changes/refactor-resource-boilerplate-core/specs/provider-framework-resource-core/spec.md
@@ -4,8 +4,8 @@
 The provider SHALL provide a shared Plugin Framework resource core that constructs Terraform resource type names from the configured provider type name, a typed component namespace, and a literal resource-name suffix. The constructed type name SHALL use the format `<provider_type_name>_<component>_<resource_name>`. The shared core SHALL support well-known component constants for `elasticsearch`, `kibana`, `fleet`, and `apm`.
 
 #### Scenario: Kibana resource type name is built from component and resource name
-- **WHEN** a resource core is configured with component `kibana` and resource name `agent_builder_tool`
-- **THEN** `Metadata` SHALL set the type name to `<provider_type_name>_kibana_agent_builder_tool`
+- **WHEN** a resource core is configured with component `kibana` and resource name `agentbuilder_tool`
+- **THEN** `Metadata` SHALL set the type name to `<provider_type_name>_kibana_agentbuilder_tool`
 
 #### Scenario: APM resource type name uses the APM namespace
 - **WHEN** a resource core is configured with component `apm` and resource name `agent_configuration`

--- a/openspec/changes/refactor-resource-boilerplate-core/specs/provider-framework-resource-core/spec.md
+++ b/openspec/changes/refactor-resource-boilerplate-core/specs/provider-framework-resource-core/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Embedded resource core constructs provider resource type names from typed namespace parts
+The provider SHALL provide a shared Plugin Framework resource core that constructs Terraform resource type names from the configured provider type name, a typed component namespace, and a literal resource-name suffix. The constructed type name SHALL use the format `<provider_type_name>_<component>_<resource_name>`. The shared core SHALL support well-known component constants for `elasticsearch`, `kibana`, `fleet`, and `apm`.
+
+#### Scenario: Kibana resource type name is built from component and resource name
+- **WHEN** a resource core is configured with component `kibana` and resource name `agent_builder_tool`
+- **THEN** `Metadata` SHALL set the type name to `<provider_type_name>_kibana_agent_builder_tool`
+
+#### Scenario: APM resource type name uses the APM namespace
+- **WHEN** a resource core is configured with component `apm` and resource name `agent_configuration`
+- **THEN** `Metadata` SHALL set the type name to `<provider_type_name>_apm_agent_configuration`
+
+### Requirement: Embedded resource core provides canonical provider client-factory wiring
+The shared Plugin Framework resource core SHALL store the configured `*clients.ProviderClientFactory` for use by the concrete resource. Its `Configure` implementation SHALL convert provider data by calling `clients.ConvertProviderDataToFactory`, append any returned diagnostics to the response, and stop before storing a client when those diagnostics contain errors. The core SHALL expose access to the stored factory through a method rather than a mutable exported field.
+
+#### Scenario: Configure stores the provider client factory
+- **WHEN** `Configure` receives provider data that converts successfully to `*clients.ProviderClientFactory`
+- **THEN** the core SHALL retain that factory for later access by the concrete resource
+
+#### Scenario: Configure does not store a client after diagnostic failure
+- **WHEN** `Configure` appends diagnostics containing errors from provider-data conversion
+- **THEN** the core SHALL not retain a configured client factory
+
+### Requirement: Embedded resource core does not define import behavior
+The shared Plugin Framework resource core SHALL NOT implement `ImportState` or otherwise provide default import behavior. Concrete resources SHALL remain responsible for explicitly defining passthrough import, custom import, or no import support according to their own schema and lifecycle behavior.
+
+#### Scenario: Resource without import remains non-importable
+- **WHEN** a concrete resource embeds the shared core and does not define its own `ImportState`
+- **THEN** embedding the core SHALL NOT make that resource satisfy `resource.ResourceWithImportState`
+
+#### Scenario: Resource with custom import retains explicit ownership
+- **WHEN** a concrete resource embeds the shared core and also defines its own `ImportState`
+- **THEN** the resource's import behavior SHALL remain defined by the explicit concrete method

--- a/openspec/changes/refactor-resource-boilerplate-core/tasks.md
+++ b/openspec/changes/refactor-resource-boilerplate-core/tasks.md
@@ -1,0 +1,25 @@
+## 1. Shared Core
+
+- [ ] 1.1 Add a new provider-wide `internal/resourcecore` package for Plugin Framework resource wiring.
+- [ ] 1.2 Define the typed `Component` constants for `elasticsearch`, `kibana`, `fleet`, and `apm`.
+- [ ] 1.3 Implement the resource core constructor, canonical `Configure`, `Metadata`, and `Client()` accessor.
+- [ ] 1.4 Document in package comments that `Component` is a type-name namespace and that `resourceName` is a literal suffix segment with no normalization.
+
+## 2. Safety Coverage
+
+- [ ] 2.1 Add unit tests for type-name generation across `elasticsearch`, `kibana`, `fleet`, and `apm` components.
+- [ ] 2.2 Add conformance tests that verify embedded-core resources satisfy `resource.ResourceWithConfigure` without accidentally gaining `resource.ResourceWithImportState`.
+- [ ] 2.3 Preserve or add explicit concrete-resource interface assertions in pilot resources so promoted methods remain visible in review.
+
+## 3. Trial Rollout
+
+- [ ] 3.1 Convert `internal/elasticsearch/ml/jobstate` to embed the shared core while preserving its existing import behavior and type name.
+- [ ] 3.2 Convert `internal/kibana/agentbuildertool` to embed the shared core while preserving its current `kibana_agentbuilder_tool` type-name suffix.
+- [ ] 3.3 Convert `internal/fleet/integration` to embed the shared core without adding import support or altering upgrade-state behavior.
+- [ ] 3.4 Convert `internal/apm/agent_configuration` to embed the shared core using the new `apm` component while preserving its Kibana-backed API logic.
+
+## 4. Verification
+
+- [ ] 4.1 Run targeted tests for `internal/resourcecore` and each pilot resource package after conversion.
+- [ ] 4.2 Confirm the pilot resources retain their existing Terraform type names and import support boundaries.
+- [ ] 4.3 Reassess readability after the four-resource pilot and decide whether to continue embedded rollout, stop at the pilot, or revert to helper-only usage.


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/2439

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared resource core design and spec for provider-wide Plugin Framework boilerplate
> - Adds an OpenSpec change manifest, design doc, proposal, requirements spec, and task checklist for a planned refactor to introduce a shared `internal/resourcecore` package.
> - The core centralises `Configure` (client-factory wiring) and `Metadata` (type-name construction as `<provider>_<component>_<resource_name>`) across resources, eliminating duplicated boilerplate.
> - Defines typed `Component` constants for `elasticsearch`, `kibana`, `fleet`, and `apm`, and explicitly excludes `ImportState` from the shared core to preserve per-resource import behaviour.
> - Outlines a staged pilot rollout across four resources with conformance tests to verify promoted-method safety.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 550ec48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->