### PR TITLE
test(fleet_output): lock in config_yaml omit-when-null behaviour (closes #1067)

### DIFF
--- a/internal/fleet/output/models_config_yaml_test.go
+++ b/internal/fleet/output/models_config_yaml_test.go
@@ -1,0 +1,190 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package output
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToAPICreate_OmitConfigYamlWhenNull asserts that when the user does not
+// configure the optional `config_yaml` attribute, the serialized request body
+// for every Fleet output type omits the field entirely rather than sending
+// `"config_yaml": null`.
+//
+// Regression test for https://github.com/elastic/terraform-provider-elasticstack/issues/1067:
+// Older Kibana spec generations emitted `ConfigYaml *string` without a
+// `,omitempty` JSON tag (or used a nullable wrapper), so a nil pointer
+// marshaled to explicit JSON null. The Fleet API rejects explicit null with
+// HTTP 400 `expected value of type [string] but got [null]`. The current
+// generated types carry `omitempty` for every output flavour; this test
+// locks that in so a future `make generate` cannot silently regress it.
+func TestToAPICreate_OmitConfigYamlWhenNull(t *testing.T) {
+	t.Parallel()
+
+	baseHosts := types.ListValueMust(types.StringType, []attr.Value{
+		types.StringValue("https://127.0.0.1:443"),
+	})
+
+	mkModel := func(outputType string) outputModel {
+		return outputModel{
+			Name:       types.StringValue("example-" + outputType),
+			Type:       types.StringValue(outputType),
+			Hosts:      baseHosts,
+			ConfigYaml: types.StringNull(), // the user-facing scenario from #1067
+		}
+	}
+
+	tests := []struct {
+		name string
+		call func(t *testing.T) []byte
+	}{
+		{
+			name: "elasticsearch create omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("elasticsearch")
+				union, diags := m.toAPICreateElasticsearchModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "elasticsearch update omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("elasticsearch")
+				union, diags := m.toAPIUpdateElasticsearchModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "logstash create omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("logstash")
+				union, diags := m.toAPICreateLogstashModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "logstash update omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("logstash")
+				union, diags := m.toAPIUpdateLogstashModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "remote_elasticsearch create omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("remote_elasticsearch")
+				m.ServiceToken = types.StringValue("token")
+				union, diags := m.toAPICreateRemoteElasticsearchModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "remote_elasticsearch update omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("remote_elasticsearch")
+				m.ServiceToken = types.StringValue("token")
+				union, diags := m.toAPIUpdateRemoteElasticsearchModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "kafka create omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("kafka")
+				union, diags := m.toAPICreateKafkaModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+		{
+			name: "kafka update omits config_yaml",
+			call: func(t *testing.T) []byte {
+				m := mkModel("kafka")
+				union, diags := m.toAPIUpdateKafkaModel(context.Background())
+				require.False(t, diags.HasError(), "diags: %v", diags)
+				b, err := union.MarshalJSON()
+				require.NoError(t, err)
+				return b
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body := tc.call(t)
+			// Assert the serialized body does not carry config_yaml at all.
+			// Using a string match first for a readable failure; a parsed
+			// check follows to catch escape-sequence surprises.
+			require.NotContains(t, string(body), "config_yaml",
+				"request body unexpectedly contains config_yaml: %s", string(body))
+
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(body, &parsed),
+				"body should be valid JSON: %s", string(body))
+			_, present := parsed["config_yaml"]
+			assert.False(t, present,
+				"config_yaml key should be absent when ConfigYaml is null, got body: %s", string(body))
+		})
+	}
+
+	// Positive control: when ConfigYaml is configured, it MUST be present so
+	// this test can't accidentally pass by masking a different bug.
+	t.Run("elasticsearch create includes config_yaml when set", func(t *testing.T) {
+		m := outputModel{
+			Name:       types.StringValue("example"),
+			Type:       types.StringValue("elasticsearch"),
+			Hosts:      baseHosts,
+			ConfigYaml: types.StringValue("bulk_max_size: 100\n"),
+		}
+		union, diags := m.toAPICreateElasticsearchModel(context.Background())
+		require.False(t, diags.HasError())
+		b, err := union.MarshalJSON()
+		require.NoError(t, err)
+		require.True(t, strings.Contains(string(b), "config_yaml"),
+			"config_yaml should be present when set, got: %s", string(b))
+	})
+}

--- a/internal/fleet/output/models_config_yaml_test.go
+++ b/internal/fleet/output/models_config_yaml_test.go
@@ -20,7 +20,6 @@ package output
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -156,12 +155,10 @@ func TestToAPICreate_OmitConfigYamlWhenNull(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			body := tc.call(t)
-			// Assert the serialized body does not carry config_yaml at all.
-			// Using a string match first for a readable failure; a parsed
-			// check follows to catch escape-sequence surprises.
-			require.NotContains(t, string(body), "config_yaml",
-				"request body unexpectedly contains config_yaml: %s", string(body))
-
+			// Parse the body so the assertion is keyed on the literal
+			// "config_yaml" top-level attribute, not any substring (e.g.
+			// `otel_exporter_config_yaml` would false-trigger a raw-string
+			// Contains check).
 			var parsed map[string]any
 			require.NoError(t, json.Unmarshal(body, &parsed),
 				"body should be valid JSON: %s", string(body))
@@ -184,7 +181,13 @@ func TestToAPICreate_OmitConfigYamlWhenNull(t *testing.T) {
 		require.False(t, diags.HasError())
 		b, err := union.MarshalJSON()
 		require.NoError(t, err)
-		require.True(t, strings.Contains(string(b), "config_yaml"),
-			"config_yaml should be present when set, got: %s", string(b))
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(b, &parsed),
+			"body should be valid JSON: %s", string(b))
+		got, present := parsed["config_yaml"]
+		require.True(t, present,
+			"config_yaml key should be present when set, got: %s", string(b))
+		assert.Equal(t, "bulk_max_size: 100\n", got)
 	})
 }


