### PR TITLE
Private location geo lat/long are doubles

### DIFF
--- a/generated/kbapi/transform_schema.go
+++ b/generated/kbapi/transform_schema.go
@@ -886,6 +886,22 @@ func transformKibanaPaths(schema *Schema) {
 		"responses.200.content.application/json.schema",
 		Map{"$ref": "#/components/schemas/Synthetics_getPrivateLocation"},
 	)
+	syntheticsPrivateLocationsPath.Post.Set(
+		"requestBody.content.application/json.schema.properties.geo.properties.lat.format",
+		"double",
+	)
+	syntheticsPrivateLocationsPath.Post.Set(
+		"requestBody.content.application/json.schema.properties.geo.properties.lon.format",
+		"double",
+	)
+	schema.Components.Set(
+		"schemas.Synthetics_getPrivateLocation.properties.geo.properties.lat.format",
+		"double",
+	)
+	schema.Components.Set(
+		"schemas.Synthetics_getPrivateLocation.properties.geo.properties.lon.format",
+		"double",
+	)
 
 	schema.Components.CreateRef(schema, "Data_views_data_view_response_object_inner", "schemas.Data_views_data_view_response_object.properties.data_view")
 	schema.Components.CreateRef(schema, "Data_views_sourcefilter_item", "schemas.Data_views_sourcefilters.items")
