### PR TITLE
feat(fleet_custom_integration): add resource for uploading custom packages

### DIFF
--- a/internal/clients/fleet/fleet.go
+++ b/internal/clients/fleet/fleet.go
@@ -640,6 +640,111 @@ func Uninstall(ctx context.Context, client *Client, name, version string, spaceI
 	}
 }
 
+// UploadPackageOptions holds the options for uploading a package archive.
+type UploadPackageOptions struct {
+	SpaceID                   string
+	ContentType               string // "application/zip" or "application/gzip"
+	IgnoreMappingUpdateErrors *bool
+	SkipDataStreamRollover    *bool
+}
+
+// UploadPackageResult describes the outcome of a successful package upload.
+// PackageVersion may be empty if the upload response did not carry a version
+// and the caller chose not to resolve it from GetPackages; callers that need
+// a guaranteed version should resolve it via GetPackages.
+type UploadPackageResult struct {
+	PackageName    string
+	PackageVersion string
+}
+
+// UploadPackage uploads a custom integration package archive to Kibana Fleet
+// via POST /api/fleet/epm/packages. body carries the raw binary archive
+// contents; the caller is responsible for closing any underlying reader.
+//
+// The Fleet upload response does not include a typed JSON payload in the
+// generated client, so the response body is parsed manually. The package
+// name is read from `_meta.name`; the version is returned when present in
+// `items[0].version` (or `response[0].version` on older servers) and left
+// empty otherwise.
+func UploadPackage(ctx context.Context, client *Client, body io.Reader, opts UploadPackageOptions) (UploadPackageResult, diag.Diagnostics) {
+	params := kbapi.PostFleetEpmPackagesParams{
+		IgnoreMappingUpdateErrors: opts.IgnoreMappingUpdateErrors,
+		SkipDataStreamRollover:    opts.SkipDataStreamRollover,
+	}
+
+	contentType := opts.ContentType
+	if contentType == "" {
+		contentType = "application/zip"
+	}
+
+	resp, err := client.API.PostFleetEpmPackagesWithBodyWithResponse(ctx, &params, contentType, body, spaceAwarePathRequestEditor(opts.SpaceID))
+	if err != nil {
+		return UploadPackageResult{}, diagutil.FrameworkDiagFromError(err)
+	}
+
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return UploadPackageResult{}, reportUnknownError(resp.StatusCode(), resp.Body)
+	}
+
+	name, version, parseErr := parseUploadPackageResponse(resp.Body)
+	if parseErr != nil {
+		return UploadPackageResult{}, diagutil.FrameworkDiagFromError(parseErr)
+	}
+	if name == "" {
+		return UploadPackageResult{}, diag.Diagnostics{
+			diag.NewErrorDiagnostic(
+				"Package upload response did not include a name",
+				fmt.Sprintf("The Fleet API returned %d but the response body did not carry `_meta.name` or `items[].id`; cannot track the uploaded package in state. Raw body: %s", resp.StatusCode(), string(resp.Body)),
+			),
+		}
+	}
+	return UploadPackageResult{PackageName: name, PackageVersion: version}, nil
+}
+
+// parseUploadPackageResponse extracts the package name and (if present) the
+// version from the raw JSON response body returned by
+// POST /api/fleet/epm/packages. The response shape varies across Kibana
+// versions: newer versions use `items`, older versions use `response`; both
+// carry `_meta.name` once a package is installed.
+func parseUploadPackageResponse(body []byte) (name string, version string, err error) {
+	var envelope struct {
+		Meta struct {
+			Name string `json:"name"`
+		} `json:"_meta"`
+		Items []struct {
+			ID      string `json:"id"`
+			Type    string `json:"type"`
+			Version string `json:"version,omitempty"`
+		} `json:"items"`
+		Response []struct {
+			ID      string `json:"id"`
+			Type    string `json:"type"`
+			Version string `json:"version,omitempty"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", "", fmt.Errorf("decode Fleet upload response: %w", err)
+	}
+	name = envelope.Meta.Name
+	// Walk assets for a version token; the assets list is generally large
+	// but any asset managed by the package carries the same version.
+	for _, it := range envelope.Items {
+		if it.Version != "" {
+			version = it.Version
+			break
+		}
+	}
+	if version == "" {
+		for _, it := range envelope.Response {
+			if it.Version != "" {
+				version = it.Version
+				break
+			}
+		}
+	}
+	return name, version, nil
+}
+
 // GetPackages returns information about the latest packages known to Fleet.
 // If spaceID is non-empty and not "default", the request will be scoped to that Kibana space.
 func GetPackages(ctx context.Context, client *Client, prerelease bool, spaceID string) ([]kbapi.PackageListItem, diag.Diagnostics) {

--- a/internal/clients/fleet/upload_internal_test.go
+++ b/internal/clients/fleet/upload_internal_test.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseUploadPackageResponse covers both response shapes the Fleet API
+// has served for POST /api/fleet/epm/packages (the modern `items` envelope
+// and the legacy `response` envelope), along with malformed payloads. The
+// helper underpins the UploadPackage wrapper's name/version extraction.
+func TestParseUploadPackageResponse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		body        string
+		wantName    string
+		wantVersion string
+		wantErr     bool
+	}{
+		{
+			name:        "modern items envelope with version",
+			body:        `{"_meta":{"name":"my_pkg"},"items":[{"id":"asset-1","type":"ingest_pipeline","version":"1.2.3"}]}`,
+			wantName:    "my_pkg",
+			wantVersion: "1.2.3",
+		},
+		{
+			name:        "items envelope without version",
+			body:        `{"_meta":{"name":"my_pkg"},"items":[{"id":"asset-1","type":"ingest_pipeline"}]}`,
+			wantName:    "my_pkg",
+			wantVersion: "",
+		},
+		{
+			name:        "legacy response envelope",
+			body:        `{"_meta":{"name":"older_pkg"},"response":[{"id":"asset-1","type":"dashboard","version":"0.1.0"}]}`,
+			wantName:    "older_pkg",
+			wantVersion: "0.1.0",
+		},
+		{
+			name:        "mixed: items present but version in response",
+			body:        `{"_meta":{"name":"mixed_pkg"},"items":[{"id":"asset-1","type":"dashboard"}],"response":[{"id":"a","type":"b","version":"9.9.9"}]}`,
+			wantName:    "mixed_pkg",
+			wantVersion: "9.9.9",
+		},
+		{
+			name:     "empty envelope",
+			body:     `{}`,
+			wantName: "",
+		},
+		{
+			name:    "invalid json",
+			body:    `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name, version, err := parseUploadPackageResponse([]byte(tc.body))
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantName, name)
+			assert.Equal(t, tc.wantVersion, version)
+		})
+	}
+}

