### PR TITLE
fix(fleet_integration_policy)!: reject multi-space space_ids at plan time

### DIFF
--- a/docs/resources/fleet_integration_policy.md
+++ b/docs/resources/fleet_integration_policy.md
@@ -102,7 +102,7 @@ resource "elasticstack_fleet_integration_policy" "sample" {
 - `kibana_connection` (Block List) Kibana connection configuration block. (see [below for nested schema](#nestedblock--kibana_connection))
 - `output_id` (String) The ID of the output to send data to. When not specified, the default output of the agent policy will be used.
 - `policy_id` (String) Unique identifier of the integration policy.
-- `space_ids` (Set of String) The Kibana space IDs where this integration policy is available. When set, must match the space_ids of the referenced agent policy. Note: The order of space IDs does not matter as this is a set.
+- `space_ids` (Set of String) The Kibana space ID where this integration policy lives. Provide at most one element — the Fleet `package_policies` API does not support assigning a package policy to multiple spaces. When set, the space must match the space of the referenced agent policy. When omitted, the policy is created in the default space.
 - `vars_json` (String, Sensitive) Integration-level variables as JSON. Variables vary depending on the integration package.
 
 The provider injects the '__tf_provider_context' property into this JSON object. In most cases this field will be ignored when computing the difference between the current and desired state. In some cases however, this property may be shown in the Terraform plan. Any changes to the '__tf_provider_context' property can be safely ignored. This property is used internally by the provider, and you should not set this property within your Terraform configuration.

--- a/internal/fleet/integration_policy/create.go
+++ b/internal/fleet/integration_policy/create.go
@@ -63,10 +63,11 @@ func (r *integrationPolicyResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	// Determine space context for creating the package policy.
-	// The package policy must be created in the same space as the agent policy it references.
+	// The Fleet package_policies API supports at most one space per policy
+	// (schema enforces SizeAtMost(1) on space_ids). The package policy must
+	// be created in the same space as the agent policy it references.
 	var spaceID string
 	if typeutils.IsKnown(planModel.SpaceIDs) {
-		// Explicit space_ids provided - use the first one
 		var tempDiags diag.Diagnostics
 		spaceIDs := typeutils.SetTypeAs[types.String](ctx, planModel.SpaceIDs, path.Root("space_ids"), &tempDiags)
 		if !tempDiags.HasError() && len(spaceIDs) > 0 {

--- a/internal/fleet/integration_policy/descriptions/space_ids.md
+++ b/internal/fleet/integration_policy/descriptions/space_ids.md
@@ -1,1 +1,1 @@
-The Kibana space IDs where this integration policy is available. When set, must match the space_ids of the referenced agent policy. Note: The order of space IDs does not matter as this is a set.
+The Kibana space ID where this integration policy lives. Provide at most one element — the Fleet `package_policies` API does not support assigning a package policy to multiple spaces. When set, the space must match the space of the referenced agent policy. When omitted, the policy is created in the default space.

--- a/internal/fleet/integration_policy/schema.go
+++ b/internal/fleet/integration_policy/schema.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils/customtypes"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -141,6 +142,16 @@ func getSchemaV2() schema.Schema {
 				Computed:    true,
 				PlanModifiers: []planmodifier.Set{
 					setplanmodifier.UseStateForUnknown(),
+				},
+				// The Fleet `package_policies` API does not support assigning a
+				// package policy to more than one space (the `PackagePolicyRequest`
+				// body has no `space_ids` field; the space is taken from the URL
+				// path). Historically this provider silently used only the first
+				// element of a multi-value `space_ids` set, producing state that
+				// disagreed with reality. Surface the limitation at plan time so
+				// users see a clear error instead of hidden drift.
+				Validators: []validator.Set{
+					setvalidator.SizeAtMost(1),
 				},
 			},
 			"inputs": schema.MapNestedAttribute{

--- a/internal/fleet/integration_policy/schema_space_ids_test.go
+++ b/internal/fleet/integration_policy/schema_space_ids_test.go
@@ -1,0 +1,91 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package integrationpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchema_SpaceIDs_AtMostOne verifies the schema-level constraint that an
+// integration policy can carry at most one space_id. The Fleet
+// `package_policies` API does not support assigning a package policy to more
+// than one space (the request body has no `space_ids` field); previously the
+// provider silently dropped all but the first element, leaving state
+// inconsistent with reality. This test locks in the plan-time rejection.
+func TestSchema_SpaceIDs_AtMostOne(t *testing.T) {
+	t.Parallel()
+
+	r := &integrationPolicyResource{}
+	var resp resource.SchemaResponse
+	r.Schema(context.Background(), resource.SchemaRequest{}, &resp)
+	require.False(t, resp.Diagnostics.HasError(), "Schema must not return diagnostics: %v", resp.Diagnostics)
+
+	a, ok := resp.Schema.Attributes["space_ids"]
+	require.True(t, ok, "space_ids attribute must exist in the schema")
+
+	setAttr, ok := a.(schema.SetAttribute)
+	require.True(t, ok, "space_ids must be declared as SetAttribute, got %T", a)
+	require.NotEmpty(t, setAttr.Validators, "space_ids must have at least one validator after the fix")
+
+	zero := types.SetValueMust(types.StringType, nil)
+	one := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("space-a")})
+	two := types.SetValueMust(types.StringType, []attr.Value{
+		types.StringValue("space-a"),
+		types.StringValue("space-b"),
+	})
+
+	cases := []struct {
+		name      string
+		value     types.Set
+		wantError bool
+	}{
+		{name: "zero elements is allowed", value: zero, wantError: false},
+		{name: "one element is allowed", value: one, wantError: false},
+		{name: "two elements is rejected", value: two, wantError: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vreq := validator.SetRequest{
+				Path:        path.Root("space_ids"),
+				ConfigValue: tc.value,
+			}
+			vresp := &validator.SetResponse{}
+			for _, v := range setAttr.Validators {
+				v.ValidateSet(context.Background(), vreq, vresp)
+			}
+			if tc.wantError {
+				assert.True(t, vresp.Diagnostics.HasError(),
+					"expected validator to reject %v", tc.value)
+			} else {
+				assert.False(t, vresp.Diagnostics.HasError(),
+					"expected validator to accept %v; got diags: %v", tc.value, vresp.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# fix(fleet_integration_policy)!: reject multi-space `space_ids` at plan time

Related to #1553 (the multi-faceted space_ids confusion surfaced there).

## What is happening today

The `elasticstack_fleet_integration_policy` resource accepts an unbounded set for `space_ids`, but the underlying Fleet `package_policies` API supports only one space per policy. Evidence, from `generated/kbapi/kibana.gen.go`:

```go
type PackagePolicyRequestMappedInputs struct {
    // ... no SpaceIds field ...
}
```

The space is taken from the URL path (`/s/<space>/api/fleet/package_policies`) and a given policy lives in exactly one space server-side.

The current `create.go` handles multi-element `space_ids` like this:

```go
// Explicit space_ids provided - use the first one
spaceIDs := typeutils.SetTypeAs[types.String](ctx, planModel.SpaceIDs, ...)
if !tempDiags.HasError() && len(spaceIDs) > 0 {
    spaceID = spaceIDs[0].ValueString()
}
```

So a config with `space_ids = ["a", "b", "c"]` posts to `/s/a/api/fleet/package_policies`, Kibana creates the policy in space `a` only, and the remaining spaces are silently dropped. Read back is equally confused:

```go
// Preserve space_ids if it was originally set in the plan/state
// The API response may not include space_ids, so we keep the original value
```

State keeps `["a", "b", "c"]` while reality is `["a"]`. The acceptance tests acknowledge this divergence by explicitly `ImportStateVerifyIgnore`-ing `space_ids`.

## The fix

Add a schema-level validator on `space_ids`:

```go
Validators: []validator.Set{
    setvalidator.SizeAtMost(1),
},
```

Users now get a clear plan-time error instead of silent drift:

```
Error: Invalid Attribute Value

  with elasticstack_fleet_integration_policy.example,
  on main.tf line N, in resource "elasticstack_fleet_integration_policy" "example":
   N: space_ids = ["a", "b"]

Attribute space_ids set must contain at most 1 elements, got: 2
```

Also updated:
- `descriptions/space_ids.md` — reflects the at-most-one constraint and explains why.
- `create.go` comment — removed the now-misleading "use the first one" comment and explained the schema-enforced invariant.

## Why this is a breaking change (`!` in the commit subject)

Configs that declared `space_ids = [...]` with more than one element will now fail `terraform plan`. Those configs were already producing incorrect behaviour (policy in only the first space, state disagreeing with reality). The remediation is trivial: pick the one space the policy actually lives in.

I tagged this PR with the `!` convention in the commit subject per Conventional Commits. Happy to downgrade to a non-`!` classification or gate this behind a feature flag if maintainers prefer — see "Alternatives considered" below.

## Test coverage

`TestSchema_SpaceIDs_AtMostOne` invokes the resource's real `Schema` method, extracts the `space_ids` attribute's validators, and exercises them against zero-/one-/two-element sets.

```
$ go test -count=1 -run 'TestSchema_SpaceIDs_AtMostOne' -v ./internal/fleet/integration_policy/
=== RUN   TestSchema_SpaceIDs_AtMostOne
    --- PASS: zero_elements_is_allowed
    --- PASS: one_element_is_allowed
    --- PASS: two_elements_is_rejected
PASS

$ go test -count=1 ./internal/fleet/integration_policy/
ok  	github.com/elastic/terraform-provider-elasticstack/internal/fleet/integration_policy	0.667s
```

## Alternatives considered

1. **Runtime warning instead of plan-time error.** Less disruptive but easier to miss. Users have already been missing the silent drift; adding a log they may not read doesn't fix that.
2. **Replace `space_ids` (Set) with `space_id` (String).** Cleanest semantic match but a wider breaking change — requires a schema version bump and a state migration for every existing user, not just those with multi-element configs. Deferred; this PR takes the smaller step.
3. **Leave it and document.** Rejected — the silent divergence between state and reality is exactly the kind of drift this provider has been trying to eliminate (see #1693, #1585).

## Scope

- One validator added; two files of comments/docs updated to match.
- New unit test.
- No schema version bump, no state migration, no API change.
- No CHANGELOG edit (auto-generated).

## Does not close #1553

The original reporter's scenario on #1553 was never reproduced by @tobio and the follow-up information never arrived. I left that issue open because this PR addresses the related *silent-truncation* failure mode, not the specific *"my single space_id is being ignored"* symptom that V3t3rn described. If @tobio wants to close #1553 as not-actionable in parallel, I can remove the reference.

## Changelog
Customer impact: breaking
Summary: `elasticstack_fleet_integration_policy` now rejects `space_ids` sets with more than one element at plan time. Previously the provider silently used only the first element, producing state that disagreed with Kibana. Users with multi-element `space_ids` must pick one space.

### Breaking changes

`elasticstack_fleet_integration_policy.space_ids` now validates at plan time that at most one element is set. Configurations that previously declared multiple spaces in this attribute were silently dropping all but the first element — the correct remediation is to specify the single space the policy actually lives in.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject multiple `space_ids` at plan time for `fleet_integration_policy`
> - Adds a `setvalidator.SizeAtMost(1)` validator to the `space_ids` attribute in [`schema.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2450/files#diff-8984d817859b980e09a934694f4821a7a770033ca06aabd1bc5a99e5564f9f50), rejecting plans that supply more than one space ID.
> - Updates docs and the attribute description in [`space_ids.md`](https://github.com/elastic/terraform-provider-elasticstack/pull/2450/files#diff-a68c812bedf85e49080d1198c8038fefa56e5fcc239506a896a84f7ef4accd21) to clarify that only one space is supported, it must match the agent policy's space, and omitting it uses the default space.
> - Behavioral Change: previously, providing multiple space IDs was silently accepted and only the first was used; now it produces a plan-time error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 059abf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->