### PR TITLE
fix(fleet_integration): detect out-of-band version changes via InstallationInfo

### DIFF
--- a/internal/fleet/integration/acc_test.go
+++ b/internal/fleet/integration/acc_test.go
@@ -185,10 +185,21 @@ func TestAccResourceIntegrationDeleted(t *testing.T) {
 	})
 }
 
+// TestAccResourceIntegration_ExternalChange asserts that out-of-band version
+// changes to an installed Fleet integration package are detected on the next
+// refresh, and that terraform plan surfaces the drift.
+//
+// Regression test for https://github.com/elastic/terraform-provider-elasticstack/issues/1585:
+// Fleet's GET /epm/packages/{name}/{version} returns status "installed"
+// whenever the package is installed at *any* version, so the provider
+// previously did not notice out-of-band upgrades. Read now consults
+// InstallationInfo.Version and records the actually-installed version in
+// state, so plan sees a diff between state and config.
 func TestAccResourceIntegration_ExternalChange(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { acctest.PreCheck(t) },
 		Steps: []resource.TestStep{
+			// Step 1: apply tcp@1.16.0 via terraform.
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
@@ -198,6 +209,11 @@ func TestAccResourceIntegration_ExternalChange(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.16.0"),
 				),
 			},
+			// Step 2: upgrade tcp to 1.17.0 via the Fleet API (out-of-band).
+			// The next refresh must record the *actually installed* version
+			// (1.17.0) in state, and the resulting plan must be non-empty
+			// because the configured version (1.16.0) no longer matches
+			// state.
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
@@ -205,8 +221,6 @@ func TestAccResourceIntegration_ExternalChange(t *testing.T) {
 				PreConfig: func() {
 					notSupported, err := versionutils.CheckIfVersionIsUnsupported(minVersionIntegration)()
 					require.NoError(t, err)
-
-					// Skip the pre-config if the version is not supported
 					if notSupported {
 						return
 					}
@@ -222,36 +236,11 @@ func TestAccResourceIntegration_ExternalChange(t *testing.T) {
 					})
 					require.Empty(t, diags)
 				},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "tcp"),
-					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.16.0"),
-				),
-			},
-			{
-				ProtoV6ProviderFactories: acctest.Providers,
-				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
-				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
-				PreConfig: func() {
-					notSupported, err := versionutils.CheckIfVersionIsUnsupported(minVersionIntegration)()
-					require.NoError(t, err)
-
-					// Skip the pre-config if the version is not supported
-					if notSupported {
-						return
-					}
-
-					client, err := clients.NewAcceptanceTestingKibanaScopedClient()
-					require.NoError(t, err)
-
-					fleetClient, err := client.GetFleetClient()
-					require.NoError(t, err)
-
-					diags := fleet.Uninstall(t.Context(), fleetClient, "tcp", "1.16.0", "", true)
-					require.Empty(t, diags)
-				},
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "tcp"),
-					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.16.0"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.17.0"),
 				),
 			},
 		},

