### PR TITLE
Factory issue intake: status comments and deterministic label removal

### DIFF
--- a/.github/workflows-src/change-factory-issue/scripts/remove_trigger_label.inline.js
+++ b/.github/workflows-src/change-factory-issue/scripts/remove_trigger_label.inline.js
@@ -1,18 +1,18 @@
 //include: ../../lib/remove-trigger-label.js
 
-const issueNumber = context.payload.pull_request?.number;
+const issueNumber = context.payload.issue?.number;
 const result = await removeTriggerLabel({
   github,
   context,
   issueNumber,
-  labelName: TRIGGER_LABEL,
+  labelName: 'change-factory',
 });
 
 core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
 core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
 
 if (result.trigger_label_removed) {
-  core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
+  core.info(`Removed trigger label change-factory from issue #${issueNumber}`);
 } else {
   core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
 }

--- a/.github/workflows-src/change-factory-issue/workflow.md.tmpl
+++ b/.github/workflows-src/change-factory-issue/workflow.md.tmpl
@@ -8,9 +8,10 @@ description: >-
 on:
   issues:
     types: [opened, labeled]
+  status-comment: true
   permissions:
     contents: read
-    issues: read
+    issues: write
     pull-requests: read
   steps:
     - name: Qualify trigger event
@@ -43,6 +44,16 @@ on:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         x-script-include: scripts/check_duplicate_pr.inline.js
+    - name: Remove trigger label
+      id: remove_trigger_label
+      if: >-
+        steps.qualify_trigger.outputs.event_eligible == 'true' &&
+        steps.check_actor_trust.outputs.actor_trusted == 'true' &&
+        steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+      uses: actions/github-script@v9
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        x-script-include: scripts/remove_trigger_label.inline.js
     - name: Finalize gate reason
       id: finalize_gate
       if: always()
@@ -90,6 +101,8 @@ jobs:
       actor_trusted_reason: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
       duplicate_pr_found: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_found }}
       duplicate_pr_url: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_url }}
+      trigger_label_removed: ${{ steps.remove_trigger_label.outputs.trigger_label_removed }}
+      trigger_label_removed_reason: ${{ steps.remove_trigger_label.outputs.trigger_label_removed_reason }}
       gate_reason: ${{ steps.finalize_gate.outputs.gate_reason }}
 tools:
   github:

--- a/.github/workflows-src/code-factory-issue/scripts/remove_trigger_label.inline.js
+++ b/.github/workflows-src/code-factory-issue/scripts/remove_trigger_label.inline.js
@@ -1,18 +1,18 @@
 //include: ../../lib/remove-trigger-label.js
 
-const issueNumber = context.payload.pull_request?.number;
+const issueNumber = context.payload.issue?.number;
 const result = await removeTriggerLabel({
   github,
   context,
   issueNumber,
-  labelName: TRIGGER_LABEL,
+  labelName: 'code-factory',
 });
 
 core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
 core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
 
 if (result.trigger_label_removed) {
-  core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
+  core.info(`Removed trigger label code-factory from issue #${issueNumber}`);
 } else {
   core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
 }

--- a/.github/workflows-src/code-factory-issue/workflow.md.tmpl
+++ b/.github/workflows-src/code-factory-issue/workflow.md.tmpl
@@ -7,9 +7,10 @@ description: >-
 on:
   issues:
     types: [opened, labeled]
+  status-comment: true
   permissions:
     contents: read
-    issues: read
+    issues: write
     pull-requests: read
   steps:
     - name: Qualify trigger event
@@ -41,6 +42,16 @@ on:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         x-script-include: scripts/check_duplicate_pr.inline.js
+    - name: Remove trigger label
+      id: remove_trigger_label
+      if: >-
+        steps.qualify_trigger.outputs.event_eligible == 'true' &&
+        steps.check_actor_trust.outputs.actor_trusted == 'true' &&
+        steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+      uses: actions/github-script@v9
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        x-script-include: scripts/remove_trigger_label.inline.js
     - name: Finalize gate reason
       id: finalize_gate
       if: always()
@@ -118,6 +129,8 @@ jobs:
       actor_trusted_reason: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
       duplicate_pr_found: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_found }}
       duplicate_pr_url: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_url }}
+      trigger_label_removed: ${{ steps.remove_trigger_label.outputs.trigger_label_removed }}
+      trigger_label_removed_reason: ${{ steps.remove_trigger_label.outputs.trigger_label_removed_reason }}
       gate_reason: ${{ steps.finalize_gate.outputs.gate_reason }}
 tools:
   github:

