### PR TITLE
Proposed SLO alignment

### DIFF
--- a/openspec/changes/align-kibana-slo-resource/.openspec.yaml
+++ b/openspec/changes/align-kibana-slo-resource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-26

--- a/openspec/changes/align-kibana-slo-resource/design.md
+++ b/openspec/changes/align-kibana-slo-resource/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The current `elasticstack_kibana_slo` resource only supports the string arm of the Kibana KQL union fields used by `kql_custom_indicator.filter`, `good`, and `total`, even though the generated API models also allow an object form with `kqlQuery` and `filters`. The resource also relies on a mix of runtime validation and schema validation, which leaves several indicator-specific errors until apply time. In addition, the resource does not yet expose `settings.sync_field`, does not manage `artifacts`, and reads but does not manage SLO enabled state.
+The current `elasticstack_kibana_slo` resource only supports the string arm of the Kibana KQL union fields used by `kql_custom_indicator.filter`, `good`, and `total`, even though the generated API models also allow an object form with `kqlQuery` and `filters`. The resource also relies on a mix of runtime validation and schema validation, which leaves several indicator-specific errors until apply time. In addition, the resource does not yet expose `settings.sync_field`, does not manage `artifacts`, and does not yet expose `enabled`, so enabled state is not currently represented in Terraform state.
 
 This change spans the Terraform schema, SLO model conversion, shared conditional validators, the Kibana SLO client helpers, acceptance tests, and the canonical OpenSpec requirements. It is therefore worth documenting the design choices before implementation.
 

