### PR TITLE
feat(openspec): add elastic-docs MCP to factory workflows

### DIFF
--- a/openspec/changes/factory-workflows-elastic-docs-mcp/.openspec.yaml
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/factory-workflows-elastic-docs-mcp/design.md
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Both factory workflows (change-factory and code-factory) are authored as gh-aw (GitHub Agentic Workflow) markdown templates under `.github/workflows-src/<name>/workflow.md.tmpl` and compiled to `.github/workflows/<name>.md` + `.github/workflows/<name>.lock.yml` via `make workflow-generate`. The `.md` and `.lock.yml` files must never be hand-edited.
+
+The gh-aw runtime supports three types of MCP servers configurable in the workflow frontmatter:
+- **Container**: Docker image run by the MCP gateway
+- **HTTP**: Remote server accessed via HTTPS from the MCP gateway  
+- **Stdio**: Local command invoked on the runner host
+
+The Elastic docs MCP server (`https://www.elastic.co/docs/_mcp/`) is a public, unauthenticated, stateless HTTP endpoint exposing tools via Streamable HTTP. No Docker image or npm package is required.
+
+The gh-aw MCP gateway runs with `--network host`, so its outbound HTTP calls may or may not traverse the squid firewall that backs `network.allowed`. To be safe, `www.elastic.co` is added to `network.allowed` in both templates; this can be removed if testing shows it is unnecessary.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give both factory agents structured, semantic access to Elastic documentation during issue investigation
+- Keep changes confined to the workflow template source files (no Go, no Terraform provider code)
+- Remain compliant with the workflows-src compile pattern
+
+**Non-Goals:**
+- Adding authentication or rate-limiting to the MCP access (the endpoint is public)
+- Modifying other workflows (kibana-spec-impact, openspec-verify-label, etc.)
+- Restricting which tools within the MCP the agent may call (all 6 are permitted)
+
+## Decisions
+
+**Decision: HTTP MCP over network-only access**
+
+The alternative (adding `www.elastic.co` to `network.allowed` only, relying on raw WebFetch) gives the agent access to HTML pages it would need to guess the URL for. The HTTP MCP provides `search_docs` for semantic discovery without knowing a URL in advance, which is the common case when investigating an unfamiliar Elastic API feature. The MCP produces structured, token-efficient results vs. full HTML pages.
+
+**Decision: Use `allowed: ["*"]` rather than an explicit tool allowlist**
+
+The elastic-docs MCP exposes only docs-related tools (search_docs, find_related_docs, get_document_by_url, analyze_document_structure, check_docs_coherence, find_docs_inconsistencies). None of these are write operations. Listing `"*"` avoids breakage if the upstream server adds new docs tools, and there is no security concern for a read-only public endpoint.
+
+**Decision: Add `www.elastic.co` to `network.allowed` in both templates**
+
+Whether the MCP gateway's outbound HTTP calls traverse squid is undocumented and may depend on gh-aw version. Adding the host is harmless and avoids a subtle failure mode. This can be revisited and removed once testing confirms it is unnecessary.
+
+**Decision: Apply to both factory workflows symmetrically**
+
+The code-factory agent benefits equally: when implementing a Terraform resource for a new or updated Elastic API, consulting the API reference reduces guesswork about parameter names, types, and behavior.
+
+## Risks / Trade-offs
+
+**[Risk] Elastic docs MCP is Technical Preview** → The endpoint may be unstable or change URL/behaviour. Mitigation: the failure mode is "agent cannot look up docs" (a graceful degradation), not a data-loss or incorrect-output risk. The prompt guidance instructs the agent to proceed without docs if the tools are unavailable.
+
+**[Risk] `www.elastic.co` in network.allowed is unnecessary** → Minor: adds a host to the allowlist that the agent could use via raw WebFetch. The agent prompt does not encourage raw fetching; this is cosmetic overhead. Mitigation: remove the entry after confirming MCP gateway networking in a test run.
+
+**[Risk] MCP gateway network mode changes in a future gh-aw version** → If a future gh-aw release routes MCP gateway traffic through squid, the `www.elastic.co` allowlist entry is already in place and no action is needed.
+
+## Migration Plan
+
+1. Edit both `workflow.md.tmpl` source templates (add `mcp-servers` block, update `network.allowed`, add prompt guidance section).
+2. Run `make workflow-generate` to regenerate compiled outputs.
+3. Verify compiled `.md` files contain the expected `mcp-servers` JSON in the lock manifest.
+4. Commit both source and compiled files together.
+5. Trigger a test `change-factory` issue referencing a specific Elastic API to verify `search_docs` is called during the agent run.
+6. If `www.elastic.co` proves unnecessary in `network.allowed`, remove it in a follow-up commit.
+
+No rollback strategy beyond reverting the commit is needed — the change is additive and the workflow degrades gracefully if the MCP endpoint is down.