--- a/.github/workflows-src/lib/change-factory-issue.test.mjs
+++ b/.github/workflows-src/lib/change-factory-issue.test.mjs
@@ -502,6 +502,8 @@ test('change-factory-issue workflow.md.tmpl wiring matches intake contract', () 
   const workflowTmpl = readFileSync(workflowTemplatePath, 'utf8');
 
   assert.match(workflowTmpl, /\non:\n  issues:\n    types: \[opened, labeled\]/);
+  assert.match(workflowTmpl, /status-comment:\s*true/);
+  assert.match(workflowTmpl, /issues:\s*write/);
 
   assert.match(
     workflowTmpl,
@@ -525,6 +527,7 @@ test('change-factory-issue workflow.md.tmpl wiring matches intake contract', () 
     'x-script-include: scripts/qualify_trigger.inline.js',
     'x-script-include: scripts/check_actor_trust.inline.js',
     'x-script-include: scripts/check_duplicate_pr.inline.js',
+    'x-script-include: scripts/remove_trigger_label.inline.js',
     'x-script-include: scripts/finalize_gate.inline.js',
   ];
   let lastIdx = -1;
@@ -541,8 +544,16 @@ test('change-factory-issue workflow.md.tmpl wiring matches intake contract', () 
 
   assert.match(
     workflowTmpl,
+    /- name: Remove trigger label\n      id: remove_trigger_label\n      if: >-\n        steps\.qualify_trigger\.outputs\.event_eligible == 'true' &&\n        steps\.check_actor_trust\.outputs\.actor_trusted == 'true' &&\n        steps\.check_duplicate_pr\.outputs\.duplicate_pr_found != 'true'/,
+  );
+
+  assert.match(
+    workflowTmpl,
     /- name: Finalize gate reason\n      id: finalize_gate\n      if: always\(\)/,
   );
+
+  assert.match(workflowTmpl, /trigger_label_removed:/);
+  assert.match(workflowTmpl, /trigger_label_removed_reason:/);
 
   assert.match(
     workflowTmpl,

--- a/.github/workflows-src/lib/code-factory-issue.test.mjs
+++ b/.github/workflows-src/lib/code-factory-issue.test.mjs
@@ -438,6 +438,15 @@ test('code-factory intake constants stay aligned with workflow template branch p
   );
 });
 
+test('code-factory-issue workflow template enables status comments and remove-label pre-activation', () => {
+  const workflowTmpl = readFileSync(codeFactoryWorkflowTmplPath, 'utf8');
+  assert.match(workflowTmpl, /status-comment:\s*true/);
+  assert.match(workflowTmpl, /name: Remove trigger label/);
+  assert.match(workflowTmpl, /x-script-include: scripts\/remove_trigger_label\.inline\.js/);
+  assert.match(workflowTmpl, /issues:\s*write/);
+  assert.match(workflowTmpl, /trigger_label_removed:/);
+});
+
 test('code-factory-issue inline scripts include intake constants before shared helpers', () => {
   const expectedHeader = [
     /^\/\/include: \.\.\/intake-constants\.js\n/,

--- a/.github/workflows-src/lib/openspec-verify-label-helpers.test.mjs
+++ b/.github/workflows-src/lib/openspec-verify-label-helpers.test.mjs
@@ -70,33 +70,81 @@ test('classifyPullRequest disallows archive/push when both headRepoId and baseRe
 // remove-trigger-label.js — removeTriggerLabel
 // ---------------------------------------------------------------------------
 
-test('removeTriggerLabel returns trigger_label_removed false when prNumber is undefined', async () => {
+test('removeTriggerLabel returns trigger_label_removed false when issueNumber is undefined', async () => {
   const result = await removeTriggerLabel({
     github: {},
     context: { repo: { owner: 'owner', repo: 'repo' } },
-    prNumber: undefined,
+    issueNumber: undefined,
+    labelName: 'verify-openspec',
   });
   assert.equal(result.trigger_label_removed, false);
   assert.ok(
-    result.trigger_label_removed_reason.includes('No pull request number'),
-    `expected "No pull request number" in reason, got: ${result.trigger_label_removed_reason}`
+    result.trigger_label_removed_reason.includes('No issue number'),
+    `expected "No issue number" in reason, got: ${result.trigger_label_removed_reason}`
+  );
+});
+
+test('removeTriggerLabel returns trigger_label_removed false when labelName is empty', async () => {
+  const result = await removeTriggerLabel({
+    github: {},
+    context: { repo: { owner: 'owner', repo: 'repo' } },
+    issueNumber: 42,
+    labelName: '   ',
+  });
+  assert.equal(result.trigger_label_removed, false);
+  assert.ok(
+    result.trigger_label_removed_reason.includes('No label name'),
+    `expected "No label name" in reason, got: ${result.trigger_label_removed_reason}`
   );
 });
 
 test('removeTriggerLabel returns trigger_label_removed true on successful API call', async () => {
+  let removedName;
   const mockGithub = {
     rest: {
       issues: {
-        removeLabel: async () => ({}),
+        removeLabel: async (args) => {
+          removedName = args.name;
+          return {};
+        },
       },
     },
   };
   const result = await removeTriggerLabel({
     github: mockGithub,
     context: { repo: { owner: 'owner', repo: 'repo' } },
-    prNumber: 42,
+    issueNumber: 42,
+    labelName: 'verify-openspec',
   });
   assert.equal(result.trigger_label_removed, true);
+  assert.equal(removedName, 'verify-openspec');
+});
+
+test('removeTriggerLabel removes a factory label from an issue when API succeeds', async () => {
+  let captured;
+  const mockGithub = {
+    rest: {
+      issues: {
+        removeLabel: async (args) => {
+          captured = args;
+          return {};
+        },
+      },
+    },
+  };
+  const result = await removeTriggerLabel({
+    github: mockGithub,
+    context: { repo: { owner: 'acme', repo: 'demo' } },
+    issueNumber: 99,
+    labelName: 'code-factory',
+  });
+  assert.equal(result.trigger_label_removed, true);
+  assert.deepEqual(captured, {
+    owner: 'acme',
+    repo: 'demo',
+    issue_number: 99,
+    name: 'code-factory',
+  });
 });
 
 test('removeTriggerLabel returns trigger_label_removed true on 404 (idempotent — label already removed)', async () => {
@@ -114,9 +162,11 @@ test('removeTriggerLabel returns trigger_label_removed true on 404 (idempotent �
   const result = await removeTriggerLabel({
     github: mockGithub,
     context: { repo: { owner: 'owner', repo: 'repo' } },
-    prNumber: 42,
+    issueNumber: 42,
+    labelName: 'change-factory',
   });
   assert.equal(result.trigger_label_removed, true);
+  assert.match(result.trigger_label_removed_reason, /change-factory/);
 });
 
 test('removeTriggerLabel returns trigger_label_removed false on non-404 API error', async () => {
@@ -134,7 +184,8 @@ test('removeTriggerLabel returns trigger_label_removed false on non-404 API erro
   const result = await removeTriggerLabel({
     github: mockGithub,
     context: { repo: { owner: 'owner', repo: 'repo' } },
-    prNumber: 42,
+    issueNumber: 42,
+    labelName: 'verify-openspec',
   });
   assert.equal(result.trigger_label_removed, false);
   assert.ok(

--- a/.github/workflows-src/lib/remove-trigger-label.js
+++ b/.github/workflows-src/lib/remove-trigger-label.js
@@ -1,16 +1,25 @@
+/** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
 const TRIGGER_LABEL = 'verify-openspec';
 
 /**
- * Removes only the verify-openspec trigger label from the triggering pull request.
- * Does not remove any other labels.
- * @param {{ github: object, context: object, prNumber: number|undefined }} opts
+ * Removes a single label from an issue or pull request (GitHub issue API).
+ * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
  * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
  */
-async function removeTriggerLabel({ github, context, prNumber }) {
-  if (!prNumber) {
+async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+  if (issueNumber === undefined || issueNumber === null) {
     return {
       trigger_label_removed: false,
-      trigger_label_removed_reason: 'No pull request number in event payload',
+      trigger_label_removed_reason: 'No issue number in event payload',
+    };
+  }
+
+  const label =
+    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+  if (!label) {
+    return {
+      trigger_label_removed: false,
+      trigger_label_removed_reason: 'No label name provided',
     };
   }
 
@@ -18,19 +27,19 @@ async function removeTriggerLabel({ github, context, prNumber }) {
     await github.rest.issues.removeLabel({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      issue_number: prNumber,
-      name: TRIGGER_LABEL,
+      issue_number: issueNumber,
+      name: label,
     });
     return {
       trigger_label_removed: true,
-      trigger_label_removed_reason: `Removed label: ${TRIGGER_LABEL}`,
+      trigger_label_removed_reason: `Removed label: ${label}`,
     };
   } catch (err) {
     // GitHub returns 404 when the label does not exist on the issue; treat as success
     if (err.status === 404) {
       return {
         trigger_label_removed: true,
-        trigger_label_removed_reason: `Label ${TRIGGER_LABEL} was not present (already removed or never applied)`,
+        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
       };
     }
     return {

--- a/.github/workflows-src/lib/remove-trigger-label.js
+++ b/.github/workflows-src/lib/remove-trigger-label.js
@@ -1,6 +1,3 @@
-/** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-const TRIGGER_LABEL = 'verify-openspec';
-
 /**
  * Removes a single label from an issue or pull request (GitHub issue API).
  * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -50,5 +47,5 @@ async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+  module.exports = { removeTriggerLabel };
 }

--- a/.github/workflows-src/openspec-verify-label/scripts/remove_trigger_label.inline.js
+++ b/.github/workflows-src/openspec-verify-label/scripts/remove_trigger_label.inline.js
@@ -1,18 +1,19 @@
 //include: ../../lib/remove-trigger-label.js
 
+const verifyTriggerLabel = 'verify-openspec';
 const issueNumber = context.payload.pull_request?.number;
 const result = await removeTriggerLabel({
   github,
   context,
   issueNumber,
-  labelName: TRIGGER_LABEL,
+  labelName: verifyTriggerLabel,
 });
 
 core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
 core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
 
 if (result.trigger_label_removed) {
-  core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
+  core.info(`Removed trigger label ${verifyTriggerLabel} from PR #${issueNumber}`);
 } else {
   core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
 }

--- a/.github/workflows/change-factory-issue.lock.yml
+++ b/.github/workflows/change-factory-issue.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ee2347a86a18a887cb334e43be804e81f14b8a2c11ba8532928c7693e02b6023","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"59508caf810e8514c3904a963e48c729870286052a9ee53428ef2215aadb2fed","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["CLAUDE_LITELLM_PROXY_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -92,7 +92,7 @@ name: "Change Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: "/** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */\nconst TRIGGER_LABEL = 'verify-openspec';\n\n/**\n * Removes a single label from an issue or pull request (GitHub issue API).\n * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts\n * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}\n */\nasync function removeTriggerLabel({ github, context, issueNumber, labelName }) {\n  if (issueNumber === undefined || issueNumber === null) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No issue number in event payload',\n    };\n  }\n\n  const label =\n    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;\n  if (!label) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No label name provided',\n    };\n  }\n\n  try {\n    await github.rest.issues.removeLabel({\n      owner: context.repo.owner,\n      repo: context.repo.repo,\n      issue_number: issueNumber,\n      name: label,\n    });\n    return {\n      trigger_label_removed: true,\n      trigger_label_removed_reason: `Removed label: ${label}`,\n    };\n  } catch (err) {\n    // GitHub returns 404 when the label does not exist on the issue; treat as success\n    if (err.status === 404) {\n      return {\n        trigger_label_removed: true,\n        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,\n      };\n    }\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: `Failed to remove label: ${err.message}`,\n    };\n  }\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = { TRIGGER_LABEL, removeTriggerLabel };\n}\n\nconst issueNumber = context.payload.issue?.number;\nconst result = await removeTriggerLabel({\n  github,\n  context,\n  issueNumber,\n  labelName: 'change-factory',\n});\n\ncore.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');\ncore.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);\n\nif (result.trigger_label_removed) {\n  core.info(`Removed trigger label change-factory from issue #${issueNumber}`);\n} else {\n  core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);\n}\n"
+      # script: "/**\n * Removes a single label from an issue or pull request (GitHub issue API).\n * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts\n * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}\n */\nasync function removeTriggerLabel({ github, context, issueNumber, labelName }) {\n  if (issueNumber === undefined || issueNumber === null) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No issue number in event payload',\n    };\n  }\n\n  const label =\n    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;\n  if (!label) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No label name provided',\n    };\n  }\n\n  try {\n    await github.rest.issues.removeLabel({\n      owner: context.repo.owner,\n      repo: context.repo.repo,\n      issue_number: issueNumber,\n      name: label,\n    });\n    return {\n      trigger_label_removed: true,\n      trigger_label_removed_reason: `Removed label: ${label}`,\n    };\n  } catch (err) {\n    // GitHub returns 404 when the label does not exist on the issue; treat as success\n    if (err.status === 404) {\n      return {\n        trigger_label_removed: true,\n        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,\n      };\n    }\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: `Failed to remove label: ${err.message}`,\n    };\n  }\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = { removeTriggerLabel };\n}\n\nconst issueNumber = context.payload.issue?.number;\nconst result = await removeTriggerLabel({\n  github,\n  context,\n  issueNumber,\n  labelName: 'change-factory',\n});\n\ncore.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');\ncore.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);\n\nif (result.trigger_label_removed) {\n  core.info(`Removed trigger label change-factory from issue #${issueNumber}`);\n} else {\n  core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);\n}\n"
   # - env:
       # ACTOR_TRUSTED: ${{ steps.check_actor_trust.outputs.actor_trusted }}
       # ACTOR_TRUSTED_REASON: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
@@ -254,19 +254,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
+          cat << 'GH_AW_PROMPT_196893d3af7842bd_EOF'
           <system>
-          GH_AW_PROMPT_91a3059ffd192834_EOF
+          GH_AW_PROMPT_196893d3af7842bd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
+          cat << 'GH_AW_PROMPT_196893d3af7842bd_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_91a3059ffd192834_EOF
+          GH_AW_PROMPT_196893d3af7842bd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
+          cat << 'GH_AW_PROMPT_196893d3af7842bd_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -299,12 +299,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_91a3059ffd192834_EOF
+          GH_AW_PROMPT_196893d3af7842bd_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
+          cat << 'GH_AW_PROMPT_196893d3af7842bd_EOF'
           </system>
           {{#runtime-import .github/workflows/change-factory-issue.md}}
-          GH_AW_PROMPT_91a3059ffd192834_EOF
+          GH_AW_PROMPT_196893d3af7842bd_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -505,9 +505,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_39cb6ad411b5cdb7_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d80f289f60f9fd2b_EOF'
           {"add_comment":{"max":1,"target":"triggering"},"create_pull_request":{"labels":["change-factory","no-changelog"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_39cb6ad411b5cdb7_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d80f289f60f9fd2b_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -727,7 +727,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_ee857d6c9203fbe5_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_20918bdb542160a5_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -767,7 +767,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ee857d6c9203fbe5_EOF
+          GH_AW_MCP_CONFIG_20918bdb542160a5_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -2516,9 +2516,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-            const TRIGGER_LABEL = 'verify-openspec';
-
             /**
              * Removes a single label from an issue or pull request (GitHub issue API).
              * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -2568,7 +2565,7 @@ jobs:
             }
 
             if (typeof module !== 'undefined') {
-              module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+              module.exports = { removeTriggerLabel };
             }
 
             const issueNumber = context.payload.issue?.number;

--- a/.github/workflows/change-factory-issue.lock.yml
+++ b/.github/workflows/change-factory-issue.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3fb787393b4a0ef396c82640088940c7c642ba43d80c41ae95ad053a23999e73","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ee2347a86a18a887cb334e43be804e81f14b8a2c11ba8532928c7693e02b6023","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["CLAUDE_LITELLM_PROXY_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,7 +55,7 @@ name: "Change Factory Issue Intake"
     - labeled
   # permissions: # Permissions applied to pre-activation job
     # contents: read
-    # issues: read
+    # issues: write
     # pull-requests: read
   # steps: # Steps injected into pre-activation job
   # - id: qualify_trigger
@@ -63,362 +63,7 @@ name: "Change Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'change-factory/issue-';
-        # const FACTORY_LABEL = 'change-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'github-keywords',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const changeFactoryIssueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const eventName = context.eventName;
-        # const eventAction = context.payload.action;
-        # const labelName = context.payload.label?.name ?? '';
-        # const issueLabels = (context.payload.issue?.labels ?? []).map(l => l.name);
-        # 
-        # const result = qualifyTriggerEvent({ eventName, eventAction, labelName, issueLabels });
-        # 
-        # core.setOutput('event_eligible', result.event_eligible ? 'true' : 'false');
-        # core.setOutput('event_eligible_reason', result.event_eligible_reason);
-        # 
-        # if (result.event_eligible) {
-          # core.info(`Event eligible: ${result.event_eligible_reason}`);
-        # } else {
-          # core.info(`Event not eligible: ${result.event_eligible_reason}`);
-        # }
+      # script: "/**\n * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'change-factory/issue-';\nconst FACTORY_LABEL = 'change-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'github-keywords',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst changeFactoryIssueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst eventName = context.eventName;\nconst eventAction = context.payload.action;\nconst labelName = context.payload.label?.name ?? '';\nconst issueLabels = (context.payload.issue?.labels ?? []).map(l => l.name);\n\nconst result = qualifyTriggerEvent({ eventName, eventAction, labelName, issueLabels });\n\ncore.setOutput('event_eligible', result.event_eligible ? 'true' : 'false');\ncore.setOutput('event_eligible_reason', result.event_eligible_reason);\n\nif (result.event_eligible) {\n  core.info(`Event eligible: ${result.event_eligible_reason}`);\n} else {\n  core.info(`Event not eligible: ${result.event_eligible_reason}`);\n}\n"
   # - id: capture_issue_context
     # name: Capture issue context
     # uses: actions/github-script@v9
@@ -433,756 +78,21 @@ name: "Change Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'change-factory/issue-';
-        # const FACTORY_LABEL = 'change-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'github-keywords',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const changeFactoryIssueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const { owner, repo } = context.repo;
-        # const sender = context.payload.sender?.login ?? '';
-        # 
-        # if (!sender) {
-          # const missing = actorTrustWhenSenderMissing();
-          # core.setOutput('actor_trusted', 'false');
-          # core.setOutput('actor_trusted_reason', missing.actor_trusted_reason);
-          # core.info('Actor not trusted: sender login is missing from the event payload.');
-        # } else {
-          # let permission = null;
-          # if (sender !== 'github-actions[bot]') {
-            # const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              # owner,
-              # repo,
-              # username: sender,
-            # });
-            # permission = data.permission;
-          # }
-        # 
-          # const result = checkActorTrust({ sender, permission });
-        # 
-          # core.setOutput('actor_trusted', result.actor_trusted ? 'true' : 'false');
-          # core.setOutput('actor_trusted_reason', result.actor_trusted_reason);
-        # 
-          # if (result.actor_trusted) {
-            # core.info(`Actor trusted: ${result.actor_trusted_reason}`);
-          # } else {
-            # core.info(`Actor not trusted: ${result.actor_trusted_reason}`);
-          # }
-        # }
+      # script: "/**\n * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'change-factory/issue-';\nconst FACTORY_LABEL = 'change-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'github-keywords',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst changeFactoryIssueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst { owner, repo } = context.repo;\nconst sender = context.payload.sender?.login ?? '';\n\nif (!sender) {\n  const missing = actorTrustWhenSenderMissing();\n  core.setOutput('actor_trusted', 'false');\n  core.setOutput('actor_trusted_reason', missing.actor_trusted_reason);\n  core.info('Actor not trusted: sender login is missing from the event payload.');\n} else {\n  let permission = null;\n  if (sender !== 'github-actions[bot]') {\n    const { data } = await github.rest.repos.getCollaboratorPermissionLevel({\n      owner,\n      repo,\n      username: sender,\n    });\n    permission = data.permission;\n  }\n\n  const result = checkActorTrust({ sender, permission });\n\n  core.setOutput('actor_trusted', result.actor_trusted ? 'true' : 'false');\n  core.setOutput('actor_trusted_reason', result.actor_trusted_reason);\n\n  if (result.actor_trusted) {\n    core.info(`Actor trusted: ${result.actor_trusted_reason}`);\n  } else {\n    core.info(`Actor not trusted: ${result.actor_trusted_reason}`);\n  }\n}\n"
   # - id: check_duplicate_pr
     # if: steps.qualify_trigger.outputs.event_eligible == 'true' && steps.check_actor_trust.outputs.actor_trusted == 'true'
     # name: Check duplicate PR
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'change-factory/issue-';
-        # const FACTORY_LABEL = 'change-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'github-keywords',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const changeFactoryIssueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const { owner, repo } = context.repo;
-        # const issueNumber = context.payload.issue?.number;
-        # const expectedBranch = changeFactoryIssueBranchName(issueNumber);
-        # 
-        # const pulls = await github.paginate(github.rest.pulls.list, {
-          # owner,
-          # repo,
-          # state: 'open',
-          # head: `${owner}:${expectedBranch}`,
-          # per_page: 100,
-        # });
-        # 
-        # const pullRequests = pulls.map(pr => ({
-          # number: pr.number,
-          # state: pr.state,
-          # head_branch: pr.head.ref,
-          # labels: pr.labels.map(l => l.name),
-          # body: pr.body ?? '',
-          # html_url: pr.html_url,
-        # }));
-        # 
-        # const result = checkDuplicatePR({ issueNumber, pullRequests });
-        # 
-        # core.setOutput('duplicate_pr_found', result.duplicate_pr_found ? 'true' : 'false');
-        # core.setOutput('duplicate_pr_url', result.duplicate_pr_url ?? '');
-        # core.setOutput('gate_reason', result.gate_reason);
-        # 
-        # if (result.duplicate_pr_found) {
-          # core.info(`Duplicate PR found: ${result.gate_reason}`);
-        # } else {
-          # core.info(`No duplicate PR: ${result.gate_reason}`);
-        # }
+      # script: "/**\n * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'change-factory/issue-';\nconst FACTORY_LABEL = 'change-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'github-keywords',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst changeFactoryIssueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst { owner, repo } = context.repo;\nconst issueNumber = context.payload.issue?.number;\nconst expectedBranch = changeFactoryIssueBranchName(issueNumber);\n\nconst pulls = await github.paginate(github.rest.pulls.list, {\n  owner,\n  repo,\n  state: 'open',\n  head: `${owner}:${expectedBranch}`,\n  per_page: 100,\n});\n\nconst pullRequests = pulls.map(pr => ({\n  number: pr.number,\n  state: pr.state,\n  head_branch: pr.head.ref,\n  labels: pr.labels.map(l => l.name),\n  body: pr.body ?? '',\n  html_url: pr.html_url,\n}));\n\nconst result = checkDuplicatePR({ issueNumber, pullRequests });\n\ncore.setOutput('duplicate_pr_found', result.duplicate_pr_found ? 'true' : 'false');\ncore.setOutput('duplicate_pr_url', result.duplicate_pr_url ?? '');\ncore.setOutput('gate_reason', result.gate_reason);\n\nif (result.duplicate_pr_found) {\n  core.info(`Duplicate PR found: ${result.gate_reason}`);\n} else {\n  core.info(`No duplicate PR: ${result.gate_reason}`);\n}\n"
+  # - id: remove_trigger_label
+    # if: steps.qualify_trigger.outputs.event_eligible == 'true' && steps.check_actor_trust.outputs.actor_trusted == 'true' && steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+    # name: Remove trigger label
+    # uses: actions/github-script@v9
+    # with:
+      # github-token: ${{ secrets.GITHUB_TOKEN }}
+      # script: "/** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */\nconst TRIGGER_LABEL = 'verify-openspec';\n\n/**\n * Removes a single label from an issue or pull request (GitHub issue API).\n * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts\n * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}\n */\nasync function removeTriggerLabel({ github, context, issueNumber, labelName }) {\n  if (issueNumber === undefined || issueNumber === null) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No issue number in event payload',\n    };\n  }\n\n  const label =\n    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;\n  if (!label) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No label name provided',\n    };\n  }\n\n  try {\n    await github.rest.issues.removeLabel({\n      owner: context.repo.owner,\n      repo: context.repo.repo,\n      issue_number: issueNumber,\n      name: label,\n    });\n    return {\n      trigger_label_removed: true,\n      trigger_label_removed_reason: `Removed label: ${label}`,\n    };\n  } catch (err) {\n    // GitHub returns 404 when the label does not exist on the issue; treat as success\n    if (err.status === 404) {\n      return {\n        trigger_label_removed: true,\n        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,\n      };\n    }\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: `Failed to remove label: ${err.message}`,\n    };\n  }\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = { TRIGGER_LABEL, removeTriggerLabel };\n}\n\nconst issueNumber = context.payload.issue?.number;\nconst result = await removeTriggerLabel({\n  github,\n  context,\n  issueNumber,\n  labelName: 'change-factory',\n});\n\ncore.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');\ncore.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);\n\nif (result.trigger_label_removed) {\n  core.info(`Removed trigger label change-factory from issue #${issueNumber}`);\n} else {\n  core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);\n}\n"
   # - env:
       # ACTOR_TRUSTED: ${{ steps.check_actor_trust.outputs.actor_trusted }}
       # ACTOR_TRUSTED_REASON: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
@@ -1197,351 +107,7 @@ name: "Change Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'change-factory/issue-';
-        # const FACTORY_LABEL = 'change-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'github-keywords',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const changeFactoryIssueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const result = computeGateReason(parseFinalizeGateEnv(process.env));
-        # 
-        # core.setOutput('gate_reason', result.gate_reason);
-        # core.info(`Gate reason: ${result.gate_reason}`);
+      # script: "/**\n * Change-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`change-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'change-factory/issue-';\nconst FACTORY_LABEL = 'change-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the change-factory label or issue labels were missing.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'github-keywords',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst changeFactoryIssueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst result = computeGateReason(parseFinalizeGateEnv(process.env));\n\ncore.setOutput('gate_reason', result.gate_reason);\ncore.info(`Gate reason: ${result.gate_reason}`);\n"
 
 permissions: {}
 
@@ -1560,10 +126,14 @@ jobs:
     permissions:
       actions: read
       contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
     outputs:
       body: ${{ steps.sanitized.outputs.body }}
-      comment_id: ""
-      comment_repo: ""
+      comment_id: ${{ steps.add-comment.outputs.comment-id }}
+      comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
+      comment_url: ${{ steps.add-comment.outputs.comment-url }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
@@ -1650,6 +220,18 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
             await main();
+      - name: Add comment with workflow run link
+        id: add-comment
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_WORKFLOW_NAME: "Change Factory Issue Intake"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
+            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1672,19 +254,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b5c50ef1370b3703_EOF'
+          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
           <system>
-          GH_AW_PROMPT_b5c50ef1370b3703_EOF
+          GH_AW_PROMPT_91a3059ffd192834_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5c50ef1370b3703_EOF'
+          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
           <safe-output-tools>
           Tools: add_comment, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_b5c50ef1370b3703_EOF
+          GH_AW_PROMPT_91a3059ffd192834_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_b5c50ef1370b3703_EOF'
+          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -1717,12 +299,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b5c50ef1370b3703_EOF
+          GH_AW_PROMPT_91a3059ffd192834_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b5c50ef1370b3703_EOF'
+          cat << 'GH_AW_PROMPT_91a3059ffd192834_EOF'
           </system>
           {{#runtime-import .github/workflows/change-factory-issue.md}}
-          GH_AW_PROMPT_b5c50ef1370b3703_EOF
+          GH_AW_PROMPT_91a3059ffd192834_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -1923,9 +505,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3d9a36ac32ae2bcc_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_39cb6ad411b5cdb7_EOF'
           {"add_comment":{"max":1,"target":"triggering"},"create_pull_request":{"labels":["change-factory","no-changelog"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3d9a36ac32ae2bcc_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_39cb6ad411b5cdb7_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -2145,7 +727,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_dacf7fc34126adff_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_ee857d6c9203fbe5_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -2185,7 +767,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_dacf7fc34126adff_EOF
+          GH_AW_MCP_CONFIG_ee857d6c9203fbe5_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -2563,6 +1145,25 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
+      - name: Update reaction comment with completion status
+        id: conclusion
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
+          GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
+          GH_AW_COMMENT_REPO: ${{ needs.activation.outputs.comment_repo }}
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_AW_WORKFLOW_NAME: "Change Factory Issue Intake"
+          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
+          GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
+          GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
+        with:
+          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/notify_comment_error.cjs');
+            await main();
 
   detection:
     needs:
@@ -2741,7 +1342,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: read
+      issues: write
       pull-requests: read
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -2760,7 +1361,10 @@ jobs:
       issue_title: ${{ steps.capture_issue_context.outputs.issue_title }}
       matched_command: ''
       qualify_trigger_result: ${{ steps.qualify_trigger.outcome }}
+      remove_trigger_label_result: ${{ steps.remove_trigger_label.outcome }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
+      trigger_label_removed: ${{ steps.remove_trigger_label.outputs.trigger_label_removed }}
+      trigger_label_removed_reason: ${{ steps.remove_trigger_label.outputs.trigger_label_removed_reason }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -3904,6 +2508,84 @@ jobs:
               core.info(`Duplicate PR found: ${result.gate_reason}`);
             } else {
               core.info(`No duplicate PR: ${result.gate_reason}`);
+            }
+      - name: Remove trigger label
+        id: remove_trigger_label
+        if: steps.qualify_trigger.outputs.event_eligible == 'true' && steps.check_actor_trust.outputs.actor_trusted == 'true' && steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
+            const TRIGGER_LABEL = 'verify-openspec';
+
+            /**
+             * Removes a single label from an issue or pull request (GitHub issue API).
+             * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
+             * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
+             */
+            async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+              if (issueNumber === undefined || issueNumber === null) {
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: 'No issue number in event payload',
+                };
+              }
+
+              const label =
+                typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+              if (!label) {
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: 'No label name provided',
+                };
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label,
+                });
+                return {
+                  trigger_label_removed: true,
+                  trigger_label_removed_reason: `Removed label: ${label}`,
+                };
+              } catch (err) {
+                // GitHub returns 404 when the label does not exist on the issue; treat as success
+                if (err.status === 404) {
+                  return {
+                    trigger_label_removed: true,
+                    trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
+                  };
+                }
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: `Failed to remove label: ${err.message}`,
+                };
+              }
+            }
+
+            if (typeof module !== 'undefined') {
+              module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+            }
+
+            const issueNumber = context.payload.issue?.number;
+            const result = await removeTriggerLabel({
+              github,
+              context,
+              issueNumber,
+              labelName: 'change-factory',
+            });
+
+            core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
+            core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
+
+            if (result.trigger_label_removed) {
+              core.info(`Removed trigger label change-factory from issue #${issueNumber}`);
+            } else {
+              core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
             }
       - name: Finalize gate reason
         id: finalize_gate

--- a/.github/workflows/change-factory-issue.md
+++ b/.github/workflows/change-factory-issue.md
@@ -9,9 +9,10 @@ description: >-
 on:
   issues:
     types: [opened, labeled]
+  status-comment: true
   permissions:
     contents: read
-    issues: read
+    issues: write
     pull-requests: read
   steps:
     - name: Qualify trigger event
@@ -1144,6 +1145,88 @@ on:
             core.info(`No duplicate PR: ${result.gate_reason}`);
           }
           
+    - name: Remove trigger label
+      id: remove_trigger_label
+      if: >-
+        steps.qualify_trigger.outputs.event_eligible == 'true' &&
+        steps.check_actor_trust.outputs.actor_trusted == 'true' &&
+        steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+      uses: actions/github-script@v9
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
+          const TRIGGER_LABEL = 'verify-openspec';
+          
+          /**
+           * Removes a single label from an issue or pull request (GitHub issue API).
+           * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
+           * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
+           */
+          async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+            if (issueNumber === undefined || issueNumber === null) {
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: 'No issue number in event payload',
+              };
+            }
+          
+            const label =
+              typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+            if (!label) {
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: 'No label name provided',
+              };
+            }
+          
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: label,
+              });
+              return {
+                trigger_label_removed: true,
+                trigger_label_removed_reason: `Removed label: ${label}`,
+              };
+            } catch (err) {
+              // GitHub returns 404 when the label does not exist on the issue; treat as success
+              if (err.status === 404) {
+                return {
+                  trigger_label_removed: true,
+                  trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
+                };
+              }
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: `Failed to remove label: ${err.message}`,
+              };
+            }
+          }
+          
+          if (typeof module !== 'undefined') {
+            module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+          }
+          
+          const issueNumber = context.payload.issue?.number;
+          const result = await removeTriggerLabel({
+            github,
+            context,
+            issueNumber,
+            labelName: 'change-factory',
+          });
+          
+          core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
+          core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
+          
+          if (result.trigger_label_removed) {
+            core.info(`Removed trigger label change-factory from issue #${issueNumber}`);
+          } else {
+            core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
+          }
+          
     - name: Finalize gate reason
       id: finalize_gate
       if: always()
@@ -1536,6 +1619,8 @@ jobs:
       actor_trusted_reason: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
       duplicate_pr_found: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_found }}
       duplicate_pr_url: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_url }}
+      trigger_label_removed: ${{ steps.remove_trigger_label.outputs.trigger_label_removed }}
+      trigger_label_removed_reason: ${{ steps.remove_trigger_label.outputs.trigger_label_removed_reason }}
       gate_reason: ${{ steps.finalize_gate.outputs.gate_reason }}
 tools:
   github:

--- a/.github/workflows/change-factory-issue.md
+++ b/.github/workflows/change-factory-issue.md
@@ -1155,9 +1155,6 @@ on:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-          const TRIGGER_LABEL = 'verify-openspec';
-          
           /**
            * Removes a single label from an issue or pull request (GitHub issue API).
            * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -1207,7 +1204,7 @@ on:
           }
           
           if (typeof module !== 'undefined') {
-            module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+            module.exports = { removeTriggerLabel };
           }
           
           const issueNumber = context.payload.issue?.number;

--- a/.github/workflows/code-factory-issue.lock.yml
+++ b/.github/workflows/code-factory-issue.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fcf26d70e5a2619326ac760181f1be97c5eeccadf4a6854347693a8ce63c5106","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b588c123cd5967d15dbcaf99365a7e62c6c6f6963e14cb867e9abdc31cd10bea","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["CLAUDE_LITELLM_PROXY_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"hashicorp/setup-terraform","sha":"5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85","version":"v4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -94,7 +94,7 @@ name: "Code Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: "/** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */\nconst TRIGGER_LABEL = 'verify-openspec';\n\n/**\n * Removes a single label from an issue or pull request (GitHub issue API).\n * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts\n * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}\n */\nasync function removeTriggerLabel({ github, context, issueNumber, labelName }) {\n  if (issueNumber === undefined || issueNumber === null) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No issue number in event payload',\n    };\n  }\n\n  const label =\n    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;\n  if (!label) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No label name provided',\n    };\n  }\n\n  try {\n    await github.rest.issues.removeLabel({\n      owner: context.repo.owner,\n      repo: context.repo.repo,\n      issue_number: issueNumber,\n      name: label,\n    });\n    return {\n      trigger_label_removed: true,\n      trigger_label_removed_reason: `Removed label: ${label}`,\n    };\n  } catch (err) {\n    // GitHub returns 404 when the label does not exist on the issue; treat as success\n    if (err.status === 404) {\n      return {\n        trigger_label_removed: true,\n        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,\n      };\n    }\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: `Failed to remove label: ${err.message}`,\n    };\n  }\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = { TRIGGER_LABEL, removeTriggerLabel };\n}\n\nconst issueNumber = context.payload.issue?.number;\nconst result = await removeTriggerLabel({\n  github,\n  context,\n  issueNumber,\n  labelName: 'code-factory',\n});\n\ncore.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');\ncore.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);\n\nif (result.trigger_label_removed) {\n  core.info(`Removed trigger label code-factory from issue #${issueNumber}`);\n} else {\n  core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);\n}\n"
+      # script: "/**\n * Removes a single label from an issue or pull request (GitHub issue API).\n * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts\n * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}\n */\nasync function removeTriggerLabel({ github, context, issueNumber, labelName }) {\n  if (issueNumber === undefined || issueNumber === null) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No issue number in event payload',\n    };\n  }\n\n  const label =\n    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;\n  if (!label) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No label name provided',\n    };\n  }\n\n  try {\n    await github.rest.issues.removeLabel({\n      owner: context.repo.owner,\n      repo: context.repo.repo,\n      issue_number: issueNumber,\n      name: label,\n    });\n    return {\n      trigger_label_removed: true,\n      trigger_label_removed_reason: `Removed label: ${label}`,\n    };\n  } catch (err) {\n    // GitHub returns 404 when the label does not exist on the issue; treat as success\n    if (err.status === 404) {\n      return {\n        trigger_label_removed: true,\n        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,\n      };\n    }\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: `Failed to remove label: ${err.message}`,\n    };\n  }\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = { removeTriggerLabel };\n}\n\nconst issueNumber = context.payload.issue?.number;\nconst result = await removeTriggerLabel({\n  github,\n  context,\n  issueNumber,\n  labelName: 'code-factory',\n});\n\ncore.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');\ncore.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);\n\nif (result.trigger_label_removed) {\n  core.info(`Removed trigger label code-factory from issue #${issueNumber}`);\n} else {\n  core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);\n}\n"
   # - env:
       # ACTOR_TRUSTED: ${{ steps.check_actor_trust.outputs.actor_trusted }}
       # ACTOR_TRUSTED_REASON: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
@@ -253,19 +253,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
+          cat << 'GH_AW_PROMPT_c7e9edc812843984_EOF'
           <system>
-          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
+          GH_AW_PROMPT_c7e9edc812843984_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
+          cat << 'GH_AW_PROMPT_c7e9edc812843984_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
+          GH_AW_PROMPT_c7e9edc812843984_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
+          cat << 'GH_AW_PROMPT_c7e9edc812843984_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -298,12 +298,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
+          GH_AW_PROMPT_c7e9edc812843984_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
+          cat << 'GH_AW_PROMPT_c7e9edc812843984_EOF'
           </system>
           {{#runtime-import .github/workflows/code-factory-issue.md}}
-          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
+          GH_AW_PROMPT_c7e9edc812843984_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -522,9 +522,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e002a85ea40ed77c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d911cc0b47f8502a_EOF'
           {"create_pull_request":{"labels":["code-factory"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e002a85ea40ed77c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_d911cc0b47f8502a_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -721,7 +721,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_ee61fb80230887af_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_ca873abd0ae1c21d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -761,7 +761,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ee61fb80230887af_EOF
+          GH_AW_MCP_CONFIG_ca873abd0ae1c21d_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -2507,9 +2507,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-            const TRIGGER_LABEL = 'verify-openspec';
-
             /**
              * Removes a single label from an issue or pull request (GitHub issue API).
              * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -2559,7 +2556,7 @@ jobs:
             }
 
             if (typeof module !== 'undefined') {
-              module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+              module.exports = { removeTriggerLabel };
             }
 
             const issueNumber = context.payload.issue?.number;

--- a/.github/workflows/code-factory-issue.lock.yml
+++ b/.github/workflows/code-factory-issue.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f45d49495d57ac6a50c4fb3c2e7dcb9b779f6c1a8b1cde630d0ade6083923610","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"fcf26d70e5a2619326ac760181f1be97c5eeccadf4a6854347693a8ce63c5106","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/claude-sonnet-4-6"}
 # gh-aw-manifest: {"version":1,"secrets":["CLAUDE_LITELLM_PROXY_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"hashicorp/setup-terraform","sha":"5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85","version":"v4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -58,7 +58,7 @@ name: "Code Factory Issue Intake"
     - labeled
   # permissions: # Permissions applied to pre-activation job
     # contents: read
-    # issues: read
+    # issues: write
     # pull-requests: read
   # steps: # Steps injected into pre-activation job
   # - id: qualify_trigger
@@ -66,362 +66,7 @@ name: "Code Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'code-factory/issue-';
-        # const FACTORY_LABEL = 'code-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the code-factory label.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'closes-literal',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const issueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const eventName = context.eventName;
-        # const eventAction = context.payload.action;
-        # const labelName = context.payload.label?.name ?? '';
-        # const issueLabels = (context.payload.issue?.labels ?? []).map(l => l.name);
-        # 
-        # const result = qualifyTriggerEvent({ eventName, eventAction, labelName, issueLabels });
-        # 
-        # core.setOutput('event_eligible', result.event_eligible ? 'true' : 'false');
-        # core.setOutput('event_eligible_reason', result.event_eligible_reason);
-        # 
-        # if (result.event_eligible) {
-          # core.info(`Event eligible: ${result.event_eligible_reason}`);
-        # } else {
-          # core.info(`Event not eligible: ${result.event_eligible_reason}`);
-        # }
+      # script: "/**\n * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'code-factory/issue-';\nconst FACTORY_LABEL = 'code-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the code-factory label.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'closes-literal',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst issueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst eventName = context.eventName;\nconst eventAction = context.payload.action;\nconst labelName = context.payload.label?.name ?? '';\nconst issueLabels = (context.payload.issue?.labels ?? []).map(l => l.name);\n\nconst result = qualifyTriggerEvent({ eventName, eventAction, labelName, issueLabels });\n\ncore.setOutput('event_eligible', result.event_eligible ? 'true' : 'false');\ncore.setOutput('event_eligible_reason', result.event_eligible_reason);\n\nif (result.event_eligible) {\n  core.info(`Event eligible: ${result.event_eligible_reason}`);\n} else {\n  core.info(`Event not eligible: ${result.event_eligible_reason}`);\n}\n"
   # - id: capture_issue_context
     # name: Capture issue context
     # uses: actions/github-script@v9
@@ -435,756 +80,21 @@ name: "Code Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'code-factory/issue-';
-        # const FACTORY_LABEL = 'code-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the code-factory label.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'closes-literal',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const issueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const { owner, repo } = context.repo;
-        # const sender = context.payload.sender?.login ?? '';
-        # 
-        # if (!sender) {
-          # const missing = actorTrustWhenSenderMissing();
-          # core.setOutput('actor_trusted', 'false');
-          # core.setOutput('actor_trusted_reason', missing.actor_trusted_reason);
-          # core.info('Actor not trusted: sender login is missing from the event payload.');
-        # } else {
-          # let permission = null;
-          # if (sender !== 'github-actions[bot]') {
-            # const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-              # owner,
-              # repo,
-              # username: sender,
-            # });
-            # permission = data.permission;
-          # }
-        # 
-          # const result = checkActorTrust({ sender, permission });
-        # 
-          # core.setOutput('actor_trusted', result.actor_trusted ? 'true' : 'false');
-          # core.setOutput('actor_trusted_reason', result.actor_trusted_reason);
-        # 
-          # if (result.actor_trusted) {
-            # core.info(`Actor trusted: ${result.actor_trusted_reason}`);
-          # } else {
-            # core.info(`Actor not trusted: ${result.actor_trusted_reason}`);
-          # }
-        # }
+      # script: "/**\n * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'code-factory/issue-';\nconst FACTORY_LABEL = 'code-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the code-factory label.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'closes-literal',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst issueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst { owner, repo } = context.repo;\nconst sender = context.payload.sender?.login ?? '';\n\nif (!sender) {\n  const missing = actorTrustWhenSenderMissing();\n  core.setOutput('actor_trusted', 'false');\n  core.setOutput('actor_trusted_reason', missing.actor_trusted_reason);\n  core.info('Actor not trusted: sender login is missing from the event payload.');\n} else {\n  let permission = null;\n  if (sender !== 'github-actions[bot]') {\n    const { data } = await github.rest.repos.getCollaboratorPermissionLevel({\n      owner,\n      repo,\n      username: sender,\n    });\n    permission = data.permission;\n  }\n\n  const result = checkActorTrust({ sender, permission });\n\n  core.setOutput('actor_trusted', result.actor_trusted ? 'true' : 'false');\n  core.setOutput('actor_trusted_reason', result.actor_trusted_reason);\n\n  if (result.actor_trusted) {\n    core.info(`Actor trusted: ${result.actor_trusted_reason}`);\n  } else {\n    core.info(`Actor not trusted: ${result.actor_trusted_reason}`);\n  }\n}\n"
   # - id: check_duplicate_pr
     # if: steps.qualify_trigger.outputs.event_eligible == 'true' && steps.check_actor_trust.outputs.actor_trusted == 'true'
     # name: Check duplicate PR
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'code-factory/issue-';
-        # const FACTORY_LABEL = 'code-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the code-factory label.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'closes-literal',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const issueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const { owner, repo } = context.repo;
-        # const issueNumber = context.payload.issue?.number;
-        # const expectedBranch = issueBranchName(issueNumber);
-        # 
-        # const pulls = await github.paginate(github.rest.pulls.list, {
-          # owner,
-          # repo,
-          # state: 'open',
-          # head: `${owner}:${expectedBranch}`,
-          # per_page: 100,
-        # });
-        # 
-        # const pullRequests = pulls.map(pr => ({
-          # number: pr.number,
-          # state: pr.state,
-          # head_branch: pr.head.ref,
-          # labels: pr.labels.map(l => l.name),
-          # body: pr.body ?? '',
-          # html_url: pr.html_url,
-        # }));
-        # 
-        # const result = checkDuplicatePR({ issueNumber, pullRequests });
-        # 
-        # core.setOutput('duplicate_pr_found', result.duplicate_pr_found ? 'true' : 'false');
-        # core.setOutput('duplicate_pr_url', result.duplicate_pr_url ?? '');
-        # core.setOutput('gate_reason', result.gate_reason);
-        # 
-        # if (result.duplicate_pr_found) {
-          # core.info(`Duplicate PR found: ${result.gate_reason}`);
-        # } else {
-          # core.info(`No duplicate PR: ${result.gate_reason}`);
-        # }
+      # script: "/**\n * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'code-factory/issue-';\nconst FACTORY_LABEL = 'code-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the code-factory label.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'closes-literal',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst issueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst { owner, repo } = context.repo;\nconst issueNumber = context.payload.issue?.number;\nconst expectedBranch = issueBranchName(issueNumber);\n\nconst pulls = await github.paginate(github.rest.pulls.list, {\n  owner,\n  repo,\n  state: 'open',\n  head: `${owner}:${expectedBranch}`,\n  per_page: 100,\n});\n\nconst pullRequests = pulls.map(pr => ({\n  number: pr.number,\n  state: pr.state,\n  head_branch: pr.head.ref,\n  labels: pr.labels.map(l => l.name),\n  body: pr.body ?? '',\n  html_url: pr.html_url,\n}));\n\nconst result = checkDuplicatePR({ issueNumber, pullRequests });\n\ncore.setOutput('duplicate_pr_found', result.duplicate_pr_found ? 'true' : 'false');\ncore.setOutput('duplicate_pr_url', result.duplicate_pr_url ?? '');\ncore.setOutput('gate_reason', result.gate_reason);\n\nif (result.duplicate_pr_found) {\n  core.info(`Duplicate PR found: ${result.gate_reason}`);\n} else {\n  core.info(`No duplicate PR: ${result.gate_reason}`);\n}\n"
+  # - id: remove_trigger_label
+    # if: steps.qualify_trigger.outputs.event_eligible == 'true' && steps.check_actor_trust.outputs.actor_trusted == 'true' && steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+    # name: Remove trigger label
+    # uses: actions/github-script@v9
+    # with:
+      # github-token: ${{ secrets.GITHUB_TOKEN }}
+      # script: "/** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */\nconst TRIGGER_LABEL = 'verify-openspec';\n\n/**\n * Removes a single label from an issue or pull request (GitHub issue API).\n * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts\n * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}\n */\nasync function removeTriggerLabel({ github, context, issueNumber, labelName }) {\n  if (issueNumber === undefined || issueNumber === null) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No issue number in event payload',\n    };\n  }\n\n  const label =\n    typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;\n  if (!label) {\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: 'No label name provided',\n    };\n  }\n\n  try {\n    await github.rest.issues.removeLabel({\n      owner: context.repo.owner,\n      repo: context.repo.repo,\n      issue_number: issueNumber,\n      name: label,\n    });\n    return {\n      trigger_label_removed: true,\n      trigger_label_removed_reason: `Removed label: ${label}`,\n    };\n  } catch (err) {\n    // GitHub returns 404 when the label does not exist on the issue; treat as success\n    if (err.status === 404) {\n      return {\n        trigger_label_removed: true,\n        trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,\n      };\n    }\n    return {\n      trigger_label_removed: false,\n      trigger_label_removed_reason: `Failed to remove label: ${err.message}`,\n    };\n  }\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = { TRIGGER_LABEL, removeTriggerLabel };\n}\n\nconst issueNumber = context.payload.issue?.number;\nconst result = await removeTriggerLabel({\n  github,\n  context,\n  issueNumber,\n  labelName: 'code-factory',\n});\n\ncore.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');\ncore.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);\n\nif (result.trigger_label_removed) {\n  core.info(`Removed trigger label code-factory from issue #${issueNumber}`);\n} else {\n  core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);\n}\n"
   # - env:
       # ACTOR_TRUSTED: ${{ steps.check_actor_trust.outputs.actor_trusted }}
       # ACTOR_TRUSTED_REASON: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
@@ -1199,351 +109,7 @@ name: "Code Factory Issue Intake"
     # uses: actions/github-script@v9
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
-      # script: |
-        # /**
-         # * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with
-         # * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).
-         # */
-        # 'use strict';
-        # 
-        # const ISSUE_BRANCH_PREFIX = 'code-factory/issue-';
-        # const FACTORY_LABEL = 'code-factory';
-        # const ISSUE_OPENED_NOT_ELIGIBLE_REASON =
-          # 'Issue opened event does not qualify because the issue was created without the code-factory label.';
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # ISSUE_BRANCH_PREFIX,
-            # FACTORY_LABEL,
-            # ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # };
-        # }
-        # 
-        # /**
-         # * Shared deterministic helpers for code-factory and change-factory issue intake workflows.
-         # * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.
-         # */
-        # 
-        # /** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */
-        # const GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';
-        # 
-        # /**
-         # * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),
-         # * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.
-         # *
-         # * @param {number} issueNumber
-         # * @returns {RegExp}
-         # */
-        # function issueClosingReferencePattern(issueNumber) {
-          # return new RegExp(
-            # `\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\s*#${issueNumber}(?![0-9])`,
-            # 'i',
-          # );
-        # }
-        # 
-        # /**
-         # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params
-         # * @returns {{ event_eligible: boolean, event_eligible_reason: string }}
-         # */
-        # function factoryQualifyTriggerEvent({
-          # eventName,
-          # eventAction,
-          # labelName,
-          # issueLabels,
-          # factoryLabel,
-          # issueOpenedNotEligibleReason,
-        # }) {
-          # if (eventName !== 'issues') {
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'labeled') {
-            # if (labelName === factoryLabel) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,
-            # };
-          # }
-        # 
-          # if (eventAction === 'opened') {
-            # if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {
-              # return {
-                # event_eligible: true,
-                # event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,
-              # };
-            # }
-        # 
-            # return {
-              # event_eligible: false,
-              # event_eligible_reason: issueOpenedNotEligibleReason,
-            # };
-          # }
-        # 
-          # return {
-            # event_eligible: false,
-            # event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ sender: string, permission: string | null }} params
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryCheckActorTrust({ sender, permission }) {
-          # if (sender === 'github-actions[bot]') {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',
-            # };
-          # }
-        # 
-          # if (['write', 'maintain', 'admin'].includes(permission)) {
-            # return {
-              # actor_trusted: true,
-              # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,
-            # };
-          # }
-        # 
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}
-         # */
-        # function factoryActorTrustWhenSenderMissing() {
-          # return {
-            # actor_trusted: false,
-            # actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params
-         # * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}
-         # */
-        # function factoryCheckDuplicatePR({
-          # issueNumber,
-          # pullRequests,
-          # branchPrefix,
-          # prLabel,
-          # duplicateLinkageMode,
-        # }) {
-          # const expectedBranch = `${branchPrefix}${issueNumber}`;
-          # const expectedClosesExample = `Closes #${issueNumber}`;
-          # const bodyPattern = duplicateLinkageMode === 'closes-literal'
-            # ? new RegExp(`Closes #${issueNumber}(?![0-9])`)
-            # : issueClosingReferencePattern(issueNumber);
-        # 
-          # const duplicate = (pullRequests || []).find(pr => (
-            # pr.state === 'open' &&
-            # Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&
-            # pr.head_branch === expectedBranch &&
-            # bodyPattern.test(String(pr.body || ''))
-          # ));
-        # 
-          # if (duplicate) {
-            # if (duplicateLinkageMode === 'closes-literal') {
-              # return {
-                # duplicate_pr_found: true,
-                # duplicate_pr_url: duplicate.html_url,
-                # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,
-              # };
-            # }
-            # const url = duplicate.html_url ?? null;
-            # return {
-              # duplicate_pr_found: true,
-              # duplicate_pr_url: url,
-              # gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,
-            # };
-          # }
-        # 
-          # const linkageTail = duplicateLinkageMode === 'closes-literal'
-            # ? `canonical linkage '${expectedClosesExample}'`
-            # : `issue-closing reference such as '${expectedClosesExample}'`;
-        # 
-          # return {
-            # duplicate_pr_found: false,
-            # duplicate_pr_url: null,
-            # gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params
-         # * @param {string} factoryLabel
-         # * @returns {{ gate_reason: string }}
-         # */
-        # function factoryComputeGateReason({
-          # eventEligible,
-          # eventEligibleReason,
-          # actorTrusted,
-          # actorTrustedReason,
-          # duplicatePrFound,
-          # duplicatePrUrl,
-          # duplicateCheckGateReason,
-        # }, factoryLabel) {
-          # if (!eventEligible) {
-            # return { gate_reason: eventEligibleReason };
-          # }
-        # 
-          # if (actorTrusted === false) {
-            # return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };
-          # }
-        # 
-          # if (actorTrusted == null) {
-            # return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };
-          # }
-        # 
-          # if (duplicatePrFound === true) {
-            # return {
-              # gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,
-            # };
-          # }
-        # 
-          # if (duplicatePrFound == null) {
-            # return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };
-          # }
-        # 
-          # return {
-            # gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {string | undefined} raw
-         # * @returns {boolean | null}
-         # */
-        # function factoryParseOptionalTriStateFromEnv(raw) {
-          # if (raw == null || raw === '') {
-            # return null;
-          # }
-          # return raw === 'true';
-        # }
-        # 
-        # /**
-         # * @param {Record<string, string | undefined>} env
-         # */
-        # function factoryParseFinalizeGateEnv(env) {
-          # const e = env || {};
-          # return {
-            # eventEligible: e.EVENT_ELIGIBLE === 'true',
-            # eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',
-            # actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),
-            # actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,
-            # duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),
-            # duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,
-            # duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,
-          # };
-        # }
-        # 
-        # /**
-         # * @param {{
-         # *   branchPrefix: string,
-         # *   factoryLabel: string,
-         # *   issueOpenedNotEligibleReason: string,
-         # *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',
-         # * }} config
-         # */
-        # function createFactoryIssueIntake(config) {
-          # const {
-            # branchPrefix,
-            # factoryLabel,
-            # issueOpenedNotEligibleReason,
-            # duplicateLinkageMode,
-          # } = config;
-        # 
-          # function issueBranchName(issueNumber) {
-            # return `${branchPrefix}${issueNumber}`;
-          # }
-        # 
-          # /**
-           # * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params
-           # */
-          # function qualifyTriggerEvent(params) {
-            # return factoryQualifyTriggerEvent({
-              # ...params,
-              # factoryLabel,
-              # issueOpenedNotEligibleReason,
-            # });
-          # }
-        # 
-          # function checkActorTrust(params) {
-            # return factoryCheckActorTrust(params);
-          # }
-        # 
-          # function checkDuplicatePR(params) {
-            # return factoryCheckDuplicatePR({
-              # ...params,
-              # branchPrefix,
-              # prLabel: factoryLabel,
-              # duplicateLinkageMode,
-            # });
-          # }
-        # 
-          # function computeGateReason(params) {
-            # return factoryComputeGateReason(params, factoryLabel);
-          # }
-        # 
-          # return {
-            # issueBranchName,
-            # qualifyTriggerEvent,
-            # checkActorTrust,
-            # checkDuplicatePR,
-            # computeGateReason,
-          # };
-        # }
-        # 
-        # if (typeof module !== 'undefined') {
-          # module.exports = {
-            # issueClosingReferencePattern,
-            # factoryQualifyTriggerEvent,
-            # factoryCheckActorTrust,
-            # factoryActorTrustWhenSenderMissing,
-            # factoryCheckDuplicatePR,
-            # factoryComputeGateReason,
-            # factoryParseOptionalTriStateFromEnv,
-            # factoryParseFinalizeGateEnv,
-            # createFactoryIssueIntake,
-          # };
-        # }
-        # 
-        # const intake = createFactoryIssueIntake({
-          # branchPrefix: ISSUE_BRANCH_PREFIX,
-          # factoryLabel: FACTORY_LABEL,
-          # issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,
-          # duplicateLinkageMode: 'closes-literal',
-        # });
-        # 
-        # const qualifyTriggerEvent = intake.qualifyTriggerEvent;
-        # const checkActorTrust = intake.checkActorTrust;
-        # const checkDuplicatePR = intake.checkDuplicatePR;
-        # const computeGateReason = intake.computeGateReason;
-        # const issueBranchName = intake.issueBranchName;
-        # 
-        # function actorTrustWhenSenderMissing() {
-          # return factoryActorTrustWhenSenderMissing();
-        # }
-        # 
-        # function parseFinalizeGateEnv(env) {
-          # return factoryParseFinalizeGateEnv(env);
-        # }
-        # 
-        # const result = computeGateReason(parseFinalizeGateEnv(process.env));
-        # 
-        # core.setOutput('gate_reason', result.gate_reason);
-        # core.info(`Gate reason: ${result.gate_reason}`);
+      # script: "/**\n * Code-factory issue intake configuration. Keep `ISSUE_BRANCH_PREFIX` aligned with\n * `workflow.md.tmpl` (`code-factory/issue-${{ github.event.issue.number }}`).\n */\n'use strict';\n\nconst ISSUE_BRANCH_PREFIX = 'code-factory/issue-';\nconst FACTORY_LABEL = 'code-factory';\nconst ISSUE_OPENED_NOT_ELIGIBLE_REASON =\n  'Issue opened event does not qualify because the issue was created without the code-factory label.';\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    ISSUE_BRANCH_PREFIX,\n    FACTORY_LABEL,\n    ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  };\n}\n\n/**\n * Shared deterministic helpers for code-factory and change-factory issue intake workflows.\n * Workflow-specific configuration is passed via {@link createFactoryIssueIntake}.\n */\n\n/** GitHub-recognized issue-closing keywords (case-insensitive). See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests */\nconst GITHUB_ISSUE_CLOSING_KEYWORDS = '(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)';\n\n/**\n * GitHub closing-keyword reference: `#` is immediately followed by the issue digits (no whitespace),\n * per GitHub keyword syntax. Case-insensitive keywords; `(?![0-9])` avoids matching `#42` inside `#420`.\n *\n * @param {number} issueNumber\n * @returns {RegExp}\n */\nfunction issueClosingReferencePattern(issueNumber) {\n  return new RegExp(\n    `\\\\b${GITHUB_ISSUE_CLOSING_KEYWORDS}\\\\s*#${issueNumber}(?![0-9])`,\n    'i',\n  );\n}\n\n/**\n * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels: string[] | null | undefined, factoryLabel: string, issueOpenedNotEligibleReason: string }} params\n * @returns {{ event_eligible: boolean, event_eligible_reason: string }}\n */\nfunction factoryQualifyTriggerEvent({\n  eventName,\n  eventAction,\n  labelName,\n  issueLabels,\n  factoryLabel,\n  issueOpenedNotEligibleReason,\n}) {\n  if (eventName !== 'issues') {\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Unsupported event '${eventName || '(empty)'}'; expected 'issues'.`,\n    };\n  }\n\n  if (eventAction === 'labeled') {\n    if (labelName === factoryLabel) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue labeled event qualifies because the applied label is ${factoryLabel}.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: `Issue labeled event does not qualify because the applied label is '${labelName || '(empty)'}', not '${factoryLabel}'.`,\n    };\n  }\n\n  if (eventAction === 'opened') {\n    if (Array.isArray(issueLabels) && issueLabels.includes(factoryLabel)) {\n      return {\n        event_eligible: true,\n        event_eligible_reason: `Issue opened event qualifies because the issue already has the ${factoryLabel} label.`,\n      };\n    }\n\n    return {\n      event_eligible: false,\n      event_eligible_reason: issueOpenedNotEligibleReason,\n    };\n  }\n\n  return {\n    event_eligible: false,\n    event_eligible_reason: `Issue event action '${eventAction || '(empty)'}' is not eligible; expected 'opened' or 'labeled'.`,\n  };\n}\n\n/**\n * @param {{ sender: string, permission: string | null }} params\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryCheckActorTrust({ sender, permission }) {\n  if (sender === 'github-actions[bot]') {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: 'Trigger actor github-actions[bot] is trusted without collaborator permission lookup.',\n    };\n  }\n\n  if (['write', 'maintain', 'admin'].includes(permission)) {\n    return {\n      actor_trusted: true,\n      actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is trusted with repository permission '${permission}'.`,\n    };\n  }\n\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: `Trigger actor '${sender || '(empty)'}' is not trusted; repository permission '${permission || '(none)'}' does not meet the required write/maintain/admin policy.`,\n  };\n}\n\n/**\n * @returns {{ actor_trusted: boolean, actor_trusted_reason: string }}\n */\nfunction factoryActorTrustWhenSenderMissing() {\n  return {\n    actor_trusted: false,\n    actor_trusted_reason: 'Trigger actor could not be identified; sender login is missing from the event payload.',\n  };\n}\n\n/**\n * @param {{ issueNumber: number, pullRequests: Array<{ number: number, state: string, head_branch: string, labels: string[], body: string, html_url: string }>, branchPrefix: string, prLabel: string, duplicateLinkageMode: 'closes-literal' | 'github-keywords' }} params\n * @returns {{ duplicate_pr_found: boolean, duplicate_pr_url: string | null | undefined, gate_reason: string }}\n */\nfunction factoryCheckDuplicatePR({\n  issueNumber,\n  pullRequests,\n  branchPrefix,\n  prLabel,\n  duplicateLinkageMode,\n}) {\n  const expectedBranch = `${branchPrefix}${issueNumber}`;\n  const expectedClosesExample = `Closes #${issueNumber}`;\n  const bodyPattern = duplicateLinkageMode === 'closes-literal'\n    ? new RegExp(`Closes #${issueNumber}(?![0-9])`)\n    : issueClosingReferencePattern(issueNumber);\n\n  const duplicate = (pullRequests || []).find(pr => (\n    pr.state === 'open' &&\n    Array.isArray(pr.labels) && pr.labels.includes(prLabel) &&\n    pr.head_branch === expectedBranch &&\n    bodyPattern.test(String(pr.body || ''))\n  ));\n\n  if (duplicate) {\n    if (duplicateLinkageMode === 'closes-literal') {\n      return {\n        duplicate_pr_found: true,\n        duplicate_pr_url: duplicate.html_url,\n        gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${duplicate.html_url}) for issue #${issueNumber} on branch '${expectedBranch}' with canonical linkage '${expectedClosesExample}'.`,\n      };\n    }\n    const url = duplicate.html_url ?? null;\n    return {\n      duplicate_pr_found: true,\n      duplicate_pr_url: url,\n      gate_reason: `Found existing linked ${prLabel} PR #${duplicate.number} (${url ?? '(unknown URL)'}) for issue #${issueNumber} on branch '${expectedBranch}' with issue-closing reference such as '${expectedClosesExample}'.`,\n    };\n  }\n\n  const linkageTail = duplicateLinkageMode === 'closes-literal'\n    ? `canonical linkage '${expectedClosesExample}'`\n    : `issue-closing reference such as '${expectedClosesExample}'`;\n\n  return {\n    duplicate_pr_found: false,\n    duplicate_pr_url: null,\n    gate_reason: `No open linked ${prLabel} PR found for issue #${issueNumber}; expected label '${prLabel}', branch '${expectedBranch}', and ${linkageTail}.`,\n  };\n}\n\n/**\n * @param {{ eventEligible: boolean, eventEligibleReason: string, actorTrusted: boolean | null, actorTrustedReason: string | null, duplicatePrFound: boolean | null, duplicatePrUrl: string | null, duplicateCheckGateReason: string | null }} params\n * @param {string} factoryLabel\n * @returns {{ gate_reason: string }}\n */\nfunction factoryComputeGateReason({\n  eventEligible,\n  eventEligibleReason,\n  actorTrusted,\n  actorTrustedReason,\n  duplicatePrFound,\n  duplicatePrUrl,\n  duplicateCheckGateReason,\n}, factoryLabel) {\n  if (!eventEligible) {\n    return { gate_reason: eventEligibleReason };\n  }\n\n  if (actorTrusted === false) {\n    return { gate_reason: actorTrustedReason || 'Trigger actor is not trusted.' };\n  }\n\n  if (actorTrusted == null) {\n    return { gate_reason: 'Actor trust could not be determined; the trust check step did not produce an output.' };\n  }\n\n  if (duplicatePrFound === true) {\n    return {\n      gate_reason: duplicateCheckGateReason || `Found existing linked ${factoryLabel} PR: ${duplicatePrUrl || '(unknown URL)'}.`,\n    };\n  }\n\n  if (duplicatePrFound == null) {\n    return { gate_reason: 'Duplicate PR check did not complete; the check step did not produce an output.' };\n  }\n\n  return {\n    gate_reason: duplicateCheckGateReason || `All deterministic gates passed: event eligible, actor trusted, and no linked ${factoryLabel} PR found.`,\n  };\n}\n\n/**\n * @param {string | undefined} raw\n * @returns {boolean | null}\n */\nfunction factoryParseOptionalTriStateFromEnv(raw) {\n  if (raw == null || raw === '') {\n    return null;\n  }\n  return raw === 'true';\n}\n\n/**\n * @param {Record<string, string | undefined>} env\n */\nfunction factoryParseFinalizeGateEnv(env) {\n  const e = env || {};\n  return {\n    eventEligible: e.EVENT_ELIGIBLE === 'true',\n    eventEligibleReason: e.EVENT_ELIGIBLE_REASON ?? '',\n    actorTrusted: factoryParseOptionalTriStateFromEnv(e.ACTOR_TRUSTED),\n    actorTrustedReason: e.ACTOR_TRUSTED_REASON ?? null,\n    duplicatePrFound: factoryParseOptionalTriStateFromEnv(e.DUPLICATE_PR_FOUND),\n    duplicatePrUrl: e.DUPLICATE_PR_URL && e.DUPLICATE_PR_URL !== '' ? e.DUPLICATE_PR_URL : null,\n    duplicateCheckGateReason: e.DUPLICATE_GATE_REASON ?? null,\n  };\n}\n\n/**\n * @param {{\n *   branchPrefix: string,\n *   factoryLabel: string,\n *   issueOpenedNotEligibleReason: string,\n *   duplicateLinkageMode: 'closes-literal' | 'github-keywords',\n * }} config\n */\nfunction createFactoryIssueIntake(config) {\n  const {\n    branchPrefix,\n    factoryLabel,\n    issueOpenedNotEligibleReason,\n    duplicateLinkageMode,\n  } = config;\n\n  function issueBranchName(issueNumber) {\n    return `${branchPrefix}${issueNumber}`;\n  }\n\n  /**\n   * @param {{ eventName: string, eventAction: string, labelName: string, issueLabels?: string[] | null | undefined }} params\n   */\n  function qualifyTriggerEvent(params) {\n    return factoryQualifyTriggerEvent({\n      ...params,\n      factoryLabel,\n      issueOpenedNotEligibleReason,\n    });\n  }\n\n  function checkActorTrust(params) {\n    return factoryCheckActorTrust(params);\n  }\n\n  function checkDuplicatePR(params) {\n    return factoryCheckDuplicatePR({\n      ...params,\n      branchPrefix,\n      prLabel: factoryLabel,\n      duplicateLinkageMode,\n    });\n  }\n\n  function computeGateReason(params) {\n    return factoryComputeGateReason(params, factoryLabel);\n  }\n\n  return {\n    issueBranchName,\n    qualifyTriggerEvent,\n    checkActorTrust,\n    checkDuplicatePR,\n    computeGateReason,\n  };\n}\n\nif (typeof module !== 'undefined') {\n  module.exports = {\n    issueClosingReferencePattern,\n    factoryQualifyTriggerEvent,\n    factoryCheckActorTrust,\n    factoryActorTrustWhenSenderMissing,\n    factoryCheckDuplicatePR,\n    factoryComputeGateReason,\n    factoryParseOptionalTriStateFromEnv,\n    factoryParseFinalizeGateEnv,\n    createFactoryIssueIntake,\n  };\n}\n\nconst intake = createFactoryIssueIntake({\n  branchPrefix: ISSUE_BRANCH_PREFIX,\n  factoryLabel: FACTORY_LABEL,\n  issueOpenedNotEligibleReason: ISSUE_OPENED_NOT_ELIGIBLE_REASON,\n  duplicateLinkageMode: 'closes-literal',\n});\n\nconst qualifyTriggerEvent = intake.qualifyTriggerEvent;\nconst checkActorTrust = intake.checkActorTrust;\nconst checkDuplicatePR = intake.checkDuplicatePR;\nconst computeGateReason = intake.computeGateReason;\nconst issueBranchName = intake.issueBranchName;\n\nfunction actorTrustWhenSenderMissing() {\n  return factoryActorTrustWhenSenderMissing();\n}\n\nfunction parseFinalizeGateEnv(env) {\n  return factoryParseFinalizeGateEnv(env);\n}\n\nconst result = computeGateReason(parseFinalizeGateEnv(process.env));\n\ncore.setOutput('gate_reason', result.gate_reason);\ncore.info(`Gate reason: ${result.gate_reason}`);\n"
 
 permissions: {}
 
@@ -1562,10 +128,14 @@ jobs:
     permissions:
       actions: read
       contents: read
+      discussions: write
+      issues: write
+      pull-requests: write
     outputs:
       body: ${{ steps.sanitized.outputs.body }}
-      comment_id: ""
-      comment_repo: ""
+      comment_id: ${{ steps.add-comment.outputs.comment-id }}
+      comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
+      comment_url: ${{ steps.add-comment.outputs.comment-url }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
@@ -1652,6 +222,18 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
             await main();
+      - name: Add comment with workflow run link
+        id: add-comment
+        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_WORKFLOW_NAME: "Code Factory Issue Intake"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
+            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1671,19 +253,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_07e078247cfb4234_EOF'
+          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
           <system>
-          GH_AW_PROMPT_07e078247cfb4234_EOF
+          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_07e078247cfb4234_EOF'
+          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_07e078247cfb4234_EOF
+          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_07e078247cfb4234_EOF'
+          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -1716,12 +298,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_07e078247cfb4234_EOF
+          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_07e078247cfb4234_EOF'
+          cat << 'GH_AW_PROMPT_d4f70d1dd3074b18_EOF'
           </system>
           {{#runtime-import .github/workflows/code-factory-issue.md}}
-          GH_AW_PROMPT_07e078247cfb4234_EOF
+          GH_AW_PROMPT_d4f70d1dd3074b18_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -1940,9 +522,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4b960cfe09516592_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e002a85ea40ed77c_EOF'
           {"create_pull_request":{"labels":["code-factory"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"]},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4b960cfe09516592_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e002a85ea40ed77c_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -2139,7 +721,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_c1af8b0ad16c94a8_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_ee61fb80230887af_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -2179,7 +761,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c1af8b0ad16c94a8_EOF
+          GH_AW_MCP_CONFIG_ee61fb80230887af_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -2556,6 +1138,25 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
+      - name: Update reaction comment with completion status
+        id: conclusion
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        env:
+          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
+          GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
+          GH_AW_COMMENT_REPO: ${{ needs.activation.outputs.comment_repo }}
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_AW_WORKFLOW_NAME: "Code Factory Issue Intake"
+          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
+          GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
+          GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
+        with:
+          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/notify_comment_error.cjs');
+            await main();
 
   detection:
     needs:
@@ -2734,7 +1335,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      issues: read
+      issues: write
       pull-requests: read
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
@@ -2752,7 +1353,10 @@ jobs:
       issue_body: ${{ steps.capture_issue_context.outputs.issue_body }}
       matched_command: ''
       qualify_trigger_result: ${{ steps.qualify_trigger.outcome }}
+      remove_trigger_label_result: ${{ steps.remove_trigger_label.outcome }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
+      trigger_label_removed: ${{ steps.remove_trigger_label.outputs.trigger_label_removed }}
+      trigger_label_removed_reason: ${{ steps.remove_trigger_label.outputs.trigger_label_removed_reason }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -3895,6 +2499,84 @@ jobs:
               core.info(`Duplicate PR found: ${result.gate_reason}`);
             } else {
               core.info(`No duplicate PR: ${result.gate_reason}`);
+            }
+      - name: Remove trigger label
+        id: remove_trigger_label
+        if: steps.qualify_trigger.outputs.event_eligible == 'true' && steps.check_actor_trust.outputs.actor_trusted == 'true' && steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
+            const TRIGGER_LABEL = 'verify-openspec';
+
+            /**
+             * Removes a single label from an issue or pull request (GitHub issue API).
+             * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
+             * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
+             */
+            async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+              if (issueNumber === undefined || issueNumber === null) {
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: 'No issue number in event payload',
+                };
+              }
+
+              const label =
+                typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+              if (!label) {
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: 'No label name provided',
+                };
+              }
+
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label,
+                });
+                return {
+                  trigger_label_removed: true,
+                  trigger_label_removed_reason: `Removed label: ${label}`,
+                };
+              } catch (err) {
+                // GitHub returns 404 when the label does not exist on the issue; treat as success
+                if (err.status === 404) {
+                  return {
+                    trigger_label_removed: true,
+                    trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
+                  };
+                }
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: `Failed to remove label: ${err.message}`,
+                };
+              }
+            }
+
+            if (typeof module !== 'undefined') {
+              module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+            }
+
+            const issueNumber = context.payload.issue?.number;
+            const result = await removeTriggerLabel({
+              github,
+              context,
+              issueNumber,
+              labelName: 'code-factory',
+            });
+
+            core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
+            core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
+
+            if (result.trigger_label_removed) {
+              core.info(`Removed trigger label code-factory from issue #${issueNumber}`);
+            } else {
+              core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
             }
       - name: Finalize gate reason
         id: finalize_gate

--- a/.github/workflows/code-factory-issue.md
+++ b/.github/workflows/code-factory-issue.md
@@ -8,9 +8,10 @@ description: >-
 on:
   issues:
     types: [opened, labeled]
+  status-comment: true
   permissions:
     contents: read
-    issues: read
+    issues: write
     pull-requests: read
   steps:
     - name: Qualify trigger event
@@ -1142,6 +1143,88 @@ on:
             core.info(`No duplicate PR: ${result.gate_reason}`);
           }
           
+    - name: Remove trigger label
+      id: remove_trigger_label
+      if: >-
+        steps.qualify_trigger.outputs.event_eligible == 'true' &&
+        steps.check_actor_trust.outputs.actor_trusted == 'true' &&
+        steps.check_duplicate_pr.outputs.duplicate_pr_found != 'true'
+      uses: actions/github-script@v9
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
+          const TRIGGER_LABEL = 'verify-openspec';
+          
+          /**
+           * Removes a single label from an issue or pull request (GitHub issue API).
+           * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
+           * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
+           */
+          async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+            if (issueNumber === undefined || issueNumber === null) {
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: 'No issue number in event payload',
+              };
+            }
+          
+            const label =
+              typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+            if (!label) {
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: 'No label name provided',
+              };
+            }
+          
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: label,
+              });
+              return {
+                trigger_label_removed: true,
+                trigger_label_removed_reason: `Removed label: ${label}`,
+              };
+            } catch (err) {
+              // GitHub returns 404 when the label does not exist on the issue; treat as success
+              if (err.status === 404) {
+                return {
+                  trigger_label_removed: true,
+                  trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
+                };
+              }
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: `Failed to remove label: ${err.message}`,
+              };
+            }
+          }
+          
+          if (typeof module !== 'undefined') {
+            module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+          }
+          
+          const issueNumber = context.payload.issue?.number;
+          const result = await removeTriggerLabel({
+            github,
+            context,
+            issueNumber,
+            labelName: 'code-factory',
+          });
+          
+          core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
+          core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
+          
+          if (result.trigger_label_removed) {
+            core.info(`Removed trigger label code-factory from issue #${issueNumber}`);
+          } else {
+            core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
+          }
+          
     - name: Finalize gate reason
       id: finalize_gate
       if: always()
@@ -1564,6 +1647,8 @@ jobs:
       actor_trusted_reason: ${{ steps.check_actor_trust.outputs.actor_trusted_reason }}
       duplicate_pr_found: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_found }}
       duplicate_pr_url: ${{ steps.check_duplicate_pr.outputs.duplicate_pr_url }}
+      trigger_label_removed: ${{ steps.remove_trigger_label.outputs.trigger_label_removed }}
+      trigger_label_removed_reason: ${{ steps.remove_trigger_label.outputs.trigger_label_removed_reason }}
       gate_reason: ${{ steps.finalize_gate.outputs.gate_reason }}
 tools:
   github:

--- a/.github/workflows/code-factory-issue.md
+++ b/.github/workflows/code-factory-issue.md
@@ -1153,9 +1153,6 @@ on:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-          const TRIGGER_LABEL = 'verify-openspec';
-          
           /**
            * Removes a single label from an issue or pull request (GitHub issue API).
            * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -1205,7 +1202,7 @@ on:
           }
           
           if (typeof module !== 'undefined') {
-            module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+            module.exports = { removeTriggerLabel };
           }
           
           const issueNumber = context.payload.issue?.number;

--- a/.github/workflows/openspec-verify-label.lock.yml
+++ b/.github/workflows/openspec-verify-label.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"5c6659c72689b1a461cb46e83ad25b62eddc12394035bb4e72c44f7ae8f3cb56","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/gpt-5.4"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3faeb1a7741ae3b1abeec3276b9cf80bef07cbc20351088cfb9abc53e0f0808b","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/gpt-5.4"}
 # gh-aw-manifest: {"version":1,"secrets":["CLAUDE_LITELLM_PROXY_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"hashicorp/setup-terraform","sha":"5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85","version":"v4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -108,19 +108,28 @@ name: "OpenSpec verify (label)"
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
       # script: |
+        # /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
         # const TRIGGER_LABEL = 'verify-openspec';
         # 
         # /**
-         # * Removes only the verify-openspec trigger label from the triggering pull request.
-         # * Does not remove any other labels.
-         # * @param {{ github: object, context: object, prNumber: number|undefined }} opts
+         # * Removes a single label from an issue or pull request (GitHub issue API).
+         # * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
          # * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
          # */
-        # async function removeTriggerLabel({ github, context, prNumber }) {
-          # if (!prNumber) {
+        # async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+          # if (issueNumber === undefined || issueNumber === null) {
             # return {
               # trigger_label_removed: false,
-              # trigger_label_removed_reason: 'No pull request number in event payload',
+              # trigger_label_removed_reason: 'No issue number in event payload',
+            # };
+          # }
+        # 
+          # const label =
+            # typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+          # if (!label) {
+            # return {
+              # trigger_label_removed: false,
+              # trigger_label_removed_reason: 'No label name provided',
             # };
           # }
         # 
@@ -128,19 +137,19 @@ name: "OpenSpec verify (label)"
             # await github.rest.issues.removeLabel({
               # owner: context.repo.owner,
               # repo: context.repo.repo,
-              # issue_number: prNumber,
-              # name: TRIGGER_LABEL,
+              # issue_number: issueNumber,
+              # name: label,
             # });
             # return {
               # trigger_label_removed: true,
-              # trigger_label_removed_reason: `Removed label: ${TRIGGER_LABEL}`,
+              # trigger_label_removed_reason: `Removed label: ${label}`,
             # };
           # } catch (err) {
             # // GitHub returns 404 when the label does not exist on the issue; treat as success
             # if (err.status === 404) {
               # return {
                 # trigger_label_removed: true,
-                # trigger_label_removed_reason: `Label ${TRIGGER_LABEL} was not present (already removed or never applied)`,
+                # trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
               # };
             # }
             # return {
@@ -154,14 +163,19 @@ name: "OpenSpec verify (label)"
           # module.exports = { TRIGGER_LABEL, removeTriggerLabel };
         # }
         # 
-        # const prNumber = context.payload.pull_request?.number;
-        # const result = await removeTriggerLabel({ github, context, prNumber });
+        # const issueNumber = context.payload.pull_request?.number;
+        # const result = await removeTriggerLabel({
+          # github,
+          # context,
+          # issueNumber,
+          # labelName: TRIGGER_LABEL,
+        # });
         # 
         # core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
         # core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
         # 
         # if (result.trigger_label_removed) {
-          # core.info(`Removed trigger label verify-openspec from PR #${prNumber}`);
+          # core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
         # } else {
           # core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
         # }
@@ -446,19 +460,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a4d6a23992d62890_EOF'
+          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
           <system>
-          GH_AW_PROMPT_a4d6a23992d62890_EOF
+          GH_AW_PROMPT_d9de7201c057ced6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a4d6a23992d62890_EOF'
+          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:25), submit_pull_request_review, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_a4d6a23992d62890_EOF
+          GH_AW_PROMPT_d9de7201c057ced6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_a4d6a23992d62890_EOF'
+          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -491,12 +505,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_a4d6a23992d62890_EOF
+          GH_AW_PROMPT_d9de7201c057ced6_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a4d6a23992d62890_EOF'
+          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
           </system>
           {{#runtime-import .github/workflows/openspec-verify-label.md}}
-          GH_AW_PROMPT_a4d6a23992d62890_EOF
+          GH_AW_PROMPT_d9de7201c057ced6_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -702,9 +716,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6439a285b5d09069_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_884789fbfdead84c_EOF'
           {"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"target":"triggering"},"report_incomplete":{},"submit_pull_request_review":{"max":1,"target":"triggering"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6439a285b5d09069_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_884789fbfdead84c_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -942,7 +956,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_ae8e944693bdb7c1_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_6c6f9ab52c13f511_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -982,7 +996,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ae8e944693bdb7c1_EOF
+          GH_AW_MCP_CONFIG_6c6f9ab52c13f511_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1623,19 +1637,28 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
             const TRIGGER_LABEL = 'verify-openspec';
 
             /**
-             * Removes only the verify-openspec trigger label from the triggering pull request.
-             * Does not remove any other labels.
-             * @param {{ github: object, context: object, prNumber: number|undefined }} opts
+             * Removes a single label from an issue or pull request (GitHub issue API).
+             * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
              * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
              */
-            async function removeTriggerLabel({ github, context, prNumber }) {
-              if (!prNumber) {
+            async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+              if (issueNumber === undefined || issueNumber === null) {
                 return {
                   trigger_label_removed: false,
-                  trigger_label_removed_reason: 'No pull request number in event payload',
+                  trigger_label_removed_reason: 'No issue number in event payload',
+                };
+              }
+
+              const label =
+                typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+              if (!label) {
+                return {
+                  trigger_label_removed: false,
+                  trigger_label_removed_reason: 'No label name provided',
                 };
               }
 
@@ -1643,19 +1666,19 @@ jobs:
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: prNumber,
-                  name: TRIGGER_LABEL,
+                  issue_number: issueNumber,
+                  name: label,
                 });
                 return {
                   trigger_label_removed: true,
-                  trigger_label_removed_reason: `Removed label: ${TRIGGER_LABEL}`,
+                  trigger_label_removed_reason: `Removed label: ${label}`,
                 };
               } catch (err) {
                 // GitHub returns 404 when the label does not exist on the issue; treat as success
                 if (err.status === 404) {
                   return {
                     trigger_label_removed: true,
-                    trigger_label_removed_reason: `Label ${TRIGGER_LABEL} was not present (already removed or never applied)`,
+                    trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
                   };
                 }
                 return {
@@ -1669,14 +1692,19 @@ jobs:
               module.exports = { TRIGGER_LABEL, removeTriggerLabel };
             }
 
-            const prNumber = context.payload.pull_request?.number;
-            const result = await removeTriggerLabel({ github, context, prNumber });
+            const issueNumber = context.payload.pull_request?.number;
+            const result = await removeTriggerLabel({
+              github,
+              context,
+              issueNumber,
+              labelName: TRIGGER_LABEL,
+            });
 
             core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
             core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
 
             if (result.trigger_label_removed) {
-              core.info(`Removed trigger label verify-openspec from PR #${prNumber}`);
+              core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
             } else {
               core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
             }

--- a/.github/workflows/openspec-verify-label.lock.yml
+++ b/.github/workflows/openspec-verify-label.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3faeb1a7741ae3b1abeec3276b9cf80bef07cbc20351088cfb9abc53e0f0808b","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/gpt-5.4"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e274f530951ebc862f7fd919effa374ea2e3b8b71303162a5092559feab9c00f","compiler_version":"v0.68.3","strict":true,"agent_id":"claude","agent_model":"llm-gateway/gpt-5.4"}
 # gh-aw-manifest: {"version":1,"secrets":["CLAUDE_LITELLM_PROXY_API_KEY","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"hashicorp/setup-terraform","sha":"5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85","version":"v4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -108,9 +108,6 @@ name: "OpenSpec verify (label)"
     # with:
       # github-token: ${{ secrets.GITHUB_TOKEN }}
       # script: |
-        # /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-        # const TRIGGER_LABEL = 'verify-openspec';
-        # 
         # /**
          # * Removes a single label from an issue or pull request (GitHub issue API).
          # * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -160,22 +157,23 @@ name: "OpenSpec verify (label)"
         # }
         # 
         # if (typeof module !== 'undefined') {
-          # module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+          # module.exports = { removeTriggerLabel };
         # }
         # 
+        # const verifyTriggerLabel = 'verify-openspec';
         # const issueNumber = context.payload.pull_request?.number;
         # const result = await removeTriggerLabel({
           # github,
           # context,
           # issueNumber,
-          # labelName: TRIGGER_LABEL,
+          # labelName: verifyTriggerLabel,
         # });
         # 
         # core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
         # core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
         # 
         # if (result.trigger_label_removed) {
-          # core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
+          # core.info(`Removed trigger label ${verifyTriggerLabel} from PR #${issueNumber}`);
         # } else {
           # core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
         # }
@@ -460,19 +458,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
+          cat << 'GH_AW_PROMPT_6164009fc13ccbe3_EOF'
           <system>
-          GH_AW_PROMPT_d9de7201c057ced6_EOF
+          GH_AW_PROMPT_6164009fc13ccbe3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
+          cat << 'GH_AW_PROMPT_6164009fc13ccbe3_EOF'
           <safe-output-tools>
           Tools: create_pull_request_review_comment(max:25), submit_pull_request_review, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_d9de7201c057ced6_EOF
+          GH_AW_PROMPT_6164009fc13ccbe3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
+          cat << 'GH_AW_PROMPT_6164009fc13ccbe3_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -505,12 +503,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_d9de7201c057ced6_EOF
+          GH_AW_PROMPT_6164009fc13ccbe3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_d9de7201c057ced6_EOF'
+          cat << 'GH_AW_PROMPT_6164009fc13ccbe3_EOF'
           </system>
           {{#runtime-import .github/workflows/openspec-verify-label.md}}
-          GH_AW_PROMPT_d9de7201c057ced6_EOF
+          GH_AW_PROMPT_6164009fc13ccbe3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -716,9 +714,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_884789fbfdead84c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_82f72987b8a5c398_EOF'
           {"create_pull_request_review_comment":{"max":25,"side":"RIGHT","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"if_no_changes":"warn","max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"target":"triggering"},"report_incomplete":{},"submit_pull_request_review":{"max":1,"target":"triggering"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_884789fbfdead84c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_82f72987b8a5c398_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -956,7 +954,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
-          cat << GH_AW_MCP_CONFIG_6c6f9ab52c13f511_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_b4bd3b18263d2053_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -996,7 +994,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6c6f9ab52c13f511_EOF
+          GH_AW_MCP_CONFIG_b4bd3b18263d2053_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1637,9 +1635,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-            const TRIGGER_LABEL = 'verify-openspec';
-
             /**
              * Removes a single label from an issue or pull request (GitHub issue API).
              * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -1689,22 +1684,23 @@ jobs:
             }
 
             if (typeof module !== 'undefined') {
-              module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+              module.exports = { removeTriggerLabel };
             }
 
+            const verifyTriggerLabel = 'verify-openspec';
             const issueNumber = context.payload.pull_request?.number;
             const result = await removeTriggerLabel({
               github,
               context,
               issueNumber,
-              labelName: TRIGGER_LABEL,
+              labelName: verifyTriggerLabel,
             });
 
             core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
             core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
 
             if (result.trigger_label_removed) {
-              core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
+              core.info(`Removed trigger label ${verifyTriggerLabel} from PR #${issueNumber}`);
             } else {
               core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
             }

--- a/.github/workflows/openspec-verify-label.md
+++ b/.github/workflows/openspec-verify-label.md
@@ -65,9 +65,6 @@ on:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
-          const TRIGGER_LABEL = 'verify-openspec';
-          
           /**
            * Removes a single label from an issue or pull request (GitHub issue API).
            * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
@@ -117,22 +114,23 @@ on:
           }
           
           if (typeof module !== 'undefined') {
-            module.exports = { TRIGGER_LABEL, removeTriggerLabel };
+            module.exports = { removeTriggerLabel };
           }
           
+          const verifyTriggerLabel = 'verify-openspec';
           const issueNumber = context.payload.pull_request?.number;
           const result = await removeTriggerLabel({
             github,
             context,
             issueNumber,
-            labelName: TRIGGER_LABEL,
+            labelName: verifyTriggerLabel,
           });
           
           core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
           core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
           
           if (result.trigger_label_removed) {
-            core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
+            core.info(`Removed trigger label ${verifyTriggerLabel} from PR #${issueNumber}`);
           } else {
             core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
           }

--- a/.github/workflows/openspec-verify-label.md
+++ b/.github/workflows/openspec-verify-label.md
@@ -65,19 +65,28 @@ on:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          /** Label removed by OpenSpec verify (label) pre-activation; exported for callers and tests. */
           const TRIGGER_LABEL = 'verify-openspec';
           
           /**
-           * Removes only the verify-openspec trigger label from the triggering pull request.
-           * Does not remove any other labels.
-           * @param {{ github: object, context: object, prNumber: number|undefined }} opts
+           * Removes a single label from an issue or pull request (GitHub issue API).
+           * @param {{ github: object, context: object, issueNumber: number|undefined, labelName: string|undefined }} opts
            * @returns {Promise<{ trigger_label_removed: boolean, trigger_label_removed_reason: string }>}
            */
-          async function removeTriggerLabel({ github, context, prNumber }) {
-            if (!prNumber) {
+          async function removeTriggerLabel({ github, context, issueNumber, labelName }) {
+            if (issueNumber === undefined || issueNumber === null) {
               return {
                 trigger_label_removed: false,
-                trigger_label_removed_reason: 'No pull request number in event payload',
+                trigger_label_removed_reason: 'No issue number in event payload',
+              };
+            }
+          
+            const label =
+              typeof labelName === 'string' && labelName.trim() !== '' ? labelName.trim() : null;
+            if (!label) {
+              return {
+                trigger_label_removed: false,
+                trigger_label_removed_reason: 'No label name provided',
               };
             }
           
@@ -85,19 +94,19 @@ on:
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: prNumber,
-                name: TRIGGER_LABEL,
+                issue_number: issueNumber,
+                name: label,
               });
               return {
                 trigger_label_removed: true,
-                trigger_label_removed_reason: `Removed label: ${TRIGGER_LABEL}`,
+                trigger_label_removed_reason: `Removed label: ${label}`,
               };
             } catch (err) {
               // GitHub returns 404 when the label does not exist on the issue; treat as success
               if (err.status === 404) {
                 return {
                   trigger_label_removed: true,
-                  trigger_label_removed_reason: `Label ${TRIGGER_LABEL} was not present (already removed or never applied)`,
+                  trigger_label_removed_reason: `Label ${label} was not present (already removed or never applied)`,
                 };
               }
               return {
@@ -111,14 +120,19 @@ on:
             module.exports = { TRIGGER_LABEL, removeTriggerLabel };
           }
           
-          const prNumber = context.payload.pull_request?.number;
-          const result = await removeTriggerLabel({ github, context, prNumber });
+          const issueNumber = context.payload.pull_request?.number;
+          const result = await removeTriggerLabel({
+            github,
+            context,
+            issueNumber,
+            labelName: TRIGGER_LABEL,
+          });
           
           core.setOutput('trigger_label_removed', result.trigger_label_removed ? 'true' : 'false');
           core.setOutput('trigger_label_removed_reason', result.trigger_label_removed_reason);
           
           if (result.trigger_label_removed) {
-            core.info(`Removed trigger label verify-openspec from PR #${prNumber}`);
+            core.info(`Removed trigger label verify-openspec from PR #${issueNumber}`);
           } else {
             core.info(`Trigger label removal skipped: ${result.trigger_label_removed_reason}`);
           }

--- a/openspec/changes/factory-workflows-label-command/tasks.md
+++ b/openspec/changes/factory-workflows-label-command/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Shared remove-label helper
 
-- [ ] 1.1 Generalize `.github/workflows-src/lib/remove-trigger-label.js` to accept **label name** and **issue number** (issue API), preserving 404-treat-as-success behavior
-- [ ] 1.2 Update `.github/workflows-src/openspec-verify-label/scripts/remove_trigger_label.inline.js` to call the generalized helper with `verify-openspec` and the PR/issue number so behavior stays unchanged
-- [ ] 1.3 Add unit tests for the generalized helper (cover factory labels and issue path, plus existing verify behavior)
+- [x] 1.1 Generalize `.github/workflows-src/lib/remove-trigger-label.js` to accept **label name** and **issue number** (issue API), preserving 404-treat-as-success behavior
+- [x] 1.2 Update `.github/workflows-src/openspec-verify-label/scripts/remove_trigger_label.inline.js` to call the generalized helper with `verify-openspec` and the PR/issue number so behavior stays unchanged
+- [x] 1.3 Add unit tests for the generalized helper (cover factory labels and issue path, plus existing verify behavior)
 
 ## 2. Factory workflow templates
 
-- [ ] 2.1 In `.github/workflows-src/code-factory-issue/workflow.md.tmpl`, **keep** `on.issues.types: [opened, labeled]` (current triggers); add **`status-comment: true`** to `on:`
-- [ ] 2.2 Add a **Remove factory trigger label** (or equivalent name) step in **`on.steps`** after gating outputs needed for the agent `if:` are available, using `actions/github-script@v9` and `x-script-include` to a new script that calls the generalized helper with **`code-factory`** and `context.payload.issue.number`; mirror openspec-verify-label lines 24–30 structurally
-- [ ] 2.3 Add **`issues: write`** to `on.permissions` for pre-activation if not already present, consistent with label removal
-- [ ] 2.4 Wire **`jobs.pre-activation.outputs`** for remove-step outputs if the compiled workflow needs them (optional; follow verify workflow if useful)
-- [ ] 2.5 Repeat **2.1–2.4** for `.github/workflows-src/change-factory-issue/workflow.md.tmpl` with **`change-factory`**
+- [x] 2.1 In `.github/workflows-src/code-factory-issue/workflow.md.tmpl`, **keep** `on.issues.types: [opened, labeled]` (current triggers); add **`status-comment: true`** to `on:`
+- [x] 2.2 Add a **Remove factory trigger label** (or equivalent name) step in **`on.steps`** after gating outputs needed for the agent `if:` are available, using `actions/github-script@v9` and `x-script-include` to a new script that calls the generalized helper with **`code-factory`** and `context.payload.issue.number`; mirror openspec-verify-label lines 24–30 structurally
+- [x] 2.3 Add **`issues: write`** to `on.permissions` for pre-activation if not already present, consistent with label removal
+- [x] 2.4 Wire **`jobs.pre-activation.outputs`** for remove-step outputs if the compiled workflow needs them (optional; follow verify workflow if useful)
+- [x] 2.5 Repeat **2.1–2.4** for `.github/workflows-src/change-factory-issue/workflow.md.tmpl` with **`change-factory`**
 
 ## 3. Regenerate and validate
 
-- [ ] 3.1 Run `make workflow-generate` (or documented equivalent) and commit regenerated `code-factory-issue.*` and `change-factory-issue.*` under `.github/workflows/`
-- [ ] 3.2 Run workflow lib tests and fix any `if:` ordering / skipped-step output issues for the remove step
-- [ ] 3.3 Sync delta specs into `openspec/specs/` when ready; run `openspec validate` / `make check-openspec`
+- [x] 3.1 Run `make workflow-generate` (or documented equivalent) and commit regenerated `code-factory-issue.*` and `change-factory-issue.*` under `.github/workflows/`
+- [x] 3.2 Run workflow lib tests and fix any `if:` ordering / skipped-step output issues for the remove step
+- [x] 3.3 Sync delta specs into `openspec/specs/` when ready; run `openspec validate` / `make check-openspec`

--- a/openspec/specs/ci-change-factory-issue-intake/spec.md
+++ b/openspec/specs/ci-change-factory-issue-intake/spec.md
@@ -113,3 +113,30 @@ If the triggering issue lacks enough context for the agent to create a coherent 
 - **WHEN** the issue title and body provide enough context to identify the change scope and capability area
 - **THEN** the agent SHALL create the linked OpenSpec proposal pull request without requiring a GitHub comment exploration loop
 
+### Requirement: Workflow status comments on the issue include the run link
+The workflow SHALL set `status-comment: true` in the top-level `on:` configuration (see GitHub Agentic Workflows [status comments](https://github.github.com/gh-aw/reference/triggers/#status-comments-status-comment)) so the activation job posts a status comment on the triggering issue when the run starts and updates it when the run completes, including a link to the workflow run as provided by the framework.
+
+#### Scenario: Status comment enabled
+- **WHEN** maintainers inspect the authored `change-factory` issue-intake workflow `on:` frontmatter
+- **THEN** it SHALL include `status-comment: true` (or an object form that enables status comments for issues)
+
+#### Scenario: No custom comment step for run linkage
+- **WHEN** the workflow is authored for `change-factory` issue intake
+- **THEN** the repository SHALL NOT rely on a custom implementation-job step solely to post the workflow run URL to the issue; run visibility SHALL be covered by `status-comment` as above
+
+### Requirement: Workflow removes the factory trigger label in pre-activation when the agent proceeds
+The workflow SHALL include a deterministic pre-activation step that removes the `change-factory` label from the triggering issue **using the same mechanism as** OpenSpec verify (label): `actions/github-script@v9` with `x-script-include` to an inline script that delegates to the shared `.github/workflows-src/lib/remove-trigger-label.js` helper (generalized to accept the factory label name and issue number). The step SHALL run only when the workflow would proceed to the proposal agent (eligible qualifying issue event, trusted actor, and no open linked `change-factory` pull request per existing duplicate suppression). The workflow SHALL grant `issues: write` to pre-activation where required for label removal.
+
+#### Scenario: Remove step mirrors verify workflow pattern
+- **WHEN** maintainers inspect the authored `change-factory` issue-intake workflow `on.steps`
+- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label), with the `Remove trigger label` step using `actions/github-script@v9` and `x-script-include` to include the shared trigger-label removal script/helper path
+- **AND** the included script SHALL reuse the generalized `remove-trigger-label` library (not a forked copy of the GitHub API logic)
+
+#### Scenario: Label removed only when agent gate passes
+- **WHEN** pre-activation determines the proposal agent SHALL run for the issue
+- **THEN** the remove-label step SHALL run and SHALL attempt to remove `change-factory` from that issue
+
+#### Scenario: Label retained when agent does not run
+- **WHEN** pre-activation suppresses the agent (ineligible event, untrusted actor, or duplicate linked PR)
+- **THEN** the workflow SHALL NOT remove `change-factory` solely as a side effect of this intake run
+

--- a/openspec/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/specs/ci-code-factory-issue-intake/spec.md
@@ -76,3 +76,30 @@ When the deterministic gate passes, the workflow agent SHALL treat the triggerin
 - **WHEN** the agent creates the `code-factory` pull request
 - **THEN** the pull request SHALL include explicit issue linkage metadata so later workflow runs can identify it as the canonical PR for the issue
 
+### Requirement: Workflow status comments on the issue include the run link
+The workflow SHALL set `status-comment: true` in the top-level `on:` configuration (see GitHub Agentic Workflows [status comments](https://github.github.com/gh-aw/reference/triggers/#status-comments-status-comment)) so the activation job posts a status comment on the triggering issue when the run starts and updates it when the run completes, including a link to the workflow run as provided by the framework.
+
+#### Scenario: Status comment enabled
+- **WHEN** maintainers inspect the authored `code-factory` issue-intake workflow `on:` frontmatter
+- **THEN** it SHALL include `status-comment: true` (or an object form that enables status comments for issues)
+
+#### Scenario: No custom comment step for run linkage
+- **WHEN** the workflow is authored for `code-factory` issue intake
+- **THEN** the repository SHALL NOT rely on a custom implementation-job step solely to post the workflow run URL to the issue; run visibility SHALL be covered by `status-comment` as above
+
+### Requirement: Workflow removes the factory trigger label in pre-activation when the agent proceeds
+The workflow SHALL include a deterministic pre-activation step that removes the `code-factory` label from the triggering issue **using the same mechanism as** OpenSpec verify (label): `actions/github-script@v9` with `x-script-include` to an inline script that delegates to the shared `.github/workflows-src/lib/remove-trigger-label.js` helper (generalized to accept the factory label name and issue number). The step SHALL run only when the workflow would proceed to the implementation agent (eligible qualifying issue event, trusted actor, and no open linked `code-factory` pull request per existing duplicate suppression). The workflow SHALL grant `issues: write` to pre-activation where required for label removal.
+
+#### Scenario: Remove step mirrors verify workflow pattern
+- **WHEN** maintainers inspect the authored `code-factory` issue-intake workflow `on.steps`
+- **THEN** it SHALL include a remove-label step structurally equivalent to OpenSpec verify (label), including step name `Remove trigger label`, `uses: actions/github-script@v9`, and an `x-script-include` reference for the inline script
+- **AND** the included script SHALL reuse the generalized `remove-trigger-label` library (not a forked copy of the GitHub API logic)
+
+#### Scenario: Label removed only when agent gate passes
+- **WHEN** pre-activation determines the implementation agent SHALL run for the issue
+- **THEN** the remove-label step SHALL run and SHALL attempt to remove `code-factory` from that issue
+
+#### Scenario: Label retained when agent does not run
+- **WHEN** pre-activation suppresses the agent (ineligible event, untrusted actor, or duplicate linked PR)
+- **THEN** the workflow SHALL NOT remove `code-factory` solely as a side effect of this intake run
+


### PR DESCRIPTION
## OpenSpec

Implements change `factory-workflows-label-command`: keep `issues` triggers, add `status-comment: true`, reuse generalized `remove-trigger-label.js` for factory pre-activation (same pattern as OpenSpec verify label), regenerate workflows, sync specs.

## Delivery checklist

- [x] Shared helper + verify inline + unit tests
- [x] Code Factory / Change Factory templates, scripts, permissions, outputs
- [x] `make workflow-generate`, workflow lib tests, `make lint`, `make build`, `make check-openspec`

## Notes

After CI is green and review feedback is addressed, add label `verify-openspec` to run OpenSpec verification on this PR per repo workflow.


## Changelog

Customer impact: none

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add status comments and deterministic trigger label removal to factory issue intake workflows
> - The `change-factory` and `code-factory` issue intake workflows now post a status comment with the workflow run link on eligible events, then update that comment with final conclusions at the end of the run.
> - A new pre-activation step removes the respective trigger label (`change-factory` or `code-factory`) from the triggering issue when the event is eligible, the actor is trusted, and no duplicate PR exists; outcome is exposed as job outputs.
> - The shared [`remove-trigger-label.js`](https://github.com/elastic/terraform-provider-elasticstack/pull/2503/files#diff-fd40ef43b5238c868c005eb2d7ea208eb2cd4076f7e73b53bf75af97eaa23e43) helper is generalized to accept explicit `issueNumber` and `labelName` parameters instead of using a hardcoded constant, with added validation for missing values.
> - The `openspec-verify-label` workflow's label removal step is updated to pass `issueNumber` and `labelName` explicitly, matching the new helper API.
> - Issues write permissions are added to the relevant jobs across all three workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa02722.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
