### PR TITLE
Change factory

### DIFF
--- a/openspec/changes/change-factory/.openspec.yaml
+++ b/openspec/changes/change-factory/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-26

--- a/openspec/changes/change-factory/design.md
+++ b/openspec/changes/change-factory/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The repository already has `code-factory` issue intake automation that turns trusted labeled issues into implementation pull requests. It also uses OpenSpec as the normal entry point for feature and workflow changes, but there is no equivalent automation that turns a labeled issue into a reviewable OpenSpec change proposal.
+
+`change-factory` should stay close to the proven `code-factory` intake shape while changing the agent contract from implementation to proposal authoring. The triggering issue remains the source of truth, but the output is an OpenSpec change under `openspec/changes/<id>/` and a linked pull request, not provider code.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Create a label-gated issue workflow for trusted maintainers to request OpenSpec change proposals.
+- Reuse deterministic gating patterns for trigger qualification, actor trust, and duplicate linked pull request suppression.
+- Keep the agent focused on OpenSpec artifact creation: proposal, design, tasks, and delta specs.
+- Bootstrap only the tooling required for OpenSpec authoring and workflow validation.
+- Produce exactly one linked pull request per triggering issue.
+
+**Non-Goals:**
+
+- Implement the requested provider/workflow behavior inside the same run.
+- Provision the Elastic Stack or run acceptance tests.
+- Add a GitHub-comment or GitHub-Discussion exploration loop in the first version.
+- Replace existing manual OpenSpec proposal authoring workflows.
+
+## Decisions
+
+### Use a dedicated `change-factory` issue label and branch namespace
+
+The workflow should trigger from `issues.opened` and `issues.labeled` events using a dedicated `change-factory` label. It should create proposal branches under `change-factory/issue-<issue-number>`.
+
+Alternatives considered:
+
+- Reuse `code-factory`: rejected because implementation and proposal-generation contracts have different toolchains, outputs, and guardrails.
+- Use a sub-label such as `code-factory:proposal`: rejected because the behavior is distinct enough to deserve separate duplicate detection, labeling, and safe-output policy.
+
+### Keep deterministic pre-activation before agent reasoning
+
+The workflow should adapt the existing deterministic gates from `code-factory`: event qualification, actor trust, duplicate linked pull request detection, and a consolidated gate reason. This keeps permission and idempotency decisions outside the model prompt.
+
+Alternatives considered:
+
+- Let the agent inspect existing pull requests and decide whether to continue: rejected because duplicate suppression should be stable across reruns and independent of model behavior.
+
+### Generate a pull request containing only OpenSpec change artifacts
+
+The agent should derive an OpenSpec change id from the issue title/body, create or update `openspec/changes/<id>/`, validate the artifacts, and open a single pull request labeled `change-factory`. The prompt should explicitly prohibit implementation changes unless needed for repository-authored workflow metadata in a future extension.
+
+Alternatives considered:
+
+- Create a comment with proposed requirements instead of a PR: rejected for v1 because PR review provides normal diff review, CI, and `verify-openspec` follow-up.
+- Create canonical specs directly under `openspec/specs/`: rejected because new work should flow through active changes.
+
+### Bootstrap OpenSpec tooling without Elastic Stack setup
+
+The workflow should configure Node from `package.json` and install repository npm dependencies so the OpenSpec CLI is available. It should not start the Elastic Stack, create ES API keys, set up Fleet, or run acceptance tests. Go setup should be included only if the chosen validation/generation path requires repository Go tooling, such as workflow-source compilation checks.
+
+Alternatives considered:
+
+- Run the full `code-factory` environment: rejected because it is slow and gives the agent unnecessary access to runtime services.
+- Avoid all repository setup and rely on global tooling: rejected because OpenSpec is pinned in `package.json`.
+
+### Defer exploration loops
+
+If issue context is too ambiguous to produce a coherent proposal, the v1 workflow should use `noop` with a concise clarification request. Interactive exploration through issue comments or GitHub Discussions should be a later, separately specified workflow/state.
+
+Alternatives considered:
+
+- Drive `/openspec-explore` through issue comments immediately: rejected for v1 because it requires state tracking, bot-loop prevention, comment trust policy, and clear rules for which comments are authoritative.
+
+## Risks / Trade-offs
+
+- Ambiguous issues may produce weak proposals → Prefer `noop` over speculative artifacts when core scope is unclear.
+- Proposal quality depends on issue context → The prompt should require preserving assumptions and open questions in the generated artifacts.
+- Duplicate detection can miss manually created PRs without canonical metadata → Require deterministic branch, label, and explicit issue linkage in the PR body.
+- Omitting Go setup may break workflow-generation validation if the implementation uses `make check-workflows` → Choose validation commands during implementation based on the final workflow source path, and include Go only when needed.

