### PR TITLE
Proposal to complete migration to resourcecore

### DIFF
--- a/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/.openspec.yaml
+++ b/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/design.md
+++ b/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`internal/resourcecore` already defines the provider-wide Plugin Framework resource wiring for Terraform type-name construction, provider-data conversion, and client-factory storage. The first rollout intentionally stopped at four pilot resources so the team could validate promoted-method behavior, import boundaries, and readability before widening adoption.
+
+Issue [#2454](https://github.com/elastic/terraform-provider-elasticstack/issues/2454) shows that many remaining Plugin Framework resources still duplicate the same `Configure` and `Metadata` bodies that `resourcecore` was created to own. Most of that duplication is in Fleet and Kibana resources whose `Configure` behavior already matches the canonical early-return semantics in `resourcecore`. Some other Plugin Framework resources still differ slightly, such as assigning the converted client even when diagnostics are present, so this change needs an explicit compatibility boundary instead of assuming every Plugin Framework resource can be migrated mechanically.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Migrate the remaining compatible Plugin Framework resources that manually duplicate `client`, `Configure`, and `Metadata` wiring to embed `*resourcecore.Core`.
+- Preserve each migrated resource's Terraform type name, import semantics, CRUD logic, schema, and state-upgrade behavior exactly.
+- Extend verification so the broader rollout remains safe after moving beyond the original four-resource pilot.
+- Capture the rollout requirement in the existing `provider-framework-resource-core` capability rather than leaving the spec scoped only to pilots.
+
+**Non-Goals:**
+- Changing Terraform resource names, schema shape, import identifiers, or external API behavior.
+- Converting Plugin Framework data sources or SDK resources.
+- Forcing resources with non-canonical `Configure` behavior onto `resourcecore` as part of this change.
+- Moving CRUD, validation, or state-upgrade logic into `resourcecore`.
+
+## Decisions
+
+### Scope the rollout to resources already compatible with `resourcecore`
+
+This change will migrate resources whose local boilerplate is semantically equivalent to the shared core: they store a `*clients.ProviderClientFactory`, use `clients.ConvertProviderDataToFactory(req.ProviderData)`, append diagnostics, return early on errors, and construct a static Terraform type name from fixed namespace parts. Resources that still have materially different `Configure` behavior will be left for separate follow-up work so the migration remains a refactor rather than a behavior change.
+
+**Alternative considered:** migrate every remaining Plugin Framework resource in one pass. Rejected because some packages still differ in `Configure` semantics, and folding those behavior changes into this refactor would make review and rollback substantially harder.
+
+### Preserve resource-local import ownership and all non-bootstrap behavior
+
+Each migrated resource will embed `*resourcecore.Core`, initialize it in the constructor with the correct component and literal resource-name suffix, and replace direct client-field reads with `r.Client()`. The concrete resource will keep its explicit `ImportState`, schema, CRUD, and state-upgrade methods unchanged.
+
+This preserves the resourcecore contract that import behavior remains local to the resource, while still removing the duplicated `client` field plus `Configure`/`Metadata` bodies.
+
+**Alternative considered:** add more behavior to `resourcecore`, such as default import handling or shared CRUD helpers. Rejected because issue `#2454` is specifically about bootstrap duplication, and widening the abstraction would create a much larger design surface.
+
+### Use literal component and resource-name pairs to preserve exact type names
+
+Every migrated resource will configure the core with the exact component and literal suffix that reproduces its existing Terraform type name, including legacy spellings. This keeps the rollout safe for resources such as `agentbuilder_workflow`-style packages whose Go package names, type names, and Terraform suffixes are not always trivially derivable from one another.
+
+**Alternative considered:** derive the core suffix from package names automatically. Rejected because the current provider still contains legacy naming variants and inconsistent package naming patterns.
+
+### Verify the widened rollout with a provider registry test plus targeted package coverage
+
+The existing `internal/resourcecore` unit and conformance tests already protect core semantics. This change will add a provider-package unit test that iterates the resources registered in `provider/plugin_framework.go`, instantiates each registered resource, and asserts that the concrete resource embeds `*resourcecore.Core`. That provider-level inventory test will be complemented by targeted tests for the shared core and for representative migrated packages across the widened rollout, especially resources with passthrough import, custom import, and no import support.
+
+**Alternative considered:** rely only on compilation and the existing shared-core tests. Rejected because the widened rollout spans many packages and import variants, and the provider registry is the actual source of truth for what the provider exposes.
+
+## Risks / Trade-offs
+
+- [A resource may look mechanically compatible while still relying on slightly different `Configure` behavior] → Audit each candidate resource before conversion and leave outliers for a separate follow-up.
+- [Embedding can obscure where the client now comes from during review] → Keep constructor initialization explicit and use `r.Client()` consistently so client access remains easy to trace.
+- [Literal suffix mistakes could silently change Terraform type names] → Preserve type-name strings by mapping each resource to an explicit component plus literal suffix and cover representative names in tests.
+- [The rollout may touch many packages at once] → Convert resources in small groups, grouped by component or import shape, so regressions are easier to isolate.
+
+## Migration Plan
+
+1. Inventory the remaining Plugin Framework resources that still duplicate canonical `client` / `Configure` / `Metadata` wiring and separate compatible resources from outliers.
+2. Convert compatible resources to embed `*resourcecore.Core`, initialize the core in constructors, and replace direct client-field usage with `Client()`.
+3. Keep explicit `ImportState`, schema, CRUD, and state-upgrade methods unchanged for every converted resource.
+4. Add the provider-package registry test for `provider/plugin_framework.go`, then run targeted tests for `./internal/resourcecore/...` and representative migrated packages that cover passthrough import, custom import, and no-import resource shapes.
+5. Leave any audited incompatibilities out of scope for this change and capture them in follow-up work if needed.
+
+Rollback is straightforward because the rollout is internal-only: each converted resource can revert to its prior explicit `client`, `Configure`, and `Metadata` implementation without state migration.
+
+## Open Questions
+
+- Whether the provider registry test should cover only the standard resource set from `Provider.resources(...)` or also the experimental resource set returned by `Provider.experimentalResources(...)`.

--- a/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/proposal.md
+++ b/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The provider now has a shared Plugin Framework `resourcecore`, but most remaining Plugin Framework resources still hand-roll the same `Configure` and `Metadata` boilerplate. That duplication keeps issue [#2454](https://github.com/elastic/terraform-provider-elasticstack/issues/2454) alive, makes provider-wide wiring fixes harder to roll out consistently, and creates avoidable review noise across dozens of resources.
+
+## What Changes
+
+- Migrate the remaining compatible Plugin Framework resources that still duplicate canonical provider-data conversion and Terraform type-name construction to embed `internal/resourcecore.Core`.
+- Preserve each resource's existing Terraform type name, import behavior, CRUD logic, schema, and state-upgrade behavior while removing only the repeated `client` field plus `Configure` and `Metadata` wiring.
+- Add a provider-package unit test that iterates the resources registered in `provider/plugin_framework.go` and verifies the registered Plugin Framework resources embed `resourcecore.Core`.
+- Add or extend verification so the broader rollout proves `resourcecore` works across the remaining compatible resource shapes without changing user-facing behavior.
+- Document the broader rollout in the `provider-framework-resource-core` capability so the shared-core contract covers provider-wide adoption instead of only the original pilot resources.
+
+## Capabilities
+
+### New Capabilities
+<!-- None -->
+
+### Modified Capabilities
+- `provider-framework-resource-core`: expand the shared-core capability from a pilot embedding to the remaining compatible Plugin Framework resources that currently duplicate canonical `Configure` and `Metadata` wiring
+
+## Impact
+
+- Affected code primarily under `internal/fleet/` and `internal/kibana/`, plus any additional Plugin Framework resource packages found during implementation to already match the canonical `resourcecore` semantics.
+- A new provider-package registry test, plus any additional targeted tests and/or compile-time conformance checks for the widened rollout.
+- No Terraform schema, type-name, import-identifier, or API contract changes are intended for end users.

--- a/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/specs/provider-framework-resource-core/spec.md
+++ b/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/specs/provider-framework-resource-core/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Compatible Plugin Framework resources use the shared resource core for bootstrap wiring
+For every Plugin Framework resource in this provider whose bootstrap logic is limited to storing a `*clients.ProviderClientFactory`, converting `ProviderData` through the canonical `clients.ConvertProviderDataToFactory` flow, constructing a static Terraform type name from fixed namespace parts, and leaving import/CRUD/state behavior on the concrete resource, the provider SHALL implement that bootstrap wiring by embedding `internal/resourcecore.Core` instead of re-declaring a `client` field plus resource-local `Configure` and `Metadata` methods. Each migrated resource SHALL initialize the core with the component namespace and literal resource-name suffix that preserve its pre-existing Terraform type name exactly, and SHALL keep any explicit `ImportState` behavior on the concrete resource.
+
+#### Scenario: Compatible Fleet resource preserves custom import behavior
+- **WHEN** `elasticstack_fleet_agent_download_source` is implemented through the shared resource core
+- **THEN** it SHALL configure the core with component `fleet` and resource name `agent_download_source`
+- **AND** its explicit composite-ID `ImportState` behavior SHALL remain defined on the concrete resource
+
+#### Scenario: Compatible Kibana resource preserves passthrough import behavior
+- **WHEN** `elasticstack_kibana_dashboard` is implemented through the shared resource core
+- **THEN** it SHALL configure the core with component `kibana` and resource name `dashboard`
+- **AND** its explicit passthrough `ImportState` behavior SHALL remain defined on the concrete resource
+
+#### Scenario: Compatible resource without import remains non-importable
+- **WHEN** a compatible Plugin Framework resource without an explicit `ImportState` is migrated to embed the shared resource core
+- **THEN** it SHALL continue not to satisfy `resource.ResourceWithImportState`

--- a/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/tasks.md
+++ b/openspec/changes/migrate-remaining-pf-resources-to-resourcecore/tasks.md
@@ -1,0 +1,16 @@
+## 1. Audit rollout scope
+
+- [ ] 1.1 Inventory the remaining Plugin Framework resources that still duplicate canonical `client` / `Configure` / `Metadata` wiring and classify them as compatible or out-of-scope based on current `resourcecore` semantics.
+- [ ] 1.2 Record the component namespace, literal resource-name suffix, and import shape for each compatible resource so the migration preserves existing Terraform type names and import behavior.
+
+## 2. Migrate compatible resources
+
+- [ ] 2.1 Convert the compatible Fleet resources to embed `*resourcecore.Core`, initialize the core in their constructors, and replace direct client-field access with `Client()`.
+- [ ] 2.2 Convert the compatible Kibana resources to embed `*resourcecore.Core`, initialize the core in their constructors, and replace direct client-field access with `Client()`.
+- [ ] 2.3 Convert any additional audited compatible Plugin Framework resources outside Fleet and Kibana, or explicitly leave audited outliers for follow-up if they still differ from canonical `resourcecore` behavior.
+
+## 3. Verify the rollout
+
+- [ ] 3.1 Add a provider-package unit test that iterates the resources registered in `provider/plugin_framework.go` and asserts the registered Plugin Framework resources embed `*resourcecore.Core`.
+- [ ] 3.2 Add or update targeted tests and compile-time assertions that cover representative migrated resources with passthrough import, custom import, and no import support.
+- [ ] 3.3 Run targeted `go test` coverage for `./internal/resourcecore/...`, the provider package, and representative migrated packages, then run `make build`.


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/2454

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add proposal and design documents for migrating remaining Plugin Framework resources to `resourcecore`
> Adds an OpenSpec change proposal under [openspec/changes/migrate-remaining-pf-resources-to-resourcecore/](https://github.com/elastic/terraform-provider-elasticstack/pull/2455/files#diff-d94360a793ab2ed753e3c3d34895b7ba236aa541d825d6313aa2dfa9ff09c39e) to complete the migration of compatible Plugin Framework resources to `internal/resourcecore`.
>
> - [proposal.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2455/files#diff-0fc448e51a39cb2280357d5d8854e6d61c86984f5ea9096908fc6aa765d6d8a9) describes motivation, affected resources, and capability updates including a new provider-level registry test
> - [design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2455/files#diff-60a5622fd873b6538b670c4d2f5970d8529a497864eef2ee0e6958775d3c1e2c) covers migration plan, decisions, risks, and scope constraints (compatible resources only, preserving type names and import behavior)
> - [spec.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2455/files#diff-519328f830a29ce57bb40755b36293a40f47377b2fca87f53cca0066f4a26dac) formalizes requirements: embed `resourcecore.Core` for bootstrap wiring while keeping existing Terraform type names and import semantics
> - [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2455/files#diff-7bdb1027547e00b71f320092d9d14bbfef7416820be591235e31d9a05dba7235) provides a checklist covering audit, per-resource migration, and verification steps
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aed2ce7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->