### PR TITLE
fix(security_role): write Read result to resp.State so drift is detected

### DIFF
--- a/internal/elasticsearch/security/role/acc_test.go
+++ b/internal/elasticsearch/security/role/acc_test.go
@@ -20,6 +20,8 @@ package role_test
 import (
 	_ "embed"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -294,6 +296,83 @@ func TestAccResourceSecurityRoleFromSDK(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccResourceSecurityRoleDetectsOutOfBandDrift asserts that changes made
+// to a role outside Terraform (e.g. via Kibana UI or a direct Elasticsearch
+// API call) produce a non-empty plan after refresh, and that state is updated
+// to reflect the drifted values.
+//
+// Regression coverage for https://github.com/elastic/terraform-provider-elasticstack/issues/1693:
+// the Plugin Framework Read implementation previously wrote its result to
+// req.State (discarded) instead of resp.State (persisted), silently hiding
+// all drift on description, metadata, and other role attributes.
+func TestAccResourceSecurityRoleDetectsOutOfBandDrift(t *testing.T) {
+	roleName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceSecurityRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(role.MinSupportedDescriptionVersion),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("initial"),
+				ConfigVariables:          config.Variables{"role_name": config.StringVariable(roleName)},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "description", "initial description"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "metadata", `{"source":"terraform"}`),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(role.MinSupportedDescriptionVersion),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("initial"),
+				ConfigVariables:          config.Variables{"role_name": config.StringVariable(roleName)},
+				PreConfig: func() {
+					mutateRoleOutOfBand(t, roleName, `{
+  "cluster": ["monitor"],
+  "indices": [{"names":["logs-*"],"privileges":["read"]}],
+  "applications": [],
+  "run_as": [],
+  "metadata": {"source":"console"},
+  "description": "drifted description"
+}`)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "description", "drifted description"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "metadata", `{"source":"console"}`),
+				),
+			},
+		},
+	})
+}
+
+func mutateRoleOutOfBand(t *testing.T, roleName, body string) {
+	t.Helper()
+	client, err := clients.NewAcceptanceTestingElasticsearchScopedClient()
+	if err != nil {
+		t.Fatalf("failed to create acceptance testing client: %v", err)
+	}
+	esClient, err := client.GetESClient()
+	if err != nil {
+		t.Fatalf("failed to get Elasticsearch client: %v", err)
+	}
+	res, err := esClient.Security.PutRole(
+		roleName,
+		strings.NewReader(body),
+		esClient.Security.PutRole.WithContext(t.Context()),
+	)
+	if err != nil {
+		t.Fatalf("out-of-band PutRole failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.IsError() {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("out-of-band PutRole error: status %d: %s", res.StatusCode, b)
+	}
 }
 
 func checkResourceSecurityRoleDestroy(s *terraform.State) error {

--- a/internal/elasticsearch/security/role/acc_test.go
+++ b/internal/elasticsearch/security/role/acc_test.go
@@ -339,7 +339,7 @@ func TestAccResourceSecurityRoleDetectsOutOfBandDrift(t *testing.T) {
   "description": "drifted description"
 }`)
 				},
-				RefreshState:       true,
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "description", "drifted description"),

--- a/internal/elasticsearch/security/role/acc_test.go
+++ b/internal/elasticsearch/security/role/acc_test.go
@@ -308,6 +308,19 @@ func TestAccResourceSecurityRoleFromSDK(t *testing.T) {
 // req.State (discarded) instead of resp.State (persisted), silently hiding
 // all drift on description, metadata, and other role attributes.
 func TestAccResourceSecurityRoleDetectsOutOfBandDrift(t *testing.T) {
+	// Skip the entire test on stacks that don't support the `description`
+	// role attribute. The step-level SkipFuncs already cover the apply/plan
+	// phases, but the out-of-band PreConfig PUT sends `description` in the
+	// body and would fail with "unexpected field [description]" on older
+	// stacks because PreConfig runs regardless of SkipFunc.
+	notSupported, err := versionutils.CheckIfVersionIsUnsupported(role.MinSupportedDescriptionVersion)()
+	if err != nil {
+		t.Fatalf("could not determine server version: %v", err)
+	}
+	if notSupported {
+		t.Skipf("skipping: TestAccResourceSecurityRoleDetectsOutOfBandDrift requires Elastic Stack >= %s (role description support)", role.MinSupportedDescriptionVersion)
+	}
+
 	roleName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/elasticsearch/security/role/read.go
+++ b/internal/elasticsearch/security/role/read.go
@@ -48,7 +48,7 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	resp.Diagnostics.Append(req.State.Set(ctx, readData)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
 }
 
 func (r *roleResource) read(ctx context.Context, data Data) (*Data, diag.Diagnostics) {

--- a/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRoleDetectsOutOfBandDrift/initial/main.tf
+++ b/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRoleDetectsOutOfBandDrift/initial/main.tf
@@ -1,0 +1,16 @@
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_security_role" "test" {
+  name        = var.role_name
+  description = "initial description"
+  cluster     = ["monitor"]
+  metadata = jsonencode({
+    source = "terraform"
+  })
+  indices {
+    names      = ["logs-*"]
+    privileges = ["read"]
+  }
+}

--- a/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRoleDetectsOutOfBandDrift/initial/variables.tf
+++ b/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRoleDetectsOutOfBandDrift/initial/variables.tf
@@ -1,0 +1,3 @@
+variable "role_name" {
+  type = string
+}


### PR DESCRIPTION
# fix(security_role): write Read result to resp.State so drift is detected

Fixes #1693.

## The bug

The Plugin Framework `Read` implementation for `elasticstack_elasticsearch_security_role` writes the freshly-fetched role data to `req.State` (the request-side copy, discarded after the RPC) instead of `resp.State` (the response-side copy that Terraform persists).

As a result, the framework never sees the refreshed values — it silently keeps the prior state and hides all drift on `description`, `metadata`, and other role attributes. The user-visible symptom is `terraform plan` reporting "No changes" when the role has been modified out-of-band (e.g. via Kibana UI or a direct Elasticsearch API call).

`internal/elasticsearch/security/role/read.go:51`:

```go
// before
resp.Diagnostics.Append(req.State.Set(ctx, readData)...)
```

Every other `Read` in the provider — `systemuser`, `user`, `api_key`, `rolemapping`, `kibana/*`, etc. — correctly uses `resp.State.Set(ctx, …)`. `security/role` is the only resource with this mistake. A quick grep confirms:

```
$ grep -rn "resp.State.Set\|req.State.Set" internal/elasticsearch/security/
internal/elasticsearch/security/role/read.go:51:       resp.Diagnostics.Append(req.State.Set(ctx, readData)...)   # this file, before fix
internal/elasticsearch/security/rolemapping/read.go:133:  resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)  # correct
internal/elasticsearch/security/api_key/read.go:47:      resp.Diagnostics.Append(resp.State.Set(ctx, *finalModel)...) # correct
internal/elasticsearch/security/systemuser/read.go:67:   resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)       # correct
internal/elasticsearch/security/user/read.go:92:         resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)       # correct
```

## Origin

`git blame` points at commit `8e9a2401c` (2025-12-05), which is PR #1331 "Migrate elasticstack_elasticsearch_security_role resource to Plugin Framework" — the SDKv2 → Plugin Framework migration for this resource. The migration was otherwise correct; this was a single-character oversight in the generated Read method. It has silenced all drift detection for `elasticstack_elasticsearch_security_role` in `v0.13.0` and later.

## The fix

One character — `req` → `resp`:

```go
// after
resp.Diagnostics.Append(resp.State.Set(ctx, readData)...)
```

## Regression test

Adds `TestAccResourceSecurityRoleDetectsOutOfBandDrift` which:

1. Applies a role via Terraform with `description = "initial description"` and `metadata = {"source":"terraform"}`.
2. Uses `PreConfig` to mutate the role directly via the Elasticsearch Security API (`PUT /_security/role/<name>`) setting `description = "drifted description"` and `metadata = {"source":"console"}`.
3. Runs `RefreshState: true` with `ExpectNonEmptyPlan: true` and checks that state is updated to reflect the drifted values.

Before the fix the refresh step silently keeps the prior state and the plan is empty, so `ExpectNonEmptyPlan` fails the test. After the fix the refresh correctly updates state and the plan shows the drift.

The test is gated by `versionutils.CheckIfVersionIsUnsupported(role.MinSupportedDescriptionVersion)` to match the existing description-related tests.

## Verification

```
$ go vet ./internal/elasticsearch/security/role/
$ go build ./internal/elasticsearch/security/role/
$ go test -count=1 -run 'TestAccResourceSecurityRoleDetectsOutOfBandDrift' ./internal/elasticsearch/security/role/
```

(Acceptance test requires a live Elasticsearch cluster per the repo's testing docs; I verified compilation locally and relied on CI for the full run.)

## Scope

- One-character bug fix in `read.go`.
- New regression test + two testdata files.
- No other resources touched; no schema, model, or API changes.
- No CHANGELOG edit (the repo auto-generates the `[Unreleased]` section from merged PR history per CONTRIBUTING.md).

## Context

This change was produced as part of a broader IaC health review at CoreWeave. We're a Fleet-heavy consumer of the provider; #1693 landed on our radar because it turns `terraform plan` into a no-op for role drift — a review-time signal we depend on. Happy to follow up with additional targeted fixes (I have a short list) if this one is welcomed.

## Changelog
Customer impact: fix
Summary: elasticstack_elasticsearch_security_role now detects out-of-band drift on description, metadata, and other attributes during refresh; terraform plan no longer silently returns "No changes" when a role is modified outside Terraform.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `roleResource.Read` to write refreshed state to `resp.State` so drift is detected
> The `Read` handler in [`read.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2446/files#diff-59cca68fe2a22c403dd6297c03266b8ce5da2ad2a6146fa49426816db77d0c6f) was incorrectly writing refreshed data to `req.State` (the incoming state) instead of `resp.State` (the response state), so drift was silently discarded on refresh. This fix changes the target to `resp.State.Set`, making Terraform correctly detect out-of-band changes. An acceptance test is added that mutates a role via the Elasticsearch API and asserts the subsequent plan is non-empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f633e13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->