### PR TITLE
Auto generate skill for agent-skills-sandbox repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,14 @@ workflow-test: ## Run unit tests for workflow source generation
 check-workflows: ## Check generated workflow markdown sources
 	@ go run ./scripts/compile-workflow-sources --manifest .github/workflows-src/manifest.json --check --verbose
 
+.PHONY: skill-generate
+skill-generate: ## Generate the elasticstack-terraform agent skill into dist/skill/
+	@ go run ./scripts/generate-skill -provider-version $(VERSION)
+
+.PHONY: skill-test
+skill-test: ## Run unit tests for the skill generator
+	@ go test ./scripts/generate-skill/... -count=1
+
 .PHONY: gen
 gen: docs-generate ## Generate the code and documentation
 	@ go generate ./...

--- a/scripts/generate-skill/README.md
+++ b/scripts/generate-skill/README.md
@@ -1,0 +1,76 @@
+# generate-skill
+
+Generates an agent Skill directory (`dist/skill/elasticstack-terraform/`) that teaches coding agents how to write Terraform configuration against the `elastic/elasticstack` provider.
+
+## Why
+
+Manually maintaining a skill for 100+ resources and data sources is not tractable and would drift instantly. This generator treats `openspec/specs/` as the authoritative schema source, merges it with the `docs/` output from tfplugindocs, and layers in hand-seeded static content from `assets/`.
+
+## Design principles
+
+- **Progressive disclosure.** The top-level `SKILL.md` is a small router (< 150 lines). The per-entity detail, the entity index, the provider block reference, and the gotchas live in separate files that the agent loads only when a task calls for them.
+- **Deterministic.** No timestamps or network calls in content. Rerunning the generator on the same inputs produces byte-identical output.
+- **No third-party dependencies.** Standard library only.
+
+## Output layout
+
+```
+dist/skill/elasticstack-terraform/
+├── SKILL.md                        # Copied verbatim from assets/SKILL.md
+├── GENERATED.md                    # Provenance (generated)
+└── references/
+    ├── index.md                    # assets/references/index.md with {{ENTITIES}} substituted
+    ├── context-checklist.md        # Copied verbatim from assets/
+    ├── provider.md                 # Copied verbatim from assets/
+    ├── gotchas.md                  # Copied verbatim from assets/
+    ├── resources/<short_name>.md   # Generated (one per resource)
+    └── data-sources/<short_name>.md # Generated (one per data source)
+```
+
+## What you can hand-edit
+
+Everything under `assets/` is hand-editable Markdown. The generator copies it into the output tree unchanged, except for `references/index.md` where `{{ENTITIES}}` is replaced with the Markdown entity table. Edit `assets/SKILL.md`, `assets/references/provider.md`, etc. freely — no Go changes required.
+
+The per-entity files under `references/resources/` and `references/data-sources/` are fully generated from `openspec/specs/` + `docs/`. If you need to change their shape, edit `scripts/generate-skill/emit.go` (`writeEntityRef`).
+
+## Running
+
+```sh
+make skill-generate      # writes to dist/skill/elasticstack-terraform/
+make skill-test          # runs the parser unit tests
+```
+
+Custom invocation:
+
+```sh
+go run ./scripts/generate-skill \
+  -specs openspec/specs \
+  -docs  docs \
+  -assets scripts/generate-skill/assets \
+  -out   dist/skill/elasticstack-terraform \
+  -provider-version 0.14.4 \
+  -v
+```
+
+## Inputs
+
+- `openspec/specs/<capability>/spec.md` — authoritative schema and requirements. Parser extracts:
+  - H1 entity name (`elasticstack_*`)
+  - `Resource implementation:` / `Data source implementation:` lines
+  - `## Purpose` and `## Schema` sections
+  - Requirement sentences matching gotcha needles (force-new, deletion, version gates, JSON handling, import, connection)
+- `docs/resources/*.md` and `docs/data-sources/*.md` — tfplugindocs output. Parser extracts:
+  - Frontmatter `subcategory` and `description`
+  - First `terraform` fenced block after `## Example Usage`
+- `scripts/generate-skill/assets/` — hand-edited Markdown, copied verbatim. `assets/references/index.md` must contain the `{{ENTITIES}}` placeholder.
+
+## Editing the skill
+
+- To change wording, add guidance, or restructure non-per-entity pages: edit the corresponding file under `assets/` and rerun `make skill-generate`.
+- To add a new hand-authored page: drop a file into `assets/<rel_path>` and link to it from `assets/SKILL.md`. It will be copied to `dist/skill/elasticstack-terraform/<rel_path>`.
+- To change how per-entity files look: edit `emit.go` (`writeEntityRef`).
+- To change how the entity index tables are rendered: edit `emit.go` (`renderEntityTables`).
+
+## Tests
+
+`entities_test.go` pins the spec/docs parsers so changes to the upstream format fail loudly.

--- a/scripts/generate-skill/README.md
+++ b/scripts/generate-skill/README.md
@@ -4,11 +4,12 @@ Generates an agent Skill directory (`dist/skill/elasticstack-terraform/`) that t
 
 ## Why
 
-Manually maintaining a skill for 100+ resources and data sources is not tractable and would drift instantly. This generator treats `openspec/specs/` as the authoritative schema source, merges it with the `docs/` output from tfplugindocs, and layers in hand-seeded static content from `assets/`.
+Manually maintaining a skill for 100+ resources and data sources is not tractable and would drift instantly. This generator uses `docs/` (tfplugindocs output) as the sole source of truth and layers in hand-seeded static content from `assets/`.
 
 ## Design principles
 
-- **Progressive disclosure.** The top-level `SKILL.md` is a small router (< 150 lines). The per-entity detail, the entity index, the provider block reference, and the gotchas live in separate files that the agent loads only when a task calls for them.
+- **Progressive disclosure.** The top-level `SKILL.md` is a small router. The per-entity detail, the entity index, the provider block reference, and the gotchas live in separate files that the agent loads only when a task calls for them.
+- **Docs as source of truth.** Per-entity reference files are the docs pages copied verbatim — no re-rendering, no drift.
 - **Deterministic.** No timestamps or network calls in content. Rerunning the generator on the same inputs produces byte-identical output.
 - **No third-party dependencies.** Standard library only.
 
@@ -16,35 +17,35 @@ Manually maintaining a skill for 100+ resources and data sources is not tractabl
 
 ```
 dist/skill/elasticstack-terraform/
-├── SKILL.md                        # Copied verbatim from assets/SKILL.md
-├── GENERATED.md                    # Provenance (generated)
+├── SKILL.md                         # Copied verbatim from assets/SKILL.md
+├── GENERATED.md                     # Provenance (generated)
 └── references/
-    ├── index.md                    # assets/references/index.md with {{ENTITIES}} substituted
-    ├── context-checklist.md        # Copied verbatim from assets/
-    ├── provider.md                 # Copied verbatim from assets/
-    ├── gotchas.md                  # Copied verbatim from assets/
-    ├── resources/<short_name>.md   # Generated (one per resource)
-    └── data-sources/<short_name>.md # Generated (one per data source)
+    ├── index.md                     # assets/references/index.md with {{ENTITIES}} substituted
+    ├── context-checklist.md         # Copied verbatim from assets/
+    ├── provider.md                  # Copied verbatim from assets/
+    ├── gotchas.md                   # Copied verbatim from assets/
+    ├── elastic-docs.md              # Copied verbatim from assets/
+    ├── resources/<short_name>.md    # Copied verbatim from docs/resources/
+    └── data-sources/<short_name>.md # Copied verbatim from docs/data-sources/
 ```
 
 ## What you can hand-edit
 
-Everything under `assets/` is hand-editable Markdown. The generator copies it into the output tree unchanged, except for `references/index.md` where `{{ENTITIES}}` is replaced with the Markdown entity table. Edit `assets/SKILL.md`, `assets/references/provider.md`, etc. freely — no Go changes required.
+Everything under `assets/` is hand-editable Markdown. The generator copies it into the output tree unchanged, except for `references/index.md` where `{{ENTITIES}}` is replaced with the generated entity list. Edit `assets/SKILL.md`, `assets/references/provider.md`, etc. freely — no Go changes required.
 
-The per-entity files under `references/resources/` and `references/data-sources/` are fully generated from `openspec/specs/` + `docs/`. If you need to change their shape, edit `scripts/generate-skill/emit.go` (`writeEntityRef`).
+The per-entity files under `references/resources/` and `references/data-sources/` are copied verbatim from `docs/`. To change them, update the docs source and rerun the generator.
 
 ## Running
 
 ```sh
 make skill-generate      # writes to dist/skill/elasticstack-terraform/
-make skill-test          # runs the parser unit tests
+make skill-test          # runs unit tests
 ```
 
 Custom invocation:
 
 ```sh
 go run ./scripts/generate-skill \
-  -specs openspec/specs \
   -docs  docs \
   -assets scripts/generate-skill/assets \
   -out   dist/skill/elasticstack-terraform \
@@ -54,23 +55,15 @@ go run ./scripts/generate-skill \
 
 ## Inputs
 
-- `openspec/specs/<capability>/spec.md` — authoritative schema and requirements. Parser extracts:
-  - H1 entity name (`elasticstack_*`)
-  - `Resource implementation:` / `Data source implementation:` lines
-  - `## Purpose` and `## Schema` sections
-  - Requirement sentences matching gotcha needles (force-new, deletion, version gates, JSON handling, import, connection)
-- `docs/resources/*.md` and `docs/data-sources/*.md` — tfplugindocs output. Parser extracts:
-  - Frontmatter `subcategory` and `description`
-  - First `terraform` fenced block after `## Example Usage`
+- `docs/resources/*.md` and `docs/data-sources/*.md` — tfplugindocs output, copied verbatim into the skill. Frontmatter `description` is also used to build the entity index.
 - `scripts/generate-skill/assets/` — hand-edited Markdown, copied verbatim. `assets/references/index.md` must contain the `{{ENTITIES}}` placeholder.
 
 ## Editing the skill
 
-- To change wording, add guidance, or restructure non-per-entity pages: edit the corresponding file under `assets/` and rerun `make skill-generate`.
-- To add a new hand-authored page: drop a file into `assets/<rel_path>` and link to it from `assets/SKILL.md`. It will be copied to `dist/skill/elasticstack-terraform/<rel_path>`.
-- To change how per-entity files look: edit `emit.go` (`writeEntityRef`).
-- To change how the entity index tables are rendered: edit `emit.go` (`renderEntityTables`).
+- To change wording or add guidance to non-per-entity pages: edit the corresponding file under `assets/` and rerun `make skill-generate`.
+- To add a new hand-authored page: drop a file into `assets/<rel_path>` and link to it from `assets/SKILL.md`.
+- To change how the entity index list is rendered: edit `emit.go` (`renderEntityList`).
 
 ## Tests
 
-`entities_test.go` pins the spec/docs parsers so changes to the upstream format fail loudly.
+`entities_test.go` covers the docs frontmatter parser and entity discovery logic.

--- a/scripts/generate-skill/assets/SKILL.md
+++ b/scripts/generate-skill/assets/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: terraform-elasticstack-provider
 description: >
-  Author Terraform configuration that uses the elastic/elasticstack provider to manage Elasticsearch, Kibana, Fleet,
-  and APM resources and data sources. Use when writing, reviewing, or refactoring .tf files that reference
+  Author Terraform configuration that uses the elastic/elasticstack provider to manage Elasticsearch, Kibana, and Fleet
+  resources and data sources. Use when writing, reviewing, or refactoring .tf files that reference
   elasticstack_* resources or data sources, or that configure the elasticstack provider block. Covers schema lookup,
   lifecycle semantics, provider connections, and common gotchas.
 compatibility: "Terraform 1.0+, elasticstack ~> 0.14"
@@ -20,7 +20,7 @@ Author correct HCL for the `elastic/elasticstack` Terraform provider. The author
 
 Follow these steps, in order, before emitting HCL.
 
-1. Capture context. Record Terraform version, target provider version, target stack flavor (Elasticsearch Cloud, Serverless, ECK, self-hosted), and which subsystems the user needs (Elasticsearch, Kibana, Fleet, APM). See [references/context-checklist.md](references/context-checklist.md).
+1. Capture context. Record Terraform version, target provider version, target stack flavor (Elasticsearch Cloud, Serverless, ECK, self-hosted), and which subsystems the user needs (Elasticsearch, Kibana, Fleet). See [references/context-checklist.md](references/context-checklist.md).
 2. Pick the entity. Consult [references/index.md](references/index.md) to find the `elasticstack_*` resource or data source that matches the task.
 3. Load the per-entity file from `references/resources/` or `references/data-sources/`. Read the schema block, the lifecycle notes, and the example. Do not guess attribute names.
 4. Emit the provider block. Follow [references/provider.md](references/provider.md) for `required_providers`, auth environment variables, and per-subsystem connection blocks.