--- a/openspec/changes/change-factory/proposal.md
+++ b/openspec/changes/change-factory/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Maintainers currently have an agentic path for issue-driven implementation, but not for issue-driven OpenSpec proposal creation. A focused `change-factory` workflow would let trusted labeled issues become reviewable OpenSpec change pull requests without provisioning the Elastic Stack or asking the agent to implement code.
+
+## What Changes
+
+- Add a GitHub Agentic Workflow that reacts to trusted issue events labeled `change-factory`.
+- Reuse the deterministic intake shape from `code-factory`: label qualification, actor trust checks, duplicate linked pull request suppression, deterministic branch naming, and a single linked pull request contract.
+- Instruct the agent to create an OpenSpec change proposal from the issue title/body, including `proposal.md`, `design.md`, `tasks.md`, and required delta specs under `openspec/changes/<id>/`.
+- Keep the workflow proposal-focused: it must not implement provider behavior, start the Elastic Stack, or run acceptance tests.
+- Bootstrap only the toolchains needed to author and validate OpenSpec artifacts, with Node/OpenSpec as required and Go only if repository workflow-generation or validation commands require it.
+- Defer any interactive exploration via GitHub comments or Discussions to a future workflow/state rather than including it in the initial `change-factory` behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-change-factory-issue-intake`: Defines the issue-labeled agentic workflow that creates exactly one linked OpenSpec change proposal pull request from a trusted GitHub issue.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- New workflow source under `.github/workflows-src/` and generated workflow artifacts under `.github/workflows/`.
+- New deterministic workflow helper logic and tests for trigger qualification, trust/duplicate gating, and linked pull request identification, likely adapted from the existing `code-factory` helpers.
+- Agent prompt contract for creating and validating OpenSpec change artifacts from issue context.
+- CI/workflow generation paths may need updates so the new workflow source is compiled and checked with existing workflow tooling.

--- a/openspec/changes/change-factory/specs/ci-change-factory-issue-intake/spec.md
+++ b/openspec/changes/change-factory/specs/ci-change-factory-issue-intake/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Workflow source is repository-authored and generated
+The repository SHALL define the `change-factory` issue-intake automation as a repository-authored GitHub Agentic Workflow source under `.github/workflows-src/` that generates checked-in workflow artifacts under `.github/workflows/`. Deterministic GitHub-script logic used for trigger qualification, trust checks, or duplicate detection SHALL be factored into repository-local helper code that can be tested independently of the compiled workflow.
+
+#### Scenario: Maintainer updates the workflow source
+- **WHEN** maintainers modify the `change-factory` issue-intake workflow
+- **THEN** the authored source SHALL live under `.github/workflows-src/`
+- **AND** the generated workflow artifacts SHALL be checked in under `.github/workflows/`
+
+#### Scenario: Deterministic gating logic is tested outside the workflow wrapper
+- **WHEN** maintainers validate trigger qualification, trust policy, or duplicate detection
+- **THEN** the repository SHALL support focused tests for the extracted helper logic without requiring execution of the compiled workflow
+
+### Requirement: Workflow activates only for qualifying `change-factory` issue events
+The workflow MAY subscribe to GitHub `issues.opened` and `issues.labeled` events, but it SHALL activate the proposal agent only for eligible `change-factory` issue triggers. Eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `change-factory`, and `issues.opened` when the issue already includes the `change-factory` label at creation time.
+
+#### Scenario: Label applied after issue creation
+- **WHEN** an `issues.labeled` event is received and `github.event.label.name` is `change-factory`
+- **THEN** the workflow SHALL treat the event as eligible to activate the proposal agent
+
+#### Scenario: Issue opens with the trigger label already present
+- **WHEN** an `issues.opened` event is received and the issue's initial labels include `change-factory`
+- **THEN** the workflow SHALL treat the event as eligible to activate the proposal agent
+
+#### Scenario: Non-trigger issue event is ignored
+- **WHEN** an `issues` event is received without the `change-factory` label in the qualifying position for that event type
+- **THEN** the workflow SHALL NOT activate the proposal agent for that event
+
+### Requirement: Trigger actor must be trusted
+Before agent activation, the workflow SHALL determine whether the triggering actor is trusted. The actor SHALL be trusted if the sender is `github-actions[bot]`; otherwise the workflow SHALL query repository collaborator permissions and SHALL require effective repository permission `write`, `maintain`, or `admin`.
+
+#### Scenario: GitHub Actions opens a labeled issue
+- **WHEN** the sender is `github-actions[bot]` and the event otherwise qualifies for `change-factory` issue intake
+- **THEN** the workflow SHALL treat the trigger as trusted without requiring a collaborator-permission lookup
+
+#### Scenario: Maintainer applies the label
+- **WHEN** a human actor triggers an otherwise eligible `change-factory` issue event and the repository permission lookup returns `write`, `maintain`, or `admin`
+- **THEN** the workflow SHALL treat the trigger as trusted
+
+#### Scenario: Untrusted actor attempts to trigger automation
+- **WHEN** a non-bot actor triggers an otherwise eligible `change-factory` issue event and the repository permission lookup does not return `write`, `maintain`, or `admin`
+- **THEN** the workflow SHALL skip agent activation
+
+### Requirement: Workflow suppresses duplicate linked pull requests
+Before agent activation, the workflow SHALL detect whether an open linked `change-factory` pull request already exists for the triggering issue. A pull request SHALL be treated as linked only when it is open, carries the `change-factory` label, uses the deterministic branch name `change-factory/issue-<issue-number>`, and includes explicit issue linkage metadata such as `Closes #<issue-number>`.
+
+#### Scenario: Existing linked PR prevents a duplicate run
+- **WHEN** the workflow finds an open pull request that satisfies the linked `change-factory` PR criteria for the triggering issue
+- **THEN** the workflow SHALL skip agent activation instead of opening a duplicate pull request
+
+#### Scenario: Unrelated PR does not block issue intake
+- **WHEN** an open pull request mentions the issue or has a similar title but does not satisfy the full linked `change-factory` PR criteria
+- **THEN** the workflow SHALL NOT treat that pull request as the canonical linked PR for duplicate suppression
+
+### Requirement: Agent creates exactly one linked OpenSpec proposal pull request
+When the deterministic gate passes, the workflow agent SHALL treat the triggering issue title and body as the authoritative source for requested proposal scope, SHALL work on the deterministic branch `change-factory/issue-<issue-number>`, and SHALL create or update exactly one linked pull request labeled `change-factory`. The pull request SHALL contain one active OpenSpec change under `openspec/changes/<change-id>/` with the artifacts required for implementation readiness by the active OpenSpec schema.
+
+#### Scenario: Eligible issue creates a linked proposal PR
+- **WHEN** the workflow runs for a trusted eligible issue event and no open linked `change-factory` pull request already exists
+- **THEN** the agent SHALL create an OpenSpec change proposal on branch `change-factory/issue-<issue-number>`
+- **AND** it SHALL open one linked pull request carrying the `change-factory` label
+
+#### Scenario: Pull request metadata preserves deterministic linkage
+- **WHEN** the agent creates the `change-factory` pull request
+- **THEN** the pull request SHALL include explicit issue linkage metadata so later workflow runs can identify it as the canonical PR for the issue
+
+#### Scenario: Proposal artifacts are implementation-ready
+- **WHEN** the agent completes a proposal pull request
+- **THEN** the pull request SHALL include all OpenSpec artifacts required before implementation can begin according to the repository's active OpenSpec schema
+
+### Requirement: Workflow remains proposal-only
+The `change-factory` workflow SHALL NOT implement the requested provider, CI, or documentation behavior as part of the proposal-generation run. It SHALL limit repository changes to OpenSpec change artifacts and any workflow metadata required by the proposal workflow itself.
+
+#### Scenario: Issue asks for provider behavior
+- **WHEN** a qualifying issue describes a new Terraform resource, data source, or provider behavior change
+- **THEN** the agent SHALL create OpenSpec proposal artifacts for that work
+- **AND** it SHALL NOT implement provider code in the same pull request
+
+#### Scenario: Proposal requires assumptions
+- **WHEN** the issue context is sufficient to propose a change but leaves secondary details unresolved
+- **THEN** the agent SHALL capture assumptions or open questions in the OpenSpec artifacts rather than implementing speculative behavior
+
+### Requirement: Workflow bootstraps only proposal-authoring tooling
+Before the proposal agent runs OpenSpec commands, the workflow SHALL provision the repository tooling needed to author and validate OpenSpec artifacts. At minimum, it SHALL set up Node using `actions/setup-node` with `node-version-file: package.json` and SHALL install repository npm dependencies so the local OpenSpec CLI is available. The workflow SHALL NOT start the Elastic Stack, create Elasticsearch API keys, set up Fleet, or run Terraform acceptance tests.
+
+#### Scenario: OpenSpec CLI is available before agent reasoning
+- **WHEN** the agent starts for a qualifying `change-factory` run
+- **THEN** deterministic setup SHALL have made the repository-pinned OpenSpec CLI available in the workspace
+
+#### Scenario: Elastic Stack services are not provisioned
+- **WHEN** the `change-factory` workflow prepares the proposal-authoring environment
+- **THEN** it SHALL NOT run Elastic Stack, Fleet, or Elasticsearch API-key setup steps
+
+#### Scenario: Acceptance tests are out of scope
+- **WHEN** the proposal agent validates its work
+- **THEN** it SHALL validate OpenSpec structure rather than running Terraform acceptance tests
+
+### Requirement: Unclear issues result in noop rather than an exploration loop
+If the triggering issue lacks enough context for the agent to create a coherent OpenSpec proposal, the workflow SHALL emit a single no-op result with a concise clarification reason instead of opening an exploratory comment thread, creating a GitHub Discussion, or producing speculative proposal artifacts.
+
+#### Scenario: Core scope is unclear
+- **WHEN** the issue title and body do not provide enough information to determine the proposed change scope
+- **THEN** the agent SHALL use `noop` with a concise explanation of what clarification is needed
+
+#### Scenario: Issue is clear enough for a proposal
+- **WHEN** the issue title and body provide enough context to identify the change scope and capability area
+- **THEN** the agent SHALL create the linked OpenSpec proposal pull request without requiring a GitHub comment exploration loop

