### PR TITLE
fix(fleet_agent_policy): preserve null description when API returns empty string

### DIFF
--- a/internal/fleet/agentpolicy/models.go
+++ b/internal/fleet/agentpolicy/models.go
@@ -101,7 +101,17 @@ func (model *agentPolicyModel) populateFromAPI(ctx context.Context, data *kbapi.
 	model.ID = types.StringValue(data.Id)
 	model.PolicyID = types.StringValue(data.Id)
 	model.DataOutputID = types.StringPointerValue(data.DataOutputId)
-	model.Description = types.StringPointerValue(data.Description)
+	// The Fleet API normalizes an omitted description to an empty string in
+	// its response body. When the user's plan omits description (null), that
+	// empty string would be written to state and trigger "Provider produced
+	// inconsistent result after apply: was null, but now cty.StringVal("")".
+	// Treat an API empty-string as equivalent to null when the configured
+	// value is already null. See https://github.com/elastic/terraform-provider-elasticstack/issues/993.
+	if data.Description != nil && *data.Description == "" && model.Description.IsNull() {
+		// preserve null to match the plan; Kibana treats null and "" as equivalent for description
+	} else {
+		model.Description = types.StringPointerValue(data.Description)
+	}
 	model.DownloadSourceID = types.StringPointerValue(data.DownloadSourceId)
 	model.FleetServerHostID = types.StringPointerValue(data.FleetServerHostId)
 

--- a/internal/fleet/agentpolicy/models.go
+++ b/internal/fleet/agentpolicy/models.go
@@ -106,9 +106,13 @@ func (model *agentPolicyModel) populateFromAPI(ctx context.Context, data *kbapi.
 	// empty string would be written to state and trigger "Provider produced
 	// inconsistent result after apply: was null, but now cty.StringVal("")".
 	// Treat an API empty-string as equivalent to null when the configured
-	// value is already null. See https://github.com/elastic/terraform-provider-elasticstack/issues/993.
-	if data.Description != nil && *data.Description == "" && model.Description.IsNull() {
-		// preserve null to match the plan; Kibana treats null and "" as equivalent for description
+	// value is already null. Kibana treats null and "" as equivalent for
+	// this field. See https://github.com/elastic/terraform-provider-elasticstack/issues/993.
+	apiEmpty := data.Description != nil && *data.Description == ""
+	if apiEmpty && model.Description.IsNull() {
+		// Explicit no-op: keep the null we already have in state so the
+		// plan/apply round-trip stays consistent.
+		model.Description = types.StringNull()
 	} else {
 		model.Description = types.StringPointerValue(data.Description)
 	}

--- a/internal/fleet/agentpolicy/models_test.go
+++ b/internal/fleet/agentpolicy/models_test.go
@@ -18,8 +18,10 @@
 package agentpolicy
 
 import (
+	"context"
 	"testing"
 
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -157,6 +159,88 @@ func TestConvertHostNameFormatToAgentFeature(t *testing.T) {
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.want.Name, got.Name)
 			assert.Equal(t, tt.want.Enabled, got.Enabled)
+		})
+	}
+}
+
+// TestPopulateFromAPI_Description_Null_vs_EmptyString asserts the
+// null-preserving behavior for the `description` attribute. Regression test
+// for https://github.com/elastic/terraform-provider-elasticstack/issues/993:
+// the Fleet API returns an empty string for an unset description, which
+// previously triggered "Provider produced inconsistent result after apply:
+// was null, but now cty.StringVal("")" whenever the user's plan omitted the
+// attribute.
+func TestPopulateFromAPI_Description_Null_vs_EmptyString(t *testing.T) {
+	emptyStr := ""
+	foo := "foo"
+
+	tests := []struct {
+		name          string
+		initial       types.String // the pre-populate plan/state value
+		apiValue      *string      // data.Description as returned by Fleet
+		wantNull      bool
+		wantValue     string // only meaningful when wantNull is false
+	}{
+		{
+			name:     "null in plan and nil from API stays null",
+			initial:  types.StringNull(),
+			apiValue: nil,
+			wantNull: true,
+		},
+		{
+			name:     "null in plan and empty string from API stays null",
+			initial:  types.StringNull(),
+			apiValue: &emptyStr,
+			wantNull: true,
+		},
+		{
+			name:      "null in plan and value from API adopts value",
+			initial:   types.StringNull(),
+			apiValue:  &foo,
+			wantNull:  false,
+			wantValue: "foo",
+		},
+		{
+			name:      "empty string in plan and empty string from API stays empty string",
+			initial:   types.StringValue(""),
+			apiValue:  &emptyStr,
+			wantNull:  false,
+			wantValue: "",
+		},
+		{
+			name:      "value in plan and matching value from API stays value",
+			initial:   types.StringValue("foo"),
+			apiValue:  &foo,
+			wantNull:  false,
+			wantValue: "foo",
+		},
+		{
+			name:      "value in plan and different value from API adopts API value",
+			initial:   types.StringValue("foo"),
+			apiValue:  &emptyStr, // user removed out-of-band; Kibana response is ""
+			wantNull:  false,
+			wantValue: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &agentPolicyModel{
+				Description: tc.initial,
+			}
+			data := &kbapi.AgentPolicy{
+				Id:          "policy-id",
+				Description: tc.apiValue,
+			}
+			diags := model.populateFromAPI(context.Background(), data)
+			assert.False(t, diags.HasError(), "populateFromAPI produced unexpected error diags: %v", diags)
+
+			if tc.wantNull {
+				assert.True(t, model.Description.IsNull(), "expected Description to be null, got %q", model.Description.ValueString())
+			} else {
+				assert.False(t, model.Description.IsNull(), "expected Description to be set, got null")
+				assert.Equal(t, tc.wantValue, model.Description.ValueString())
+			}
 		})
 	}
 }