### PR DESCRIPTION
# test(fleet_output): lock in `config_yaml` omit-when-null behaviour

Closes #1067.

## Status of the underlying bug

**The user-visible bug from #1067 no longer reproduces on `main`.** I verified this in two ways:

1. **Generated-type inspection.** Every Fleet output flavour in `generated/kbapi/kibana.gen.go` declares `ConfigYaml *string` with the `,omitempty` JSON tag:

   ```
   ConfigYaml *string `json:"config_yaml,omitempty"` (×5 occurrences — elasticsearch, kafka, logstash, remote_elasticsearch, elastic_defend)
   ```

2. **Direct marshal check.** With `model.ConfigYaml = types.StringNull()`, `ValueStringPointer()` returns `nil`, and the resulting struct marshals without the field:

   ```
   Direct marshal:      {"hosts":[...],"name":"Example","type":"elasticsearch"}
   Union marshal:       {"hosts":[...],"name":"Example","type":"elasticsearch"}
   Ptr-to-empty marshal: {"config_yaml":"", ...}      # only when user sets config_yaml = ""
   ```

So the original v0.11.14 symptom (`{ "config_yaml": null, ... }` in the HTTP body, rejected by Kibana with `expected value of type [string] but got [null]`) is resolved by the kbapi regeneration that is already in `main`.

## Why a test anyway

Nothing in the unit test suite locks this behaviour in. A future `make generate` run against a Kibana OpenAPI spec that drops `omitempty` — or switches the field to a nullable wrapper like `nullable.Nullable[string]` — would silently re-break the bug, and we'd only find out in acceptance tests or after customers hit it in prod again.

This PR adds a single test file, `internal/fleet/output/models_config_yaml_test.go`, with a table-driven test (`TestToAPICreate_OmitConfigYamlWhenNull`) that:

- For every Fleet output resource flavour — `elasticsearch`, `logstash`, `kafka`, `remote_elasticsearch` — on both the `toAPICreate*Model` and `toAPIUpdate*Model` paths, builds an `outputModel` with `ConfigYaml = types.StringNull()`, runs the model-to-API conversion, marshals the resulting union to JSON, and asserts `config_yaml` is absent from both the raw string and the parsed object.
- Includes a positive-control subtest asserting `config_yaml` IS present when the user configures it, so the test cannot pass by masking a different regression.

```
$ go test -count=1 -run 'TestToAPICreate_OmitConfigYamlWhenNull' -v ./internal/fleet/output/
=== RUN   TestToAPICreate_OmitConfigYamlWhenNull
    --- PASS: elasticsearch_create_omits_config_yaml
    --- PASS: elasticsearch_update_omits_config_yaml
    --- PASS: logstash_create_omits_config_yaml
    --- PASS: logstash_update_omits_config_yaml
    --- PASS: remote_elasticsearch_create_omits_config_yaml
    --- PASS: remote_elasticsearch_update_omits_config_yaml
    --- PASS: kafka_create_omits_config_yaml
    --- PASS: kafka_update_omits_config_yaml
    --- PASS: elasticsearch_create_includes_config_yaml_when_set
PASS
ok   github.com/elastic/terraform-provider-elasticstack/internal/fleet/output   0.884s
```

## Scope

- New file only (`models_config_yaml_test.go`); no production code changes.
- 9 subtests covering all output flavours, create and update paths, plus a positive control.
- No CHANGELOG edit (auto-generated).

## Changelog
Customer impact: none
Summary: regression test only — locks in existing behaviour where `config_yaml` is omitted from Fleet output requests when the user does not configure it.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lock in `config_yaml` omit-when-null serialization behavior for Fleet output types
> Adds a table-driven test in [models_config_yaml_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2449/files#diff-98568241310510746b27691a057f90d802768df547c55e1263c9a58dce09bd54) to pin the JSON serialization behavior of `outputModel` to API conversion methods. The test verifies that `config_yaml` is absent from the serialized JSON when set to `types.StringNull()` for elasticsearch, logstash, remote_elasticsearch, and kafka output types, and includes a positive control confirming the key appears when explicitly set.
>
> #### 🖇️ Linked Issues
> Closes issue #1067.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3b026e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->