### PR TITLE
Deduplicate kibana connection test setup

### DIFF
--- a/internal/acctest/kibana_connection.go
+++ b/internal/acctest/kibana_connection.go
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package acctest
+
+import (
+	"maps"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+type kibanaConnectionAuth struct {
+	apiKey   string
+	username string
+	password string
+}
+
+func acceptanceTestKibanaConnectionAuth() kibanaConnectionAuth {
+	apiKey := os.Getenv("KIBANA_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
+	}
+
+	username := os.Getenv("KIBANA_USERNAME")
+	if username == "" {
+		username = os.Getenv("ELASTICSEARCH_USERNAME")
+	}
+
+	password := os.Getenv("KIBANA_PASSWORD")
+	if password == "" {
+		password = os.Getenv("ELASTICSEARCH_PASSWORD")
+	}
+
+	return kibanaConnectionAuth{
+		apiKey:   apiKey,
+		username: username,
+		password: password,
+	}
+}
+
+func acceptanceTestKibanaEndpoint() string {
+	return strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))
+}
+
+func KibanaConnectionVariables(additional ...config.Variables) config.Variables {
+	auth := acceptanceTestKibanaConnectionAuth()
+	vars := config.Variables{
+		"kibana_endpoints": config.ListVariable(config.StringVariable(acceptanceTestKibanaEndpoint())),
+		"api_key":          config.StringVariable(auth.apiKey),
+		"username":         config.StringVariable(auth.username),
+		"password":         config.StringVariable(auth.password),
+	}
+
+	for _, extra := range additional {
+		maps.Copy(vars, extra)
+	}
+
+	return vars
+}
+
+func KibanaConnectionAuthChecks(resourceName string) []resource.TestCheckFunc {
+	auth := acceptanceTestKibanaConnectionAuth()
+	if auth.apiKey != "" {
+		return []resource.TestCheckFunc{
+			resource.TestCheckResourceAttr(resourceName, "kibana_connection.0.api_key", auth.apiKey),
+		}
+	}
+
+	return []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "kibana_connection.0.username", auth.username),
+		resource.TestCheckResourceAttr(resourceName, "kibana_connection.0.password", auth.password),
+	}
+}

--- a/internal/apm/agent_configuration/acc_test.go
+++ b/internal/apm/agent_configuration/acc_test.go
@@ -19,8 +19,6 @@ package agentconfiguration_test
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -158,7 +156,9 @@ func TestAccResourceAgentConfiguration_kibanaConnection(t *testing.T) {
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory(""),
-				ConfigVariables:          testAccAgentConfigurationKibanaConnectionVariables(serviceName),
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"service_name": config.StringVariable(serviceName),
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_apm_agent_configuration.test_config", "id", expectedID),
 					resource.TestCheckResourceAttr("elasticstack_apm_agent_configuration.test_config", "service_name", serviceName),
@@ -172,16 +172,20 @@ func TestAccResourceAgentConfiguration_kibanaConnection(t *testing.T) {
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory(""),
-				ConfigVariables:          testAccAgentConfigurationKibanaConnectionVariables(serviceName),
-				ResourceName:             "elasticstack_apm_agent_configuration.test_config",
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"kibana_connection"},
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"service_name": config.StringVariable(serviceName),
+				}),
+				ResourceName:            "elasticstack_apm_agent_configuration.test_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kibana_connection"},
 			},
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccAgentConfigurationKibanaConnectionVariables(serviceName),
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"service_name": config.StringVariable(serviceName),
+				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_apm_agent_configuration.test_config", "id", expectedID),
 					resource.TestCheckResourceAttr("elasticstack_apm_agent_configuration.test_config", "service_name", serviceName),
@@ -194,41 +198,16 @@ func TestAccResourceAgentConfiguration_kibanaConnection(t *testing.T) {
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccAgentConfigurationKibanaConnectionVariables(serviceName),
-				ResourceName:             "elasticstack_apm_agent_configuration.test_config",
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"kibana_connection"},
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"service_name": config.StringVariable(serviceName),
+				}),
+				ResourceName:            "elasticstack_apm_agent_configuration.test_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kibana_connection"},
 			},
 		},
 	})