--- a/openspec/changes/change-factory/specs/ci-change-factory-issue-intake/spec.md
+++ b/openspec/changes/change-factory/specs/ci-change-factory-issue-intake/spec.md
@@ -1,3 +1,11 @@
+# `ci-change-factory-issue-intake` — Issue-labeled OpenSpec proposal factory
+
+Workflow implementation: authored source under `.github/workflows-src/change-factory-issue/`, compiled to `.github/workflows/change-factory-issue.md`.
+
+## Purpose
+
+Define requirements for a GitHub Agentic Workflow that reacts to trusted GitHub issues labeled `change-factory` and creates exactly one linked OpenSpec change proposal pull request, without implementing provider behavior or provisioning the Elastic Stack.
+
 ## ADDED Requirements
 
 ### Requirement: Workflow source is repository-authored and generated

--- a/openspec/changes/change-factory/tasks.md
+++ b/openspec/changes/change-factory/tasks.md
@@ -1,0 +1,26 @@
+## 1. Deterministic Intake
+
+- [ ] 1.1 Add repository-local helper logic for `change-factory` trigger qualification, actor trust, duplicate linked pull request detection, and consolidated gate reasons.
+- [ ] 1.2 Add focused tests for the deterministic helper logic, covering eligible issue events, ignored labels/events, trusted and untrusted actors, linked PR detection, and unrelated PRs.
+- [ ] 1.3 Reuse or adapt existing `code-factory` script include patterns so the workflow source can call the deterministic helpers from pre-activation steps.
+
+## 2. Workflow Source
+
+- [ ] 2.1 Add an authored `.github/workflows-src/change-factory-issue/` workflow template that triggers on issue `opened` and `labeled` events.
+- [ ] 2.2 Configure pre-activation outputs for issue context, gate reason, trust status, duplicate PR status, and duplicate PR URL.
+- [ ] 2.3 Configure the agent job to run only after deterministic gates pass and to use branch `change-factory/issue-<issue-number>`.
+- [ ] 2.4 Configure safe outputs so the agent can create at most one linked pull request labeled `change-factory` and at most one no-op result.
+
+## 3. Agent Prompt and Tooling
+
+- [ ] 3.1 Write the agent prompt to treat the issue title/body as authoritative and create exactly one OpenSpec change under `openspec/changes/<change-id>/`.
+- [ ] 3.2 Instruct the agent to create all artifacts required for implementation readiness by the active OpenSpec schema: proposal, design, tasks, and delta specs.
+- [ ] 3.3 Instruct the agent to validate OpenSpec artifacts and avoid provider implementation, Elastic Stack setup, Fleet setup, API-key creation, and Terraform acceptance tests.
+- [ ] 3.4 Define the no-op behavior for issues that are too ambiguous to propose safely, including a concise clarification reason.
+
+## 4. Workflow Generation and Verification
+
+- [ ] 4.1 Add the new workflow source to the workflow-source manifest so generated workflow artifacts are checked in.
+- [ ] 4.2 Generate the workflow markdown and compiled lock artifacts with the repository workflow tooling.
+- [ ] 4.3 Run focused workflow helper tests and workflow generation checks.
+- [ ] 4.4 Run OpenSpec validation for the new change.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `change-factory` OpenSpec workflow design, proposal, and intake spec
- Introduces the `change-factory` agentic workflow as a companion to the existing `code-factory`, triggered by GitHub issues labeled `change-factory`.
- Adds [design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2482/files#diff-603ec1a01c0e07337ba2c04796e19f4fc641c091333ec547f6049b244f832195) and [proposal.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2482/files#diff-e93b2583b6ccd0e4f78ed6b116aa35121c2abc86f313d7659355839cd225b66c) covering goals, decisions, and trade-offs (e.g. deferring exploration loops, no Elastic Stack provisioning).
- Adds [spec.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2482/files#diff-198a583d58b5610151de258a635af6d5113c475e40753f356087b9cc51e699c1) for `ci-change-factory-issue-intake`, defining trusted-actor policy, duplicate PR suppression, deterministic branch naming (`change-factory/issue-<number>`), and agent behavior scoped to OpenSpec artifact creation only.
- Tooling bootstrap is intentionally minimal: Node and repo npm deps for the OpenSpec CLI, with no provider implementation or acceptance test provisioning.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8703f14.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->