### PR TITLE
Deduplicate kibana connection test setup

### DIFF
--- a/internal/kibana/connector_data_source_test.go
+++ b/internal/kibana/connector_data_source_test.go
@@ -18,9 +18,7 @@
 package kibana_test
 
 import (
-	"os"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -112,7 +110,7 @@ func TestAccDataSourceKibanaConnector_kibanaConnection(t *testing.T) {
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("kibana_connection"),
-				ConfigVariables:          testAccConnectorKibanaConnectionVariables(),
+				ConfigVariables:          acctest.KibanaConnectionVariables(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.elasticstack_kibana_action_connector.test", "name", "kbconn_connector"),
 					resource.TestCheckResourceAttr("data.elasticstack_kibana_action_connector.test", "connector_type_id", ".slack"),
@@ -124,30 +122,4 @@ func TestAccDataSourceKibanaConnector_kibanaConnection(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccConnectorKibanaConnectionVariables() config.Variables {
-	apiKey := os.Getenv("KIBANA_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("ELASTICSEARCH_API_KEY")
-	}
-
-	username := os.Getenv("KIBANA_USERNAME")
-	if username == "" {
-		username = os.Getenv("ELASTICSEARCH_USERNAME")
-	}
-
-	password := os.Getenv("KIBANA_PASSWORD")
-	if password == "" {
-		password = os.Getenv("ELASTICSEARCH_PASSWORD")
-	}
-
-	endpoint := strings.TrimSpace(os.Getenv("KIBANA_ENDPOINT"))
-
-	return config.Variables{
-		"kibana_endpoint": config.StringVariable(endpoint),
-		"api_key":         config.StringVariable(apiKey),
-		"username":        config.StringVariable(username),
-		"password":        config.StringVariable(password),
-	}
 }

--- a/internal/kibana/testdata/TestAccDataSourceKibanaConnector_kibanaConnection/kibana_connection/main.tf
+++ b/internal/kibana/testdata/TestAccDataSourceKibanaConnector_kibanaConnection/kibana_connection/main.tf
@@ -1,5 +1,5 @@
-variable "kibana_endpoint" {
-  type = string
+variable "kibana_endpoints" {
+  type = list(string)
 }
 
 variable "api_key" {
@@ -35,7 +35,7 @@ data "elasticstack_kibana_action_connector" "test" {
   name = elasticstack_kibana_action_connector.test.name
 
   kibana_connection {
-    endpoints = [var.kibana_endpoint]
+    endpoints = var.kibana_endpoints
     insecure  = false
     api_key   = var.api_key != "" ? var.api_key : null
     username  = var.api_key == "" && var.username != "" ? var.username : null


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/2469

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate Kibana connection test setup by using shared `acctest.KibanaConnectionVariables()`
> - Removes the local `testAccConnectorKibanaConnectionVariables` helper from [connector_data_source_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2476/files#diff-31191cfc1de2af8aac417288a13d1db4364fa64f2ad5972ff7684dc071c3fccb) and replaces it with the shared `acctest.KibanaConnectionVariables()` function.
> - Updates [main.tf](https://github.com/elastic/terraform-provider-elasticstack/pull/2476/files#diff-c6b32aa8451c602f1176bd1221aea3ea03cf8a65b42013d065937a8218a4eec0) to accept a `kibana_endpoints` list variable instead of a single `kibana_endpoint` string, passing it directly to `endpoints`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbd433c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->