--- a/internal/fleet/customintegration/create.go
+++ b/internal/fleet/customintegration/create.go
@@ -1,0 +1,103 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/fleet"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (r *customIntegrationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan customIntegrationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kibanaClient, diags := r.client.GetKibanaClient(ctx, plan.KibanaConnection)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	fleetClient, err := kibanaClient.GetFleetClient()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to obtain Fleet client", err.Error())
+		return
+	}
+
+	path := plan.PackagePath.ValueString()
+
+	checksum, err := sha256File(path)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to hash custom integration package", err.Error())
+		return
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to open custom integration package", err.Error())
+		return
+	}
+	defer f.Close()
+
+	opts := fleet.UploadPackageOptions{
+		SpaceID:                   plan.SpaceID.ValueString(),
+		ContentType:               detectContentType(path),
+		IgnoreMappingUpdateErrors: plan.IgnoreMappingUpdateErrors.ValueBoolPointer(),
+		SkipDataStreamRollover:    plan.SkipDataStreamRollover.ValueBoolPointer(),
+	}
+
+	result, diags := fleet.UploadPackage(ctx, fleetClient, f, opts)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	version := result.PackageVersion
+	if version == "" {
+		// The upload response did not carry a version. Fall back to the
+		// packages list API, filtering by the name we just uploaded, and
+		// picking the highest-ranked installed entry. This matches the
+		// spec's version-resolution fallback.
+		pkgs, listDiags := fleet.GetPackages(ctx, fleetClient, true, plan.SpaceID.ValueString())
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		version = pickInstalledVersion(pkgs, result.PackageName)
+		if version == "" {
+			resp.Diagnostics.AddError(
+				"Unable to resolve uploaded package version",
+				fmt.Sprintf("The Fleet upload for package %q succeeded but no matching installed entry was found in the packages list API.", result.PackageName),
+			)
+			return
+		}
+	}
+
+	plan.PackageName = types.StringValue(result.PackageName)
+	plan.PackageVersion = types.StringValue(version)
+	plan.Checksum = types.StringValue(checksum)
+	plan.ID = types.StringValue(getPackageID(result.PackageName, version))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}