--- a/openspec/changes/factory-workflows-elastic-docs-mcp/proposal.md
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The change-factory and code-factory agent workflows have no access to Elastic documentation during issue investigation, forcing the agent to operate without authoritative API reference when authoring OpenSpec proposals or implementing provider code for unfamiliar or newly-introduced Elastic features. The Elastic docs MCP server provides a public, unauthenticated HTTP endpoint with structured semantic search that solves this directly.
+
+## What Changes
+
+- Add the Elastic docs MCP server (`https://www.elastic.co/docs/_mcp/`) to the `mcp-servers` frontmatter block of both factory workflow templates, giving the agent access to `search_docs`, `find_related_docs`, `get_document_by_url`, and related tools.
+- Add `www.elastic.co` to the `network.allowed` list in both workflow templates (required for MCP gateway outbound calls if squid is in the path; to be confirmed by testing).
+- Update the agent prompt in both workflow templates to instruct when and how to use the docs tools during issue investigation.
+- Regenerate the compiled `.md` and `.lock.yml` workflow artifacts from the updated templates.
+
+## Capabilities
+
+### New Capabilities
+
+None — this change does not introduce new Terraform resources or data sources.
+
+### Modified Capabilities
+
+- `ci-change-factory-issue-intake`: Adds a requirement that the proposal agent has access to Elastic documentation via the elastic-docs MCP server during issue investigation.
+- `ci-code-factory-issue-intake`: Adds a requirement that the implementation agent has access to Elastic documentation via the elastic-docs MCP server during issue investigation.
+
+## Impact
+
+- `.github/workflows-src/change-factory-issue/workflow.md.tmpl` — source template to modify
+- `.github/workflows-src/code-factory-issue/workflow.md.tmpl` — source template to modify
+- `.github/workflows/change-factory-issue.md` — regenerated compiled output
+- `.github/workflows/change-factory-issue.lock.yml` — regenerated compiled output
+- `.github/workflows/code-factory-issue.md` — regenerated compiled output
+- `.github/workflows/code-factory-issue.lock.yml` — regenerated compiled output
+- No Go source, Terraform provider code, tests, or generated clients are affected.

--- a/openspec/changes/factory-workflows-elastic-docs-mcp/specs/ci-change-factory-issue-intake/spec.md
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/specs/ci-change-factory-issue-intake/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Proposal agent has structured access to Elastic documentation
+The `change-factory` workflow SHALL configure the Elastic docs MCP server as an HTTP MCP server in the workflow frontmatter so that the proposal agent can query Elastic documentation during issue investigation. The workflow frontmatter SHALL include `www.elastic.co` in `network.allowed` and SHALL declare an `mcp-servers.elastic-docs` entry pointing to `https://www.elastic.co/docs/_mcp/`. The agent prompt SHALL instruct the agent to use the docs MCP tools (`search_docs`, `find_related_docs`, `get_document_by_url`) when investigating the API behavior, parameters, or constraints referenced by a `change-factory` issue.
+
+#### Scenario: Agent investigates an unfamiliar Elastic API feature
+- **WHEN** a `change-factory` issue references an Elastic API endpoint or feature the agent has not encountered before
+- **THEN** the agent SHALL use the elastic-docs MCP `search_docs` tool to locate relevant Elastic documentation before authoring the OpenSpec proposal
+- **AND** it SHALL use findings from the documentation to populate accurate API parameter names, types, and behavior in the delta specs
+
+#### Scenario: Elastic docs MCP server is unavailable
+- **WHEN** the elastic-docs MCP tools return an error or are unreachable during a `change-factory` run
+- **THEN** the agent SHALL proceed with proposal authoring using the information available in the issue and the repository codebase
+- **AND** it SHALL NOT block the run or emit `noop` solely because the docs MCP is unavailable
+
+#### Scenario: Maintainer inspects compiled workflow for docs MCP configuration
+- **WHEN** maintainers inspect the compiled `change-factory-issue.md` workflow
+- **THEN** the workflow frontmatter SHALL include `mcp-servers.elastic-docs` with `url: https://www.elastic.co/docs/_mcp/`
+- **AND** `network.allowed` SHALL include `www.elastic.co`