@@ -1545,8 +1561,8 @@ func fixSyntheticsMonitorModels(schema *Schema) {
 	schema.Components.Set("schemas.geo_pos", Map{
 		"additionalProperties": false,
 		"properties": Map{
-			"lat": Map{"type": "number"},
-			"lon": Map{"type": "number"},
+			"lat": Map{"format": "double", "type": "number"},
+			"lon": Map{"format": "double", "type": "number"},
 		},
 		"type": "object",
 	})

--- a/internal/kibana/synthetics/privatelocation/schema.go
+++ b/internal/kibana/synthetics/privatelocation/schema.go
@@ -98,7 +98,7 @@ func privateLocationSchema() schema.Schema {
 }
 
 // privateLocationToCreateBody converts a Terraform model into a kbapi create request body.
-// Tags are passed as *[]string and geo coordinates are explicitly converted from float64 to float32.
+// Tags are passed as *[]string and geo coordinates preserve float64 precision.
 func privateLocationToCreateBody(m tfModelV0) kbapi.PostPrivateLocationJSONRequestBody {
 	body := kbapi.PostPrivateLocationJSONRequestBody{
 		Label:         m.Label.ValueString(),
@@ -112,11 +112,11 @@ func privateLocationToCreateBody(m tfModelV0) kbapi.PostPrivateLocationJSONReque
 
 	if m.Geo != nil {
 		body.Geo = &struct {
-			Lat float32 `json:"lat"`
-			Lon float32 `json:"lon"`
+			Lat float64 `json:"lat"`
+			Lon float64 `json:"lon"`
 		}{
-			Lat: float32(m.Geo.Lat.ValueFloat64()),
-			Lon: float32(m.Geo.Lon.ValueFloat64()),
+			Lat: m.Geo.Lat.ValueFloat64(),
+			Lon: m.Geo.Lon.ValueFloat64(),
 		}
 	}
 
@@ -178,11 +178,9 @@ func tagsFromAdditionalProperties(loc kbapi.SyntheticsGetPrivateLocation) []stri
 }
 
 // geoFromAPIResponse converts the nested geo struct from the API response to a tfGeoConfigV0.
-// The API returns float32 values, which we wrap in Float32PrecisionValue so that Terraform
-// treats them as semantically equal to the user-supplied float64 config values.
 func geoFromAPIResponse(geo *struct {
-	Lat float32 `json:"lat"`
-	Lon float32 `json:"lon"`
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
 }) *tfGeoConfigV0 {
 	if geo == nil {
 		return nil

--- a/internal/kibana/synthetics/privatelocation/schema_test.go
+++ b/internal/kibana/synthetics/privatelocation/schema_test.go
@@ -36,7 +36,7 @@ func Test_roundtrip(t *testing.T) {
 		label         string
 		agentPolicyID string
 		tags          []string
-		geo           *struct{ Lat, Lon float32 }
+		geo           *struct{ Lat, Lon float64 }
 		wantTags      []string
 		wantGeoNil    bool
 	}{
@@ -54,7 +54,7 @@ func Test_roundtrip(t *testing.T) {
 			label:         "label-2",
 			agentPolicyID: "agent-policy-id-2",
 			tags:          []string{"tag-1", "tag-2", "tag-3"},
-			geo:           &struct{ Lat, Lon float32 }{Lat: 43.2, Lon: 23.1},
+			geo:           &struct{ Lat, Lon float64 }{Lat: 43.2, Lon: 23.1},
 			wantTags:      []string{"tag-1", "tag-2", "tag-3"},
 		},
 		{
@@ -73,7 +73,7 @@ func Test_roundtrip(t *testing.T) {
 			spaceID:       "",
 			label:         "label-4",
 			agentPolicyID: "agent-policy-id-4",
-			geo:           &struct{ Lat, Lon float32 }{Lat: 43.2, Lon: 23.1},
+			geo:           &struct{ Lat, Lon float64 }{Lat: 43.2, Lon: 23.1},
 		},
 	}
 	for _, tt := range tests {
@@ -146,7 +146,7 @@ func Test_privateLocationFromAPI_tags(t *testing.T) {
 	assert.Equal(t, "region:us-east", model.Tags[1].ValueString())
 }
 
-// Test_privateLocationFromAPI_geo verifies that geo coordinates round-trip within float32 precision.
+// Test_privateLocationFromAPI_geo verifies that geo coordinates round-trip through the generated client model.
 func Test_privateLocationFromAPI_geo(t *testing.T) {
 	jsonPayload := `{
 		"id": "geo-loc",
@@ -161,9 +161,8 @@ func Test_privateLocationFromAPI_geo(t *testing.T) {
 	model := privateLocationFromAPI(loc, "", types.List{})
 
 	require.NotNil(t, model.Geo)
-	// float32 precision: accept up to ~0.001 delta
-	assert.InDelta(t, 48.8566, model.Geo.Lat.ValueFloat64(), 0.001)
-	assert.InDelta(t, 2.3522, model.Geo.Lon.ValueFloat64(), 0.001)
+	assert.InDelta(t, 48.8566, model.Geo.Lat.ValueFloat64(), 1e-9)
+	assert.InDelta(t, 2.3522, model.Geo.Lon.ValueFloat64(), 1e-9)
 	assert.Empty(t, model.Tags)
 }
 
@@ -187,8 +186,8 @@ func Test_privateLocationFromAPI_tagsAndGeo(t *testing.T) {
 	assert.Equal(t, "a", model.Tags[0].ValueString())
 	assert.Equal(t, "b", model.Tags[1].ValueString())
 	require.NotNil(t, model.Geo)
-	assert.InDelta(t, 10.5, model.Geo.Lat.ValueFloat64(), 0.001)
-	assert.InDelta(t, -20.3, model.Geo.Lon.ValueFloat64(), 0.001)
+	assert.InDelta(t, 10.5, model.Geo.Lat.ValueFloat64(), 1e-9)
+	assert.InDelta(t, -20.3, model.Geo.Lon.ValueFloat64(), 1e-9)
 }
 
 // Test_normalizePostResponse verifies that a POST response body (map[string]interface{}) can be
@@ -220,6 +219,6 @@ func Test_normalizePostResponse(t *testing.T) {
 	assert.Equal(t, "fresh", tags[1])
 
 	require.NotNil(t, loc.Geo)
-	assert.InDelta(t, 51.5074, float64(loc.Geo.Lat), 0.001)
-	assert.InDelta(t, -0.1278, float64(loc.Geo.Lon), 0.001)
+	assert.InDelta(t, 51.5074, loc.Geo.Lat, 1e-9)
+	assert.InDelta(t, -0.1278, loc.Geo.Lon, 1e-9)
 }


### PR DESCRIPTION
Fixes 9.4 acceptance tests. 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change private location geo lat/lon fields from float32 to float64
> - Updates the OpenAPI schema transformation in [`transform_schema.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2457/files#diff-b9ff7c8cb4308ced5fa5d0d950af42a4664bc322a004ddfe024c9023a7f14faf) to mark `lat`/`lon` fields as `format: double` for private location and `geo_pos` schemas, causing the generator to emit `float64` types in [`kibana.gen.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2457/files#diff-60e75af26d5b444491aacc4ee6d689b53ab2b6991a9f8df5f5a049e70678bb53).
> - Updates [`schema.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2457/files#diff-13ffbdc20521b044096a488a2f77ea92ec1ace3426da1f7601c25cb081adfe2d) to use `float64` when building the POST request body and when reading the API response, avoiding truncation of coordinate precision.
> - Tightens test tolerances in [`schema_test.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2457/files#diff-750c6e3b1c350138d18dc920e7f270e2ed82a752e161888ace3780eda326a906) from `0.001` to `1e-9` to match double-precision expectations.
> - Behavioral Change: geo coordinates sent to and received from the Kibana API now carry full float64 precision instead of being truncated to float32.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51d8ed5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->