--- a/openspec/changes/align-kibana-slo-resource/design.md
+++ b/openspec/changes/align-kibana-slo-resource/design.md
@@ -1,0 +1,105 @@
+## Context
+
+The current `elasticstack_kibana_slo` resource only supports the string arm of the Kibana KQL union fields used by `kql_custom_indicator.filter`, `good`, and `total`, even though the generated API models also allow an object form with `kqlQuery` and `filters`. The resource also relies on a mix of runtime validation and schema validation, which leaves several indicator-specific errors until apply time. In addition, the resource does not yet expose `settings.sync_field`, does not manage `artifacts`, and reads but does not manage SLO enabled state.
+
+This change spans the Terraform schema, SLO model conversion, shared conditional validators, the Kibana SLO client helpers, acceptance tests, and the canonical OpenSpec requirements. It is therefore worth documenting the design choices before implementation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add support for the object-form KQL union fields without breaking existing string-based configurations.
+- Move indicator-specific validation to provider plan time where the provider can express the rule.
+- Align simple schema validators with the current generated SLO API model where the repo has no evidence for a broader historical contract.
+- Expose `settings.sync_field`, `artifacts`, and `enabled` in the Terraform resource.
+- Implement write support for `enabled` using the actual SLO API surface exposed by the generated client.
+
+**Non-Goals:**
+- Redesign the entire SLO schema around dynamic JSON-like blocks.
+- Change the existing indicator block model or the one-indicator-only resource shape.
+- Replace the current string KQL attributes with a breaking schema migration in this change.
+- Expand support beyond the current `artifacts.dashboards[].id` shape modeled in the filtered spec.
+
+## Decisions
+
+### 1. Additive `_kql` attributes for object-form KQL unions
+
+The resource will keep the current string attributes:
+- `kql_custom_indicator.filter`
+- `kql_custom_indicator.good`
+- `kql_custom_indicator.total`
+
+It will add parallel object-form attributes with a `_kql` suffix:
+- `filter_kql`
+- `good_kql`
+- `total_kql`
+
+Each `_kql` attribute will model the object union arm with:
+- `kql_query`
+- `filters`
+
+This preserves backward compatibility for existing configurations while allowing the provider to round-trip the full Kibana API shape. A more invasive replacement with a single unified object would be cleaner conceptually, but it would either break existing configuration or require a more complex state and schema migration than this change needs.
+
+### 2. Enforce one representation per KQL field
+
+For each of `filter`, `good`, and `total`, the provider will enforce that only one of the string or `_kql` forms is configured. This keeps plans unambiguous and avoids precedence rules that would be hard to explain. The read path will populate whichever representation was used in configuration when possible; when the API returns the object form with filters, the provider should retain that richer form in state rather than degrading it to the string-only representation.
+
+### 3. Reuse conditional validators for indicator-specific rules
+
+The provider already has reusable conditional validators in `internal/utils/validators/conditional.go`, including relative-path helpers that work well for nested list elements. This change will use those validators in the SLO schema to enforce rules such as:
+- metric `field` required except for `doc_count`
+- metric `field` forbidden for `doc_count`
+- timeslice `percentile` required only for `percentile`
+- timeslice `percentile` forbidden for non-`percentile`
+- indicator-specific required nested blocks that are currently only rejected in model conversion
+
+If the current helper error text is awkward for multi-value conditions, the utility may be tightened as part of this change, but the main plan is to reuse the existing validator pattern rather than invent a SLO-only validation mechanism.
+
+### 4. Align schema validation to the generated contract unless proven otherwise
+
+The repo currently shows a mismatch between the Terraform `slo_id` validator (`8..48`) and the generated SLO create model comment (`8..36`). The workspace does not contain evidence that earlier stack versions allowed a longer SLO id, so this change will align the provider to `8..36` unless implementation uncovers stronger version-specific evidence.
+
+The same principle applies to other simple validators:
+- custom metric `aggregation` will be restricted to `sum` and `doc_count`
+- metric names will be validated against `^[A-Z]$`
+- `time_window.type` will be restricted to `rolling` and `calendarAligned`
+
+### 5. Manage `enabled` through dedicated APIs, not update payloads
+
+The generated `SLOsUpdateSloRequest` does not include an `enabled` field, but the generated client exposes `EnableSloOpWithResponse` and `DisableSloOpWithResponse`. The resource will therefore manage `enabled` as a first-class Terraform attribute, but write reconciliation will be implemented by:
+1. creating or updating the SLO definition with the standard create/update APIs
+2. calling enable or disable if the post-write server state does not match the planned `enabled` value
+3. reading back the SLO again to settle state
+
+This matches the actual API shape and avoids baking assumptions about hidden update-body support into the resource.
+
+### 6. Expose `artifacts` as modeled metadata
+
+The filtered spec currently models `artifacts` as dashboard references under `artifacts.dashboards[].id`. This change will expose that exact shape rather than inventing a more generic artifact model. The provider should treat it as managed metadata attached to the SLO definition, not as derived or computed server-only state.
+
+### 7. Keep `settings.sync_field` in the existing `settings` object
+
+`settings.sync_field` belongs in the existing `settings` block alongside `sync_delay`, `frequency`, and `prevent_initial_backfill`. This avoids another top-level field and keeps the Terraform schema aligned with the generated `SLOsSettings` structure. The settings object handling in the model layer and any state-upgrade logic will be updated accordingly.
+
+## Risks / Trade-offs
+
+- **Schema growth in `kql_custom_indicator`** → Mitigation: use a consistent `_kql` suffix and keep the object shape minimal so it reads as a parallel representation, not a second subsystem.
+- **State round-tripping for KQL unions may be subtle** → Mitigation: add focused unit tests for all string/object combinations and read-back behavior involving `filters`.
+- **`enabled` writes may require extra API calls and read-backs** → Mitigation: keep the sequence explicit and only invoke enable/disable when the desired state differs from the server state.
+- **`slo_id` alignment to 36 could reject configs that previously planned locally** → Mitigation: confirm no stronger in-repo evidence exists before implementation and document the narrowed contract in the change artifacts.
+- **Conditional validation can become noisy if misapplied to nested blocks** → Mitigation: mirror existing validator usage patterns from other resources and keep runtime validation only for cases the framework cannot express cleanly.
+
+## Migration Plan
+
+The preferred rollout is additive and low risk:
+1. Add new schema fields and validators.
+2. Extend model conversion and client helpers.
+3. Add or update tests to lock in round-trip and validation behavior.
+4. Regenerate resource docs.
+
+No external data migration is expected. Existing configurations using string KQL inputs will continue to work. If a user adopts `_kql` inputs, state should converge through normal read-after-create and read-after-update behavior. If `enabled` is added with a defaulted value, implementation should ensure the default matches current server behavior to avoid surprise diffs.
+
+## Open Questions
+
+- Whether `filter` on timeslice `doc_count` metrics should remain accepted unless the API proves otherwise, or be forbidden up front for stricter alignment.
+- Whether `artifacts` should be exposed immediately for both create and update, or staged behind read support first if acceptance testing shows server-side normalization.
+- Whether state-upgrade logic needs an explicit schema version bump for the expanded `settings` object and new `_kql` fields, or whether the plugin framework can absorb the additive changes without a dedicated upgrader.