@@ -75,7 +75,7 @@ Follow these steps, in order, before emitting HCL.
 
 - Emit a `required_providers` block that pins `elastic/elasticstack` to an exact or `~>` version on every new configuration.
 - Use `jsonencode({...})` for every JSON-shaped attribute (mappings, settings, queries, metadata, role `global` / `metadata`, ingest processors, alert params). Never embed raw JSON strings.
-- Prefer the provider-level `elasticsearch {}` / `kibana {}` / `fleet {}` / `apm {}` blocks. Do not mix them with per-resource `elasticsearch_connection {}` blocks — the latter is deprecated on most resources.
+- Prefer the provider-level `elasticsearch {}` / `kibana {}` / `fleet {}` blocks. Do not mix them with per-resource `elasticsearch_connection {}` blocks — the latter is deprecated on most resources.
 - Source credentials from environment variables or variables. Never inline secrets as string literals in HCL.
 - Treat the per-entity reference files as authoritative for attribute names, types, defaults, and lifecycle. Do not guess from memory.
 - When a user targets Elastic Cloud Serverless, verify the resource is supported there before emitting HCL. See `references/gotchas.md`.

--- a/scripts/generate-skill/assets/SKILL.md
+++ b/scripts/generate-skill/assets/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: terraform-elasticstack-provider
+description: >
+  Author Terraform configuration that uses the elastic/elasticstack provider to manage Elasticsearch, Kibana, Fleet,
+  and APM resources and data sources. Use when writing, reviewing, or refactoring .tf files that reference
+  elasticstack_* resources or data sources, or that configure the elasticstack provider block. Covers schema lookup,
+  lifecycle semantics, provider connections, and common gotchas.
+compatibility: "Terraform 1.0+, elasticstack ~> 0.14"
+metadata:
+  author: terraform-providers-admins
+  version: "{{VERSION}}"
+  visibility: internal
+---
+
+# Terraform elasticstack Provider
+
+Author correct HCL for the `elastic/elasticstack` Terraform provider. The authoritative schema for each resource and data source lives under `references/` and loads on demand. Treat the per-entity reference file as the source of truth for attribute names, types, defaults, and lifecycle behavior.
+
+## Workflow
+
+Follow these steps, in order, before emitting HCL.
+
+1. Capture context. Record Terraform version, target provider version, target stack flavor (Elasticsearch Cloud, Serverless, ECK, self-hosted), and which subsystems the user needs (Elasticsearch, Kibana, Fleet, APM). See [references/context-checklist.md](references/context-checklist.md).
+2. Pick the entity. Consult [references/index.md](references/index.md) to find the `elasticstack_*` resource or data source that matches the task.
+3. Load the per-entity file from `references/resources/` or `references/data-sources/`. Read the schema block, the lifecycle notes, and the example. Do not guess attribute names.
+4. Emit the provider block. Follow [references/provider.md](references/provider.md) for `required_providers`, auth environment variables, and per-subsystem connection blocks.
+5. Cross-check against [references/gotchas.md](references/gotchas.md). Verify JSON attributes, deletion protection, connection precedence, and version gates before finalizing.
+6. For content inside JSON-shaped attributes (mapping field types, query DSL, ingest processor bodies, detection rule params, ILM actions, Kibana rule params) consult [references/elastic-docs.md](references/elastic-docs.md). Do not guess JSON content.
+
+## When to load which reference
+
+| Scenario | Load |
+|---|---|
+| Starting a new configuration | `references/context-checklist.md`, then `references/provider.md` |
+| Writing a specific resource (e.g. `elasticstack_kibana_alerting_rule`) | `references/resources/<short_name>.md` |
+| Reading state with a data source | `references/data-sources/<short_name>.md` |
+| Auth, connections, or multi-stack setup | `references/provider.md` |
+| Error or unexpected plan diff | `references/gotchas.md` |
+| Discovering what's available | `references/index.md` |
+| Authoring JSON content (mappings, queries, rule params) inside HCL | `references/elastic-docs.md` |
+
+## Examples
+
+### User asks for an index with a mapping
+
+> "Create an Elasticsearch index named `events` with a keyword field `user.id` and a text field `message`."
+
+1. Load `references/resources/elasticsearch_index.md` for the schema.
+2. Load `references/elastic-docs.md` only if the user's mapping requires field types you need to verify.
+3. Emit HCL with `required_providers`, a `provider "elasticstack"` block, and a resource using `jsonencode` for `mappings`.
+
+### User asks for a Kibana alerting rule
+
+> "Create a Kibana alerting rule that fires when error count exceeds 10 in 5 minutes."
+
+1. Load `references/resources/kibana_alerting_rule.md` for the schema.
+2. Load `references/elastic-docs.md` to confirm the `params` JSON shape for the rule type.
+3. Emit HCL with `jsonencode` around `params`.
+
+### User hits `deletion_protection` error on destroy
+
+> "Terraform refuses to destroy my `elasticstack_elasticsearch_index`."
+
+1. Load `references/gotchas.md` (section on deletion protection).
+2. Explain the two-step removal: set `deletion_protection = false` and apply, then remove the resource.
+
+### User asks about an attribute that does not exist
+
+> "What's the `retention` attribute on `elasticstack_elasticsearch_index`?"
+
+1. Load `references/resources/elasticsearch_index.md` and confirm no such attribute exists.
+2. Tell the user plainly. Suggest the closest real feature (e.g. ILM policy via `elasticstack_elasticsearch_index_lifecycle`) and link to its reference file.
+
+## Guidelines
+
+- Emit a `required_providers` block that pins `elastic/elasticstack` to an exact or `~>` version on every new configuration.
+- Use `jsonencode({...})` for every JSON-shaped attribute (mappings, settings, queries, metadata, role `global` / `metadata`, ingest processors, alert params). Never embed raw JSON strings.
+- Prefer the provider-level `elasticsearch {}` / `kibana {}` / `fleet {}` / `apm {}` blocks. Do not mix them with per-resource `elasticsearch_connection {}` blocks — the latter is deprecated on most resources.
+- Source credentials from environment variables or variables. Never inline secrets as string literals in HCL.
+- Treat the per-entity reference files as authoritative for attribute names, types, defaults, and lifecycle. Do not guess from memory.
+- When a user targets Elastic Cloud Serverless, verify the resource is supported there before emitting HCL. See `references/gotchas.md`.
+- When a change will destroy data (force-new attributes on stateful resources like indices), call it out explicitly and recommend a reviewed `terraform plan` and a `moved` block or manual reindex.
+- Return the output contract for every generated configuration: assumptions, required provider version, the HCL, and a `terraform init` + `terraform plan` validation plan.

--- a/scripts/generate-skill/assets/references/context-checklist.md
+++ b/scripts/generate-skill/assets/references/context-checklist.md
@@ -24,7 +24,6 @@ If the user hasn't said, ask — or state an assumption (default: hosted ESS, cu
 - [ ] Elasticsearch — always required to configure the `elasticsearch {}` provider block.
 - [ ] Kibana resources? Configure `kibana {}`.
 - [ ] Fleet resources? Configure `fleet {}` (Fleet server URL + service token).
-- [ ] APM resources? Configure `apm {}`.
 
 ## State backend and delivery
 

--- a/scripts/generate-skill/assets/references/context-checklist.md
+++ b/scripts/generate-skill/assets/references/context-checklist.md
@@ -1,0 +1,37 @@
+# Pre-flight context checklist
+
+Capture these before writing HCL. State assumptions explicitly when the user hasn't said.
+
+## Runtime and version
+
+- [ ] Minimum Terraform version?
+- [ ] Target `elastic/elasticstack` provider version (pin with `version = "~> X.Y"` or exact).
+- [ ] Is `elastic/ec` (Elastic Cloud) also in play? It's a separate provider.
+
+## Stack flavor
+
+Pick one — behavior differs:
+
+- Elastic Cloud (Elasticsearch Service / ESS) hosted deployment
+- Elastic Cloud Serverless (many stack APIs are unavailable or differently shaped)
+- Elastic Cloud on Kubernetes (ECK)
+- Self-hosted / on-prem Elastic Stack
+
+If the user hasn't said, ask — or state an assumption (default: hosted ESS, current major).
+
+## Subsystems
+
+- [ ] Elasticsearch — always required to configure the `elasticsearch {}` provider block.
+- [ ] Kibana resources? Configure `kibana {}`.
+- [ ] Fleet resources? Configure `fleet {}` (Fleet server URL + service token).
+- [ ] APM resources? Configure `apm {}`.
+
+## State backend and delivery
+
+- [ ] Where does state live? Remote backend or local?
+- [ ] Is there CI enforcing plan/apply separation?
+- [ ] Anything production-critical in scope? If so, require a reviewed plan before apply.
+
+## Authentication
+
+Prefer environment variables over inline credentials. See `references/provider.md`.