--- a/openspec/changes/factory-workflows-elastic-docs-mcp/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/specs/ci-code-factory-issue-intake/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Workflow frontmatter allows required agent ecosystems
+The `code-factory` issue-intake workflow SHALL declare an authored AWF network policy that allows the default allowlist plus the Node and Go ecosystems, allows `elastic.litellm-prod.ai` for the Claude engine's Anthropic-compatible proxy access, and allows `www.elastic.co` for the Elastic docs MCP server.
+
+#### Scenario: Maintainer inspects workflow frontmatter
+- **WHEN** maintainers inspect the authored `code-factory` issue-intake workflow frontmatter
+- **THEN** `network.allowed` SHALL include `defaults`
+- **AND** `network.allowed` SHALL include `node`
+- **AND** `network.allowed` SHALL include `go`
+- **AND** `network.allowed` SHALL include `elastic.litellm-prod.ai`
+- **AND** `network.allowed` SHALL include `www.elastic.co`
+
+## ADDED Requirements
+
+### Requirement: Implementation agent has structured access to Elastic documentation
+The `code-factory` workflow SHALL configure the Elastic docs MCP server as an HTTP MCP server in the workflow frontmatter so that the implementation agent can query Elastic documentation during issue investigation and implementation. The workflow frontmatter SHALL declare an `mcp-servers.elastic-docs` entry pointing to `https://www.elastic.co/docs/_mcp/`. The agent prompt SHALL instruct the agent to use the docs MCP tools (`search_docs`, `find_related_docs`, `get_document_by_url`) when investigating the API behavior, parameters, or constraints required to implement a `code-factory` issue.
+
+#### Scenario: Agent investigates API behavior before implementing a resource
+- **WHEN** a `code-factory` issue involves an Elastic API endpoint or feature whose full parameter set is not evident from the existing codebase
+- **THEN** the agent SHALL use the elastic-docs MCP `search_docs` tool to retrieve authoritative API documentation before writing implementation code
+
+#### Scenario: Elastic docs MCP server is unavailable
+- **WHEN** the elastic-docs MCP tools return an error or are unreachable during a `code-factory` run
+- **THEN** the agent SHALL proceed with implementation using the information available in the issue and the repository codebase
+- **AND** it SHALL NOT block the run solely because the docs MCP is unavailable
+
+#### Scenario: Maintainer inspects compiled workflow for docs MCP configuration
+- **WHEN** maintainers inspect the compiled `code-factory-issue.md` workflow
+- **THEN** the workflow frontmatter SHALL include `mcp-servers.elastic-docs` with `url: https://www.elastic.co/docs/_mcp/`

--- a/openspec/changes/factory-workflows-elastic-docs-mcp/tasks.md
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/tasks.md
@@ -1,0 +1,22 @@
+## 1. Update change-factory workflow template
+
+- [ ] 1.1 In `.github/workflows-src/change-factory-issue/workflow.md.tmpl`, add `www.elastic.co` to the `network.allowed` list (alongside `defaults`, `node`, `elastic.litellm-prod.ai`)
+- [ ] 1.2 In the same template, add an `mcp-servers` frontmatter block with an `elastic-docs` entry: `url: "https://www.elastic.co/docs/_mcp/"` and `allowed: ["*"]`
+- [ ] 1.3 In the same template, add a prompt section instructing the agent to use the elastic-docs MCP tools (`search_docs`, `find_related_docs`, `get_document_by_url`) during issue investigation before authoring proposal artifacts, and to proceed gracefully if the MCP is unavailable
+
+## 2. Update code-factory workflow template
+
+- [ ] 2.1 In `.github/workflows-src/code-factory-issue/workflow.md.tmpl`, add `www.elastic.co` to the `network.allowed` list (alongside `defaults`, `node`, `go`, `elastic.litellm-prod.ai`)
+- [ ] 2.2 In the same template, add an `mcp-servers` frontmatter block with an `elastic-docs` entry: `url: "https://www.elastic.co/docs/_mcp/"` and `allowed: ["*"]`
+- [ ] 2.3 In the same template, add a prompt section instructing the agent to use the elastic-docs MCP tools during issue investigation before implementing provider code, and to proceed gracefully if the MCP is unavailable
+
+## 3. Regenerate compiled workflow artifacts
+
+- [ ] 3.1 Run `make workflow-generate` to recompile both templates and regenerate the four files: `change-factory-issue.md`, `change-factory-issue.lock.yml`, `code-factory-issue.md`, `code-factory-issue.lock.yml`
+- [ ] 3.2 Verify the compiled `change-factory-issue.md` frontmatter contains `mcp-servers.elastic-docs` and `www.elastic.co` in `network.allowed`
+- [ ] 3.3 Verify the compiled `code-factory-issue.md` frontmatter contains `mcp-servers.elastic-docs` and `www.elastic.co` in `network.allowed`
+- [ ] 3.4 Verify the `change-factory-issue.lock.yml` manifest JSON references the MCP gateway configuration (check the `mcpServers` block in the generated `start_mcp_gateway` step)
+
+## 4. Validate OpenSpec artifacts
+
+- [ ] 4.1 Run `OPENSPEC_TELEMETRY=0 ./node_modules/.bin/openspec validate factory-workflows-elastic-docs-mcp --type change` and fix any reported problems