--- a/openspec/changes/align-kibana-slo-resource/design.md
+++ b/openspec/changes/align-kibana-slo-resource/design.md
@@ -60,7 +60,7 @@ The repo currently shows a mismatch between the Terraform `slo_id` validator (`8
 
 The same principle applies to other simple validators:
 - custom metric `aggregation` will be restricted to `sum` and `doc_count`
-- metric names will be validated against `^[A-Z]$`
+- metric variable names used in SLO equations will be validated against `^[A-Z]$`, matching the generated API contract that documents valid options as `A-Z`
 - `time_window.type` will be restricted to `rolling` and `calendarAligned`
 
 ### 5. Manage `enabled` through dedicated APIs, not update payloads

--- a/openspec/changes/align-kibana-slo-resource/proposal.md
+++ b/openspec/changes/align-kibana-slo-resource/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `elasticstack_kibana_slo` resource has drifted from the current Kibana SLO API in several places, which leads to missing functionality, weaker plan-time validation, and at least one known incompatibility around KQL filter object variants. Capturing this now lets the provider support the current API surface more completely while tightening validation before more consumers depend on the current gaps.
+
+## What Changes
+
+- Add additive object-form KQL inputs with a `_kql` suffix for `filter`, `good`, and `total`, while preserving the existing string attributes for backward compatibility.
+- Support the Kibana KQL union shape for those fields so the resource can send and read back both string and object forms.
+- Improve provider-side validation for indicator-specific required and forbidden fields using conditional validators, moving failures from apply-time to plan-time where possible.
+- Align simple schema validators with the API, including `slo_id` length, custom metric aggregation values, metric name format, and `time_window.type`.
+- Add support for `settings.sync_field`.
+- Add support for SLO `enabled` management, including write behavior if the API requires dedicated enable or disable operations rather than update-body fields.
+- Add support for the `artifacts` field exposed by the SLO API.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `kibana-slo`: align the SLO resource requirements with the current Kibana SLO API for KQL input shape support, validation behavior, settings coverage, enabled-state management, and supported request fields.
+
+## Impact
+
+- Affected code is centered in `internal/kibana/slo/`, `internal/clients/kibanaoapi/slo.go`, and the conditional validator utilities under `internal/utils/validators/`.
+- Affected interfaces include the Terraform schema for `elasticstack_kibana_slo`, SLO CRUD request construction, and acceptance and unit test coverage for SLO behavior.
+- The change is intended to be backward compatible for existing string-based KQL configurations by introducing additive `_kql` inputs rather than replacing current attributes.

--- a/openspec/changes/align-kibana-slo-resource/specs/kibana-slo/spec.md
+++ b/openspec/changes/align-kibana-slo-resource/specs/kibana-slo/spec.md
@@ -1,9 +1,21 @@
+# Delta Spec: `elasticstack_kibana_slo` Alignment
+
+Base spec: `openspec/specs/kibana-slo/spec.md`
+Last requirement in base spec: REQ-035
+This delta introduces: REQ-036 to REQ-040
+
+---
+
+This delta defines the target behavior introduced by change `align-kibana-slo-resource`. It describes the requirements the implementation will satisfy once the change is applied; it is not intended to claim that the current implementation already meets these behaviors.
+
 ## ADDED Requirements
 
-### Requirement: Mapping — `kql_custom_indicator` string and object-form KQL inputs
+### Requirement: Mapping — `kql_custom_indicator` string and object-form KQL inputs (REQ-036)
 The `kql_custom_indicator` block SHALL support both the existing string form and an additive object form for `filter`, `good`, and `total`. The object-form attributes SHALL use the names `filter_kql`, `good_kql`, and `total_kql`, and each SHALL model the Kibana KQL object variant with `kql_query` and `filters`. For each logical field, the provider SHALL allow exactly one representation to be configured: either the existing string attribute or the new `_kql` attribute.
 
 On write, when a string form is configured, the provider SHALL serialize the string arm of the generated kbapi union. When a `_kql` object form is configured, the provider SHALL serialize the object arm of the generated kbapi union, including both `kqlQuery` and `filters` when provided. On read, the provider SHALL round-trip object-form responses without discarding `filters`.
+
+Mutual exclusivity SHALL apply to practitioner-configured values. The `_kql` attributes SHALL support computed state so the provider can retain a richer object-form API response when it cannot be represented losslessly by the legacy string attribute alone.
 
 #### Scenario: String-form KQL input remains supported
 - **WHEN** `kql_custom_indicator.good` is configured as a string and `good_kql` is unset
@@ -21,7 +33,15 @@ On write, when a string form is configured, the provider SHALL serialize the str
 - **WHEN** the Kibana API returns object-form `filter`, `good`, or `total` values containing `filters`
 - **THEN** the provider SHALL preserve that object-form information in state rather than degrading it to the string-only representation
 
-### Requirement: Validation — indicator-specific conditional fields
+#### Scenario: Richer response upgrades state representation
+- **WHEN** configuration uses the legacy string form for a KQL field and the API response includes an object-form value with `filters`
+- **THEN** the provider SHALL retain the `_kql` state representation for that field and SHALL treat the legacy string attribute as unset in state for that field
+
+#### Scenario: Configured representation is preserved when lossless
+- **WHEN** configuration uses the legacy string form for a KQL field and the API response is representable losslessly as the same string form
+- **THEN** the provider SHALL keep the string representation in state for that field and SHALL leave the corresponding `_kql` attribute unset
+
+### Requirement: Validation — indicator-specific conditional fields (REQ-037)
 The provider SHALL validate indicator-specific required and forbidden fields at plan time where the Terraform Plugin Framework can express the rule. This SHALL include nested indicator blocks that are currently only rejected during model conversion and conditional field rules driven by sibling `aggregation` values.
 
 At minimum, plan-time validation SHALL cover:
@@ -46,7 +66,7 @@ At minimum, plan-time validation SHALL cover:
 - **WHEN** a `timeslice_metric_indicator.metric.metrics` entry has `aggregation = "percentile"` and `percentile` is unset
 - **THEN** the provider SHALL return a plan-time validation error
 
-### Requirement: Validation — simple schema constraints aligned with the API
+### Requirement: Validation — simple schema constraints aligned with the API (REQ-038)
 The provider SHALL validate simple SLO schema constraints at plan time to match the current generated SLO API contract and generated union types. The resource SHALL:
 - restrict `slo_id` to 8 through 36 characters and `[a-zA-Z0-9_-]+`
 - restrict `metric_custom_indicator.{good,total}.metrics[].aggregation` to `sum` or `doc_count`
@@ -69,7 +89,7 @@ The provider SHALL validate simple SLO schema constraints at plan time to match 
 - **WHEN** `time_window.type` is set to a value other than `rolling` or `calendarAligned`
 - **THEN** the provider SHALL return a plan-time validation error
 
-### Requirement: Mapping — `artifacts` field
+### Requirement: Mapping — `artifacts` field (REQ-039)
 The resource SHALL expose the SLO `artifacts` field using the shape currently modeled by the filtered Kibana spec. The provider SHALL support `artifacts.dashboards[].id` on create and update, and SHALL round-trip the same structure from read responses.
 
 #### Scenario: Artifacts are sent on create
@@ -80,8 +100,10 @@ The resource SHALL expose the SLO `artifacts` field using the shape currently mo
 - **WHEN** the Kibana API returns dashboard references under `artifacts`
 - **THEN** the provider SHALL populate the Terraform `artifacts` state with those references
 
-### Requirement: Management — `enabled` state
+### Requirement: Management — `enabled` state (REQ-040)
 The resource SHALL expose SLO enabled state as a managed Terraform attribute. Because the generated update request model does not include `enabled`, the provider SHALL manage write reconciliation through the dedicated Kibana enable and disable SLO APIs rather than by extending the update request body.
+
+If `enabled` is omitted from configuration, the provider SHALL preserve server behavior rather than forcing a value. In that case, it SHALL read the returned enabled state into Terraform state and SHALL NOT call the enable or disable APIs solely to normalize the value.
 
 #### Scenario: Disabled SLO is disabled after create
 - **WHEN** configuration sets `enabled = false` and the created SLO is initially enabled
@@ -90,6 +112,10 @@ The resource SHALL expose SLO enabled state as a managed Terraform attribute. Be
 #### Scenario: Enabled SLO is re-enabled on update
 - **WHEN** configuration sets `enabled = true` for an existing disabled SLO
 - **THEN** the provider SHALL call the Kibana enable SLO API and SHALL read the SLO again before writing final state
+
+#### Scenario: Enabled unset preserves server behavior
+- **WHEN** `enabled` is omitted from configuration
+- **THEN** the provider SHALL record the server-returned enabled value in state and SHALL NOT issue enable or disable API calls only to force a default
 
 ## MODIFIED Requirements
 

--- a/openspec/changes/align-kibana-slo-resource/specs/kibana-slo/spec.md
+++ b/openspec/changes/align-kibana-slo-resource/specs/kibana-slo/spec.md
@@ -1,0 +1,140 @@
+## ADDED Requirements
+
+### Requirement: Mapping — `kql_custom_indicator` string and object-form KQL inputs
+The `kql_custom_indicator` block SHALL support both the existing string form and an additive object form for `filter`, `good`, and `total`. The object-form attributes SHALL use the names `filter_kql`, `good_kql`, and `total_kql`, and each SHALL model the Kibana KQL object variant with `kql_query` and `filters`. For each logical field, the provider SHALL allow exactly one representation to be configured: either the existing string attribute or the new `_kql` attribute.
+
+On write, when a string form is configured, the provider SHALL serialize the string arm of the generated kbapi union. When a `_kql` object form is configured, the provider SHALL serialize the object arm of the generated kbapi union, including both `kqlQuery` and `filters` when provided. On read, the provider SHALL round-trip object-form responses without discarding `filters`.
+
+#### Scenario: String-form KQL input remains supported
+- **WHEN** `kql_custom_indicator.good` is configured as a string and `good_kql` is unset
+- **THEN** the provider SHALL serialize the string arm of the Kibana KQL union for `good`
+
+#### Scenario: Object-form KQL input is serialized
+- **WHEN** `kql_custom_indicator.good_kql` is configured with `kql_query` and one or more `filters`
+- **THEN** the provider SHALL serialize the object arm of the Kibana KQL union for `good`
+
+#### Scenario: Multiple representations are rejected
+- **WHEN** both `kql_custom_indicator.total` and `kql_custom_indicator.total_kql` are configured
+- **THEN** the provider SHALL return a plan-time validation error for conflicting representations of the same logical field
+
+#### Scenario: Object-form response preserves filters
+- **WHEN** the Kibana API returns object-form `filter`, `good`, or `total` values containing `filters`
+- **THEN** the provider SHALL preserve that object-form information in state rather than degrading it to the string-only representation
+
+### Requirement: Validation — indicator-specific conditional fields
+The provider SHALL validate indicator-specific required and forbidden fields at plan time where the Terraform Plugin Framework can express the rule. This SHALL include nested indicator blocks that are currently only rejected during model conversion and conditional field rules driven by sibling `aggregation` values.
+
+At minimum, plan-time validation SHALL cover:
+- `metric_custom_indicator.good` and `metric_custom_indicator.total`
+- `histogram_custom_indicator.good` and `histogram_custom_indicator.total`
+- `timeslice_metric_indicator.metric`
+- `metric_custom_indicator.{good,total}.metrics[].field` required unless `aggregation = "doc_count"`
+- `metric_custom_indicator.{good,total}.metrics[].field` forbidden when `aggregation = "doc_count"`
+- `timeslice_metric_indicator.metric.metrics[].field` required for aggregations that require a field
+- `timeslice_metric_indicator.metric.metrics[].field` forbidden when `aggregation = "doc_count"`
+- `timeslice_metric_indicator.metric.metrics[].percentile` required when `aggregation = "percentile"` and forbidden otherwise
+
+#### Scenario: Missing metric field for non-doc_count is rejected
+- **WHEN** a `metric_custom_indicator` metric entry has `aggregation = "sum"` and `field` is unset
+- **THEN** the provider SHALL return a plan-time validation error
+
+#### Scenario: Field on doc_count metric is rejected
+- **WHEN** a `timeslice_metric_indicator.metric.metrics` entry has `aggregation = "doc_count"` and `field` is set
+- **THEN** the provider SHALL return a plan-time validation error
+
+#### Scenario: Missing percentile is rejected
+- **WHEN** a `timeslice_metric_indicator.metric.metrics` entry has `aggregation = "percentile"` and `percentile` is unset
+- **THEN** the provider SHALL return a plan-time validation error
+
+### Requirement: Validation — simple schema constraints aligned with the API
+The provider SHALL validate simple SLO schema constraints at plan time to match the current generated SLO API contract and generated union types. The resource SHALL:
+- restrict `slo_id` to 8 through 36 characters and `[a-zA-Z0-9_-]+`
+- restrict `metric_custom_indicator.{good,total}.metrics[].aggregation` to `sum` or `doc_count`
+- restrict metric `name` fields that map to the generated metric unions to `^[A-Z]$`
+- restrict `time_window.type` to `rolling` or `calendarAligned`
+
+#### Scenario: Oversized slo_id is rejected
+- **WHEN** `slo_id` is set to a value longer than 36 characters
+- **THEN** the provider SHALL return a plan-time validation error
+
+#### Scenario: Invalid custom metric aggregation is rejected
+- **WHEN** a `metric_custom_indicator` metric entry uses `aggregation = "avg"`
+- **THEN** the provider SHALL return a plan-time validation error
+
+#### Scenario: Invalid metric name is rejected
+- **WHEN** a metric entry uses `name = "AA"`
+- **THEN** the provider SHALL return a plan-time validation error
+
+#### Scenario: Invalid time window type is rejected
+- **WHEN** `time_window.type` is set to a value other than `rolling` or `calendarAligned`
+- **THEN** the provider SHALL return a plan-time validation error
+
+### Requirement: Mapping — `artifacts` field
+The resource SHALL expose the SLO `artifacts` field using the shape currently modeled by the filtered Kibana spec. The provider SHALL support `artifacts.dashboards[].id` on create and update, and SHALL round-trip the same structure from read responses.
+
+#### Scenario: Artifacts are sent on create
+- **WHEN** the configuration includes `artifacts` with dashboard references
+- **THEN** the create request SHALL include those dashboard references in the SLO `artifacts` payload
+
+#### Scenario: Artifacts are updated from read
+- **WHEN** the Kibana API returns dashboard references under `artifacts`
+- **THEN** the provider SHALL populate the Terraform `artifacts` state with those references
+
+### Requirement: Management — `enabled` state
+The resource SHALL expose SLO enabled state as a managed Terraform attribute. Because the generated update request model does not include `enabled`, the provider SHALL manage write reconciliation through the dedicated Kibana enable and disable SLO APIs rather than by extending the update request body.
+
+#### Scenario: Disabled SLO is disabled after create
+- **WHEN** configuration sets `enabled = false` and the created SLO is initially enabled
+- **THEN** the provider SHALL call the Kibana disable SLO API before the final read-back
+
+#### Scenario: Enabled SLO is re-enabled on update
+- **WHEN** configuration sets `enabled = true` for an existing disabled SLO
+- **THEN** the provider SHALL call the Kibana enable SLO API and SHALL read the SLO again before writing final state
+
+## MODIFIED Requirements
+
+### Requirement: Update flow (REQ-019)
+On update, the resource SHALL convert the Terraform plan to an API model and call the Kibana Update SLO API using the `slo_id` and `space_id` from the current composite `id`. If the planned `enabled` value differs from the server state after the definition update, the resource SHALL call the dedicated Kibana enable or disable SLO API as needed. The resource SHALL perform a read-back after successful write operations to populate computed fields into state.
+
+#### Scenario: Update calls API and reads back
+- **WHEN** an existing SLO has a changed `name` in the Terraform plan
+- **THEN** the provider SHALL call the Kibana Update SLO API and SHALL perform a subsequent get to populate computed fields in state
+
+#### Scenario: Update reconciles enabled state through dedicated APIs
+- **WHEN** an existing SLO changes only its `enabled` value in the Terraform plan
+- **THEN** the provider SHALL call the Kibana enable or disable SLO API instead of attempting to send `enabled` in the update request body
+
+### Requirement: Read flow (REQ-020)
+On read, the resource SHALL parse the composite `id` from state to extract `space_id` and `slo_id`, then call the Kibana Get SLO API. If the API returns HTTP 404, the resource SHALL remove itself from state without error. On a successful response, the resource SHALL update all state attributes from the API response, including `enabled`, `artifacts`, and any supported `settings` members.
+
+#### Scenario: Successful read maps all attributes
+- **WHEN** a valid get-SLO API response is returned
+- **THEN** all supported attributes, including `name`, `description`, `budgeting_method`, `time_window`, `objective`, `indicator`, `settings`, `group_by`, `tags`, `slo_id`, `space_id`, `enabled`, and `artifacts`, SHALL be updated in state from the response
+
+### Requirement: Mapping — `settings` block (REQ-024)
+The `settings` block uses `UseStateForUnknown` on its object plan modifier. When the `settings` block is configured, the resource SHALL send `sync_delay`, `frequency`, `prevent_initial_backfill`, and `sync_field` where those values are known. When the `settings` block is not configured, no settings SHALL be sent. After reading from the API, if the `settings` block was previously configured in state, the resource SHALL update the `settings` object in state from the API response; if it was not configured, `settings` SHALL remain null in state.
+
+#### Scenario: Settings omitted when not configured
+- **WHEN** create runs with no `settings` block in configuration
+- **THEN** the create request SHALL NOT include a `settings` payload
+
+#### Scenario: Sync field is sent when configured
+- **WHEN** `settings.sync_field` is configured with a known value
+- **THEN** the provider SHALL include `syncField` in the SLO settings payload
+
+### Requirement: Mapping — `metric_custom_indicator` doc_count aggregation (REQ-035)
+When a `metric_custom_indicator` metric entry uses `aggregation = "doc_count"`, the `field` attribute SHALL be optional and the provider SHALL NOT send `field` to the Kibana API. For all other supported `metric_custom_indicator` aggregation types, `field` SHALL be required. The schema SHALL declare `field` as optional for `metric_custom_indicator.{good,total}.metrics`, SHALL validate `aggregation` as `sum` or `doc_count`, and SHALL validate metric `name` values against the generated union contract.
+
+On write, when `aggregation = "doc_count"` the provider SHALL serialise the metric using the no-field API variant. For all other supported aggregations the provider SHALL use the field-bearing API variant. After a successful read-back, when the API returns a `doc_count` metric the provider SHALL store `field = null` in state.
+
+#### Scenario: Doc count omits field
+- **WHEN** a `metric_custom_indicator` good or total metric has `aggregation = "doc_count"` and `field` is not set
+- **THEN** the provider SHALL serialize the no-field API variant and SHALL accept the configuration
+
+#### Scenario: Doc count round-trips with null field
+- **WHEN** the Kibana API returns a `metric_custom_indicator` metric with `aggregation = "doc_count"`
+- **THEN** the provider SHALL store `field = null` in state for that metric
+
+#### Scenario: Non-doc_count requires field
+- **WHEN** a `metric_custom_indicator` metric has `aggregation != "doc_count"` and a non-null `field`
+- **THEN** the provider SHALL serialize the field-bearing API variant for that metric

--- a/openspec/changes/align-kibana-slo-resource/tasks.md
+++ b/openspec/changes/align-kibana-slo-resource/tasks.md
@@ -1,0 +1,22 @@
+## 1. Schema and validation alignment
+
+- [ ] 1.1 Update `internal/kibana/slo/schema.go` to add `filter_kql`, `good_kql`, and `total_kql` object-form attributes under `kql_custom_indicator`
+- [ ] 1.2 Add schema-level exclusivity and conditional validation so each KQL field accepts either the legacy string form or the new `_kql` form, but not both
+- [ ] 1.3 Add provider-side conditional validators for indicator-specific required and forbidden fields using `internal/utils/validators/conditional.go`
+- [ ] 1.4 Align simple validators for `slo_id`, custom metric aggregations, metric names, and `time_window.type`
+- [ ] 1.5 Add `settings.sync_field`, `artifacts`, and `enabled` to the SLO Terraform schema
+
+## 2. Model and client behavior
+
+- [ ] 2.1 Extend the SLO Terraform model types in `internal/kibana/slo/models.go` and `models_kql_custom_indicator.go` to serialize and read back both KQL union forms
+- [ ] 2.2 Extend settings and artifact mapping so `sync_field` and `artifacts.dashboards[].id` flow through create, update, and read
+- [ ] 2.3 Add `enabled` to the internal SLO model and read-path mapping from Kibana responses
+- [ ] 2.4 Extend `internal/clients/kibanaoapi/slo.go` with helper functions for enable and disable operations and wire them into SLO create and update reconciliation
+- [ ] 2.5 Verify whether additive schema changes require a state upgrader and implement one if needed
+
+## 3. Verification and documentation
+
+- [ ] 3.1 Add or update unit tests for KQL union conversion, settings mapping, artifact mapping, enabled handling, and tightened validation
+- [ ] 3.2 Add or update acceptance tests covering `_kql` inputs, `enabled` behavior, `sync_field`, and validation failures for invalid SLO configurations
+- [ ] 3.3 Regenerate `docs/resources/kibana_slo.md` and confirm the new `_kql`, `sync_field`, `artifacts`, and `enabled` fields are documented clearly
+- [ ] 3.4 Run the relevant build and test commands for the touched SLO code paths and resolve any regressions


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/867

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SLO alignment proposal and delta spec for `elasticstack_kibana_slo` resource
> - Adds a design document, proposal, and delta spec outlining planned changes to the `elasticstack_kibana_slo` Terraform resource.
> - Introduces object-form KQL inputs (`*_kql` fields) as an additive change, with mutual exclusivity enforced between string and object forms.
> - Aligns validators with the generated API (e.g., `slo_id` length 8–36, aggregations, metric name, `time_window.type`) and adds `settings.sync_field` support.
> - Plans to manage the `enabled` state via dedicated enable/disable API calls rather than the main update endpoint, and exposes SLO artifacts as computed attributes.
> - Adds a [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2489/files#diff-18d3701d85cf777e92be6d9b100ab59afc177f791dae5a6c8e514c7cbafb02dd) checklist covering schema, model, client, tests, and docs changes needed to implement the proposal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2aa50a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->