--- a/internal/fleet/agentpolicy/models_test.go
+++ b/internal/fleet/agentpolicy/models_test.go
@@ -175,11 +175,11 @@ func TestPopulateFromAPI_Description_Null_vs_EmptyString(t *testing.T) {
 	foo := "foo"
 
 	tests := []struct {
-		name          string
-		initial       types.String // the pre-populate plan/state value
-		apiValue      *string      // data.Description as returned by Fleet
-		wantNull      bool
-		wantValue     string // only meaningful when wantNull is false
+		name      string
+		initial   types.String // the pre-populate plan/state value
+		apiValue  *string      // data.Description as returned by Fleet
+		wantNull  bool
+		wantValue string // only meaningful when wantNull is false
 	}{
 		{
 			name:     "null in plan and nil from API stays null",


### PR DESCRIPTION
# fix(fleet_agent_policy): preserve null description when API returns empty string

Fixes #993.

## The bug

Per the issue repro:

1. Create an agent policy via Terraform with no `description` attribute configured.
2. Add a description via the Kibana UI (Fleet → Agent Policies → Settings).
3. Remove the description via the Kibana UI. Kibana normalizes "removed" to an empty string in its response.
4. `terraform apply` fails:

   ```
   Error: Provider produced inconsistent result after apply
   ...produced an unexpected new value: .description: was null, but now cty.StringVal("").
   ```

## Root cause

`internal/fleet/agentpolicy/models.go:104` unconditionally overwrote `model.Description` from the API response:

```go
// before
model.Description = types.StringPointerValue(data.Description)
```

When the user's plan omits `description` (so `model.Description` arrives null) but the API returns an empty string (`data.Description = &""`), `StringPointerValue(&"")` yields `types.StringValue("")` — not null. Terraform then sees plan said null, apply produced `""`, and errors out.

Biscout42 suggested `UseStateForUnknown` in a comment on the issue; that would work for a fresh create but not for the out-of-band remove scenario in the repro, where the plan is null (not unknown). The right fix is to normalize at the populate step.

## The fix

When the API returns an empty string **and** the current model value is null, keep null. Otherwise fall back to the previous behavior.

```go
// after
if data.Description != nil && *data.Description == "" && model.Description.IsNull() {
    // preserve null to match the plan; Kibana treats null and "" as equivalent for description
} else {
    model.Description = types.StringPointerValue(data.Description)
}
```

Kibana accepts `null` and `""` interchangeably for this field, so the user-observable semantics don't change. What changes is that Terraform's plan/apply consistency contract is honored.

## Coverage

All six combinations of plan × API are covered by a new table-driven unit test, `TestPopulateFromAPI_Description_Null_vs_EmptyString`:

| plan (initial) | API (response) | expected |
|---|---|---|
| null | nil | null |
| null | `""` | null ← the bug repro |
| null | `"foo"` | `"foo"` |
| `""` | `""` | `""` |
| `"foo"` | `"foo"` | `"foo"` |
| `"foo"` | `""` | `""` (accepts out-of-band removal) |

```
$ go test -count=1 -run 'TestPopulateFromAPI_Description' -v ./internal/fleet/agentpolicy/
=== RUN   TestPopulateFromAPI_Description_Null_vs_EmptyString
  ... all 6 subtests PASS
$ go test -count=1 ./internal/fleet/agentpolicy/
ok  	github.com/elastic/terraform-provider-elasticstack/internal/fleet/agentpolicy	0.661s
$ go vet ./internal/fleet/agentpolicy/
<clean>
```

## Scope

- 5-line behavioral change in one resource's `populateFromAPI`.
- New table-driven unit test covering the fix and existing behavior.
- No schema change, no API change, no behavior change for users who set `description` explicitly.
- No CHANGELOG edit (auto-generated per CONTRIBUTING.md).

## Follow-up considerations (not in this PR)

`DataOutputID`, `MonitoringOutputID`, `DownloadSourceID`, `FleetServerHostID` in the same model use the same `types.StringPointerValue` pattern. If Kibana exhibits the same `null → ""` normalization on any of them, they would have the same bug. I left those alone in this PR to keep the change focused on the reported issue, but happy to file follow-up PRs if maintainers confirm the pattern holds.

## Changelog
Customer impact: fix
Summary: elasticstack_fleet_agent_policy no longer errors with "Provider produced inconsistent result" when the Fleet API returns an empty description for a policy whose description is unset in the Terraform configuration.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve null `Description` in `agentPolicyModel.populateFromAPI` when API returns empty string
> The Fleet API returns an empty string for `Description` when none is set, but the Terraform state may hold a null value. Previously, `populateFromAPI` in [models.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2448/files#diff-41f2350d9cf63ef125c2d120bc8af98af9da4b86686e8d4e05e2c53331d4a4f2) would overwrite a null `Description` with an empty string, causing spurious diffs. Now, if the API returns a non-nil empty string and the current model value is null, the field stays null. A table-driven test covering null, empty, and non-empty combinations is added in [models_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2448/files#diff-3e978e3b2aea86545e5b84550d424f92176e3dfa28c04c4ee5b36e0599af7c7e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f6f811.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->