--- a/openspec/changes/factory-workflows-elastic-docs-mcp/tasks.md
+++ b/openspec/changes/factory-workflows-elastic-docs-mcp/tasks.md
@@ -2,13 +2,13 @@
 
 - [ ] 1.1 In `.github/workflows-src/change-factory-issue/workflow.md.tmpl`, add `www.elastic.co` to the `network.allowed` list (alongside `defaults`, `node`, `elastic.litellm-prod.ai`)
 - [ ] 1.2 In the same template, add an `mcp-servers` frontmatter block with an `elastic-docs` entry: `url: "https://www.elastic.co/docs/_mcp/"` and `allowed: ["*"]`
-- [ ] 1.3 In the same template, add a prompt section instructing the agent to use the elastic-docs MCP tools (`search_docs`, `find_related_docs`, `get_document_by_url`) during issue investigation before authoring proposal artifacts, and to proceed gracefully if the MCP is unavailable
+- [ ] 1.3 In the same template, add an `## Elastic documentation` prompt section immediately after `## OpenSpec tooling` (around line 148) that: (a) tells the agent an `elastic-docs` MCP server is available with tools `search_docs`, `find_related_docs`, and `get_document_by_url`; (b) instructs it to use `search_docs` to look up API behaviour, parameters, and constraints for the feature described in the issue before authoring proposal artifacts; and (c) instructs it to proceed without docs if the MCP tools are unavailable rather than blocking the run
 
 ## 2. Update code-factory workflow template
 
 - [ ] 2.1 In `.github/workflows-src/code-factory-issue/workflow.md.tmpl`, add `www.elastic.co` to the `network.allowed` list (alongside `defaults`, `node`, `go`, `elastic.litellm-prod.ai`)
 - [ ] 2.2 In the same template, add an `mcp-servers` frontmatter block with an `elastic-docs` entry: `url: "https://www.elastic.co/docs/_mcp/"` and `allowed: ["*"]`
-- [ ] 2.3 In the same template, add a prompt section instructing the agent to use the elastic-docs MCP tools during issue investigation before implementing provider code, and to proceed gracefully if the MCP is unavailable
+- [ ] 2.3 In the same template, add an `## Elastic documentation` prompt section immediately after `## Test environment` and before `## Task` (around line 172) that: (a) tells the agent an `elastic-docs` MCP server is available with tools `search_docs`, `find_related_docs`, and `get_document_by_url`; (b) instructs it to use `search_docs` to look up API behaviour, parameters, and constraints for the feature described in the issue before writing implementation code; and (c) instructs it to proceed without docs if the MCP tools are unavailable rather than blocking the run
 
 ## 3. Regenerate compiled workflow artifacts
 


### PR DESCRIPTION
## Summary

- Adds an OpenSpec change proposal (`factory-workflows-elastic-docs-mcp`) for wiring the public Elastic docs MCP server into both `change-factory` and `code-factory` agent workflows
- The MCP endpoint (`https://www.elastic.co/docs/_mcp/`) is public, unauthenticated, and exposes structured semantic search tools (`search_docs`, `find_related_docs`, `get_document_by_url`) — no auth config required
- Delta specs update `ci-change-factory-issue-intake` and `ci-code-factory-issue-intake` with the new requirements; design records the key decisions (HTTP MCP over raw network, graceful degradation if MCP is unavailable)

## Test plan

- [ ] Run `/opsx:apply` to implement the template changes and regenerate compiled workflow artifacts
- [ ] Trigger a test `change-factory` issue referencing a specific Elastic API (e.g. `_knn_search`) and verify the agent calls `search_docs` during its run
- [ ] Verify `code-factory` similarly has docs access
- [ ] If testing confirms `www.elastic.co` in `network.allowed` is unnecessary for the MCP gateway path, remove it in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add elastic-docs MCP server to factory workflow specs
> - Adds OpenSpec change manifests, design docs, and specs for integrating the Elastic docs HTTP MCP server (`https://www.elastic.co/docs/_mcp/`) into both `ci-change-factory-issue-intake` and `ci-code-factory-issue-intake` workflow templates.
> - Both workflow specs now require an `elastic-docs` MCP server entry and `www.elastic.co` added to `network.allowed`.
> - Agent prompt requirements are updated to instruct use of docs tools, with graceful degradation if the MCP is unavailable.
> - Includes a task checklist covering template edits, artifact regeneration, and OpenSpec validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f5bcc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->