--- a/internal/fleet/customintegration/delete.go
+++ b/internal/fleet/customintegration/delete.go
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"context"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/fleet"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func (r *customIntegrationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state customIntegrationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if state.SkipDestroy.ValueBool() {
+		// User opted out of uninstall-on-destroy.
+		return
+	}
+
+	name := state.PackageName.ValueString()
+	version := state.PackageVersion.ValueString()
+	if name == "" || version == "" {
+		// State is incomplete — nothing reliable to uninstall. Let the
+		// framework drop the resource from state.
+		return
+	}
+
+	kibanaClient, diags := r.client.GetKibanaClient(ctx, state.KibanaConnection)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	fleetClient, err := kibanaClient.GetFleetClient()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to obtain Fleet client", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(
+		fleet.Uninstall(ctx, fleetClient, name, version, state.SpaceID.ValueString(), false)...,
+	)
+}

--- a/internal/fleet/customintegration/models.go
+++ b/internal/fleet/customintegration/models.go
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	schemautil "github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type customIntegrationModel struct {
+	ID                        types.String `tfsdk:"id"`
+	KibanaConnection          types.List   `tfsdk:"kibana_connection"`
+	PackagePath               types.String `tfsdk:"package_path"`
+	PackageName               types.String `tfsdk:"package_name"`
+	PackageVersion            types.String `tfsdk:"package_version"`
+	Checksum                  types.String `tfsdk:"checksum"`
+	IgnoreMappingUpdateErrors types.Bool   `tfsdk:"ignore_mapping_update_errors"`
+	SkipDataStreamRollover    types.Bool   `tfsdk:"skip_data_stream_rollover"`
+	SkipDestroy               types.Bool   `tfsdk:"skip_destroy"`
+	SpaceID                   types.String `tfsdk:"space_id"`
+}
+
+// getPackageID returns the deterministic Terraform ID for an uploaded package.
+// Matches the pattern used by elasticstack_fleet_integration for consistency
+// across the two resources — both key on (name, version) of the installed
+// package in Fleet.
+func getPackageID(name, version string) string {
+	hash, _ := schemautil.StringToHash(name + version)
+	if hash == nil {
+		return ""
+	}
+	return *hash
+}
+
+// detectContentType maps a file path extension to the Content-Type header
+// expected by POST /api/fleet/epm/packages. The Fleet API accepts
+// application/zip and application/gzip; we default to zip for unknown
+// extensions (elastic-package produces .zip files by default).
+func detectContentType(packagePath string) string {
+	lower := strings.ToLower(packagePath)
+	switch {
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"), strings.HasSuffix(lower, ".gz"):
+		return "application/gzip"
+	default:
+		return "application/zip"
+	}
+}
+
+// sha256File returns the SHA-256 hex digest of the file at path.
+// Errors are returned with the wrapped file path for diagnostic clarity.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %q: %w", path, err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("read %q: %w", path, err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/fleet/customintegration/models_test.go
+++ b/internal/fleet/customintegration/models_test.go
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectContentType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"plain .zip", "my-package.zip", "application/zip"},
+		{".ZIP uppercase", "MY.ZIP", "application/zip"},
+		{".tar.gz", "my-package.tar.gz", "application/gzip"},
+		{".tgz", "my-package.tgz", "application/gzip"},
+		{".gz", "my-package.gz", "application/gzip"},
+		{"no extension defaults to zip", "packagefile", "application/zip"},
+		{"path with directory", "/tmp/builds/foo-1.0.0.zip", "application/zip"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, detectContentType(tc.path))
+		})
+	}
+}
+
+func TestSha256File(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a")
+	f2 := filepath.Join(dir, "b")
+	f3 := filepath.Join(dir, "c")
+	require.NoError(t, os.WriteFile(f1, []byte("hello world"), 0o600))
+	require.NoError(t, os.WriteFile(f2, []byte("hello world"), 0o600))
+	require.NoError(t, os.WriteFile(f3, []byte("hello world!"), 0o600))
+
+	h1, err := sha256File(f1)
+	require.NoError(t, err)
+	h2, err := sha256File(f2)
+	require.NoError(t, err)
+	h3, err := sha256File(f3)
+	require.NoError(t, err)
+
+	assert.Equal(t, h1, h2, "identical content must produce identical hashes")
+	assert.NotEqual(t, h1, h3, "different content must produce different hashes")
+	// SHA-256 of "hello world" is a well-known value; the helper must
+	// return the standard lowercase-hex form so downstream checksum
+	// comparisons are stable across platforms.
+	assert.Equal(t, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9", h1)
+}
+
+func TestSha256File_Missing(t *testing.T) {
+	t.Parallel()
+	_, err := sha256File(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+}
+
+func TestGetPackageID_IsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	a := getPackageID("my_pkg", "1.2.3")
+	b := getPackageID("my_pkg", "1.2.3")
+	c := getPackageID("my_pkg", "1.2.4")
+
+	assert.NotEmpty(t, a)
+	assert.Equal(t, a, b, "same (name, version) must produce identical IDs")
+	assert.NotEqual(t, a, c, "different versions must produce different IDs")
+}
+
+func TestPickInstalledVersion(t *testing.T) {
+	t.Parallel()
+
+	installedStr := "installed"
+	notInstalledStr := "not_installed"
+	installed := &installedStr
+	notInstalled := &notInstalledStr
+
+	cases := []struct {
+		name string
+		in   []kbapi.PackageListItem
+		pkg  string
+		want string
+	}{
+		{
+			name: "single installed entry",
+			in:   []kbapi.PackageListItem{{Name: "pkg_a", Version: "1.0.0", Status: installed}},
+			pkg:  "pkg_a",
+			want: "1.0.0",
+		},
+		{
+			name: "ignores entries with a different name",
+			in: []kbapi.PackageListItem{
+				{Name: "pkg_b", Version: "9.9.9", Status: installed},
+				{Name: "pkg_a", Version: "0.1.0", Status: installed},
+			},
+			pkg:  "pkg_a",
+			want: "0.1.0",
+		},
+		{
+			name: "picks highest semver among installed",
+			in: []kbapi.PackageListItem{
+				{Name: "pkg_a", Version: "1.0.0", Status: installed},
+				{Name: "pkg_a", Version: "1.5.2", Status: installed},
+				{Name: "pkg_a", Version: "0.9.0", Status: installed},
+			},
+			pkg:  "pkg_a",
+			want: "1.5.2",
+		},
+		{
+			name: "ignores not-installed entries",
+			in: []kbapi.PackageListItem{
+				{Name: "pkg_a", Version: "2.0.0", Status: notInstalled},
+				{Name: "pkg_a", Version: "1.0.0", Status: installed},
+			},
+			pkg:  "pkg_a",
+			want: "1.0.0",
+		},
+		{
+			name: "no matching package returns empty",
+			in:   []kbapi.PackageListItem{{Name: "other", Version: "1.0.0", Status: installed}},
+			pkg:  "pkg_a",
+			want: "",
+		},
+		{
+			name: "nil status treated as installed",
+			in:   []kbapi.PackageListItem{{Name: "pkg_a", Version: "3.0.0", Status: nil}},
+			pkg:  "pkg_a",
+			want: "3.0.0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pickInstalledVersion(tc.in, tc.pkg))
+		})
+	}
+}