--- a/scripts/generate-skill/assets/references/elastic-docs.md
+++ b/scripts/generate-skill/assets/references/elastic-docs.md
@@ -1,0 +1,68 @@
+# Consulting Elastic documentation
+
+Use this reference when the task requires **content inside JSON-shaped Terraform attributes** — mapping field types, query DSL, ingest processor bodies, detection rule params, ILM phase actions, Kibana alerting rule params, inference model parameters, role query DSL. Consult the Elastic docs to verify the shape of that JSON **before** emitting it inside `jsonencode(...)`.
+
+## When to consult Elastic docs
+
+Consult external Elastic documentation when the user asks about:
+
+- Mapping field types, analyzers, or mapping parameters (e.g. `copy_to`, `fields`, `index_options`).
+- Query DSL shape for `filter`, `query`, or `post_filter` attributes.
+- Ingest processor bodies beyond what's in `elasticstack_elasticsearch_ingest_processor_*` helpers.
+- Alerting rule `params` or action parameters for a specific rule type.
+- Detection rule `query` / `threshold` / `threat_mapping` content.
+- ILM policy phase actions and their parameters.
+- Inference endpoint `service_settings` or `task_settings`.
+- Model IDs, tokenizer names, or any Elastic Stack version-specific behavior.
+
+## When NOT to consult Elastic docs
+
+Do not consult external docs for:
+
+- Terraform attribute names, types, defaults, required/optional status, or force-new semantics — use `references/resources/<short_name>.md` or `references/data-sources/<short_name>.md`.
+- Provider authentication, connection blocks, or `required_providers` — use `references/provider.md`.
+- Deletion protection, JSON normalization, or connection precedence — use `references/gotchas.md`.
+
+The per-entity reference files are generated from the provider source and are more accurate than docs for Terraform-surface questions.
+
+## Preferred tool order
+
+1. The `elastic-docs` MCP server, if the agent runtime has it configured. Use `search_docs` to find the right page, then `get_document_by_url` to read it.
+2. If the MCP server is not configured, show the user the configuration snippet below and offer to continue without it.
+3. If no docs lookup is available, ask the user to share the relevant Elastic docs link and proceed with their content.
+
+## MCP configuration snippet
+
+Endpoint: `https://www.elastic.co/docs/_mcp/`
+
+Cursor / Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "elastic-docs": {
+      "url": "https://www.elastic.co/docs/_mcp/"
+    }
+  }
+}
+```
+
+VS Code:
+
+```json
+{
+  "servers": {
+    "elastic-docs": {
+      "type": "http",
+      "url": "https://www.elastic.co/docs/_mcp/"
+    }
+  }
+}
+```
+
+## Output rules for docs-sourced content
+
+- Wrap every JSON fragment from docs with `jsonencode({...})` before placing it in HCL. Never embed as a raw string literal.
+- Translate JSON `true` / `false` / `null` to HCL `true` / `false` / `null` inside `jsonencode`.
+- When docs show a sample across multiple Elastic Stack versions, pick the one matching the user's target version. Surface the version as part of the assumptions in your output.
+- Cite the docs URL in a code comment above the attribute when the content is non-obvious.

--- a/scripts/generate-skill/assets/references/gotchas.md
+++ b/scripts/generate-skill/assets/references/gotchas.md
@@ -1,0 +1,78 @@
+# Gotchas and anti-patterns
+
+Load this when finalizing HCL or when diagnosing an unexpected plan diff.
+
+## JSON-shaped attributes
+
+Many resources accept JSON strings: `mappings`, `settings`, index/security role `query`, `metadata`, `global`, ingest pipeline `processors`, etc. Always use `jsonencode`:
+
+```terraform
+mappings = jsonencode({
+  properties = {
+    field1 = { type = "keyword" }
+  }
+})
+```
+
+The provider normalizes JSON server-side, so equivalent structures with different key order will not drift. But raw string literals with inconsistent whitespace WILL.
+
+## Deletion protection
+
+Resources like `elasticstack_elasticsearch_index` default `deletion_protection = true`. To actually delete the resource you must either:
+
+1. Set `deletion_protection = false`, apply that change, then remove the resource and apply again, OR
+2. Remove the resource from state with `terraform state rm` and delete the index out-of-band.
+
+Never destroy with protection enabled.
+
+## Forces-new attributes
+
+Many Elasticsearch resources have static settings that cannot be changed in place: `number_of_shards`, `codec`, analyzers, `name`. Changing them triggers a destroy + create. For indices this means data loss. Always verify with `terraform plan` and recommend `moved` / manual reindex for production.
+
+## Connection configuration precedence
+
+Order of precedence (highest to lowest):
+
+1. Provider alias (`provider = elasticstack.prod`) — preferred.
+2. Provider-level `elasticsearch {}` / `kibana {}` / `fleet {}` block — preferred when you have one stack.
+3. Per-resource `elasticsearch_connection {}` block — **deprecated** on most resources.
+
+Never mix (2) and (3) in the same root module; configuration becomes ambiguous.
+
+## Version gates
+
+Specific attributes require minimum stack versions. Examples:
+
+- `elasticstack_elasticsearch_security_role.description` — requires Elasticsearch >= 8.15.0.
+- New Kibana alerting rule types — gated per Kibana minor.
+- Fleet features — gated per Fleet major.
+
+When the user is on an older stack, omit the attribute rather than setting it to null. The spec for each resource in `references/resources/<name>.md` lists the gates.
+
+## Serverless caveats
+
+Elastic Cloud Serverless does not expose every on-prem / ESS API. Common gaps:
+
+- Cluster-level settings (`elasticsearch_cluster_settings`) are not user-configurable.
+- ILM / snapshot repositories are managed by the platform.
+- Some ML, Watcher, and node-level APIs are unavailable.
+
+If the user targets Serverless and wants one of these, flag it rather than emitting HCL that will fail at apply time.
+
+## Import IDs
+
+Most resources use composite IDs. Patterns you will see:
+
+- `<cluster_uuid>/<name>` for Elasticsearch resources scoped to a cluster.
+- `<space_id>/<id>` for Kibana resources scoped to a space.
+- Bare name for cluster-level singletons.
+
+The per-entity spec documents the exact format; consult it before writing `terraform import` commands.
+
+## Computed-vs-optional attributes
+
+Many attributes are `optional+computed` with `UseStateForUnknown`. If you omit them, the server fills them in and Terraform tracks the value. Do NOT set them to empty strings / zero — that causes drift. Just omit the attribute.
+
+## Reading what you write
+
+For debugging use the matching `data.elasticstack_*` data source rather than hand-crafting API calls. Most resources have a paired data source (see `references/data-sources/`).

--- a/scripts/generate-skill/assets/references/index.md
+++ b/scripts/generate-skill/assets/references/index.md
@@ -1,0 +1,7 @@
+# Elasticstack entity index
+
+Every Terraform resource and data source exposed by the `elastic/elasticstack` provider. Load the linked per-entity file for the authoritative schema, lifecycle notes, and example.
+
+Entities are grouped by subcategory. Within each group, resources and data sources with the same short name share a reference file — the right column always links to the file you should read.
+
+{{ENTITIES}}

--- a/scripts/generate-skill/assets/references/index.md
+++ b/scripts/generate-skill/assets/references/index.md
@@ -1,7 +1,5 @@
 # Elasticstack entity index
 
-Every Terraform resource and data source exposed by the `elastic/elasticstack` provider. Load the linked per-entity file for the authoritative schema, lifecycle notes, and example.
-
-Entities are grouped by subcategory. Within each group, resources and data sources with the same short name share a reference file — the right column always links to the file you should read.
+Every Terraform resource and data source exposed by the `elastic/elasticstack` provider. Load the linked file for the full schema and example usage.
 
 {{ENTITIES}}

--- a/scripts/generate-skill/assets/references/provider.md
+++ b/scripts/generate-skill/assets/references/provider.md
@@ -1,0 +1,98 @@
+# Provider configuration
+
+## required_providers
+
+Always emit this, pinned:
+
+```terraform
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    elasticstack = {
+      source  = "elastic/elasticstack"
+      version = "~> 0.14"
+    }
+  }
+}
+```
+
+## Minimal provider block
+
+The provider supports four independent subsystems. Configure only what you use.
+
+```terraform
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+  fleet {}
+  apm {}
+}
+```
+
+Empty blocks pull credentials from environment variables. This is the preferred path — it keeps secrets out of HCL and state.
+
+## Environment variables
+
+| Subsystem | Endpoint env | Auth envs |
+|---|---|---|
+| Elasticsearch | `ELASTICSEARCH_ENDPOINTS` | `ELASTICSEARCH_USERNAME` + `ELASTICSEARCH_PASSWORD`, or `ELASTICSEARCH_API_KEY`, or `ELASTICSEARCH_BEARER_TOKEN` |
+| Kibana | `KIBANA_ENDPOINT` | `KIBANA_USERNAME` + `KIBANA_PASSWORD`, or `KIBANA_API_KEY` |
+| Fleet | `FLEET_ENDPOINT` | `FLEET_USERNAME` + `FLEET_PASSWORD`, `FLEET_API_KEY`, or a service token |
+| APM | `APM_ENDPOINT` | `APM_API_KEY`, `APM_SECRET_TOKEN`, or user/password |
+
+## Inline credentials (only when env vars are impractical)
+
+```terraform
+provider "elasticstack" {
+  elasticsearch {
+    endpoints = ["https://es.example:9243"]
+    api_key   = var.es_api_key
+  }
+  kibana {
+    endpoints = ["https://kibana.example:9243"]
+    api_key   = var.kibana_api_key
+  }
+}
+```
+
+Always source secrets from variables, never inline literals.
+
+## Multiple stacks
+
+Use provider aliases when managing more than one deployment:
+
+```terraform
+provider "elasticstack" {
+  alias = "prod"
+  elasticsearch { endpoints = [var.prod_es] }
+}
+
+provider "elasticstack" {
+  alias = "staging"
+  elasticsearch { endpoints = [var.staging_es] }
+}
+
+resource "elasticstack_elasticsearch_index" "prod_idx" {
+  provider = elasticstack.prod
+  name     = "events"
+}
+```
+
+## Elastic Cloud integration
+
+When also using `elastic/ec` to create deployments, feed outputs into `elasticstack`:
+
+```terraform
+provider "elasticstack" {
+  elasticsearch {
+    username  = ec_deployment.this.elasticsearch_username
+    password  = ec_deployment.this.elasticsearch_password
+    endpoints = [ec_deployment.this.elasticsearch.https_endpoint]
+  }
+  kibana {
+    username  = ec_deployment.this.elasticsearch_username
+    password  = ec_deployment.this.elasticsearch_password
+    endpoints = [ec_deployment.this.kibana.https_endpoint]
+  }
+}
+```

--- a/scripts/generate-skill/assets/references/provider.md
+++ b/scripts/generate-skill/assets/references/provider.md
@@ -25,7 +25,6 @@ provider "elasticstack" {
   elasticsearch {}
   kibana {}
   fleet {}
-  apm {}
 }
 ```
 

--- a/scripts/generate-skill/assets/references/provider.md
+++ b/scripts/generate-skill/assets/references/provider.md
@@ -37,7 +37,6 @@ Empty blocks pull credentials from environment variables. This is the preferred 
 | Elasticsearch | `ELASTICSEARCH_ENDPOINTS` | `ELASTICSEARCH_USERNAME` + `ELASTICSEARCH_PASSWORD`, or `ELASTICSEARCH_API_KEY`, or `ELASTICSEARCH_BEARER_TOKEN` |
 | Kibana | `KIBANA_ENDPOINT` | `KIBANA_USERNAME` + `KIBANA_PASSWORD`, or `KIBANA_API_KEY` |
 | Fleet | `FLEET_ENDPOINT` | `FLEET_USERNAME` + `FLEET_PASSWORD`, `FLEET_API_KEY`, or a service token |
-| APM | `APM_ENDPOINT` | `APM_API_KEY`, `APM_SECRET_TOKEN`, or user/password |
 
 ## Inline credentials (only when env vars are impractical)
 

--- a/scripts/generate-skill/emit.go
+++ b/scripts/generate-skill/emit.go
@@ -22,12 +22,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 )
 
 type generator struct {
 	entities        []*entity
+	docsDir         string
 	assetsDir       string
 	outDir          string
 	providerVersion string
@@ -51,16 +51,13 @@ func (g *generator) emit() error {
 		}
 	}
 
-	// Copy hand-editable templates first (SKILL.md, index.md, context-checklist.md,
-	// provider.md, gotchas.md). writeIndex then replaces the {{ENTITIES}} marker
-	// in index.md with the generated entity tables.
 	if err := g.copyStaticAssets(); err != nil {
 		return err
 	}
 	if err := g.writeIndex(); err != nil {
 		return err
 	}