-}
-
-func testAccAgentConfigurationKibanaConnectionVariables(serviceName string) config.Variables {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-
-	kibanaEndpoint := strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))
-
-	return config.Variables{
-		"service_name": config.StringVariable(serviceName),
-		"kibana_endpoints": config.ListVariable(
-			config.StringVariable(kibanaEndpoint),
-		),
-		"api_key":  config.StringVariable(apiKey),
-		"username": config.StringVariable(username),
-		"password": config.StringVariable(password),
-	}
 }
 
 func TestAccResourceAgentConfiguration_minimal(t *testing.T) {

--- a/internal/fleet/integration/acc_test.go
+++ b/internal/fleet/integration/acc_test.go
@@ -20,9 +20,7 @@ package integration_test
 import (
 	"context"
 	_ "embed"
-	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -118,7 +116,7 @@ func TestAccResourceIntegration_kibanaConnection(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.Providers,
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
-				ConfigVariables:          testAccResourceIntegrationKibanaConnectionVariables(),
+				ConfigVariables:          acctest.KibanaConnectionVariables(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "tcp"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.16.0"),
@@ -131,7 +129,7 @@ func TestAccResourceIntegration_kibanaConnection(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.Providers,
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccResourceIntegrationKibanaConnectionVariables(),
+				ConfigVariables:          acctest.KibanaConnectionVariables(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "tcp"),
 					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.17.0"),
@@ -142,31 +140,6 @@ func TestAccResourceIntegration_kibanaConnection(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccResourceIntegrationKibanaConnectionVariables() config.Variables {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-	kibanaEndpoint := strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))
-
-	return config.Variables{
-		"kibana_endpoints": config.ListVariable(
-			config.StringVariable(kibanaEndpoint),
-		),
-		"api_key":  config.StringVariable(apiKey),
-		"username": config.StringVariable(username),
-		"password": config.StringVariable(password),
-	}
 }
 
 func TestAccResourceIntegrationWithPolicy(t *testing.T) {

--- a/internal/fleet/integrationds/data_source_test.go
+++ b/internal/fleet/integrationds/data_source_test.go
@@ -133,7 +133,7 @@ func TestAccDataSourceIntegrationKibanaConnection(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.Providers,
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegrationDataSource),
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("read"),
-				ConfigVariables:          testAccIntegrationKibanaConnectionVariables(),
+				ConfigVariables:          acctest.KibanaConnectionVariables(),
 				Check: resource.ComposeTestCheckFunc(
 					append([]resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(integrationDataSourceResourceName, "id"),
@@ -143,7 +143,7 @@ func TestAccDataSourceIntegrationKibanaConnection(t *testing.T) {
 						resource.TestCheckResourceAttr(integrationDataSourceResourceName, "kibana_connection.0.endpoints.#", "1"),
 						resource.TestCheckResourceAttr(integrationDataSourceResourceName, "kibana_connection.0.endpoints.0", strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))),
 						resource.TestCheckResourceAttr(integrationDataSourceResourceName, "kibana_connection.0.insecure", "false"),
-					}, testAccIntegrationKibanaConnectionAuthChecks()...)...,
+					}, acctest.KibanaConnectionAuthChecks(integrationDataSourceResourceName)...)...,
 				),
 			},
 		},
@@ -207,56 +207,4 @@ func fleetPackageVersion(packageName string, prerelease bool, spaceID string) (s
 	}
 
 	return "", fmt.Errorf("%w: %q (prerelease=%t, space_id=%q)", errFleetPackageNotFound, packageName, prerelease, spaceID)
-}
-
-func testAccIntegrationKibanaConnectionVariables() config.Variables {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-
-	return config.Variables{
-		"kibana_endpoints": config.ListVariable(config.StringVariable(strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT")))),
-		"api_key":          config.StringVariable(apiKey),
-		"username":         config.StringVariable(username),
-		"password":         config.StringVariable(password),
-	}
-}
-
-func testAccIntegrationKibanaConnectionAuthChecks() []resource.TestCheckFunc {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-
-	if apiKey != "" {
-		return []resource.TestCheckFunc{
-			resource.TestCheckResourceAttr(integrationDataSourceResourceName, "kibana_connection.0.api_key", apiKey),
-		}
-	}
-
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-
-	return []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(integrationDataSourceResourceName, "kibana_connection.0.username", username),
-		resource.TestCheckResourceAttr(integrationDataSourceResourceName, "kibana_connection.0.password", password),
-	}
 }

--- a/internal/fleet/outputds/acc_test.go
+++ b/internal/fleet/outputds/acc_test.go
@@ -143,7 +143,7 @@ func TestAccDataSourceOutputKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionOutput),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("data"),
-				ConfigVariables:          testAccOutputKibanaConnectionVariables(),
+				ConfigVariables:          acctest.KibanaConnectionVariables(),
 				Check: resource.ComposeTestCheckFunc(
 					append([]resource.TestCheckFunc{
 						resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "id", "outputs"),
@@ -152,63 +152,11 @@ func TestAccDataSourceOutputKibanaConnection(t *testing.T) {
 						resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "kibana_connection.0.endpoints.#", "1"),
 						resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "kibana_connection.0.endpoints.0", strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))),
 						resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "kibana_connection.0.insecure", "false"),
-					}, testAccOutputKibanaConnectionAuthChecks()...)...,
+					}, acctest.KibanaConnectionAuthChecks("data.elasticstack_fleet_output.test")...)...,
 				),
 			},
 		},
 	})