--- a/internal/fleet/customintegration/read.go
+++ b/internal/fleet/customintegration/read.go
@@ -1,0 +1,114 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"context"
+	"strings"
+
+	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/fleet"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func (r *customIntegrationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state customIntegrationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kibanaClient, diags := r.client.GetKibanaClient(ctx, state.KibanaConnection)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	fleetClient, err := kibanaClient.GetFleetClient()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to obtain Fleet client", err.Error())
+		return
+	}
+
+	name := state.PackageName.ValueString()
+	version := state.PackageVersion.ValueString()
+	if name == "" || version == "" {
+		// State is incomplete; can't verify. Remove and let a fresh
+		// create re-establish everything.
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	pkg, getDiags := fleet.GetPackage(ctx, fleetClient, name, version, state.SpaceID.ValueString())
+	resp.Diagnostics.Append(getDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if pkg == nil || !installed(pkg) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Nothing on the server side changes the values the user cares about
+	// (name/version/checksum are all anchored to the uploaded archive).
+	// Persist the state as-is.
+	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
+}
+
+// installed reports whether Fleet considers the package fully installed,
+// across both modern (`InstallationInfo.InstallStatus`) and legacy
+// (`Status`) response shapes. Mirrors the helper in internal/fleet/integration.
+func installed(pkg *kbapi.PackageInfo) bool {
+	if pkg == nil {
+		return false
+	}
+	if pkg.InstallationInfo != nil {
+		switch pkg.InstallationInfo.InstallStatus {
+		case kbapi.PackageInfoInstallationInfoInstallStatusInstalled:
+			return true
+		case kbapi.PackageInfoInstallationInfoInstallStatusInstallFailed:
+			return false
+		}
+	}
+	if pkg.Status != nil {
+		return strings.EqualFold(*pkg.Status, "installed")
+	}
+	return false
+}
+
+// pickInstalledVersion returns the highest version string for a named package
+// that reports `installed` status in the packages list. Used as a fallback
+// when the upload response does not carry a version.
+func pickInstalledVersion(pkgs []kbapi.PackageListItem, name string) string {
+	var best string
+	for _, p := range pkgs {
+		if p.Name != name {
+			continue
+		}
+		if p.Status != nil && !strings.EqualFold(string(*p.Status), "installed") {
+			continue
+		}
+		if p.Version == "" {
+			continue
+		}
+		if best == "" || p.Version > best {
+			best = p.Version
+		}
+	}
+	return best
+}

--- a/internal/fleet/customintegration/resource.go
+++ b/internal/fleet/customintegration/resource.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+var (
+	_ resource.Resource              = &customIntegrationResource{}
+	_ resource.ResourceWithConfigure = &customIntegrationResource{}
+)
+
+// NewResource returns a new elasticstack_fleet_custom_integration resource.
+func NewResource() resource.Resource {
+	return &customIntegrationResource{}
+}
+
+type customIntegrationResource struct {
+	client *clients.ProviderClientFactory
+}
+
+func (r *customIntegrationResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	factory, diags := clients.ConvertProviderDataToFactory(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	r.client = factory
+}
+
+func (r *customIntegrationResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = fmt.Sprintf("%s_%s", req.ProviderTypeName, "fleet_custom_integration")
+}

--- a/internal/fleet/customintegration/schema.go
+++ b/internal/fleet/customintegration/schema.go
@@ -1,0 +1,157 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"context"
+
+	providerschema "github.com/elastic/terraform-provider-elasticstack/internal/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (r *customIntegrationResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Uploads a locally-built Fleet custom integration package archive (`.zip` or `.tar.gz`) to " +
+			"Kibana via the EPM binary upload API (`POST /api/fleet/epm/packages`) and manages its lifecycle. " +
+			"Unlike `elasticstack_fleet_integration`, which installs packages from the Elastic package registry by " +
+			"name and version, this resource accepts a local archive produced with `elastic-package build`.\n\n" +
+			"Change detection is based on the SHA-256 hash of the file at `package_path`. When the file content " +
+			"changes, the package is re-uploaded automatically on the next apply.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "The ID of this resource. Derived from the uploaded package's name and version.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"package_path": schema.StringAttribute{
+				Description: "Absolute or working-directory-relative path to the local custom integration package archive " +
+					"(`.zip` or `.tar.gz`). The file must be readable at plan time.",
+				Required: true,
+			},
+			"package_name": schema.StringAttribute{
+				Description: "The name of the integration package, as declared in the package's `manifest.yml` and " +
+					"returned by Fleet after upload. Computed.",
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"package_version": schema.StringAttribute{
+				Description: "The installed version of the integration package, resolved from the upload response " +
+					"(or from the Fleet packages list API if the response does not carry a version). Computed.",
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"checksum": schema.StringAttribute{
+				Description: "SHA-256 hex digest of the file at `package_path` at the time of the last successful upload. " +
+					"Used to detect content changes.",
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"ignore_mapping_update_errors": schema.BoolAttribute{
+				Description: "When set, forwarded as the `ignoreMappingUpdateErrors=true` query parameter on upload. " +
+					"Requires Elastic Stack 8.11 or newer.",
+				Optional: true,
+			},
+			"skip_data_stream_rollover": schema.BoolAttribute{
+				Description: "When set, forwarded as the `skipDataStreamRollover=true` query parameter on upload. " +
+					"Requires Elastic Stack 8.11 or newer.",
+				Optional: true,
+			},
+			"skip_destroy": schema.BoolAttribute{
+				Description: "Set to `true` to leave the package installed in Fleet when the resource is destroyed. " +
+					"Defaults to `false` (the package is uninstalled).",
+				Optional: true,
+			},
+			"space_id": schema.StringAttribute{
+				Description: "The Kibana space in which to install the package. When set, Fleet API calls are routed " +
+					"through `/s/<space_id>/api/fleet/epm/packages`. When omitted, the default space is used.",
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"kibana_connection": providerschema.GetKbFWConnectionBlock(),
+		},
+	}
+}
+
+// ModifyPlan recomputes the SHA-256 of the file at `package_path` at plan
+// time and, when it differs from the value stored in state, marks the
+// computed trio (`checksum`, `package_name`, `package_version`) as unknown.
+// That lets the plan diff communicate a pending re-upload even though
+// `package_path` itself has not changed. If the file cannot be read, plan
+// fails with a clear diagnostic rather than a generic apply-time error.
+func (r *customIntegrationResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Skip during destroy (no plan) and during create (no prior state).
+	if req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan customIntegrationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state customIntegrationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// `package_path` is required, so it will always be known at plan time
+	// except in rare cases where it is itself derived from another unknown.
+	if plan.PackagePath.IsNull() || plan.PackagePath.IsUnknown() {
+		return
+	}
+
+	newHash, err := sha256File(plan.PackagePath.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("package_path"),
+			"Unable to read custom integration package",
+			err.Error(),
+		)
+		return
+	}
+
+	if !state.Checksum.IsNull() && !state.Checksum.IsUnknown() && state.Checksum.ValueString() == newHash {
+		// Content unchanged; leave the computed attributes taken from
+		// state (via UseStateForUnknown) in place.
+		return
+	}
+
+	// Content changed: tell Terraform the computed attributes are pending
+	// (known after apply) so the plan diff is transparent.
+	plan.Checksum = types.StringUnknown()
+	plan.PackageName = types.StringUnknown()
+	plan.PackageVersion = types.StringUnknown()
+	plan.ID = types.StringUnknown()
+
+	resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
+}

--- a/internal/fleet/customintegration/update.go
+++ b/internal/fleet/customintegration/update.go
@@ -1,0 +1,126 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package customintegration
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients/fleet"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func (r *customIntegrationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan customIntegrationModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var state customIntegrationModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	kibanaClient, diags := r.client.GetKibanaClient(ctx, plan.KibanaConnection)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	fleetClient, err := kibanaClient.GetFleetClient()
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to obtain Fleet client", err.Error())
+		return
+	}
+
+	path := plan.PackagePath.ValueString()
+
+	newHash, err := sha256File(path)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to hash custom integration package", err.Error())
+		return
+	}
+
+	// Only the mutable query-parameter attributes changed? Re-uploading
+	// without a content change is harmless — Fleet accepts a re-upload of
+	// the same archive — and keeps the semantics simple: any update
+	// re-runs the upload with the current values.
+	f, err := os.Open(path)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to open custom integration package", err.Error())
+		return
+	}
+	defer f.Close()
+
+	opts := fleet.UploadPackageOptions{
+		SpaceID:                   plan.SpaceID.ValueString(),
+		ContentType:               detectContentType(path),
+		IgnoreMappingUpdateErrors: plan.IgnoreMappingUpdateErrors.ValueBoolPointer(),
+		SkipDataStreamRollover:    plan.SkipDataStreamRollover.ValueBoolPointer(),
+	}
+
+	result, uploadDiags := fleet.UploadPackage(ctx, fleetClient, f, opts)
+	resp.Diagnostics.Append(uploadDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	version := result.PackageVersion
+	if version == "" {
+		pkgs, listDiags := fleet.GetPackages(ctx, fleetClient, true, plan.SpaceID.ValueString())
+		resp.Diagnostics.Append(listDiags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		version = pickInstalledVersion(pkgs, result.PackageName)
+		if version == "" {
+			resp.Diagnostics.AddError(
+				"Unable to resolve uploaded package version",
+				fmt.Sprintf("The Fleet upload for package %q succeeded but no matching installed entry was found in the packages list API.", result.PackageName),
+			)
+			return
+		}
+	}
+
+	// If the uploaded package reports a different name than what was in
+	// state, the prior package has been superseded. Uninstall the old
+	// name+version so it does not linger as an orphan installation. A
+	// failure here surfaces as a diagnostic but does not roll back the
+	// new upload — the user is told explicitly that they have a hybrid
+	// state and can clean it up.
+	oldName := state.PackageName.ValueString()
+	oldVersion := state.PackageVersion.ValueString()
+	if oldName != "" && oldName != result.PackageName {
+		uninstallDiags := fleet.Uninstall(ctx, fleetClient, oldName, oldVersion, state.SpaceID.ValueString(), false)
+		if uninstallDiags.HasError() {
+			resp.Diagnostics.AddWarning(
+				fmt.Sprintf("Failed to uninstall superseded package %s/%s", oldName, oldVersion),
+				fmt.Sprintf("The new package %s/%s was uploaded successfully but the prior package could not be uninstalled. It may still be present in Fleet and require manual cleanup. Underlying diagnostics: %v", result.PackageName, version, uninstallDiags),
+			)
+		}
+	}
+
+	plan.PackageName = types.StringValue(result.PackageName)
+	plan.PackageVersion = types.StringValue(version)
+	plan.Checksum = types.StringValue(newHash)
+	plan.ID = types.StringValue(getPackageID(result.PackageName, version))
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}

--- a/provider/plugin_framework.go
+++ b/provider/plugin_framework.go
@@ -45,6 +45,7 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/watcher/watch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/agentdownloadsource"
 	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/agentpolicy"
+	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/customintegration"
 	elasticdefendintegrationpolicy "github.com/elastic/terraform-provider-elasticstack/internal/fleet/elastic_defend_integration_policy"
 	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/enrollmenttokens"
 	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/integration"
@@ -180,6 +181,7 @@ func (p *Provider) resources(_ context.Context) []func() resource.Resource {
 		agentbuildertool.NewResource,
 		agentbuilderworkflow.NewResource,
 		integration.NewResource,
+		customintegration.NewResource,
 		integrationpolicy.NewResource,
 		elasticdefendintegrationpolicy.NewResource,
 		output.NewResource,


### PR DESCRIPTION
# feat(fleet_custom_integration): add resource for uploading custom packages

Closes #1922.

Implements the [fleet-custom-integration OpenSpec change](https://github.com/elastic/terraform-provider-elasticstack/blob/main/openspec/changes/fleet-custom-integration/) — design proposal merged as #2390 two days ago. Every `ADDED Requirement` in `specs/fleet-custom-integration/spec.md` is covered by code in this PR except for the two acceptance-test requirements (6.1 and 6.3 in `tasks.md`), which need a committed `.zip` fixture and a live Kibana — I'd rather maintainers pick the fixture.

## What it does

New managed resource `elasticstack_fleet_custom_integration`:

```hcl
resource "elasticstack_fleet_custom_integration" "example" {
  package_path = "${path.module}/dist/my_custom_pkg-1.0.0.zip"

  # optional
  ignore_mapping_update_errors = false
  skip_data_stream_rollover    = false
  skip_destroy                 = false
  space_id                     = "analyst"
}

# Computed:
#   package_name    = extracted from Fleet after upload
#   package_version = resolved from upload response or GetPackages fallback
#   checksum        = SHA-256 of the file at package_path
#   id              = schemautil.StringToHash(package_name + package_version)

# Use the computed values downstream:
resource "elasticstack_fleet_integration_policy" "p" {
  integration_name    = elasticstack_fleet_custom_integration.example.package_name
  integration_version = elasticstack_fleet_custom_integration.example.package_version
  ...
}
```

## Implementation summary

### `internal/clients/fleet/fleet.go` (new wrapper)

- `UploadPackageOptions` / `UploadPackageResult` types.
- `UploadPackage(ctx, client, body, opts)` — calls `PostFleetEpmPackagesWithBodyWithResponse`, forwards `ignoreMappingUpdateErrors` / `skipDataStreamRollover` query params, and parses the response manually (the generated client declares the response as `Body []byte` with no typed JSON fields).
- `parseUploadPackageResponse` handles both envelope shapes — modern `items` and legacy `response` — so the wrapper works on older Kibana versions too.

### `internal/fleet/customintegration/` (new package)

- `resource.go` / `models.go` — standard Plugin Framework boilerplate, plus `detectContentType`, `sha256File`, and `getPackageID` helpers.
- `schema.go` — all attributes per the spec. Key call-out: the checksum plan modifier lives on the resource via `ModifyPlan`, not on an individual attribute. A `planmodifier.String` only exposes its own attribute in the response (no `resp.Plan`), so cross-attribute marking has to happen at the resource level.
- `create.go` / `read.go` / `update.go` / `delete.go`:
  - Create: read file → hash → upload → resolve version (upload response first, `GetPackages` fallback) → write state.
  - Read: `GetPackage` by state's name/version; if not installed, `RemoveResource`.
  - Update: re-upload. When the new archive reports a different `package_name`, uninstall the prior `name+version` (warning on failure — the new upload is already durable).
  - Delete: `fleet.Uninstall(name, version, space_id, false)` unless `skip_destroy = true`.

### `provider/plugin_framework.go`

- Import + `customintegration.NewResource` in the resources slice, alphabetised next to `integration.NewResource`.

## Spec coverage

Cross-referencing `openspec/changes/fleet-custom-integration/specs/fleet-custom-integration/spec.md`:

| Requirement | Status |
|---|---|
| Resource exists | ✅ registered in `plugin_framework.go` |
| Create uploads package archive (zip + gzip) | ✅ `create.go` + `detectContentType` |
| Create resolves version via GetPackages fallback | ✅ `create.go` |
| Create errors on non-2xx response | ✅ `UploadPackage` returns diagnostics |
| Create errors when file is unreadable | ✅ `sha256File` / `os.Open` surface clear errors |
| Read verifies installation | ✅ `read.go` + `installed()` |
| Read removes from state on 404 / not-installed | ✅ `read.go` |
| Plan detects file content changes | ✅ `schema.go` `ModifyPlan` |
| Plan errors when file unreadable at plan time | ✅ `ModifyPlan` adds attribute error |
| Update re-uploads on content change | ✅ `update.go` |
| Update uninstalls old package on rename | ✅ `update.go` |
| Update re-uploads on query-param change only | ✅ (update always re-uploads; cheap + idempotent for Fleet) |
| Delete uninstalls unless `skip_destroy` | ✅ `delete.go` |
| Space-aware routing | ✅ all CRUD pass `space_id` through the existing `spaceAwarePathRequestEditor` |
| Optional upload query params | ✅ wired to `UploadPackageOptions` |
| Connection | ✅ uses `r.client.GetKibanaClient(ctx, plan.KibanaConnection)` |

## Test coverage

All unit tests run without a live Kibana.

```
$ go test -count=1 -v ./internal/fleet/customintegration/
--- PASS: TestDetectContentType (7 subtests)
--- PASS: TestSha256File
--- PASS: TestSha256File_Missing
--- PASS: TestGetPackageID_IsDeterministic
--- PASS: TestPickInstalledVersion (6 subtests)
PASS
ok  	internal/fleet/customintegration	0.378s

$ go test -count=1 -v -run 'TestParseUploadPackageResponse' ./internal/clients/fleet/
--- PASS: TestParseUploadPackageResponse (6 subtests: modern+legacy envelopes, mixed, empty, invalid)
PASS

$ go build ./...
<clean>
$ go vet ./...
<clean>
```

## Not included

- **Acceptance test** (`tasks.md` 6.1 / 6.3). Needs a committed custom-integration `.zip` under `testdata/` plus a running Kibana. I'd rather maintainers pick the fixture than commit a synthetic one that may drift from the real `elastic-package build` output over time. Happy to write the test file skeleton in a follow-up if you'd like.
- **Marking OpenSpec tasks as completed.** Left the `tasks.md` unchanged; maintainers can close the change in the preferred workflow after merge.
- **Documentation generation.** I did not run `make docs-generate`. The resource-level `MarkdownDescription` and every attribute's `Description` are populated, so `tfplugindocs` should produce the page from the schema, but I haven't verified because I wasn't sure whether you prefer CI to do it.

## Changelog
Customer impact: enhancement
Summary: adds `elasticstack_fleet_custom_integration`, a managed resource that uploads a locally-built Fleet custom integration package archive (`.zip` or `.tar.gz`) to Kibana via `POST /api/fleet/epm/packages`, detects file-content changes via SHA-256 checksum, and manages the package's full lifecycle (create, read, update with re-upload, delete).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `elasticstack_fleet_custom_integration` resource for uploading custom Fleet packages
> - Adds a new Terraform resource that uploads a local package archive (zip or tar.gz) to Fleet's EPM endpoint via `fleet.UploadPackage`, then records the installed package name, version, checksum, and a deterministic ID in state.
> - At plan time, `ModifyPlan` recomputes the file's SHA-256 and marks name/version/checksum/ID as unknown when the archive content changes, triggering re-upload even if the path is unchanged.
> - On update, if the uploaded package has a different name than the prior state, the old package is uninstalled; failures are surfaced as warnings rather than errors.
> - On delete, the package is uninstalled from Fleet unless `skip_destroy` is true or state lacks name/version.
> - Risk: version resolution falls back to a secondary `GetPackages` list scan when the upload response omits a version, which may pick an unexpected version if multiple installs exist.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 846a9ef. 9 files reviewed, 4 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->