--- a/internal/fleet/integration/acc_test.go
+++ b/internal/fleet/integration/acc_test.go
@@ -38,6 +38,11 @@ import (
 var (
 	minVersionIntegration       = version.Must(version.NewVersion("8.6.0"))
 	minVersionIntegrationPolicy = version.Must(version.NewVersion("8.10.0"))
+	// minVersionInstallationInfo is the first Fleet release that populates
+	// PackageInfo.InstallationInfo on GET /epm/packages/{name}/{version}.
+	// Tests that rely on the actually-installed version (as opposed to the
+	// version echoed back from the request path) require this floor.
+	minVersionInstallationInfo = version.Must(version.NewVersion("8.9.0"))
 )
 
 //go:embed testdata/TestAccResourceIntegrationFromSDK/main.tf
@@ -202,7 +207,7 @@ func TestAccResourceIntegration_ExternalChange(t *testing.T) {
 			// Step 1: apply tcp@1.16.0 via terraform.
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
-				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionInstallationInfo),
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "tcp"),
@@ -213,10 +218,15 @@ func TestAccResourceIntegration_ExternalChange(t *testing.T) {
 			// The next refresh must record the *actually installed* version
 			// (1.17.0) in state, and the resulting plan must be non-empty
 			// because the configured version (1.16.0) no longer matches
-			// state.
+			// state. Relies on PackageInfo.InstallationInfo being populated
+			// by Fleet, which is why the step is gated on
+			// minVersionInstallationInfo rather than the broader
+			// minVersionIntegration — on pre-8.9 servers the Read fallback
+			// returns the requested (state) version and no drift is
+			// observable through the integration GET alone.
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
-				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionInstallationInfo),
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
 				PreConfig: func() {
 					notSupported, err := versionutils.CheckIfVersionIsUnsupported(minVersionIntegration)()

--- a/internal/fleet/integration/read.go
+++ b/internal/fleet/integration/read.go
@@ -60,7 +60,17 @@ func (r *integrationResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	stateModel.ID = types.StringValue(getPackageID(name, version))
+	// Fleet's GET /epm/packages/{name}/{version} reports status "installed"
+	// whenever the package is installed at *any* version, regardless of the
+	// version path parameter. Use InstallationInfo.Version when present so
+	// Terraform observes out-of-band upgrades and downgrades as drift.
+	// See https://github.com/elastic/terraform-provider-elasticstack/issues/1585.
+	installedVersion := version
+	if pkg.InstallationInfo != nil && pkg.InstallationInfo.Version != "" {
+		installedVersion = pkg.InstallationInfo.Version
+	}
+	stateModel.Version = types.StringValue(installedVersion)
+	stateModel.ID = types.StringValue(getPackageID(name, installedVersion))
 
 	diags = resp.State.Set(ctx, stateModel)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
# fix(fleet_integration): detect out-of-band version changes via InstallationInfo

Fixes #1585.

## The bug

Per @tobio's writeup in #1585:

> 1. Install a package via the TF resource, for example `tcp` at version `1.16.0`
> 2. Upgrade the package via Kibana UI or devtools, for example `tcp` to `1.17.0`
> 3. `terraform plan`
>
> Expected: Terraform should downgrade the package back to 1.16.0
> Actual: No changes required

Fleet's `GET /epm/packages/{name}/{version}` reports `status: installed` whenever the package is installed at *any* version — the version in the path parameter is not used to decide the installed-status flag. The Read implementation in `internal/fleet/integration/read.go` trusted that flag and never noticed when the actually-installed version differed from the version recorded in state:

```go
// before
if pkg == nil || !fleetPackageInstalled(pkg) {
    resp.State.RemoveResource(ctx)
    return
}
stateModel.ID = types.StringValue(getPackageID(name, version))
```

`version` here is the stale value from state, not what Fleet says is actually installed. State is never updated, so `terraform plan` sees `state.version == config.version` and reports no diff.

## The fix

The response body does carry the actually-installed version in `pkg.InstallationInfo.Version` (see `generated/kbapi/kibana.gen.go:63053`). Consult that when populating state:

```go
// after
installedVersion := version
if pkg.InstallationInfo != nil && pkg.InstallationInfo.Version != "" {
    installedVersion = pkg.InstallationInfo.Version
}
stateModel.Version = types.StringValue(installedVersion)
stateModel.ID = types.StringValue(getPackageID(name, installedVersion))
```

With this in place:
- Refresh writes `installedVersion` into state.
- Plan diffs `state.version` (actual) against `config.version` (desired) and surfaces the drift.
- Update (which delegates to Create → `InstallPackage`) runs to reconcile on the next apply.

`InstallationInfo` is the authoritative source on recent Kibana versions. If it is absent (older servers), the fallback path preserves the previous behavior by keeping `version` from state — `fleetPackageInstalled`'s existing `Status` fallback continues to gate `RemoveResource` for the "package gone" case.

## Test updates

The existing `TestAccResourceIntegration_ExternalChange` codified the buggy behavior: step 2 installed `tcp@1.17.0` out-of-band and then asserted that `state.version` was still `"1.16.0"`. That assertion is exactly what #1585 is complaining about.

Replaced with a proper drift-detection test using `PlanOnly: true, ExpectNonEmptyPlan: true` (same pattern as `TestAccResourceIntegrationDeleted`), asserting:
- After the out-of-band upgrade, `state.version == "1.17.0"` (actual installed).
- Plan is non-empty (terraform wants to downgrade back to `1.16.0`).

The redundant step 3 (out-of-band uninstall) was dropped — `TestAccResourceIntegrationDeleted` already covers that case.

## Verification

```
$ go vet ./internal/fleet/integration/
$ go build ./internal/fleet/integration/
$ go test -count=1 -run 'TestAccResourceIntegration_ExternalChange' ./internal/fleet/integration/
```

Acceptance test requires a live Elasticsearch + Kibana (per the repo testing docs); the above ran to completion locally for compile/vet, and I relied on CI for the full acceptance run. Happy to rerun locally with a containerised stack if you want me to confirm the test result before merge.

## Scope

- Read-only behavioral change in a single resource (`elasticstack_fleet_integration`).
- No schema, no API, no model changes — the fix uses a field already generated from the Kibana OpenAPI spec.
- Existing acceptance test rewritten to assert correct behavior; new test function count unchanged.
- No CHANGELOG edit (the repo auto-generates the `[Unreleased]` section from merged PR history per CONTRIBUTING.md).

## Context

This is the second in a short series of targeted CoreWeave-authored fixes against this provider. The first is #2446 (`security_role` silent drift). The list lives behind internal planning — happy to continue if these are welcome.

## Changelog
Customer impact: fix
Summary: elasticstack_fleet_integration now detects out-of-band package upgrades and downgrades during refresh by consulting InstallationInfo.Version; terraform plan surfaces the drift instead of reporting "No changes".


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect out-of-band integration version changes via `InstallationInfo` in Fleet resource reads
> - [read.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2447/files#diff-5319ee2508fe0fe646cb174c486e85c24dbd8e6ba98363e68deaa1c84e847ed8): `Read` now derives the installed package version from `pkg.InstallationInfo.Version` when available, updating both `stateModel.Version` and the resource ID to reflect the actually installed version rather than the requested version.
> - This causes Terraform to detect plan drift when a package is upgraded or downgraded outside of Terraform, surfacing out-of-band changes correctly.
> - [acc_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2447/files#diff-aaef4b65af6a17f4aea136d36cdc736d23ed916a5c5d331172eac30b25e776bd): The acceptance test `TestAccResourceIntegration_ExternalChange` is updated to upgrade `tcp` from `1.16.0` to `1.17.0` via the Fleet API and assert a non-empty plan, and is now gated on Fleet >= `8.9.0` (the first version that populates `InstallationInfo`).
> - Behavioral Change: `Read` now records the installed version instead of the requested version in state when `InstallationInfo` is present, which will trigger plan drift for any existing resources whose installed version differs from configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bae5902.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->