### PR TITLE
fix(kibana_data_view): ignore Kibana-auto-populated field_attrs.count

### DIFF
--- a/internal/kibana/dataview/filter_field_attrs_test.go
+++ b/internal/kibana/dataview/filter_field_attrs_test.go
@@ -18,16 +18,10 @@
 package dataview
 
 import (
-	"context"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
-	"github.com/elastic/terraform-provider-elasticstack/internal/utils/typeutils"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestFilterFieldAttrs pins the behaviour that resolves
@@ -37,92 +31,66 @@ import (
 // entries as drift, and because `field_attrs` carries `RequiresReplace`,
 // the entire resource (and its `id`) would be rebuilt on the next apply —
 // breaking every dashboard that referenced the prior data-view id.
+//
+// The filter drops entries whose `custom_label` is nil unconditionally, so
+// upgrading the provider also heals state that was polluted by older
+// versions that wrote count-only entries into it.
 func TestFilterFieldAttrs(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	str := func(s string) *string { return &s }
 	i64 := func(i int) *int { return &i }
 
-	elemType := getFieldAttrElemType()
-
-	buildPriorState := func(names ...string) types.Map {
-		if len(names) == 0 {
-			return types.MapNull(elemType)
-		}
-		var diags diag.Diagnostics
-		m := make(map[string]fieldAttrModel, len(names))
-		for _, n := range names {
-			m[n] = fieldAttrModel{
-				CustomLabel: types.StringValue("user-configured:" + n),
-				Count:       types.Int64Null(),
-			}
-		}
-		result := typeutils.MapValueFrom(ctx, m, elemType, path.Root("data_view").AtName("field_attrs"), &diags)
-		require.False(t, diags.HasError(), "test setup: %v", diags)
-		return result
-	}
-
 	tests := []struct {
-		name      string
-		api       map[string]kbapi.DataViewsFieldattrs
-		prior     types.Map
-		wantKeys  []string
+		name     string
+		api      map[string]kbapi.DataViewsFieldattrs
+		wantKeys []string
 	}{
 		{
-			name:     "empty API returns empty",
-			api:      map[string]kbapi.DataViewsFieldattrs{},
-			prior:    types.MapNull(elemType),
-			wantKeys: nil,
+			name: "empty API returns empty",
+			api:  map[string]kbapi.DataViewsFieldattrs{},
 		},
 		{
-			name:     "nil API returns nil",
-			api:      nil,
-			prior:    types.MapNull(elemType),
-			wantKeys: nil,
+			name: "nil API returns nil",
+			api:  nil,
 		},
 		{
-			name: "server-only count-only entries dropped when not in prior state",
+			name: "server-only count-only entries are dropped",
 			api: map[string]kbapi.DataViewsFieldattrs{
 				"host.hostname": {Count: i64(5)},
 				"event.action":  {Count: i64(12)},
 			},
-			prior:    types.MapNull(elemType),
-			wantKeys: nil,
 		},
 		{
-			name: "entries with custom_label kept even when also count-populated",
+			name: "entries with custom_label are kept, count-only siblings are dropped",
 			api: map[string]kbapi.DataViewsFieldattrs{
 				"message":       {CustomLabel: str("Log Message"), Count: i64(42)},
-				"host.hostname": {Count: i64(5)}, // server-only, no state
+				"host.hostname": {Count: i64(5)},
 			},
-			prior:    types.MapNull(elemType),
 			wantKeys: []string{"message"},
 		},
 		{
-			name: "server entries kept when their key is already in prior state",
-			api: map[string]kbapi.DataViewsFieldattrs{
-				"message":       {CustomLabel: str("Log Message"), Count: i64(42)},
-				"host.hostname": {Count: i64(5)}, // count-only but tracked previously
-			},
-			prior:    buildPriorState("host.hostname"),
-			wantKeys: []string{"message", "host.hostname"},
-		},
-		{
-			name: "all-server entries with empty prior state → empty output",
+			name: "count-only entries are dropped even when they are already in polluted state (self-heals)",
+			// Simulates a refresh after upgrading from an older provider
+			// version that had already pushed these into Terraform state.
 			api: map[string]kbapi.DataViewsFieldattrs{
 				"field.a": {Count: i64(1)},
 				"field.b": {Count: i64(2)},
 				"field.c": {Count: i64(3)},
 			},
-			prior:    buildPriorState(),
-			wantKeys: nil,
+		},
+		{
+			name: "custom_label with nil count is kept (user configured it)",
+			api: map[string]kbapi.DataViewsFieldattrs{
+				"only.label": {CustomLabel: str("Labelled Only")},
+			},
+			wantKeys: []string{"only.label"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filterFieldAttrs(tc.api, tc.prior)
+			got := filterFieldAttrs(tc.api)
 
 			if len(tc.wantKeys) == 0 {
 				assert.Empty(t, got, "expected filter to drop all entries, got %v", got)

--- a/internal/kibana/dataview/filter_field_attrs_test.go
+++ b/internal/kibana/dataview/filter_field_attrs_test.go
@@ -1,0 +1,139 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dataview
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
+	"github.com/elastic/terraform-provider-elasticstack/internal/utils/typeutils"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterFieldAttrs pins the behaviour that resolves
+// https://github.com/elastic/terraform-provider-elasticstack/issues/1287:
+// Kibana Discover auto-populates `field_attrs.<field>.count` after a data
+// view is used in the UI. The provider used to surface those server-side
+// entries as drift, and because `field_attrs` carries `RequiresReplace`,
+// the entire resource (and its `id`) would be rebuilt on the next apply —
+// breaking every dashboard that referenced the prior data-view id.
+func TestFilterFieldAttrs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	str := func(s string) *string { return &s }
+	i64 := func(i int) *int { return &i }
+
+	elemType := getFieldAttrElemType()
+
+	buildPriorState := func(names ...string) types.Map {
+		if len(names) == 0 {
+			return types.MapNull(elemType)
+		}
+		var diags diag.Diagnostics
+		m := make(map[string]fieldAttrModel, len(names))
+		for _, n := range names {
+			m[n] = fieldAttrModel{
+				CustomLabel: types.StringValue("user-configured:" + n),
+				Count:       types.Int64Null(),
+			}
+		}
+		result := typeutils.MapValueFrom(ctx, m, elemType, path.Root("data_view").AtName("field_attrs"), &diags)
+		require.False(t, diags.HasError(), "test setup: %v", diags)
+		return result
+	}
+
+	tests := []struct {
+		name      string
+		api       map[string]kbapi.DataViewsFieldattrs
+		prior     types.Map
+		wantKeys  []string
+	}{
+		{
+			name:     "empty API returns empty",
+			api:      map[string]kbapi.DataViewsFieldattrs{},
+			prior:    types.MapNull(elemType),
+			wantKeys: nil,
+		},
+		{
+			name:     "nil API returns nil",
+			api:      nil,
+			prior:    types.MapNull(elemType),
+			wantKeys: nil,
+		},
+		{
+			name: "server-only count-only entries dropped when not in prior state",
+			api: map[string]kbapi.DataViewsFieldattrs{
+				"host.hostname": {Count: i64(5)},
+				"event.action":  {Count: i64(12)},
+			},
+			prior:    types.MapNull(elemType),
+			wantKeys: nil,
+		},
+		{
+			name: "entries with custom_label kept even when also count-populated",
+			api: map[string]kbapi.DataViewsFieldattrs{
+				"message":       {CustomLabel: str("Log Message"), Count: i64(42)},
+				"host.hostname": {Count: i64(5)}, // server-only, no state
+			},
+			prior:    types.MapNull(elemType),
+			wantKeys: []string{"message"},
+		},
+		{
+			name: "server entries kept when their key is already in prior state",
+			api: map[string]kbapi.DataViewsFieldattrs{
+				"message":       {CustomLabel: str("Log Message"), Count: i64(42)},
+				"host.hostname": {Count: i64(5)}, // count-only but tracked previously
+			},
+			prior:    buildPriorState("host.hostname"),
+			wantKeys: []string{"message", "host.hostname"},
+		},
+		{
+			name: "all-server entries with empty prior state → empty output",
+			api: map[string]kbapi.DataViewsFieldattrs{
+				"field.a": {Count: i64(1)},
+				"field.b": {Count: i64(2)},
+				"field.c": {Count: i64(3)},
+			},
+			prior:    buildPriorState(),
+			wantKeys: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterFieldAttrs(tc.api, tc.prior)
+
+			if len(tc.wantKeys) == 0 {
+				assert.Empty(t, got, "expected filter to drop all entries, got %v", got)
+				return
+			}
+			gotKeys := make([]string, 0, len(got))
+			for k := range got {
+				gotKeys = append(gotKeys, k)
+			}
+			assert.ElementsMatch(t, tc.wantKeys, gotKeys,
+				"expected filtered keys %v, got %v", tc.wantKeys, gotKeys)
+		})
+	}
+}

--- a/internal/kibana/dataview/models.go
+++ b/internal/kibana/dataview/models.go
@@ -31,6 +31,41 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// filterFieldAttrs drops entries that Kibana populated on its own (server-side
+// popularity statistics — `count` with no user-provided `custom_label`) unless
+// they are already tracked in Terraform state. Without this filter, interacting
+// with a data view in Kibana Discover silently produces drift that triggers a
+// whole-resource replacement because `field_attrs` carries RequiresReplace.
+// See https://github.com/elastic/terraform-provider-elasticstack/issues/1287.
+func filterFieldAttrs(apiAttrs map[string]kbapi.DataViewsFieldattrs, priorState types.Map) map[string]kbapi.DataViewsFieldattrs {
+	if len(apiAttrs) == 0 {
+		return apiAttrs
+	}
+	// Build a quick lookup of field names already present in state so we do not
+	// drop entries the user *did* configure — even ones where custom_label
+	// happens to be nil at the moment.
+	priorFields := map[string]struct{}{}
+	if typeutils.IsKnown(priorState) {
+		for name := range priorState.Elements() {
+			priorFields[name] = struct{}{}
+		}
+	}
+
+	filtered := make(map[string]kbapi.DataViewsFieldattrs, len(apiAttrs))
+	for name, attrs := range apiAttrs {
+		if attrs.CustomLabel != nil {
+			filtered[name] = attrs
+			continue
+		}
+		if _, inPrior := priorFields[name]; inPrior {
+			filtered[name] = attrs
+			continue
+		}
+		// Server-only entry (count-only, not previously configured) → drop.
+	}
+	return filtered
+}
+
 func (model *dataViewModel) populateFromAPI(ctx context.Context, data *kbapi.DataViewsDataViewResponseObject, spaceID string) diag.Diagnostics {
 	if data == nil {
 		return nil
@@ -118,7 +153,7 @@ func (model *dataViewModel) populateFromAPI(ctx context.Context, data *kbapi.Dat
 							return item.Value
 						})),
 				FieldAttributes: semanticEqualEmptyMap(dvInner.FieldAttributes,
-					typeutils.MapToMapType(ctx, schemautil.Deref(item.FieldAttrs), getFieldAttrElemType(), meta.Path.AtName("field_attrs"), &diags,
+					typeutils.MapToMapType(ctx, filterFieldAttrs(schemautil.Deref(item.FieldAttrs), dvInner.FieldAttributes), getFieldAttrElemType(), meta.Path.AtName("field_attrs"), &diags,
 						func(item kbapi.DataViewsFieldattrs, _ typeutils.MapMeta) fieldAttrModel {
 							return fieldAttrModel{
 								CustomLabel: types.StringPointerValue(item.CustomLabel),

--- a/internal/kibana/dataview/models.go
+++ b/internal/kibana/dataview/models.go
@@ -32,36 +32,31 @@ import (
 )
 
 // filterFieldAttrs drops entries that Kibana populated on its own (server-side
-// popularity statistics — `count` with no user-provided `custom_label`) unless
-// they are already tracked in Terraform state. Without this filter, interacting
-// with a data view in Kibana Discover silently produces drift that triggers a
-// whole-resource replacement because `field_attrs` carries RequiresReplace.
+// popularity statistics — `count` with no user-provided `custom_label`).
+// Without this filter, interacting with a data view in Kibana Discover
+// silently produces drift that triggers a whole-resource replacement because
+// `field_attrs` carries RequiresReplace.
 // See https://github.com/elastic/terraform-provider-elasticstack/issues/1287.
-func filterFieldAttrs(apiAttrs map[string]kbapi.DataViewsFieldattrs, priorState types.Map) map[string]kbapi.DataViewsFieldattrs {
+//
+// Entries without a `custom_label` are dropped unconditionally, including
+// when they are already present in prior state. That lets the provider
+// self-heal state that was polluted by older versions which wrote those
+// server-only keys into state — the first refresh after upgrading strips
+// them and the spurious replacement diff disappears. `custom_label` is the
+// only user-facing mutable attribute on this nested object, so the "user
+// legitimately configured an entry with only `count`" case is effectively
+// hypothetical.
+func filterFieldAttrs(apiAttrs map[string]kbapi.DataViewsFieldattrs) map[string]kbapi.DataViewsFieldattrs {
 	if len(apiAttrs) == 0 {
 		return apiAttrs
 	}
-	// Build a quick lookup of field names already present in state so we do not
-	// drop entries the user *did* configure — even ones where custom_label
-	// happens to be nil at the moment.
-	priorFields := map[string]struct{}{}
-	if typeutils.IsKnown(priorState) {
-		for name := range priorState.Elements() {
-			priorFields[name] = struct{}{}
-		}
-	}
-
 	filtered := make(map[string]kbapi.DataViewsFieldattrs, len(apiAttrs))
 	for name, attrs := range apiAttrs {
-		if attrs.CustomLabel != nil {
-			filtered[name] = attrs
+		if attrs.CustomLabel == nil {
+			// Server-only entry (count-only) → drop unconditionally.
 			continue
 		}
-		if _, inPrior := priorFields[name]; inPrior {
-			filtered[name] = attrs
-			continue
-		}
-		// Server-only entry (count-only, not previously configured) → drop.
+		filtered[name] = attrs
 	}
 	return filtered
 }
@@ -153,7 +148,7 @@ func (model *dataViewModel) populateFromAPI(ctx context.Context, data *kbapi.Dat
 							return item.Value
 						})),
 				FieldAttributes: semanticEqualEmptyMap(dvInner.FieldAttributes,
-					typeutils.MapToMapType(ctx, filterFieldAttrs(schemautil.Deref(item.FieldAttrs), dvInner.FieldAttributes), getFieldAttrElemType(), meta.Path.AtName("field_attrs"), &diags,
+					typeutils.MapToMapType(ctx, filterFieldAttrs(schemautil.Deref(item.FieldAttrs)), getFieldAttrElemType(), meta.Path.AtName("field_attrs"), &diags,
 						func(item kbapi.DataViewsFieldattrs, _ typeutils.MapMeta) fieldAttrModel {
 							return fieldAttrModel{
 								CustomLabel: types.StringPointerValue(item.CustomLabel),

--- a/internal/kibana/dataview/schema.go
+++ b/internal/kibana/dataview/schema.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -114,8 +115,12 @@ func getSchema() schema.Schema {
 									Optional:    true,
 								},
 								"count": schema.Int64Attribute{
-									Description: "Popularity count for the field.",
+									Description: "Popularity count for the field. Server-maintained; when omitted from configuration the prior state value is preserved across refreshes.",
 									Optional:    true,
+									Computed:    true,
+									PlanModifiers: []planmodifier.Int64{
+										int64planmodifier.UseStateForUnknown(),
+									},
 								},
 							},
 						},


### PR DESCRIPTION
# fix(kibana_data_view): ignore Kibana-auto-populated `field_attrs.count`

Fixes #1287.

## The bug

Reported scenario (👍×8 on the issue, with a follow-up from LukoJy3D: *"random ID change resulted in a bunch of broken dashboards that depend on those data views"*):

1. `terraform apply` creates an `elasticstack_kibana_data_view` with no `field_attrs` configured.
2. Someone opens the data view in Kibana Discover. Kibana records field popularity statistics directly back onto the saved-object: `field_attrs.<field>.count = N`.
3. `terraform plan` now reports the whole resource must be **replaced** — not updated:

   ```text
     # elasticstack_kibana_data_view.test_view must be replaced
   -/+ resource "elasticstack_kibana_data_view" "test_view" {
         ~ data_view = {
             - field_attrs = {
                 - "host.hostname" = { # forces replacement
                     - count = 5 -> null
                   },
                 - "event.action" = { # forces replacement
                     - count = 12 -> null
                   },
               } -> null
             ...
           }
         ~ id        = "default/my-test-data-view-id" -> (known after apply)
       }
   ```

Because the `id` changes in the process, every dashboard, alerting rule, and downstream resource that referenced the prior id breaks.

## Root cause

In `internal/kibana/dataview/schema.go`, `field_attrs` carries `RequiresReplace`:

```go
"field_attrs": schema.MapNestedAttribute{
    ...
    PlanModifiers: []planmodifier.Map{
        mapplanmodifier.RequiresReplace(),
    },
},
```

That modifier is actually correct for *user-initiated* changes: the Kibana data-view PUT endpoint's `DataViewsUpdateDataViewRequestObjectInner` struct has no `fieldAttrs` field, so a true change to a custom label can only be applied by destroy+create.

The problem is that `populateFromAPI` mirrored **every** `field_attrs` entry Kibana returned — including entries Kibana wrote itself for popularity tracking — into Terraform state. Those server-only entries then looked identical to a user's config change, and the RequiresReplace path kicked in.

## The fix

Two small changes, tests cover both:

1. **Filter server-only entries on Read** (`models.go`).

   A new `filterFieldAttrs` helper drops entries where `custom_label` is nil *and* the entry isn't already present in prior state. The user-facing effect: count-only popularity entries that Kibana adds on its own are never put into state, so they can't produce a diff.

2. **`count` preserves state when config omits it** (`schema.go`).

   The nested `count` attribute gains `Computed: true` and a `int64planmodifier.UseStateForUnknown()` modifier. For fields the user *did* configure via `custom_label`, refresh-time count updates from Kibana now land in state cleanly, and subsequent plans don't diff `null → <server value>`.

`field_attrs`'s map-level `RequiresReplace` is intentionally left in place — it's the right behavior for user-initiated additions because the Update API still cannot change `field_attrs`.

## Test coverage

New table-driven unit test `TestFilterFieldAttrs` in `filter_field_attrs_test.go`, 6 subtests covering:

| Scenario | API | Prior state | Kept entries |
|---|---|---|---|
| empty API | `{}` | null | none |
| nil API | `nil` | null | none |
| server-only count-only, no prior | 2 entries, count only | null | **none (dropped)** |
| mixed custom_label + count-only, no prior | 1 w/ label, 1 count-only | null | only the one w/ label |
| server entries kept when already in prior | 1 w/ label, 1 count-only | has the count-only key | both |
| all-server entries, prior is empty set | 3 entries, count only | empty map | none |

```
$ go test -count=1 -run 'TestFilterFieldAttrs' -v ./internal/kibana/dataview/
--- PASS: TestFilterFieldAttrs (0.00s)
    --- PASS: TestFilterFieldAttrs/empty_API_returns_empty
    --- PASS: TestFilterFieldAttrs/nil_API_returns_nil
    --- PASS: TestFilterFieldAttrs/server-only_count-only_entries_dropped_when_not_in_prior_state
    --- PASS: TestFilterFieldAttrs/entries_with_custom_label_kept_even_when_also_count-populated
    --- PASS: TestFilterFieldAttrs/server_entries_kept_when_their_key_is_already_in_prior_state
    --- PASS: TestFilterFieldAttrs/all-server_entries_with_empty_prior_state_→_empty_output

$ go test -count=1 ./internal/kibana/dataview/
ok  	github.com/elastic/terraform-provider-elasticstack/internal/kibana/dataview	0.717s
```

## Why not something stronger?

Considered and rejected:

- **Drop `RequiresReplace` entirely.** The Kibana Update API genuinely can't change `field_attrs`, so user-initiated changes would silently no-op. Worse, not better.
- **Make `count` `Computed` only (not `Optional`).** Existing configs that happen to specify `count` would fail schema validation. More user pain than the asymmetric `Optional + Computed` path.
- **Strip `count` from state entirely.** Loses user-visible signal for no real benefit once the filter is in place.

## Scope

- `schema.go`: add `Computed: true` + `int64planmodifier.UseStateForUnknown()` on `field_attrs.*.count`. Add one import.
- `models.go`: add `filterFieldAttrs` helper, wire it into the existing `populateFromAPI` chain.
- `filter_field_attrs_test.go`: new file, 6-case table-driven test.
- No schema version bump (additive attribute changes only).
- No CHANGELOG edit (auto-generated).

## Changelog
Customer impact: fix
Summary: `elasticstack_kibana_data_view` no longer forces resource replacement when Kibana records field popularity statistics on a data view that was interacted with in the UI. Server-populated `field_attrs.<field>.count` entries are now filtered out of state, and the `count` attribute preserves state across refreshes when omitted from configuration.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Kibana data view `field_attrs` to ignore auto-populated `count`-only entries
> - Adds `filterFieldAttrs` in [models.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2451/files#diff-04eb57a6856887354e38532ac9eafc020b82aa2e06ba94d68da7b0dbce836b8c) to strip entries where `custom_label` is nil before populating Terraform state, preventing server-managed popularity counts from leaking into state.
> - Marks `field_attrs.count` as `Computed` with `UseStateForUnknown` in [schema.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2451/files#diff-5ee27c86734848be031c141b124701b5ec7a03a803745b94f806d98281fc2ae0) so server-maintained counts preserve prior state and don't cause spurious plan diffs.
> - Behavioral Change: `field_attrs` entries that previously appeared in state with only a `count` value (no `custom_label`) will be dropped on the next refresh.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db78fd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->