-}
-
-func testAccOutputKibanaConnectionVariables() config.Variables {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-
-	return config.Variables{
-		"kibana_endpoints": config.ListVariable(config.StringVariable(strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT")))),
-		"api_key":          config.StringVariable(apiKey),
-		"username":         config.StringVariable(username),
-		"password":         config.StringVariable(password),
-	}
-}
-
-func testAccOutputKibanaConnectionAuthChecks() []resource.TestCheckFunc {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-
-	if apiKey != "" {
-		return []resource.TestCheckFunc{
-			resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "kibana_connection.0.api_key", apiKey),
-		}
-	}
-
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-
-	return []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "kibana_connection.0.username", username),
-		resource.TestCheckResourceAttr("data.elasticstack_fleet_output.test", "kibana_connection.0.password", password),
-	}
 }
 
 //nolint:unparam // resourceName is always the same in tests but kept for API consistency with other helpers

--- a/internal/kibana/agentbuildertool/acc_test.go
+++ b/internal/kibana/agentbuildertool/acc_test.go
@@ -19,9 +19,7 @@ package agentbuildertool_test
 
 import (
 	"fmt"
-	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -133,7 +131,9 @@ func TestAccResourceAgentBuilderToolEsqlKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "tool_id", toolID),
 					resource.TestCheckResourceAttr(resourceID, "space_id", "default"),
@@ -147,11 +147,13 @@ func TestAccResourceAgentBuilderToolEsqlKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
-				ResourceName:             resourceID,
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"kibana_connection"},
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
+				ResourceName:            resourceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kibana_connection"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					return s.RootModule().Resources[resourceID].Primary.ID, nil
 				},
@@ -160,7 +162,9 @@ func TestAccResourceAgentBuilderToolEsqlKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "tool_id", toolID),
 					resource.TestCheckResourceAttr(resourceID, "description", "Updated ES|QL tool (kibana_connection)"),
@@ -173,43 +177,19 @@ func TestAccResourceAgentBuilderToolEsqlKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
-				ResourceName:             resourceID,
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"kibana_connection"},
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
+				ResourceName:            resourceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kibana_connection"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					return s.RootModule().Resources[resourceID].Primary.ID, nil
 				},
 			},
 		},
 	})
-}
-
-func testAccKibanaBuilderToolKibanaConnectionVariables(toolID string) config.Variables {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-	kibanaEndpoint := strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))
-
-	return config.Variables{
-		"tool_id": config.StringVariable(toolID),
-		"kibana_endpoints": config.ListVariable(
-			config.StringVariable(kibanaEndpoint),
-		),
-		"api_key":  config.StringVariable(apiKey),
-		"username": config.StringVariable(username),
-		"password": config.StringVariable(password),
-	}
 }
 
 func TestAccResourceAgentBuilderToolEsqlSpace(t *testing.T) {
@@ -342,7 +322,9 @@ func TestAccResourceAgentBuilderToolWorkflowKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderWorkflowAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "tool_id", toolID),
 					resource.TestCheckResourceAttr(resourceID, "type", "workflow"),
@@ -355,11 +337,13 @@ func TestAccResourceAgentBuilderToolWorkflowKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderWorkflowAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
-				ResourceName:             resourceID,
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"kibana_connection"},
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
+				ResourceName:            resourceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kibana_connection"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					return s.RootModule().Resources[resourceID].Primary.ID, nil
 				},
@@ -368,7 +352,9 @@ func TestAccResourceAgentBuilderToolWorkflowKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderWorkflowAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceID, "tool_id", toolID),
 					resource.TestCheckResourceAttr(resourceID, "description", "Updated workflow tool (kibana_connection)"),
@@ -381,11 +367,13 @@ func TestAccResourceAgentBuilderToolWorkflowKibanaConnection(t *testing.T) {
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minKibanaAgentBuilderWorkflowAPIVersion),
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
-				ConfigVariables:          testAccKibanaBuilderToolKibanaConnectionVariables(toolID),
-				ResourceName:             resourceID,
-				ImportState:              true,
-				ImportStateVerify:        true,
-				ImportStateVerifyIgnore:  []string{"kibana_connection"},
+				ConfigVariables: acctest.KibanaConnectionVariables(config.Variables{
+					"tool_id": config.StringVariable(toolID),
+				}),
+				ResourceName:            resourceID,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"kibana_connection"},
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					return s.RootModule().Resources[resourceID].Primary.ID, nil
 				},


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/2462

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate Kibana connection test setup into shared `acctest` helpers
> - Adds `KibanaConnectionVariables` and `KibanaConnectionAuthChecks` to [kibana_connection.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2463/files#diff-6bb3d917784fe6a567e442bc0090c10271db7578c54104127b0ffba61d86ec27) as shared helpers for acceptance tests, replacing per-package duplicates.
> - `KibanaConnectionVariables` reads the Kibana endpoint and auth (API key or username/password) from environment variables, with fallback from `KIBANA_*` to `ELASTICSEARCH_*` vars, and merges any caller-supplied variables.
> - `KibanaConnectionAuthChecks` returns the appropriate `TestCheckFunc` slice based on which auth env vars are set.
> - Removes local copies of these helpers from five test files across `apm`, `fleet`, and `kibana` packages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7554347.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->