### PR TITLE
Add status comment to factory workflows

### DIFF
--- a/openspec/changes/factory-workflows-label-command/.openspec.yaml
+++ b/openspec/changes/factory-workflows-label-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-26

--- a/openspec/changes/factory-workflows-label-command/design.md
+++ b/openspec/changes/factory-workflows-label-command/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Code Factory and Change Factory are AWF sources under `.github/workflows-src/`, compiled to `.github/workflows/`. They already use **`issues: types: [opened, labeled]`** and deterministic `qualify_trigger` / trust / duplicate gating. **OpenSpec verify (label)** (`.github/workflows-src/openspec-verify-label/workflow.md.tmpl`) already implements a two-step pattern in **`on.steps`**: verify, then **`Remove trigger label`** using `actions/github-script@v9` and `x-script-include: scripts/remove_trigger_label.inline.js`, which delegates to `.github/workflows-src/lib/remove-trigger-label.js` (today PR-specific and hard-coded to `verify-openspec`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Leave the **existing `issues` triggers** unchanged.
+- Add **`status-comment: true`** in `on:` per [status comments](https://github.github.com/gh-aw/reference/triggers/#status-comments-status-comment).
+- Add a **remove factory label** pre-activation step **patterned on** openspec-verify-label (lines 24–30): same action, same `x-script-include` style, **maximal reuse** of `remove-trigger-label` by **generalizing** the library (label name + numeric issue target from `context.payload.issue`) and thin per-workflow inline scripts (or one shared include) that set outputs consistent with verify (`trigger_label_removed`, `trigger_label_removed_reason` or aligned names).
+- Expose remove-step outputs on **`pre-activation` `jobs.pre-activation.outputs`** if downstream compiled YAML needs them (mirror verify workflow).
+
+**Non-Goals:**
+
+- Introducing `label_command` or changing eligibility rules in `factoryQualifyTriggerEvent` unless the new step’s `if:` conditions require trivial expression tweaks.
+- Custom issue comments solely for workflow-run URLs (still covered by `status-comment`).
+
+## Decisions
+
+1. **`status-comment: true`** — unchanged from prior change direction; no duplicate run-link step in implementation `steps:`.
+
+2. **Generalize `remove-trigger-label.js`** — add parameters (e.g. `labelName`, `issueNumber`) and implement removal via `github.rest.issues.removeLabel` for **issues** (PRs use the same API with `issue_number`). Keep 404-as-success behavior. **Update** `openspec-verify-label/scripts/remove_trigger_label.inline.js` to pass `verify-openspec` and PR number so verify behavior stays identical.
+
+3. **When to remove the factory label** — Run the step only when the same logical gate as the **agent** would pass (eligible event, trusted actor, no duplicate linked PR), so untrusted or duplicate-suppressed runs do **not** strip the label. Express this with a composite `if:` on the step (and order steps so prerequisite outputs exist), or a single final pre-activation script—prefer matching existing step outputs (`qualify_trigger`, `check_actor_trust`, `check_duplicate_pr`) like the top-level agent `if:`.
+
+4. **`on.permissions`** — Grant **`issues: write`** for pre-activation when the remove step runs (same class of permission as openspec-verify-label’s `on.permissions`).
+
+## Risks / Trade-offs
+
+- **[Risk] Skipped `check_duplicate_pr` leaves outputs unset** — composite `if:` for remove must handle skipped-step semantics. *Mitigation:* Match conditions to the duplicate step’s `if:` chain or consolidate gate outputs in `finalize_gate` and key remove off one output.
+- **[Risk] Removing label on `issues.opened` with label present** — same as intentional one-shot: label is removed once the agent proceeds. *Mitigation:* Document for maintainers; align with product expectation.
+
+## Migration Plan
+
+1. Generalize `remove-trigger-label.js`; update verify inline script; add factory inline scripts and `on.steps` + permissions + `pre-activation` outputs.
+2. `make workflow-generate`; run workflow lib tests.
+3. Sync specs / archive change per repo process.
+
+## Open Questions
+
+- None blocking; exact output names for factory pre-activation can mirror verify or stay factory-prefixed as long as compiled AWF is valid.

--- a/openspec/changes/factory-workflows-label-command/proposal.md
+++ b/openspec/changes/factory-workflows-label-command/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Factory issue-intake should keep today’s **`issues` trigger model** (`opened` and `labeled`) while still giving maintainers **one-shot label semantics** (re-apply the factory label to re-run) and **run visibility** on the issue. GitHub Agentic Workflows [status comments](https://github.github.com/gh-aw/reference/triggers/#status-comments-status-comment) cover the workflow-run link without a custom “post URL” step; deterministic label removal can mirror the proven pattern used by **OpenSpec verify (label)** (pre-activation `github-script` + shared helper).
+
+## What Changes
+
+- **Keep** the existing **`issues: types: [opened, labeled]`** (or equivalent) trigger configuration for both **Code Factory** and **Change Factory** issue-intake workflows—no switch to `label_command`.
+- Add **`status-comment: true`** to each workflow’s top-level `on:` so the framework posts/updates a status comment on the triggering issue with the workflow run link.
+- Add a **deterministic pre-activation step** (same structural placement as `.github/workflows-src/openspec-verify-label/workflow.md.tmpl` lines 24–30: `actions/github-script@v9` + `x-script-include`) that **removes the factory trigger label** from the issue when the run is allowed to proceed to the agent, **reusing the shared `remove-trigger-label` helper** as far as practical (generalize parameters for issue number and label name rather than duplicating API logic).
+- Update OpenSpec requirements for **`ci-code-factory-issue-intake`** and **`ci-change-factory-issue-intake`** to document `status-comment` and deterministic label removal; extend or add tests for the generalized helper.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `ci-code-factory-issue-intake`: Add requirements for `status-comment: true` and for deterministic removal of the `code-factory` label in pre-activation when the agent gate passes; triggers remain `issues.opened` / `issues.labeled` as today.
+- `ci-change-factory-issue-intake`: Same for `change-factory`.
+
+## Impact
+
+- `.github/workflows-src/code-factory-issue/workflow.md.tmpl` and `.github/workflows-src/change-factory-issue/workflow.md.tmpl` (`on:` gains `status-comment: true`; `on.steps` gains remove-label step; `on.permissions` may need **`issues: write`** for label removal on issues, matching the verify workflow’s pattern).
+- `.github/workflows-src/lib/remove-trigger-label.js` (or adjacent module) generalized for **label name + issue number**, with **openspec-verify-label**’s inline script updated to call the generalized API so behavior stays single-sourced.
+- New workflow-local `scripts/remove_factory_trigger_label.inline.js` (or shared path) for each factory, following the verify workflow’s `x-script-include` pattern.
+- Regenerated `.github/workflows/*.md` / `*.lock.yml`; tests under `.github/workflows-src/lib/`.
+- Canonical specs via delta sync/archive.

--- a/openspec/changes/factory-workflows-label-command/specs/ci-change-factory-issue-intake/spec.md
+++ b/openspec/changes/factory-workflows-label-command/specs/ci-change-factory-issue-intake/spec.md
@@ -1,0 +1,30 @@
+# `ci-change-factory-issue-intake` — Delta
+
+## ADDED Requirements
+
+### Requirement: Workflow status comments on the issue include the run link
+The workflow SHALL set `status-comment: true` in the top-level `on:` configuration (see GitHub Agentic Workflows [status comments](https://github.github.com/gh-aw/reference/triggers/#status-comments-status-comment)) so the activation job posts a status comment on the triggering issue when the run starts and updates it when the run completes, including a link to the workflow run as provided by the framework.
+
+#### Scenario: Status comment enabled
+- **WHEN** maintainers inspect the authored `change-factory` issue-intake workflow `on:` frontmatter
+- **THEN** it SHALL include `status-comment: true` (or an object form that enables status comments for issues)
+
+#### Scenario: No custom comment step for run linkage
+- **WHEN** the workflow is authored for `change-factory` issue intake
+- **THEN** the repository SHALL NOT rely on a custom implementation-job step solely to post the workflow run URL to the issue; run visibility SHALL be covered by `status-comment` as above
+
+### Requirement: Workflow removes the factory trigger label in pre-activation when the agent proceeds
+The workflow SHALL include a deterministic pre-activation step that removes the `change-factory` label from the triggering issue **using the same mechanism as** OpenSpec verify (label): `actions/github-script@v9` with `x-script-include` to an inline script that delegates to the shared `.github/workflows-src/lib/remove-trigger-label.js` helper (generalized to accept the factory label name and issue number). The step SHALL run only when the workflow would proceed to the proposal agent (eligible qualifying issue event, trusted actor, and no open linked `change-factory` pull request per existing duplicate suppression). The workflow SHALL grant `issues: write` to pre-activation where required for label removal.
+
+#### Scenario: Remove step mirrors verify workflow pattern
+- **WHEN** maintainers inspect the authored `change-factory` issue-intake workflow `on.steps`
+- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label) (`workflow.md.tmpl` lines 24–30: `Remove trigger label` / `github-script` / `x-script-include`)
+- **AND** the included script SHALL reuse the generalized `remove-trigger-label` library (not a forked copy of the GitHub API logic)
+
+#### Scenario: Label removed only when agent gate passes
+- **WHEN** pre-activation determines the proposal agent SHALL run for the issue
+- **THEN** the remove-label step SHALL run and SHALL attempt to remove `change-factory` from that issue
+
+#### Scenario: Label retained when agent does not run
+- **WHEN** pre-activation suppresses the agent (ineligible event, untrusted actor, or duplicate linked PR)
+- **THEN** the workflow SHALL NOT remove `change-factory` solely as a side effect of this intake run

--- a/openspec/changes/factory-workflows-label-command/specs/ci-change-factory-issue-intake/spec.md
+++ b/openspec/changes/factory-workflows-label-command/specs/ci-change-factory-issue-intake/spec.md
@@ -18,7 +18,7 @@ The workflow SHALL include a deterministic pre-activation step that removes the 
 
 #### Scenario: Remove step mirrors verify workflow pattern
 - **WHEN** maintainers inspect the authored `change-factory` issue-intake workflow `on.steps`
-- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label) (`workflow.md.tmpl` lines 24–30: `Remove trigger label` / `github-script` / `x-script-include`)
+- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label), with the `Remove trigger label` step using `actions/github-script@v9` and `x-script-include` to include the shared trigger-label removal script/helper path
 - **AND** the included script SHALL reuse the generalized `remove-trigger-label` library (not a forked copy of the GitHub API logic)
 
 #### Scenario: Label removed only when agent gate passes

--- a/openspec/changes/factory-workflows-label-command/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/factory-workflows-label-command/specs/ci-code-factory-issue-intake/spec.md
@@ -1,0 +1,30 @@
+# `ci-code-factory-issue-intake` — Delta
+
+## ADDED Requirements
+
+### Requirement: Workflow status comments on the issue include the run link
+The workflow SHALL set `status-comment: true` in the top-level `on:` configuration (see GitHub Agentic Workflows [status comments](https://github.github.com/gh-aw/reference/triggers/#status-comments-status-comment)) so the activation job posts a status comment on the triggering issue when the run starts and updates it when the run completes, including a link to the workflow run as provided by the framework.
+
+#### Scenario: Status comment enabled
+- **WHEN** maintainers inspect the authored `code-factory` issue-intake workflow `on:` frontmatter
+- **THEN** it SHALL include `status-comment: true` (or an object form that enables status comments for issues)
+
+#### Scenario: No custom comment step for run linkage
+- **WHEN** the workflow is authored for `code-factory` issue intake
+- **THEN** the repository SHALL NOT rely on a custom implementation-job step solely to post the workflow run URL to the issue; run visibility SHALL be covered by `status-comment` as above
+
+### Requirement: Workflow removes the factory trigger label in pre-activation when the agent proceeds
+The workflow SHALL include a deterministic pre-activation step that removes the `code-factory` label from the triggering issue **using the same mechanism as** OpenSpec verify (label): `actions/github-script@v9` with `x-script-include` to an inline script that delegates to the shared `.github/workflows-src/lib/remove-trigger-label.js` helper (generalized to accept the factory label name and issue number). The step SHALL run only when the workflow would proceed to the implementation agent (eligible qualifying issue event, trusted actor, and no open linked `code-factory` pull request per existing duplicate suppression). The workflow SHALL grant `issues: write` to pre-activation where required for label removal.
+
+#### Scenario: Remove step mirrors verify workflow pattern
+- **WHEN** maintainers inspect the authored `code-factory` issue-intake workflow `on.steps`
+- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label) (`workflow.md.tmpl` lines 24–30: `Remove trigger label` / `github-script` / `x-script-include`)
+- **AND** the included script SHALL reuse the generalized `remove-trigger-label` library (not a forked copy of the GitHub API logic)
+
+#### Scenario: Label removed only when agent gate passes
+- **WHEN** pre-activation determines the implementation agent SHALL run for the issue
+- **THEN** the remove-label step SHALL run and SHALL attempt to remove `code-factory` from that issue
+
+#### Scenario: Label retained when agent does not run
+- **WHEN** pre-activation suppresses the agent (ineligible event, untrusted actor, or duplicate linked PR)
+- **THEN** the workflow SHALL NOT remove `code-factory` solely as a side effect of this intake run

--- a/openspec/changes/factory-workflows-label-command/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/factory-workflows-label-command/specs/ci-code-factory-issue-intake/spec.md
@@ -18,7 +18,7 @@ The workflow SHALL include a deterministic pre-activation step that removes the 
 
 #### Scenario: Remove step mirrors verify workflow pattern
 - **WHEN** maintainers inspect the authored `code-factory` issue-intake workflow `on.steps`
-- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label) (`workflow.md.tmpl` lines 24–30: `Remove trigger label` / `github-script` / `x-script-include`)
+- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label), including step name `Remove trigger label`, `uses: actions/github-script@v9`, and an `x-script-include` reference for the inline script
 - **AND** the included script SHALL reuse the generalized `remove-trigger-label` library (not a forked copy of the GitHub API logic)
 
 #### Scenario: Label removed only when agent gate passes

--- a/openspec/changes/factory-workflows-label-command/tasks.md
+++ b/openspec/changes/factory-workflows-label-command/tasks.md
@@ -1,0 +1,19 @@
+## 1. Shared remove-label helper
+
+- [ ] 1.1 Generalize `.github/workflows-src/lib/remove-trigger-label.js` to accept **label name** and **issue number** (issue API), preserving 404-treat-as-success behavior
+- [ ] 1.2 Update `.github/workflows-src/openspec-verify-label/scripts/remove_trigger_label.inline.js` to call the generalized helper with `verify-openspec` and the PR/issue number so behavior stays unchanged
+- [ ] 1.3 Add unit tests for the generalized helper (cover factory labels and issue path, plus existing verify behavior)
+
+## 2. Factory workflow templates
+
+- [ ] 2.1 In `.github/workflows-src/code-factory-issue/workflow.md.tmpl`, **keep** `on.issues.types: [opened, labeled]` (current triggers); add **`status-comment: true`** to `on:`
+- [ ] 2.2 Add a **Remove factory trigger label** (or equivalent name) step in **`on.steps`** after gating outputs needed for the agent `if:` are available, using `actions/github-script@v9` and `x-script-include` to a new script that calls the generalized helper with **`code-factory`** and `context.payload.issue.number`; mirror openspec-verify-label lines 24–30 structurally
+- [ ] 2.3 Add **`issues: write`** to `on.permissions` for pre-activation if not already present, consistent with label removal
+- [ ] 2.4 Wire **`jobs.pre-activation.outputs`** for remove-step outputs if the compiled workflow needs them (optional; follow verify workflow if useful)
+- [ ] 2.5 Repeat **2.1–2.4** for `.github/workflows-src/change-factory-issue/workflow.md.tmpl` with **`change-factory`**
+
+## 3. Regenerate and validate
+
+- [ ] 3.1 Run `make workflow-generate` (or documented equivalent) and commit regenerated `code-factory-issue.*` and `change-factory-issue.*` under `.github/workflows/`
+- [ ] 3.2 Run workflow lib tests and fix any `if:` ordering / skipped-step output issues for the remove step
+- [ ] 3.3 Sync delta specs into `openspec/specs/` when ready; run `openspec validate` / `make check-openspec`


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add status comments and pre-activation label removal to factory issue-intake workflows
- Adds `status-comment: true` to the `on:` block of both `ci-change-factory-issue-intake` and `ci-code-factory-issue-intake` workflows so callers receive status feedback.
- Adds a pre-activation `remove-label` step using `actions/github-script` with a generalized shared `remove-trigger-label` helper, gated to run only when the agent gate passes.
- Requires `issues: write` permission on both workflows to support the new label-removal step.
- This PR is design/spec only — implementation tasks (generalizing the helper, modifying templates, regenerating workflows) are tracked in [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2502/files#diff-860e9f18b24843dda502e356b071687f7533f0976d5062063074e113f2ffd077).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d02d7d3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->