-	if err := g.writePerEntityRefs(); err != nil {
+	if err := g.copyDocFiles(); err != nil {
 		return err
 	}
 	if err := g.writeProvenance(); err != nil {
@@ -69,78 +66,56 @@ func (g *generator) emit() error {
 	return nil
 }
 
-// indexEntitiesPlaceholder is replaced with the generated entity tables in
-// the hand-editable references/index.md template.
 const indexEntitiesPlaceholder = "{{ENTITIES}}"
 
-// writeIndex renders references/index.md by replacing {{ENTITIES}} in the
-// copied template with a Markdown table of every entity grouped by subcategory.
-// Only the table is generated; the surrounding prose is fully editable in
-// assets/references/index.md.
 func (g *generator) writeIndex() error {
 	path := filepath.Join(g.outDir, "references", "index.md")
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("read index template (expected copy of assets/references/index.md at %q): %w", path, err)
+		return fmt.Errorf("read index template: %w", err)
 	}
 	if !strings.Contains(string(raw), indexEntitiesPlaceholder) {
 		return fmt.Errorf("references/index.md template is missing %s placeholder", indexEntitiesPlaceholder)
 	}
-	rendered := strings.Replace(string(raw), indexEntitiesPlaceholder, g.renderEntityTables(), 1)
+	rendered := strings.Replace(string(raw), indexEntitiesPlaceholder, g.renderEntityList(), 1)
 	return os.WriteFile(path, []byte(rendered), 0o644)
 }
 
-// renderEntityTables produces the grouped Markdown tables that slot into the
-// index.md template's {{ENTITIES}} placeholder.
-func (g *generator) renderEntityTables() string {
-	groups := map[string][]*entity{}
-	for _, e := range g.entities {
-		cat := e.Subcategory
-		if cat == "" {
-			cat = inferSubcategory(e)
-		}
-		groups[cat] = append(groups[cat], e)
-	}
-	cats := make([]string, 0, len(groups))
-	for c := range groups {
-		cats = append(cats, c)
-	}
-	sort.Strings(cats)
-
+func (g *generator) renderEntityList() string {
 	var b strings.Builder
-	for _, cat := range cats {
-		b.WriteString("## " + cat + "\n\n")
-		b.WriteString("| Entity | Kind | Summary | Reference |\n")
-		b.WriteString("|---|---|---|---|\n")
-		ents := groups[cat]
-		sort.Slice(ents, func(i, j int) bool { return ents[i].Name < ents[j].Name })
-		for _, e := range ents {
-			kind := kindLabel(e.Kinds)
-			summary := oneLine(e.DocsSummary)
-			if summary == "" {
-				summary = oneLine(e.Purpose)
-			}
-			summary = truncate(summary, 120)
-			link := entityRefPath(e)
-			fmt.Fprintf(&b, "| `%s` | %s | %s | [%s](%s) |\n",
-				e.Name, kind, escapePipe(summary), filepath.Base(link), link)
+	for _, e := range g.entities {
+		if e.Kinds.has(kindResource) {
+			fmt.Fprintf(&b, "- `%s` (resource) — %s → references/resources/%s.md\n", e.Name, oneLine(e.ResourceSummary), e.ShortName)
 		}
-		b.WriteString("\n")
+		if e.Kinds.has(kindDataSource) {
+			fmt.Fprintf(&b, "- `%s` (data source) — %s → references/data-sources/%s.md\n", e.Name, oneLine(e.DataSrcSummary), e.ShortName)
+		}
 	}
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// writePerEntityRefs writes one reference file per entity. When an entity is
-// both resource and data source, we produce two files with cross-links.
-func (g *generator) writePerEntityRefs() error {
-	for _, e := range g.entities {
-		if e.Kinds.has(kindResource) {
-			if err := g.writeEntityRef(e, kindResource); err != nil {
+// copyDocFiles copies docs/resources/*.md and docs/data-sources/*.md verbatim
+// into references/resources/ and references/data-sources/.
+func (g *generator) copyDocFiles() error {
+	for _, sub := range []string{"resources", "data-sources"} {
+		src := filepath.Join(g.docsDir, sub)
+		dst := filepath.Join(g.outDir, "references", sub)
+		des, err := os.ReadDir(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("read %s: %w", src, err)
+		}
+		for _, de := range des {
+			if de.IsDir() || !strings.HasSuffix(de.Name(), ".md") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(src, de.Name()))
+			if err != nil {
 				return err
 			}
-		}
-		if e.Kinds.has(kindDataSource) {
-			if err := g.writeEntityRef(e, kindDataSource); err != nil {
+			if err := os.WriteFile(filepath.Join(dst, de.Name()), data, 0o644); err != nil {
 				return err
 			}
 		}
@@ -148,84 +123,6 @@ func (g *generator) writePerEntityRefs() error {
 	return nil
 }
 
-func (g *generator) writeEntityRef(e *entity, kind entityKind) error {
-	var b strings.Builder
-	label := "Resource"
-	impl := e.ResourceImpl
-	example := e.DocsExampleResource
-	if kind == kindDataSource {
-		label = "Data source"
-		impl = e.DataSourceImpl
-		example = e.DocsExampleDataSource
-	}
-
-	fmt.Fprintf(&b, "# `%s` (%s)\n\n", e.Name, strings.ToLower(label))
-
-	summary := oneLine(e.DocsSummary)
-	if summary == "" {
-		summary = oneLine(e.Purpose)
-	}
-	if summary != "" {
-		b.WriteString(summary + "\n\n")
-	}
-
-	b.WriteString("## Facts\n\n")
-	if e.Subcategory != "" {
-		b.WriteString("- Subcategory: " + e.Subcategory + "\n")
-	}
-	b.WriteString("- Kind: " + label + "\n")
-	if impl != "" {
-		b.WriteString("- Implementation: `" + impl + "`\n")
-	}
-	if kind == kindResource && e.Kinds.has(kindDataSource) {
-		b.WriteString("- See also: [data source](../data-sources/" + e.ShortName + ".md)\n")
-	}
-	if kind == kindDataSource && e.Kinds.has(kindResource) {
-		b.WriteString("- See also: [resource](../resources/" + e.ShortName + ".md)\n")
-	}
-	b.WriteString("- Spec: `openspec/specs/" + e.SpecCapability + "/spec.md`\n")
-	b.WriteString("\n")
-
-	if e.Schema != "" {
-		b.WriteString("## Schema\n\n")
-		b.WriteString(e.Schema)
-		b.WriteString("\n\n")
-	}
-
-	if example != "" {
-		b.WriteString("## Example\n\n")
-		b.WriteString("```terraform\n")
-		b.WriteString(example)
-		b.WriteString("\n```\n\n")
-	}
-
-	// Surface lifecycle / gotcha signals mined from the spec requirements.
-	if notes := mineSpecSignals(e.SpecBody); notes != "" {
-		b.WriteString("## Lifecycle & gotchas (from spec)\n\n")
-		b.WriteString(notes)
-		b.WriteString("\n\n")
-	}
-
-	b.WriteString("## Further reading\n\n")
-	b.WriteString("- Full requirements: `openspec/specs/" + e.SpecCapability + "/spec.md`\n")
-	if kind == kindResource && e.DocsResourcePath != "" {
-		b.WriteString("- Generated docs: `" + e.DocsResourcePath + "`\n")
-	}
-	if kind == kindDataSource && e.DocsDataSourcePath != "" {
-		b.WriteString("- Generated docs: `" + e.DocsDataSourcePath + "`\n")
-	}
-
-	sub := "resources"
-	if kind == kindDataSource {
-		sub = "data-sources"
-	}
-	path := filepath.Join(g.outDir, "references", sub, e.ShortName+".md")
-	return writeFile(path, b.String())
-}
-
-// copyStaticAssets copies hand-seeded content from the assets dir into the
-// skill output, applying template substitutions (currently {{VERSION}}) on
-// Markdown files. Non-Markdown files are copied byte-for-byte.
 func (g *generator) copyStaticAssets() error {
 	if _, err := os.Stat(g.assetsDir); os.IsNotExist(err) {
 		fmt.Fprintf(g.log, "note: assets dir %q does not exist; skipping static content\n", g.assetsDir)
@@ -257,10 +154,6 @@ func (g *generator) copyStaticAssets() error {
 	})
 }
 
-// applySubstitutions replaces template placeholders in hand-editable Markdown
-// assets. {{VERSION}} is replaced with the provider version when one was
-// supplied via -provider-version; otherwise a zero-dev sentinel is used so the
-// output still satisfies semver consumers (e.g. sandbox lint).
 func (g *generator) applySubstitutions(s string) string {
 	version := g.providerVersion
 	if version == "" {
@@ -269,9 +162,6 @@ func (g *generator) applySubstitutions(s string) string {
 	return strings.ReplaceAll(s, "{{VERSION}}", version)
 }
 
-// writeProvenance records what the skill was generated from. Intentionally the
-// only file with a mutable field (commit/version), kept separate so diffs on
-// the main content remain stable when only metadata changes.
 func (g *generator) writeProvenance() error {
 	var b strings.Builder
 	b.WriteString("# Generated skill — provenance\n\n")
@@ -281,7 +171,7 @@ func (g *generator) writeProvenance() error {
 	if g.providerVersion != "" {
 		b.WriteString("- Provider version: " + g.providerVersion + "\n")
 	}
-	b.WriteString("- Source of truth: `openspec/specs/` + `docs/`\n")
+	b.WriteString("- Source of truth: `docs/`\n")
 	b.WriteString("- Generator: `scripts/generate-skill`\n\n")
 	b.WriteString("Do not edit files in this directory by hand. Re-run `make skill-generate` from the provider repo instead.\n")
 	return writeFile(filepath.Join(g.outDir, "GENERATED.md"), b.String())
@@ -296,18 +186,6 @@ func writeFile(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)
 }
 
-func kindLabel(k entityKind) string {
-	switch {
-	case k.has(kindResource) && k.has(kindDataSource):
-		return "resource + data source"
-	case k.has(kindResource):
-		return "resource"
-	case k.has(kindDataSource):
-		return "data source"
-	}
-	return "unknown"
-}
-
 func countKind(es []*entity, k entityKind) int {
 	n := 0
 	for _, e := range es {
@@ -318,51 +196,6 @@ func countKind(es []*entity, k entityKind) int {
 	return n
 }
 
-func entityRefPath(e *entity) string {
-	if e.Kinds.has(kindResource) {
-		return "resources/" + e.ShortName + ".md"
-	}
-	return "data-sources/" + e.ShortName + ".md"
-}
-
-// inferSubcategory produces a best-effort bucket from the entity short name
-// when the docs frontmatter didn't give us one (e.g. data sources sometimes
-// omit it).
-func inferSubcategory(e *entity) string {
-	name := e.ShortName
-	switch {
-	case strings.HasPrefix(name, "elasticsearch_ingest_processor_"):
-		return "Ingest processors"
-	case strings.HasPrefix(name, "elasticsearch_security_"):
-		return "Security"
-	case strings.HasPrefix(name, "elasticsearch_ml_"):
-		return "Machine Learning"
-	case strings.HasPrefix(name, "elasticsearch_snapshot"):
-		return "Snapshot"
-	case strings.HasPrefix(name, "elasticsearch_watcher"):
-		return "Watcher"
-	case strings.HasPrefix(name, "elasticsearch_transform"):
-		return "Transform"
-	case strings.HasPrefix(name, "elasticsearch_"):
-		return "Elasticsearch"
-	case strings.HasPrefix(name, "kibana_security_"):
-		return "Kibana Security"
-	case strings.HasPrefix(name, "kibana_synthetics_"):
-		return "Kibana Synthetics"
-	case strings.HasPrefix(name, "kibana_agentbuilder_"):
-		return "Kibana Agent Builder"
-	case strings.HasPrefix(name, "kibana_"):
-		return "Kibana"
-	case strings.HasPrefix(name, "fleet_"):
-		return "Fleet"
-	case strings.HasPrefix(name, "apm_"):
-		return "APM"
-	}
-	return "Other"
-}
-
-// oneLine returns the first sentence of s, trimmed, with trailing "See: URL"
-// noise stripped so the index table stays scannable.
 func oneLine(s string) string {
 	var line string
 	for l := range strings.SplitSeq(s, "\n") {
@@ -375,11 +208,9 @@ func oneLine(s string) string {
 	if line == "" {
 		return ""
 	}
-	// Cut at first ". " to keep just the first sentence.
 	if i := strings.Index(line, ". "); i > 0 {
 		line = line[:i+1]
 	}
-	// Strip trailing "See: https://..." or "see the X documentation https://..." noise.
 	for _, marker := range []string{" See:", " see:", " See the", " see the"} {
 		if i := strings.Index(line, marker); i > 0 {
 			line = line[:i]
@@ -388,82 +219,3 @@ func oneLine(s string) string {
 	return strings.TrimSpace(line)
 }
 
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n-1] + "…"
-}
-
-func escapePipe(s string) string {
-	return strings.ReplaceAll(s, "|", `\|`)
-}
-
-// mineSpecSignals pulls bullet-points out of the spec for common gotcha
-// categories. We detect headings and SHALL/MUST sentences that mention
-// force-new, deletion protection, version compatibility, JSON normalization,
-// or import behavior.
-func mineSpecSignals(body string) string {
-	signals := []struct {
-		label   string
-		needles []string
-	}{
-		{"Forces replacement", []string{"force new", "requires replacement", "RequiresReplace"}},
-		{"Deletion / protection", []string{"deletion_protection", "delete.*refuses", "refuses to delete"}},
-		{"Version gates", []string{"requires Elasticsearch >=", "requires Kibana >=", "requires Fleet", "version >=", "Unsupported Feature"}},
-		{"JSON handling", []string{"jsonencode", "JSON (normalized)", "normalized JSON", "preserve.*unknown"}},
-		{"Import", []string{"import ", "ImportState"}},
-		{"Connection", []string{"elasticsearch_connection", "kibana_connection", "fleet_connection"}},
-	}
-
-	lines := strings.Split(body, "\n")
-	var out strings.Builder
-	for _, sig := range signals {
-		var hits []string
-		seen := map[string]struct{}{}
-		for _, l := range lines {
-			low := strings.ToLower(l)
-			match := false
-			for _, n := range sig.needles {
-				if strings.Contains(low, strings.ToLower(n)) {
-					match = true
-					break
-				}
-			}
-			if !match {
-				continue
-			}
-			trim := strings.TrimSpace(l)
-			// Skip headings and fenced markers.
-			if strings.HasPrefix(trim, "#") || strings.HasPrefix(trim, "```") {
-				continue
-			}
-			if trim == "" {
-				continue
-			}
-			// De-duplicate and cap.
-			if _, ok := seen[trim]; ok {
-				continue
-			}
-			seen[trim] = struct{}{}
-			hits = append(hits, trim)
-			if len(hits) >= 4 {
-				break
-			}
-		}
-		if len(hits) == 0 {
-			continue
-		}
-		out.WriteString("**" + sig.label + "**\n")
-		for _, h := range hits {
-			// Already-bulleted lines keep their marker; otherwise bullet them.
-			if strings.HasPrefix(h, "- ") || strings.HasPrefix(h, "* ") {
-				out.WriteString(h + "\n")
-			} else {
-				out.WriteString("- " + truncate(h, 220) + "\n")
-			}
-		}
-		out.WriteString("\n")
-	}
-	return strings.TrimRight(out.String(), "\n")
-}

--- a/scripts/generate-skill/emit.go
+++ b/scripts/generate-skill/emit.go
@@ -1,0 +1,469 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type generator struct {
+	entities        []*entity
+	assetsDir       string
+	outDir          string
+	providerVersion string
+	log             io.Writer
+	verbose         bool
+}
+
+func (g *generator) emit() error {
+	if err := os.RemoveAll(g.outDir); err != nil {
+		return fmt.Errorf("clean out dir: %w", err)
+	}
+	dirs := []string{
+		g.outDir,
+		filepath.Join(g.outDir, "references"),
+		filepath.Join(g.outDir, "references", "resources"),
+		filepath.Join(g.outDir, "references", "data-sources"),
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return err
+		}
+	}
+
+	// Copy hand-editable templates first (SKILL.md, index.md, context-checklist.md,
+	// provider.md, gotchas.md). writeIndex then replaces the {{ENTITIES}} marker
+	// in index.md with the generated entity tables.
+	if err := g.copyStaticAssets(); err != nil {
+		return err
+	}
+	if err := g.writeIndex(); err != nil {
+		return err
+	}
+	if err := g.writePerEntityRefs(); err != nil {
+		return err
+	}
+	if err := g.writeProvenance(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// indexEntitiesPlaceholder is replaced with the generated entity tables in
+// the hand-editable references/index.md template.
+const indexEntitiesPlaceholder = "{{ENTITIES}}"
+
+// writeIndex renders references/index.md by replacing {{ENTITIES}} in the
+// copied template with a Markdown table of every entity grouped by subcategory.
+// Only the table is generated; the surrounding prose is fully editable in
+// assets/references/index.md.
+func (g *generator) writeIndex() error {
+	path := filepath.Join(g.outDir, "references", "index.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read index template (expected copy of assets/references/index.md at %q): %w", path, err)
+	}
+	if !strings.Contains(string(raw), indexEntitiesPlaceholder) {
+		return fmt.Errorf("references/index.md template is missing %s placeholder", indexEntitiesPlaceholder)
+	}
+	rendered := strings.Replace(string(raw), indexEntitiesPlaceholder, g.renderEntityTables(), 1)
+	return os.WriteFile(path, []byte(rendered), 0o644)
+}
+
+// renderEntityTables produces the grouped Markdown tables that slot into the
+// index.md template's {{ENTITIES}} placeholder.
+func (g *generator) renderEntityTables() string {
+	groups := map[string][]*entity{}
+	for _, e := range g.entities {
+		cat := e.Subcategory
+		if cat == "" {
+			cat = inferSubcategory(e)
+		}
+		groups[cat] = append(groups[cat], e)
+	}
+	cats := make([]string, 0, len(groups))
+	for c := range groups {
+		cats = append(cats, c)
+	}
+	sort.Strings(cats)
+
+	var b strings.Builder
+	for _, cat := range cats {
+		b.WriteString("## " + cat + "\n\n")
+		b.WriteString("| Entity | Kind | Summary | Reference |\n")
+		b.WriteString("|---|---|---|---|\n")
+		ents := groups[cat]
+		sort.Slice(ents, func(i, j int) bool { return ents[i].Name < ents[j].Name })
+		for _, e := range ents {
+			kind := kindLabel(e.Kinds)
+			summary := oneLine(e.DocsSummary)
+			if summary == "" {
+				summary = oneLine(e.Purpose)
+			}
+			summary = truncate(summary, 120)
+			link := entityRefPath(e)
+			fmt.Fprintf(&b, "| `%s` | %s | %s | [%s](%s) |\n",
+				e.Name, kind, escapePipe(summary), filepath.Base(link), link)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// writePerEntityRefs writes one reference file per entity. When an entity is
+// both resource and data source, we produce two files with cross-links.
+func (g *generator) writePerEntityRefs() error {
+	for _, e := range g.entities {
+		if e.Kinds.has(kindResource) {
+			if err := g.writeEntityRef(e, kindResource); err != nil {
+				return err
+			}
+		}
+		if e.Kinds.has(kindDataSource) {
+			if err := g.writeEntityRef(e, kindDataSource); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (g *generator) writeEntityRef(e *entity, kind entityKind) error {
+	var b strings.Builder
+	label := "Resource"
+	impl := e.ResourceImpl
+	example := e.DocsExampleResource
+	if kind == kindDataSource {
+		label = "Data source"
+		impl = e.DataSourceImpl
+		example = e.DocsExampleDataSource
+	}
+
+	fmt.Fprintf(&b, "# `%s` (%s)\n\n", e.Name, strings.ToLower(label))
+
+	summary := oneLine(e.DocsSummary)
+	if summary == "" {
+		summary = oneLine(e.Purpose)
+	}
+	if summary != "" {
+		b.WriteString(summary + "\n\n")
+	}
+
+	b.WriteString("## Facts\n\n")
+	if e.Subcategory != "" {
+		b.WriteString("- Subcategory: " + e.Subcategory + "\n")
+	}
+	b.WriteString("- Kind: " + label + "\n")
+	if impl != "" {
+		b.WriteString("- Implementation: `" + impl + "`\n")
+	}
+	if kind == kindResource && e.Kinds.has(kindDataSource) {
+		b.WriteString("- See also: [data source](../data-sources/" + e.ShortName + ".md)\n")
+	}
+	if kind == kindDataSource && e.Kinds.has(kindResource) {
+		b.WriteString("- See also: [resource](../resources/" + e.ShortName + ".md)\n")
+	}
+	b.WriteString("- Spec: `openspec/specs/" + e.SpecCapability + "/spec.md`\n")
+	b.WriteString("\n")
+
+	if e.Schema != "" {
+		b.WriteString("## Schema\n\n")
+		b.WriteString(e.Schema)
+		b.WriteString("\n\n")
+	}
+
+	if example != "" {
+		b.WriteString("## Example\n\n")
+		b.WriteString("```terraform\n")
+		b.WriteString(example)
+		b.WriteString("\n```\n\n")
+	}
+
+	// Surface lifecycle / gotcha signals mined from the spec requirements.
+	if notes := mineSpecSignals(e.SpecBody); notes != "" {
+		b.WriteString("## Lifecycle & gotchas (from spec)\n\n")
+		b.WriteString(notes)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("## Further reading\n\n")
+	b.WriteString("- Full requirements: `openspec/specs/" + e.SpecCapability + "/spec.md`\n")
+	if kind == kindResource && e.DocsResourcePath != "" {
+		b.WriteString("- Generated docs: `" + e.DocsResourcePath + "`\n")
+	}
+	if kind == kindDataSource && e.DocsDataSourcePath != "" {
+		b.WriteString("- Generated docs: `" + e.DocsDataSourcePath + "`\n")
+	}
+
+	sub := "resources"
+	if kind == kindDataSource {
+		sub = "data-sources"
+	}
+	path := filepath.Join(g.outDir, "references", sub, e.ShortName+".md")
+	return writeFile(path, b.String())
+}
+
+// copyStaticAssets copies hand-seeded content from the assets dir into the
+// skill output, applying template substitutions (currently {{VERSION}}) on
+// Markdown files. Non-Markdown files are copied byte-for-byte.
+func (g *generator) copyStaticAssets() error {
+	if _, err := os.Stat(g.assetsDir); os.IsNotExist(err) {
+		fmt.Fprintf(g.log, "note: assets dir %q does not exist; skipping static content\n", g.assetsDir)
+		return nil
+	}
+	return filepath.WalkDir(g.assetsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(g.assetsDir, path)
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(g.outDir, rel)
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(path, ".md") {
+			data = []byte(g.applySubstitutions(string(data)))
+		}
+		return os.WriteFile(dest, data, 0o644)
+	})
+}
+
+// applySubstitutions replaces template placeholders in hand-editable Markdown
+// assets. {{VERSION}} is replaced with the provider version when one was
+// supplied via -provider-version; otherwise a zero-dev sentinel is used so the
+// output still satisfies semver consumers (e.g. sandbox lint).
+func (g *generator) applySubstitutions(s string) string {
+	version := g.providerVersion
+	if version == "" {
+		version = "0.0.0-dev"
+	}
+	return strings.ReplaceAll(s, "{{VERSION}}", version)
+}
+
+// writeProvenance records what the skill was generated from. Intentionally the
+// only file with a mutable field (commit/version), kept separate so diffs on
+// the main content remain stable when only metadata changes.
+func (g *generator) writeProvenance() error {
+	var b strings.Builder
+	b.WriteString("# Generated skill — provenance\n\n")
+	b.WriteString("This skill is auto-generated from the elastic/terraform-provider-elasticstack repository.\n\n")
+	fmt.Fprintf(&b, "- Entities: %d (resources: %d, data sources: %d)\n",
+		len(g.entities), countKind(g.entities, kindResource), countKind(g.entities, kindDataSource))
+	if g.providerVersion != "" {
+		b.WriteString("- Provider version: " + g.providerVersion + "\n")
+	}
+	b.WriteString("- Source of truth: `openspec/specs/` + `docs/`\n")
+	b.WriteString("- Generator: `scripts/generate-skill`\n\n")
+	b.WriteString("Do not edit files in this directory by hand. Re-run `make skill-generate` from the provider repo instead.\n")
+	return writeFile(filepath.Join(g.outDir, "GENERATED.md"), b.String())
+}
+
+// --- helpers ---
+
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func kindLabel(k entityKind) string {
+	switch {
+	case k.has(kindResource) && k.has(kindDataSource):
+		return "resource + data source"
+	case k.has(kindResource):
+		return "resource"
+	case k.has(kindDataSource):
+		return "data source"
+	}
+	return "unknown"
+}
+
+func countKind(es []*entity, k entityKind) int {
+	n := 0
+	for _, e := range es {
+		if e.Kinds.has(k) {
+			n++
+		}
+	}
+	return n
+}
+
+func entityRefPath(e *entity) string {
+	if e.Kinds.has(kindResource) {
+		return "resources/" + e.ShortName + ".md"
+	}
+	return "data-sources/" + e.ShortName + ".md"
+}
+
+// inferSubcategory produces a best-effort bucket from the entity short name
+// when the docs frontmatter didn't give us one (e.g. data sources sometimes
+// omit it).
+func inferSubcategory(e *entity) string {
+	name := e.ShortName
+	switch {
+	case strings.HasPrefix(name, "elasticsearch_ingest_processor_"):
+		return "Ingest processors"
+	case strings.HasPrefix(name, "elasticsearch_security_"):
+		return "Security"
+	case strings.HasPrefix(name, "elasticsearch_ml_"):
+		return "Machine Learning"
+	case strings.HasPrefix(name, "elasticsearch_snapshot"):
+		return "Snapshot"
+	case strings.HasPrefix(name, "elasticsearch_watcher"):
+		return "Watcher"
+	case strings.HasPrefix(name, "elasticsearch_transform"):
+		return "Transform"
+	case strings.HasPrefix(name, "elasticsearch_"):
+		return "Elasticsearch"
+	case strings.HasPrefix(name, "kibana_security_"):
+		return "Kibana Security"
+	case strings.HasPrefix(name, "kibana_synthetics_"):
+		return "Kibana Synthetics"
+	case strings.HasPrefix(name, "kibana_agentbuilder_"):
+		return "Kibana Agent Builder"
+	case strings.HasPrefix(name, "kibana_"):
+		return "Kibana"
+	case strings.HasPrefix(name, "fleet_"):
+		return "Fleet"
+	case strings.HasPrefix(name, "apm_"):
+		return "APM"
+	}
+	return "Other"
+}
+
+// oneLine returns the first sentence of s, trimmed, with trailing "See: URL"
+// noise stripped so the index table stays scannable.
+func oneLine(s string) string {
+	var line string
+	for l := range strings.SplitSeq(s, "\n") {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			line = l
+			break
+		}
+	}
+	if line == "" {
+		return ""
+	}
+	// Cut at first ". " to keep just the first sentence.
+	if i := strings.Index(line, ". "); i > 0 {
+		line = line[:i+1]
+	}
+	// Strip trailing "See: https://..." or "see the X documentation https://..." noise.
+	for _, marker := range []string{" See:", " see:", " See the", " see the"} {
+		if i := strings.Index(line, marker); i > 0 {
+			line = line[:i]
+		}
+	}
+	return strings.TrimSpace(line)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+func escapePipe(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+// mineSpecSignals pulls bullet-points out of the spec for common gotcha
+// categories. We detect headings and SHALL/MUST sentences that mention
+// force-new, deletion protection, version compatibility, JSON normalization,
+// or import behavior.
+func mineSpecSignals(body string) string {
+	signals := []struct {
+		label   string
+		needles []string
+	}{
+		{"Forces replacement", []string{"force new", "requires replacement", "RequiresReplace"}},
+		{"Deletion / protection", []string{"deletion_protection", "delete.*refuses", "refuses to delete"}},
+		{"Version gates", []string{"requires Elasticsearch >=", "requires Kibana >=", "requires Fleet", "version >=", "Unsupported Feature"}},
+		{"JSON handling", []string{"jsonencode", "JSON (normalized)", "normalized JSON", "preserve.*unknown"}},
+		{"Import", []string{"import ", "ImportState"}},
+		{"Connection", []string{"elasticsearch_connection", "kibana_connection", "fleet_connection"}},
+	}
+
+	lines := strings.Split(body, "\n")
+	var out strings.Builder
+	for _, sig := range signals {
+		var hits []string
+		seen := map[string]struct{}{}
+		for _, l := range lines {
+			low := strings.ToLower(l)
+			match := false
+			for _, n := range sig.needles {
+				if strings.Contains(low, strings.ToLower(n)) {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+			trim := strings.TrimSpace(l)
+			// Skip headings and fenced markers.
+			if strings.HasPrefix(trim, "#") || strings.HasPrefix(trim, "```") {
+				continue
+			}
+			if trim == "" {
+				continue
+			}
+			// De-duplicate and cap.
+			if _, ok := seen[trim]; ok {
+				continue
+			}
+			seen[trim] = struct{}{}
+			hits = append(hits, trim)
+			if len(hits) >= 4 {
+				break
+			}
+		}
+		if len(hits) == 0 {
+			continue
+		}
+		out.WriteString("**" + sig.label + "**\n")
+		for _, h := range hits {
+			// Already-bulleted lines keep their marker; otherwise bullet them.
+			if strings.HasPrefix(h, "- ") || strings.HasPrefix(h, "* ") {
+				out.WriteString(h + "\n")
+			} else {
+				out.WriteString("- " + truncate(h, 220) + "\n")
+			}
+		}
+		out.WriteString("\n")
+	}
+	return strings.TrimRight(out.String(), "\n")
+}

--- a/scripts/generate-skill/entities.go
+++ b/scripts/generate-skill/entities.go
@@ -1,0 +1,383 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// entityKind is the Terraform binding kind.
+type entityKind int
+
+const (
+	kindResource entityKind = 1 << iota
+	kindDataSource
+)
+
+func (k entityKind) has(other entityKind) bool { return k&other != 0 }
+
+// entity is a Terraform resource and/or data source as described by an
+// OpenSpec capability and (optionally) the matching tfplugindocs page.
+type entity struct {
+	// Name is the fully-qualified provider type, e.g. "elasticstack_elasticsearch_index".
+	Name string
+
+	// ShortName is Name with the "elasticstack_" prefix stripped.
+	// Used for docs filename matching and display.
+	ShortName string
+
+	// Kinds indicates whether this entity is exposed as a resource, data source, or both.
+	Kinds entityKind
+
+	// SpecCapability is the OpenSpec capability directory name (e.g. "elasticsearch-index").
+	SpecCapability string
+
+	// SpecPath is the absolute path to spec.md.
+	SpecPath string
+
+	// SpecBody is the full spec.md contents.
+	SpecBody string
+
+	// Purpose is the ## Purpose section body (trimmed).
+	Purpose string
+
+	// Schema is the ## Schema section body, verbatim (may contain multiple HCL blocks).
+	Schema string
+
+	// Implementation notes from the spec header (Resource implementation / Data source implementation lines).
+	ResourceImpl   string
+	DataSourceImpl string
+
+	// DocsResourcePath, DocsDataSourcePath point to tfplugindocs pages if present.
+	DocsResourcePath   string
+	DocsDataSourcePath string
+
+	// DocsSummary is a one-line description extracted from docs frontmatter or the first
+	// non-heading paragraph of the spec Purpose.
+	DocsSummary string
+
+	// DocsExampleResource, DocsExampleDataSource are the "Example Usage" HCL blocks from docs.
+	DocsExampleResource   string
+	DocsExampleDataSource string
+
+	// Subcategory is the docs frontmatter "subcategory" value, e.g. "Security", "Fleet", "Ingest".
+	Subcategory string
+}
+
+// loadEntities walks specsDir and docsDir and returns the merged entity list
+// sorted by Name.
+func loadEntities(specsDir, docsDir string) ([]*entity, error) {
+	specDirs, err := os.ReadDir(specsDir)
+	if err != nil {
+		return nil, fmt.Errorf("read specs dir %q: %w", specsDir, err)
+	}
+
+	byName := map[string]*entity{}
+	for _, de := range specDirs {
+		if !de.IsDir() {
+			continue
+		}
+		capability := de.Name()
+		// Skip CI / acceptance-test housekeeping specs: these describe workflows,
+		// not user-facing Terraform entities.
+		if strings.HasPrefix(capability, "ci-") || strings.HasPrefix(capability, "acceptance-") {
+			continue
+		}
+		specPath := filepath.Join(specsDir, capability, "spec.md")
+		body, err := os.ReadFile(specPath)
+		if err != nil {
+			// Some capability directories may exist without spec.md yet; skip quietly.
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read %q: %w", specPath, err)
+		}
+		ent := parseSpec(capability, specPath, string(body))
+		if ent == nil {
+			// Non-entity spec (e.g. provider-level guidance). Skip for now.
+			continue
+		}
+		byName[ent.Name] = ent
+	}
+
+	// Merge docs/resources and docs/data-sources.
+	if err := mergeDocs(byName, filepath.Join(docsDir, "resources"), kindResource); err != nil {
+		return nil, err
+	}
+	if err := mergeDocs(byName, filepath.Join(docsDir, "data-sources"), kindDataSource); err != nil {
+		return nil, err
+	}
+
+	out := make([]*entity, 0, len(byName))
+	for _, e := range byName {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// parseSpec extracts the fields we care about from a spec.md. Returns nil if
+// the spec does not describe a provider entity (no "elasticstack_*" H1 title).
+func parseSpec(capability, path, body string) *entity {
+	lines := strings.Split(body, "\n")
+	if len(lines) == 0 {
+		return nil
+	}
+	name, ok := extractEntityNameFromH1(lines[0])
+	if !ok {
+		return nil
+	}
+
+	ent := &entity{
+		Name:           name,
+		ShortName:      strings.TrimPrefix(name, "elasticstack_"),
+		SpecCapability: capability,
+		SpecPath:       path,
+		SpecBody:       body,
+	}
+
+	for _, line := range lines[:min(len(lines), 10)] {
+		if rest, ok := strings.CutPrefix(line, "Resource implementation:"); ok {
+			ent.ResourceImpl = cleanImpl(rest)
+			ent.Kinds |= kindResource
+		}
+		if rest, ok := strings.CutPrefix(line, "Data source implementation:"); ok {
+			ent.DataSourceImpl = cleanImpl(rest)
+			ent.Kinds |= kindDataSource
+		}
+	}
+
+	ent.Purpose = extractSection(body, "## Purpose")
+	ent.Schema = extractSection(body, "## Schema")
+
+	// Fallback: if the spec did not declare implementation lines (older specs),
+	// infer kind from docs presence during merge. For now assume resource.
+	if ent.Kinds == 0 {
+		ent.Kinds = kindResource
+	}
+
+	return ent
+}
+
+// extractEntityNameFromH1 parses lines like:
+//
+//	# `elasticstack_elasticsearch_index` — Schema and Functional Requirements
+//
+// Returns (name, true) when matched, otherwise ("", false).
+func extractEntityNameFromH1(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "# ") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(line, "# ")
+	// Expect backtick-quoted name.
+	if !strings.HasPrefix(rest, "`") {
+		return "", false
+	}
+	end := strings.Index(rest[1:], "`")
+	if end < 0 {
+		return "", false
+	}
+	name := rest[1 : 1+end]
+	if !strings.HasPrefix(name, "elasticstack_") {
+		return "", false
+	}
+	return name, true
+}
+
+func cleanImpl(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "`")
+	return strings.TrimSpace(s)
+}
+
+// extractSection returns the body of a markdown section starting with the given
+// heading (e.g. "## Purpose"), stopped by the next heading of equal or lesser
+// depth. The heading itself is not included.
+func extractSection(body, heading string) string {
+	lines := strings.Split(body, "\n")
+	depth := headingDepth(heading)
+	if depth == 0 {
+		return ""
+	}
+	start := -1
+	for i, l := range lines {
+		if strings.TrimRight(l, " \t") == heading {
+			start = i + 1
+			break
+		}
+	}
+	if start < 0 {
+		return ""
+	}
+	end := len(lines)
+	for i := start; i < len(lines); i++ {
+		d := headingDepth(lines[i])
+		if d > 0 && d <= depth {
+			end = i
+			break
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines[start:end], "\n"))
+}
+
+// headingDepth returns the ATX heading depth (1..6) or 0 if the line is not a
+// markdown heading. Indented headings and setext headings are ignored.
+func headingDepth(line string) int {
+	// Don't count headings inside fenced code blocks; callers should strip code
+	// fences first if that matters. For our purposes spec sections do not contain
+	// fenced "##" lines so this is adequate.
+	if !strings.HasPrefix(line, "#") {
+		return 0
+	}
+	n := 0
+	for n < len(line) && line[n] == '#' {
+		n++
+	}
+	if n == 0 || n > 6 {
+		return 0
+	}
+	if n < len(line) && line[n] != ' ' {
+		return 0
+	}
+	return n
+}
+
+// mergeDocs scans a docs directory (either "resources" or "data-sources") and
+// annotates the matching entity with docs metadata and the Example Usage block.
+// Docs filenames strip the "elasticstack_" prefix, so we match by ShortName.
+func mergeDocs(byName map[string]*entity, dir string, kind entityKind) error {
+	des, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read docs dir %q: %w", dir, err)
+	}
+	// Build a shortName -> *entity lookup.
+	byShort := map[string]*entity{}
+	for _, e := range byName {
+		byShort[e.ShortName] = e
+	}
+
+	for _, de := range des {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".md") {
+			continue
+		}
+		shortName := strings.TrimSuffix(de.Name(), ".md")
+		ent, ok := byShort[shortName]
+		if !ok {
+			// A docs page without a matching spec is a gap we surface as a warning
+			// during emit, but we don't invent an entity here.
+			continue
+		}
+		path := filepath.Join(dir, de.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %q: %w", path, err)
+		}
+		meta, example := parseDocsPage(string(raw))
+		ent.Kinds |= kind
+		if ent.Subcategory == "" {
+			ent.Subcategory = meta.Subcategory
+		}
+		if ent.DocsSummary == "" {
+			ent.DocsSummary = meta.Description
+		}
+		switch kind {
+		case kindResource:
+			ent.DocsResourcePath = path
+			ent.DocsExampleResource = example
+		case kindDataSource:
+			ent.DocsDataSourcePath = path
+			ent.DocsExampleDataSource = example
+		}
+	}
+	return nil
+}
+
+type docsMeta struct {
+	Subcategory string
+	Description string
+}
+
+// parseDocsPage extracts frontmatter fields and the first fenced terraform block
+// that follows an "## Example Usage" heading.
+func parseDocsPage(body string) (docsMeta, string) {
+	var meta docsMeta
+
+	// Frontmatter block between leading --- lines.
+	if strings.HasPrefix(body, "---\n") {
+		if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
+			fm := body[4 : 4+end]
+			meta = parseFrontmatter(fm)
+		}
+	}
+
+	example := ""
+	if idx := strings.Index(body, "## Example Usage"); idx >= 0 {
+		// Take the first ```terraform ... ``` block after the heading.
+		rest := body[idx:]
+		start := strings.Index(rest, "```terraform\n")
+		if start >= 0 {
+			blockStart := start + len("```terraform\n")
+			endOffset := strings.Index(rest[blockStart:], "\n```")
+			if endOffset >= 0 {
+				example = strings.TrimRight(rest[blockStart:blockStart+endOffset], "\n")
+			}
+		}
+	}
+	return meta, example
+}
+
+// parseFrontmatter handles the tiny subset of YAML that tfplugindocs emits.
+// Specifically single-line key: value pairs and multi-line description using
+// the literal block (|-) indicator.
+func parseFrontmatter(fm string) docsMeta {
+	var meta docsMeta
+	lines := strings.Split(fm, "\n")
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		if after, ok := strings.CutPrefix(line, "subcategory:"); ok {
+			v := strings.TrimSpace(after)
+			meta.Subcategory = strings.Trim(v, `"'`)
+		}
+		if after, ok := strings.CutPrefix(line, "description:"); ok {
+			v := strings.TrimSpace(after)
+			if v == "|-" || v == "|" {
+				// Collect indented continuation lines.
+				var parts []string
+				i++
+				for i < len(lines) && (strings.HasPrefix(lines[i], "  ") || lines[i] == "") {
+					parts = append(parts, strings.TrimSpace(lines[i]))
+					i++
+				}
+				meta.Description = strings.TrimSpace(strings.Join(parts, " "))
+				continue
+			}
+			meta.Description = strings.Trim(v, `"'`)
+		}
+		i++
+	}
+	return meta
+}

--- a/scripts/generate-skill/entities.go
+++ b/scripts/generate-skill/entities.go
@@ -35,95 +35,26 @@ const (
 
 func (k entityKind) has(other entityKind) bool { return k&other != 0 }
 
-// entity is a Terraform resource and/or data source as described by an
-// OpenSpec capability and (optionally) the matching tfplugindocs page.
+// entity holds the minimal metadata needed to build the index.
+// The full content is the docs file copied verbatim into the skill.
 type entity struct {
-	// Name is the fully-qualified provider type, e.g. "elasticstack_elasticsearch_index".
-	Name string
-
-	// ShortName is Name with the "elasticstack_" prefix stripped.
-	// Used for docs filename matching and display.
-	ShortName string
-
-	// Kinds indicates whether this entity is exposed as a resource, data source, or both.
-	Kinds entityKind
-
-	// SpecCapability is the OpenSpec capability directory name (e.g. "elasticsearch-index").
-	SpecCapability string
-
-	// SpecPath is the absolute path to spec.md.
-	SpecPath string
-
-	// SpecBody is the full spec.md contents.
-	SpecBody string
-
-	// Purpose is the ## Purpose section body (trimmed).
-	Purpose string
-
-	// Schema is the ## Schema section body, verbatim (may contain multiple HCL blocks).
-	Schema string
-
-	// Implementation notes from the spec header (Resource implementation / Data source implementation lines).
-	ResourceImpl   string
-	DataSourceImpl string
-
-	// DocsResourcePath, DocsDataSourcePath point to tfplugindocs pages if present.
-	DocsResourcePath   string
-	DocsDataSourcePath string
-
-	// DocsSummary is a one-line description extracted from docs frontmatter or the first
-	// non-heading paragraph of the spec Purpose.
-	DocsSummary string
-
-	// DocsExampleResource, DocsExampleDataSource are the "Example Usage" HCL blocks from docs.
-	DocsExampleResource   string
-	DocsExampleDataSource string
-
-	// Subcategory is the docs frontmatter "subcategory" value, e.g. "Security", "Fleet", "Ingest".
-	Subcategory string
+	Name            string // e.g. "elasticstack_elasticsearch_index"
+	ShortName       string // e.g. "elasticsearch_index"
+	Kinds           entityKind
+	ResourceSummary string
+	DataSrcSummary  string
 }
 
-// loadEntities walks specsDir and docsDir and returns the merged entity list
-// sorted by Name.
-func loadEntities(specsDir, docsDir string) ([]*entity, error) {
-	specDirs, err := os.ReadDir(specsDir)
-	if err != nil {
-		return nil, fmt.Errorf("read specs dir %q: %w", specsDir, err)
-	}
-
+// loadEntities discovers all entities from docs/resources and docs/data-sources.
+// Each .md file becomes an entity; both dirs are walked so resources that also
+// have a data source (and vice-versa) are merged into a single entry.
+func loadEntities(docsDir string) ([]*entity, error) {
 	byName := map[string]*entity{}
-	for _, de := range specDirs {
-		if !de.IsDir() {
-			continue
-		}
-		capability := de.Name()
-		// Skip CI / acceptance-test housekeeping specs: these describe workflows,
-		// not user-facing Terraform entities.
-		if strings.HasPrefix(capability, "ci-") || strings.HasPrefix(capability, "acceptance-") {
-			continue
-		}
-		specPath := filepath.Join(specsDir, capability, "spec.md")
-		body, err := os.ReadFile(specPath)
-		if err != nil {
-			// Some capability directories may exist without spec.md yet; skip quietly.
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("read %q: %w", specPath, err)
-		}
-		ent := parseSpec(capability, specPath, string(body))
-		if ent == nil {
-			// Non-entity spec (e.g. provider-level guidance). Skip for now.
-			continue
-		}
-		byName[ent.Name] = ent
-	}
 
-	// Merge docs/resources and docs/data-sources.
-	if err := mergeDocs(byName, filepath.Join(docsDir, "resources"), kindResource); err != nil {
+	if err := collectFromDir(byName, filepath.Join(docsDir, "resources"), kindResource); err != nil {
 		return nil, err
 	}
-	if err := mergeDocs(byName, filepath.Join(docsDir, "data-sources"), kindDataSource); err != nil {
+	if err := collectFromDir(byName, filepath.Join(docsDir, "data-sources"), kindDataSource); err != nil {
 		return nil, err
 	}
 
@@ -135,137 +66,9 @@ func loadEntities(specsDir, docsDir string) ([]*entity, error) {
 	return out, nil
 }
 
-// parseSpec extracts the fields we care about from a spec.md. Returns nil if
-// the spec does not describe a provider entity (no "elasticstack_*" H1 title).
-func parseSpec(capability, path, body string) *entity {
-	lines := strings.Split(body, "\n")
-	if len(lines) == 0 {
-		return nil
-	}
-	name, ok := extractEntityNameFromH1(lines[0])
-	if !ok {
-		return nil
-	}
-
-	ent := &entity{
-		Name:           name,
-		ShortName:      strings.TrimPrefix(name, "elasticstack_"),
-		SpecCapability: capability,
-		SpecPath:       path,
-		SpecBody:       body,
-	}
-
-	for _, line := range lines[:min(len(lines), 10)] {
-		if rest, ok := strings.CutPrefix(line, "Resource implementation:"); ok {
-			ent.ResourceImpl = cleanImpl(rest)
-			ent.Kinds |= kindResource
-		}
-		if rest, ok := strings.CutPrefix(line, "Data source implementation:"); ok {
-			ent.DataSourceImpl = cleanImpl(rest)
-			ent.Kinds |= kindDataSource
-		}
-	}
-
-	ent.Purpose = extractSection(body, "## Purpose")
-	ent.Schema = extractSection(body, "## Schema")
-
-	// Fallback: if the spec did not declare implementation lines (older specs),
-	// infer kind from docs presence during merge. For now assume resource.
-	if ent.Kinds == 0 {
-		ent.Kinds = kindResource
-	}
-
-	return ent
-}
-
-// extractEntityNameFromH1 parses lines like:
-//
-//	# `elasticstack_elasticsearch_index` — Schema and Functional Requirements
-//
-// Returns (name, true) when matched, otherwise ("", false).
-func extractEntityNameFromH1(line string) (string, bool) {
-	line = strings.TrimSpace(line)
-	if !strings.HasPrefix(line, "# ") {
-		return "", false
-	}
-	rest := strings.TrimPrefix(line, "# ")
-	// Expect backtick-quoted name.
-	if !strings.HasPrefix(rest, "`") {
-		return "", false
-	}
-	end := strings.Index(rest[1:], "`")
-	if end < 0 {
-		return "", false
-	}
-	name := rest[1 : 1+end]
-	if !strings.HasPrefix(name, "elasticstack_") {
-		return "", false
-	}
-	return name, true
-}
-
-func cleanImpl(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.Trim(s, "`")
-	return strings.TrimSpace(s)
-}
-
-// extractSection returns the body of a markdown section starting with the given
-// heading (e.g. "## Purpose"), stopped by the next heading of equal or lesser
-// depth. The heading itself is not included.
-func extractSection(body, heading string) string {
-	lines := strings.Split(body, "\n")
-	depth := headingDepth(heading)
-	if depth == 0 {
-		return ""
-	}
-	start := -1
-	for i, l := range lines {
-		if strings.TrimRight(l, " \t") == heading {
-			start = i + 1
-			break
-		}
-	}
-	if start < 0 {
-		return ""
-	}
-	end := len(lines)
-	for i := start; i < len(lines); i++ {
-		d := headingDepth(lines[i])
-		if d > 0 && d <= depth {
-			end = i
-			break
-		}
-	}
-	return strings.TrimSpace(strings.Join(lines[start:end], "\n"))
-}
-
-// headingDepth returns the ATX heading depth (1..6) or 0 if the line is not a
-// markdown heading. Indented headings and setext headings are ignored.
-func headingDepth(line string) int {
-	// Don't count headings inside fenced code blocks; callers should strip code
-	// fences first if that matters. For our purposes spec sections do not contain
-	// fenced "##" lines so this is adequate.
-	if !strings.HasPrefix(line, "#") {
-		return 0
-	}
-	n := 0
-	for n < len(line) && line[n] == '#' {
-		n++
-	}
-	if n == 0 || n > 6 {
-		return 0
-	}
-	if n < len(line) && line[n] != ' ' {
-		return 0
-	}
-	return n
-}
-
-// mergeDocs scans a docs directory (either "resources" or "data-sources") and
-// annotates the matching entity with docs metadata and the Example Usage block.
-// Docs filenames strip the "elasticstack_" prefix, so we match by ShortName.
-func mergeDocs(byName map[string]*entity, dir string, kind entityKind) error {
+// collectFromDir reads every .md file in dir, parses minimal metadata, and
+// creates or updates the matching entity in byName.
+func collectFromDir(byName map[string]*entity, dir string, kind entityKind) error {
 	des, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -273,46 +76,45 @@ func mergeDocs(byName map[string]*entity, dir string, kind entityKind) error {
 		}
 		return fmt.Errorf("read docs dir %q: %w", dir, err)
 	}
-	// Build a shortName -> *entity lookup.
-	byShort := map[string]*entity{}
-	for _, e := range byName {
-		byShort[e.ShortName] = e
-	}
 
 	for _, de := range des {
 		if de.IsDir() || !strings.HasSuffix(de.Name(), ".md") {
 			continue
 		}
-		shortName := strings.TrimSuffix(de.Name(), ".md")
-		ent, ok := byShort[shortName]
-		if !ok {
-			// A docs page without a matching spec is a gap we surface as a warning
-			// during emit, but we don't invent an entity here.
-			continue
-		}
-		path := filepath.Join(dir, de.Name())
-		raw, err := os.ReadFile(path)
+		raw, err := os.ReadFile(filepath.Join(dir, de.Name()))
 		if err != nil {
-			return fmt.Errorf("read %q: %w", path, err)
+			return fmt.Errorf("read %q: %w", de.Name(), err)
 		}
-		meta, example := parseDocsPage(string(raw))
+		meta := parseFrontmatter(extractFrontmatter(string(raw)))
+		shortName := strings.TrimSuffix(de.Name(), ".md")
+		fullName := "elasticstack_" + shortName
+
+		ent, ok := byName[fullName]
+		if !ok {
+			ent = &entity{Name: fullName, ShortName: shortName}
+			byName[fullName] = ent
+		}
 		ent.Kinds |= kind
-		if ent.Subcategory == "" {
-			ent.Subcategory = meta.Subcategory
-		}
-		if ent.DocsSummary == "" {
-			ent.DocsSummary = meta.Description
-		}
 		switch kind {
 		case kindResource:
-			ent.DocsResourcePath = path
-			ent.DocsExampleResource = example
+			ent.ResourceSummary = meta.Description
 		case kindDataSource:
-			ent.DocsDataSourcePath = path
-			ent.DocsExampleDataSource = example
+			ent.DataSrcSummary = meta.Description
 		}
 	}
 	return nil
+}
+
+// extractFrontmatter returns the content between the leading --- delimiters,
+// or an empty string if none is present.
+func extractFrontmatter(body string) string {
+	if !strings.HasPrefix(body, "---\n") {
+		return ""
+	}
+	if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
+		return body[4 : 4+end]
+	}
+	return ""
 }
 
 type docsMeta struct {
@@ -320,38 +122,8 @@ type docsMeta struct {
 	Description string
 }
 
-// parseDocsPage extracts frontmatter fields and the first fenced terraform block
-// that follows an "## Example Usage" heading.
-func parseDocsPage(body string) (docsMeta, string) {
-	var meta docsMeta
-
-	// Frontmatter block between leading --- lines.
-	if strings.HasPrefix(body, "---\n") {
-		if end := strings.Index(body[4:], "\n---\n"); end >= 0 {
-			fm := body[4 : 4+end]
-			meta = parseFrontmatter(fm)
-		}
-	}
-
-	example := ""
-	if idx := strings.Index(body, "## Example Usage"); idx >= 0 {
-		// Take the first ```terraform ... ``` block after the heading.
-		rest := body[idx:]
-		start := strings.Index(rest, "```terraform\n")
-		if start >= 0 {
-			blockStart := start + len("```terraform\n")
-			endOffset := strings.Index(rest[blockStart:], "\n```")
-			if endOffset >= 0 {
-				example = strings.TrimRight(rest[blockStart:blockStart+endOffset], "\n")
-			}
-		}
-	}
-	return meta, example
-}
-
-// parseFrontmatter handles the tiny subset of YAML that tfplugindocs emits.
-// Specifically single-line key: value pairs and multi-line description using
-// the literal block (|-) indicator.
+// parseFrontmatter handles the tiny subset of YAML that tfplugindocs emits:
+// single-line key: value pairs and multi-line description with the |- indicator.
 func parseFrontmatter(fm string) docsMeta {
 	var meta docsMeta
 	lines := strings.Split(fm, "\n")
@@ -365,7 +137,6 @@ func parseFrontmatter(fm string) docsMeta {
 		if after, ok := strings.CutPrefix(line, "description:"); ok {
 			v := strings.TrimSpace(after)
 			if v == "|-" || v == "|" {
-				// Collect indented continuation lines.
 				var parts []string
 				i++
 				for i < len(lines) && (strings.HasPrefix(lines[i], "  ") || lines[i] == "") {

--- a/scripts/generate-skill/entities_test.go
+++ b/scripts/generate-skill/entities_test.go
@@ -18,96 +18,10 @@
 package main
 
 import (
-	"strings"
+	"os"
+	"path/filepath"
 	"testing"
 )
-
-func TestExtractEntityNameFromH1(t *testing.T) {
-	cases := []struct {
-		in   string
-		want string
-		ok   bool
-	}{
-		{"# `elasticstack_elasticsearch_index` — Schema and Functional Requirements", "elasticstack_elasticsearch_index", true},
-		{"# `elasticstack_kibana_alerting_rule` — X", "elasticstack_kibana_alerting_rule", true},
-		{"# Not a provider entity", "", false},
-		{"## `elasticstack_foo` — subheading", "", false},
-		{"# `something_else` — nope", "", false},
-	}
-	for _, tc := range cases {
-		got, ok := extractEntityNameFromH1(tc.in)
-		if got != tc.want || ok != tc.ok {
-			t.Errorf("extractEntityNameFromH1(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
-		}
-	}
-}
-
-func TestExtractSection(t *testing.T) {
-	body := strings.Join([]string{
-		"# Title",
-		"",
-		"## Purpose",
-		"",
-		"This is the purpose.",
-		"",
-		"## Schema",
-		"",
-		"schema body",
-		"",
-		"### Subsection",
-		"",
-		"still schema",
-		"",
-		"## Requirements",
-		"",
-		"req body",
-	}, "\n")
-
-	if got := extractSection(body, "## Purpose"); got != "This is the purpose." {
-		t.Errorf("Purpose = %q", got)
-	}
-	schema := extractSection(body, "## Schema")
-	if !strings.Contains(schema, "schema body") || !strings.Contains(schema, "still schema") {
-		t.Errorf("Schema missing expected content: %q", schema)
-	}
-	if strings.Contains(schema, "req body") {
-		t.Errorf("Schema leaked into Requirements: %q", schema)
-	}
-}
-
-func TestParseSpecHeaders(t *testing.T) {
-	body := `# ` + "`elasticstack_elasticsearch_security_role`" + ` — Schema and Functional Requirements
-
-Resource implementation: ` + "`internal/elasticsearch/security/role`" + `
-Data source implementation: ` + "`internal/elasticsearch/security/role_data_source.go`" + `
-
-## Purpose
-
-Some purpose.
-
-## Schema
-
-` + "```hcl" + `
-resource "x" "y" {}
-` + "```" + `
-`
-	ent := parseSpec("elasticsearch-security-role", "/tmp/spec.md", body)
-	if ent == nil {
-		t.Fatal("entity nil")
-	}
-	if ent.Name != "elasticstack_elasticsearch_security_role" {
-		t.Errorf("Name = %q", ent.Name)
-	}
-	if !ent.Kinds.has(kindResource) || !ent.Kinds.has(kindDataSource) {
-		t.Errorf("Kinds = %d, expected both", ent.Kinds)
-	}
-	if !strings.Contains(ent.ResourceImpl, "internal/elasticsearch/security/role") {
-		t.Errorf("ResourceImpl = %q", ent.ResourceImpl)
-	}
-	if !strings.Contains(ent.Schema, "resource \"x\"") {
-		t.Errorf("Schema = %q", ent.Schema)
-	}
-}
 
 func TestParseDocsFrontmatter(t *testing.T) {
 	body := `---
@@ -118,23 +32,65 @@ description: |-
 ---
 
 # Something
-
-## Example Usage
-
-` + "```terraform" + `
-provider "elasticstack" {}
-resource "x" "y" {}
-` + "```" + `
 `
-	meta, example := parseDocsPage(body)
+	meta := parseFrontmatter(extractFrontmatter(body))
 	if meta.Subcategory != "Security" {
 		t.Errorf("Subcategory = %q", meta.Subcategory)
 	}
-	if !strings.HasPrefix(meta.Description, "Adds and updates roles") {
-		t.Errorf("Description = %q", meta.Description)
+	if meta.Description == "" {
+		t.Errorf("Description empty")
 	}
-	if !strings.Contains(example, `resource "x"`) {
-		t.Errorf("Example = %q", example)
+}
+
+func TestLoadEntities(t *testing.T) {
+	// Build a minimal fake docs tree.
+	dir := t.TempDir()
+	resDir := filepath.Join(dir, "resources")
+	dsDir := filepath.Join(dir, "data-sources")
+	if err := os.MkdirAll(resDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeDoc := func(path, sub, desc string) {
+		t.Helper()
+		content := "---\nsubcategory: \"" + sub + "\"\ndescription: |-\n  " + desc + "\n---\n# foo\n"
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeDoc(filepath.Join(resDir, "elasticsearch_index.md"), "Elasticsearch", "Manages an index.")
+	writeDoc(filepath.Join(resDir, "kibana_space.md"), "Kibana", "Manages a space.")
+	writeDoc(filepath.Join(dsDir, "elasticsearch_index.md"), "Elasticsearch", "Reads an index.")
+
+	entities, err := loadEntities(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	byName := map[string]*entity{}
+	for _, e := range entities {
+		byName[e.Name] = e
+	}
+
+	// elasticsearch_index should be both resource and data source.
+	idx, ok := byName["elasticstack_elasticsearch_index"]
+	if !ok {
+		t.Fatal("elasticstack_elasticsearch_index not found")
+	}
+	if !idx.Kinds.has(kindResource) || !idx.Kinds.has(kindDataSource) {
+		t.Errorf("elasticsearch_index kinds = %d, want both", idx.Kinds)
+	}
+	// kibana_space should be resource only.
+	ks, ok := byName["elasticstack_kibana_space"]
+	if !ok {
+		t.Fatal("elasticstack_kibana_space not found")
+	}
+	if !ks.Kinds.has(kindResource) || ks.Kinds.has(kindDataSource) {
+		t.Errorf("kibana_space kinds = %d, want resource only", ks.Kinds)
 	}
 }
 

--- a/scripts/generate-skill/entities_test.go
+++ b/scripts/generate-skill/entities_test.go
@@ -1,0 +1,147 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractEntityNameFromH1(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"# `elasticstack_elasticsearch_index` — Schema and Functional Requirements", "elasticstack_elasticsearch_index", true},
+		{"# `elasticstack_kibana_alerting_rule` — X", "elasticstack_kibana_alerting_rule", true},
+		{"# Not a provider entity", "", false},
+		{"## `elasticstack_foo` — subheading", "", false},
+		{"# `something_else` — nope", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := extractEntityNameFromH1(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("extractEntityNameFromH1(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+func TestExtractSection(t *testing.T) {
+	body := strings.Join([]string{
+		"# Title",
+		"",
+		"## Purpose",
+		"",
+		"This is the purpose.",
+		"",
+		"## Schema",
+		"",
+		"schema body",
+		"",
+		"### Subsection",
+		"",
+		"still schema",
+		"",
+		"## Requirements",
+		"",
+		"req body",
+	}, "\n")
+
+	if got := extractSection(body, "## Purpose"); got != "This is the purpose." {
+		t.Errorf("Purpose = %q", got)
+	}
+	schema := extractSection(body, "## Schema")
+	if !strings.Contains(schema, "schema body") || !strings.Contains(schema, "still schema") {
+		t.Errorf("Schema missing expected content: %q", schema)
+	}
+	if strings.Contains(schema, "req body") {
+		t.Errorf("Schema leaked into Requirements: %q", schema)
+	}
+}
+
+func TestParseSpecHeaders(t *testing.T) {
+	body := `# ` + "`elasticstack_elasticsearch_security_role`" + ` — Schema and Functional Requirements
+
+Resource implementation: ` + "`internal/elasticsearch/security/role`" + `
+Data source implementation: ` + "`internal/elasticsearch/security/role_data_source.go`" + `
+
+## Purpose
+
+Some purpose.
+
+## Schema
+
+` + "```hcl" + `
+resource "x" "y" {}
+` + "```" + `
+`
+	ent := parseSpec("elasticsearch-security-role", "/tmp/spec.md", body)
+	if ent == nil {
+		t.Fatal("entity nil")
+	}
+	if ent.Name != "elasticstack_elasticsearch_security_role" {
+		t.Errorf("Name = %q", ent.Name)
+	}
+	if !ent.Kinds.has(kindResource) || !ent.Kinds.has(kindDataSource) {
+		t.Errorf("Kinds = %d, expected both", ent.Kinds)
+	}
+	if !strings.Contains(ent.ResourceImpl, "internal/elasticsearch/security/role") {
+		t.Errorf("ResourceImpl = %q", ent.ResourceImpl)
+	}
+	if !strings.Contains(ent.Schema, "resource \"x\"") {
+		t.Errorf("Schema = %q", ent.Schema)
+	}
+}
+
+func TestParseDocsFrontmatter(t *testing.T) {
+	body := `---
+subcategory: "Security"
+page_title: "something"
+description: |-
+  Adds and updates roles in the native realm. See the role API documentation https://example for more details.
+---
+
+# Something
+
+## Example Usage
+
+` + "```terraform" + `
+provider "elasticstack" {}
+resource "x" "y" {}
+` + "```" + `
+`
+	meta, example := parseDocsPage(body)
+	if meta.Subcategory != "Security" {
+		t.Errorf("Subcategory = %q", meta.Subcategory)
+	}
+	if !strings.HasPrefix(meta.Description, "Adds and updates roles") {
+		t.Errorf("Description = %q", meta.Description)
+	}
+	if !strings.Contains(example, `resource "x"`) {
+		t.Errorf("Example = %q", example)
+	}
+}
+
+func TestOneLineStripsSeeURL(t *testing.T) {
+	in := "Creates Elasticsearch indices. See: https://example/docs"
+	want := "Creates Elasticsearch indices."
+	if got := oneLine(in); got != want {
+		t.Errorf("oneLine = %q, want %q", got, want)
+	}
+}

--- a/scripts/generate-skill/main.go
+++ b/scripts/generate-skill/main.go
@@ -35,27 +35,27 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("generate-skill", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
-	specsDir := fs.String("specs", "openspec/specs", "Path to openspec/specs directory")
 	docsDir := fs.String("docs", "docs", "Path to docs directory (tfplugindocs output)")
 	assetsDir := fs.String("assets", "scripts/generate-skill/assets", "Path to hand-seeded static content")
 	outDir := fs.String("out", "dist/skill/elasticstack-terraform", "Output directory for the generated skill")
-	providerVersion := fs.String("provider-version", "", "Provider version to stamp into metadata.version and hand-editable assets (e.g. 0.14.3). Falls back to 0.0.0-dev when empty.")
+	providerVersion := fs.String("provider-version", "", "Provider version to stamp into metadata.version (e.g. 0.14.3). Falls back to 0.0.0-dev when empty.")
 	verbose := fs.Bool("v", false, "Verbose logging")
 
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 
-	entities, err := loadEntities(*specsDir, *docsDir)
+	entities, err := loadEntities(*docsDir)
 	if err != nil {
 		return fmt.Errorf("load entities: %w", err)
 	}
 	if *verbose {
-		fmt.Fprintf(stdout, "loaded %d entities from specs/docs\n", len(entities))
+		fmt.Fprintf(stdout, "loaded %d entities from docs/\n", len(entities))
 	}
 
 	gen := &generator{
 		entities:        entities,
+		docsDir:         *docsDir,
 		assetsDir:       *assetsDir,
 		outDir:          *outDir,
 		providerVersion: *providerVersion,

--- a/scripts/generate-skill/main.go
+++ b/scripts/generate-skill/main.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("generate-skill", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	specsDir := fs.String("specs", "openspec/specs", "Path to openspec/specs directory")
+	docsDir := fs.String("docs", "docs", "Path to docs directory (tfplugindocs output)")
+	assetsDir := fs.String("assets", "scripts/generate-skill/assets", "Path to hand-seeded static content")
+	outDir := fs.String("out", "dist/skill/elasticstack-terraform", "Output directory for the generated skill")
+	providerVersion := fs.String("provider-version", "", "Provider version to stamp into metadata.version and hand-editable assets (e.g. 0.14.3). Falls back to 0.0.0-dev when empty.")
+	verbose := fs.Bool("v", false, "Verbose logging")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	entities, err := loadEntities(*specsDir, *docsDir)
+	if err != nil {
+		return fmt.Errorf("load entities: %w", err)
+	}
+	if *verbose {
+		fmt.Fprintf(stdout, "loaded %d entities from specs/docs\n", len(entities))
+	}
+
+	gen := &generator{
+		entities:        entities,
+		assetsDir:       *assetsDir,
+		outDir:          *outDir,
+		providerVersion: *providerVersion,
+		log:             stdout,
+		verbose:         *verbose,
+	}
+	if err := gen.emit(); err != nil {
+		return fmt.Errorf("emit skill: %w", err)
+	}
+	fmt.Fprintf(stdout, "wrote skill to %s (%d entities)\n", *outDir, len(entities))
+	return nil
+}


### PR DESCRIPTION
Auto generates a skill to put in elastic/agent-skills-sandbox repo

Will need to discuss if this fits here or if we would like to have another repo pull in the providers to generate and then push to that repo.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add skill generator CLI for the elasticstack-terraform agent-skills-sandbox repo
> - Adds a Go CLI at [`scripts/generate-skill`](https://github.com/elastic/terraform-provider-elasticstack/pull/2466/files#diff-29e9189664c8ba8eac41ff0ad202c4811890037b51374c105c1acbecc03ea0e8) that produces a deterministic skill directory tree under `dist/skill/` by combining hand-authored assets and provider docs.
> - Scans `docs/resources` and `docs/data-sources`, parses frontmatter, and merges entities into a generated `references/index.md` with descriptions and file links.
> - Copies static assets (including [`SKILL.md`](https://github.com/elastic/terraform-provider-elasticstack/pull/2466/files#diff-b0547e30c2cea23004fe51fcb63d84215fd0a751f9b21476d75682549621e694) and reference docs) into the output tree, substituting `{{VERSION}}` with the value passed via `--provider-version`.
> - Writes a `GENERATED.md` provenance file summarising entity counts and provider version.
> - Adds `make skill-generate` and `make skill-test` targets to invoke the generator and its unit tests respectively.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f18ed1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->