### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/internal/kibana/agentbuildertool/models.go
+++ b/internal/kibana/agentbuildertool/models.go
@@ -163,7 +163,7 @@ func (model toolModel) toAPICreateModel(ctx context.Context) (kbapi.PostAgentBui
 	body := kbapi.PostAgentBuilderToolsJSONRequestBody{
 		Id:            model.ToolID.ValueString(),
 		Type:          kbapi.PostAgentBuilderToolsJSONBodyType(model.Type.ValueString()),
-		Configuration: pointerInterfaceMapFromAnyMap(configuration),
+		Configuration: clients.PointerInterfaceMapFromAnyMap(configuration),
 	}
 
 	if !model.Description.IsNull() {
@@ -195,7 +195,7 @@ func (model toolModel) toAPIUpdateModel(ctx context.Context) (kbapi.PutAgentBuil
 		}
 	}
 
-	apiConfiguration := pointerInterfaceMapFromAnyMap(configuration)
+	apiConfiguration := clients.PointerInterfaceMapFromAnyMap(configuration)
 	body := kbapi.PutAgentBuilderToolsToolidJSONRequestBody{
 		Configuration: &apiConfiguration,
 	}
@@ -217,12 +217,4 @@ func (model toolModel) toAPIUpdateModel(ctx context.Context) (kbapi.PutAgentBuil
 	return body, diags
 }
 
-func pointerInterfaceMapFromAnyMap(input map[string]any) map[string]*any {
-	output := make(map[string]*any, len(input))
-	for k, v := range input {
-		value := v
-		output[k] = &value
-	}
 
-	return output
-}


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/elastic/terraform-provider-elasticstack/security/quality/ai-findings)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace local `pointerInterfaceMapFromAnyMap` with shared `clients.PointerInterfaceMapFromAnyMap` in agent builder tool
> Removes the local `pointerInterfaceMapFromAnyMap` helper in [models.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2484/files#diff-c171ad8cad786c2f3541a45d74fd5f1e52b426dad54fb83cdda5c0e67ab7f94a) and replaces its usage in `toAPICreateModel` and `toAPIUpdateModel` with the equivalent shared utility `clients.PointerInterfaceMapFromAnyMap`. This eliminates duplicate logic flagged as a code quality finding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a429e5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->