### PR TITLE
Proposal for Index template -> PF

### DIFF
--- a/openspec/changes/migrate-index-template-to-plugin-framework/.openspec.yaml
+++ b/openspec/changes/migrate-index-template-to-plugin-framework/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/migrate-index-template-to-plugin-framework/design.md
+++ b/openspec/changes/migrate-index-template-to-plugin-framework/design.md
@@ -1,0 +1,198 @@
+## Context
+
+`elasticstack_elasticsearch_index_template` is implemented on `terraform-plugin-sdk/v2` in `internal/elasticsearch/index/template.go` (resource) and `internal/elasticsearch/index/template_data_source.go` (data source). The resource ships several bespoke SDK behaviors that need careful preservation when porting to the Plugin Framework:
+
+1. A `DiffSuppressFunc` (`suppressAliasRoutingDerivedDiff`) that hides spurious diffs when the user sets only `alias.routing` and Elasticsearch echoes the same value into `index_routing` and `search_routing` on read.
+2. A complementary post-read "preserve user routing" pass (`extractAliasRoutingFromTemplateState` + `preserveAliasRoutingInFlattenedAliases`) that re-injects the user's `routing` value into refreshed alias state.
+3. A custom `Set` hash on `alias` keyed by `name` (`hashAliasByName`) so changes to routing-only fields don't change set membership.
+4. An 8.x update workaround for `data_stream.allow_custom_routing` that re-sends `false` when prior state had `true`.
+5. JSON normalization with `DiffJSONSuppress` for `metadata`, `mappings`, and `alias.filter`, plus `DiffIndexSettingSuppress` for `template.settings` (dotted-vs-nested key equivalence + `index.` prefix normalization).
+6. Version gating: `ignore_missing_component_templates` requires ES ≥ 8.7.0 and `template.data_stream_options` requires ES ≥ 9.1.0.
+
+Several of these workarounds were necessary because the SDK does not have first-class semantic equality. The Plugin Framework does, via `*ValuableWithSemanticEquals` interfaces, which lets us replace plan-time hacks with type-level equality that the framework consults during refresh, plan, and post-apply state comparison. Using semantic equality also avoids a real risk of "Provider produced inconsistent result after apply" errors that a plan-modifier-only solution could introduce.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Migrate the resource and data source to the Plugin Framework with no breaking changes to attribute paths, block syntax, identity format, or import behavior.
+- Replace SDK diff-suppression hacks with custom types that use semantic equality so behavior is consistent across plan, refresh, and post-apply state checking.
+- Land the resource on `resourcecore.Core` to satisfy this provider's PF resource testing contract.
+- Keep the SDK-implemented `elasticstack_elasticsearch_component_template` working unchanged.
+
+**Non-Goals:**
+- Migrating `elasticstack_elasticsearch_component_template` (tracked separately).
+- Reworking the schema shape (e.g. flattening `template { … }` into a nested attribute, or moving `alias` from a block to an attribute).
+- Changing the public spec for `data_stream_options`, `ignore_missing_component_templates`, or version gating semantics.
+- Removing the `template.alias` set semantics; users continue to write `alias { … }` blocks.
+
+## Decisions
+
+### 1. Use `resourcecore.Core` for the resource and explicit `datasource.DataSourceWithConfigure` for the data source
+
+The `internal/resourcecore` package exposes `Configure`, `Metadata`, and `Client()` for resources only; data sources are wired explicitly. This change follows the same split that `ilm`, `index`, and `datastreamlifecycle` use. Concretely:
+
+```go
+type Resource struct {
+    *resourcecore.Core
+}
+
+func newResource() *Resource {
+    return &Resource{
+        Core: resourcecore.New(resourcecore.ComponentElasticsearch, "index_template"),
+    }
+}
+```
+
+CRUD methods (`Create`, `Read`, `Update`, `Delete`, `ImportState`, `ValidateConfig`) live on `*Resource`. There is no `UpgradeState`: state from the SDK implementation is forward-compatible (see Decision 8).
+
+### 2. Custom type with `ObjectValuableWithSemanticEquals` for the `alias` element
+
+The alias element type implements `basetypes.ObjectValuableWithSemanticEquals` so that the framework treats two alias values as equal when they differ only in API-derived `index_routing`/`search_routing`. Concretely the element is equal when:
+
+- `name`, `is_hidden`, `is_write_index`, and `routing` are equal between the two values.
+- `filter` is JSON-equal (delegates to `jsontypes.Normalized` on the inner attribute).
+- For each of `index_routing` and `search_routing`: either the values are equal, or the prior value (`v` receiver) is null/empty AND the new value equals the new value's `routing` field (i.e. it's an API-derived echo).
+
+Crucially, semantic equality is consulted during refresh, plan, *and* post-apply state comparison. That means a plan-modifier-only approach is rejected here: a plan modifier solves the plan diff but does not protect against "Provider produced inconsistent result after apply" when state and refresh disagree. Semantic equality is the framework's documented mechanism for this exact problem.
+
+This decision also resolves the alias-set hashing concern. Plugin Framework set membership is determined by element equality, deferring to `SemanticEquals` when implemented. Two aliases with the same `name` but routing-only differences therefore collapse to one set member, replicating `hashAliasByName` without a custom hasher hook (which Plugin Framework does not expose).
+
+The legacy "preserve user routing on read" workaround (`extractAliasRoutingFromTemplateState`/`preserveAliasRoutingInFlattenedAliases`) is *not* ported to PF; it is unnecessary once semantic equality is in place.
+
+#### Strict vs permissive equivalence
+
+The semantic-equality predicate matches the existing SDK behavior of `suppressAliasRoutingDerivedDiff` (line-for-line):
+
+```text
+v.index_routing ≡ new.index_routing  ⇔
+    v.index_routing == new.index_routing
+    OR (v.index_routing is null/empty AND new.index_routing == new.routing AND new.routing != "")
+```
+
+Receiver `v` represents the prior/state value and the argument is the new value, matching the convention used in `internal/utils/customtypes/json_with_defaults_value.go`. The same rule applies to `search_routing`.
+
+### 3. Keep `alias` as `SetNestedBlock`, not `SetNestedAttribute`
+
+`alias { name = "x" }` is the existing HCL syntax. `SetNestedAttribute` would require `alias = [{ name = "x" }]`, which is a breaking change. Plugin Framework permits a `CustomType` on `NestedBlockObject`, so we attach our alias custom type to the block's nested object. This matches the syntax users have today and gives us semantic equality for the element.
+
+### 4. Custom type for `template.settings`
+
+A new type `customtypes.IndexSettingsValue` is added under `internal/utils/customtypes/`. It:
+
+- Embeds `jsontypes.Normalized`.
+- Implements `basetypes.StringValuableWithSemanticEquals` whose comparator parses both strings as JSON, runs `flattenMap` (port from `internal/tfsdkutils/diffs.go`) to produce dotted keys, runs `normalizeIndexSettings` (port) to ensure all keys have the `index.` prefix and all values are stringified, and compares with `reflect.DeepEqual`.
+- Implements `xattr.ValidateableAttribute` to enforce that the value parses to a JSON object (replaces SDK-side `stringIsJSONObject`).
+
+The `tfsdkutils.DiffIndexSettingSuppress` helper remains in place for `component_template.go`. The flattening/normalization helpers are exported (or duplicated) into the customtype as needed; we keep the SDK copy intact rather than refactoring it.
+
+### 5. JSON-normalized fields use `jsontypes.Normalized`
+
+- `metadata`, `template.mappings`, `template.alias.filter` → `jsontypes.NormalizedType{}`.
+- These types already provide `StringSemanticEquals` for JSON normalization.
+- For `mappings` we additionally enforce JSON-object shape via `xattr.ValidateableAttribute` (either by extending `jsontypes.Normalized` in a small wrapper or by running validation in `ValidateConfig`); the choice is left to implementation.
+
+### 6. Version gating remains in Create/Update
+
+The two version gates (`ignore_missing_component_templates` ≥ 8.7.0; `template.data_stream_options` ≥ 9.1.0) require the live server version, which is not available at validate time. They stay in Create/Update, return `fwdiag` error diagnostics, and skip the API call on failure — identical observable behavior to the SDK implementation.
+
+### 7. 8.x `allow_custom_routing` workaround in Update
+
+The Plugin Framework equivalent of `d.GetChange("data_stream")` is reading `req.State` in the Update path. The Update method:
+
+1. Loads prior state.
+2. Loads plan.
+3. If prior state had `data_stream.allow_custom_routing == true`, sets the request body's `allow_custom_routing` even when the planned value is `false`/null. This preserves the existing 8.x compatibility behavior.
+
+### 8. Convert `MaxItems: 1` blocks to `SingleNestedBlock`
+
+The SDK schema uses six `MaxItems: 1` collections that semantically model "an optional/required single object":
+
+| Block path | SDK shape | PF target |
+|---|---|---|
+| `data_stream` | `TypeList`, Optional, MaxItems 1 | `SingleNestedBlock`, optional |
+| `template` | `TypeList`, Optional, MaxItems 1 | `SingleNestedBlock`, optional |
+| `template.lifecycle` | **`TypeSet`**, Optional, MaxItems 1 | `SingleNestedBlock`, optional |
+| `template.data_stream_options` | `TypeList`, Optional, MaxItems 1 | `SingleNestedBlock`, optional |
+| `template.data_stream_options.failure_store` | `TypeList`, **Required**, MaxItems 1 | `SingleNestedBlock`, required-when-DSO-present |
+| `template.data_stream_options.failure_store.lifecycle` | `TypeList`, Optional, MaxItems 1 | `SingleNestedBlock`, optional |
+
+`SingleNestedBlock` is the Plugin Framework equivalent of "exactly one object or none". Two consequences worth calling out:
+
+- Plugin Framework `SingleNestedBlock` does not have a `Required` flag. The current `failure_store` Required semantic ("if `data_stream_options` is configured, `failure_store` is required") is enforced via `ValidateConfig` (or a config-level validator) returning an error diagnostic when `data_stream_options` is non-null and `failure_store` is null. This matches REQ-032's existing scenario "data_stream_options without failure_store rejected at plan time".
+- HCL syntax `data_stream { hidden = true }` continues to work for `SingleNestedBlock`. There is **no breaking HCL change** for users.
+
+The `template.alias` set remains a `SetNestedBlock` because it is a true many-element collection, not a `MaxItems: 1` collection. Decision 2's alias custom type is unaffected.
+
+### 9. Identity, import, and state migration
+
+- ID format: `<cluster_uuid>/<template_name>`. Computed via `client.ID(ctx, name)` in Create.
+- Import: `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)` — same passthrough behavior as the SDK's `schema.ImportStatePassthroughContext`.
+- State schema version is **bumped from `0` to `1`**. The new resource implements `resource.ResourceWithUpgradeState` registering an upgrader for version `0`.
+
+The upgrader rewrites the six single-item collections from list-/set-shaped to object-shaped. Because Plugin Framework `UpgradeState` does not require a v0 schema definition when using `RawState` JSON, the upgrader is implemented as a JSON-level transform:
+
+```text
+For each path P in:
+  data_stream
+  template
+  template.0.lifecycle
+  template.0.data_stream_options
+  template.0.data_stream_options.0.failure_store
+  template.0.data_stream_options.0.failure_store.0.lifecycle
+
+Apply (pseudo-code, recursive after the parent has been collapsed):
+  raw[P] is null      → unchanged (still null)
+  raw[P] is []        → null
+  raw[P] is [obj]     → obj
+  raw[P] is otherwise → diagnostic error (corrupt prior state)
+```
+
+Order matters: collapse the parent (`template`, `data_stream_options`, `failure_store`) before walking into its children, so the path indices `…0.…` no longer apply by the time the inner level is rewritten. The implementation walks the JSON tree top-down to keep this invariant. Set-shaped values (`template.lifecycle` was `TypeSet` in the SDK) serialize identically to lists in tfstate, so the same `[]` / `[obj]` collapse rule applies; no Set-specific handling is needed.
+
+The upgrader preserves all leaf attribute values byte-for-byte; only the surrounding container shape changes. Custom types (`jsontypes.Normalized` for JSON strings, `IndexSettingsValue`, alias element type) accept the same string/object payloads after the shape transform.
+
+If the prior state is malformed (e.g. multi-element list at one of the listed paths), the upgrader returns an error diagnostic identifying the path. This should never occur because the SDK schema enforced `MaxItems: 1`, but failing loudly is preferable to silently dropping data.
+
+`TestAccResourceIndexTemplateFromSDK` covers the upgrade end-to-end: pin the last SDK provider release, create a resource exercising every collapsed block, then re-apply with the new PF provider and assert no diff. Acceptance tests are the source of truth for state forward-compatibility.
+
+### 10. Client diags strategy
+
+`internal/clients/elasticsearch.PutIndexTemplate`, `GetIndexTemplate`, and `DeleteIndexTemplate` are migrated to return `fwdiag.Diagnostics`:
+
+- Use `diagutil.CheckErrorFromFW()` for HTTP error responses.
+- Use `diagutil.FrameworkDiagFromError()` or `fwdiag.NewErrorDiagnostic()` for non-HTTP errors.
+
+These three functions have only one caller (`template.go`) plus one test reference (`template_test.go`), both of which move into the new PF package in the same change. No `SDKDiagsFromFramework` shim is needed.
+
+### 11. Data source shares Read with the resource
+
+A package-private `readIndexTemplate(ctx, client, name) (Model, fwdiag.Diagnostics)` helper is the single source of truth. The resource's `Read` and the data source's `Read` both call it. The data source schema is a Computed-only mirror of the resource schema; it is constructed in the same package to keep descriptions aligned.
+
+### 12. Component template entanglement — duplicate, don't share
+
+`expandTemplate`, `flattenTemplateData`, `extractAliasRoutingFromTemplateState`, `preserveAliasRoutingInFlattenedAliases`, `hashAliasByName`, and `stringIsJSONObject` in the SDK package are still used by `component_template.go`. Sharing them with the PF package would require those helpers to operate on both `map[string]any` (SDK) and typed PF model values, which is awkward.
+
+Decision: duplicate the expand/flatten logic inside the PF `template/` package (operating on typed model values), and leave the SDK helpers untouched until component template is migrated separately. Acceptance: temporary duplication is bounded (≈ 200 LOC) and ends when component template lands.
+
+## Risks / Trade-offs
+
+- **Custom-type complexity for the alias element.** Implementing `ObjectValuableWithSemanticEquals` is more code than a simple plan modifier. The trade-off is correctness across plan/apply rather than just plan, plus it reduces supplemental Read-time workarounds. Mitigated by unit tests that exhaustively cover the semantic-equality matrix (null/empty/derived/explicit on both sides).
+- **Index settings custom type risk.** The settings comparator must remain byte-equivalent to `DiffIndexSettingSuppress`. Mitigated by lifting the existing test cases from `internal/utils/utils_test.go` and re-running them against the new type.
+- **Code duplication with component template.** Two parallel implementations of `expandTemplate`/`flattenTemplateData` exist until CT is migrated. Drift is possible but contained because the SDK copies are frozen except for bug fixes.
+- **State migration correctness.** The v0→v1 upgrader rewrites six container shapes; a bug here can silently drop user data. Mitigated by (a) per-path explicit transformation logic with no fallthrough, (b) error diagnostics on unexpected shapes, (c) `TestAccResourceIndexTemplateFromSDK` exercising every collapsed block end-to-end against the last SDK release, and (d) targeted unit tests on the upgrader against synthesized v0 JSON state covering null, empty list, single-element list, and (error case) multi-element list per path.
+- **Set semantic equality at scale.** Semantic equality is invoked pairwise during set comparison; the alias set is small (typically <10 elements) so this is not a performance concern.
+
+## Migration Plan
+
+1. Land the new client diag signatures and the new `IndexSettingsValue` custom type behind their existing callers.
+2. Land the new PF `template/` package with full schema, models, custom types, and CRUD wired to Plugin Framework.
+3. Switch provider registration from SDK to PF (atomic with step 2).
+4. Move acceptance tests; add `TestAccResourceIndexTemplateFromSDK`.
+5. Delete the SDK files (`template.go`, `template_data_source.go`).
+
+The migration is delivered in a single change because step 3 is necessarily atomic.
+
+## Open Questions
+
+1. Should the `mappings` JSON-object enforcement live in the custom type (a thin wrapper around `jsontypes.Normalized`) or in `ValidateConfig`? Either matches today's behavior; resolved during implementation based on which produces clearer error messages.
+2. Should the data source surface `not found` as an error diagnostic (as a data source typically does) rather than removing-from-state semantics inherited from the resource? Today's SDK data source delegates to the resource Read which clears the ID — i.e. silently succeeds with empty state. This is a latent UX bug; preserving today's behavior is the safe choice for this migration. Note for follow-up.

--- a/openspec/changes/migrate-index-template-to-plugin-framework/proposal.md
+++ b/openspec/changes/migrate-index-template-to-plugin-framework/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`elasticstack_elasticsearch_index_template` (resource and data source) is one of the last large schemas still implemented on `terraform-plugin-sdk/v2`. It also carries some of the trickiest bespoke SDK behavior in this provider — alias routing diff suppression, `DiffIndexSettingSuppress`, an 8.x `allow_custom_routing` workaround, and version gating — which are difficult to evolve and review while the resource straddles two frameworks. Migrating to the Plugin Framework brings it in line with the modernized Elasticsearch index family (`ilm`, `index`, `datastreamlifecycle`, `index_template_ilm_attachment`), enables the `resourcecore.Core` testing contract, and replaces SDK-specific workarounds with first-class custom types that use semantic equality.
+
+The migration is additive in user-visible terms: the resource type name, attribute paths, block syntax, identity format (`<cluster_uuid>/<template_name>`), and import behavior are all preserved. Existing state authored by the SDK implementation must continue to work after upgrading.
+
+## What Changes
+
+- Add a new Plugin Framework resource implementation under `internal/elasticsearch/index/template/` that mirrors today's `internal/elasticsearch/index/template.go` schema and behavior, embedding `resourcecore.Core`.
+- Add a Plugin Framework data source under the same package, sharing the read path with the resource.
+- Convert all `MaxItems: 1` blocks in the resource schema (`data_stream`, `template`, `template.lifecycle`, `template.data_stream_options`, `template.data_stream_options.failure_store`, `template.data_stream_options.failure_store.lifecycle`) from the SDK list/set-with-`MaxItems:1` idiom to Plugin Framework `SingleNestedBlock` declarations. Mirror the same shape on the data source.
+- Bump the resource state schema version from `0` to `1` and provide an `UpgradeState` implementation that rewrites list-/set-shaped values (`[{…}]` or `[]`) to plain object-shaped values (`{…}` or `null`) for each of the six converted blocks.
+- Replace the SDK alias-routing `DiffSuppressFunc` (`suppressAliasRoutingDerivedDiff`) and the post-read "preserve user routing" workaround with an `ObjectValuableWithSemanticEquals` custom type for the alias element.
+- Replace the SDK `DiffIndexSettingSuppress` with a new `IndexSettingsValue` custom type in `internal/utils/customtypes/` that implements `StringValuableWithSemanticEquals` and validates JSON-object input.
+- Use `jsontypes.Normalized` for `metadata`, `template.mappings`, and `template.alias.filter`.
+- Migrate `clients/elasticsearch.PutIndexTemplate` / `GetIndexTemplate` / `DeleteIndexTemplate` to return `fwdiag.Diagnostics`. (No SDK callers remain after migration; component template does not use these helpers.)
+- Register the new resource and data source in `provider/plugin_framework.go`; remove the SDK entries from `provider/provider.go`.
+- Move and port the existing `template_test.go` and `template_data_source_test.go` into the new package; add `TestAccResourceIndexTemplateFromSDK` covering upgrade from the last SDK-based provider release.
+- Delete the SDK files (`template.go`, `template_data_source.go`, and SDK-only helpers no longer used elsewhere).
+
+Component template is intentionally **out of scope**. The shared SDK helpers (`expandTemplate`, `flattenTemplateData`, `extractAliasRoutingFromTemplateState`, `preserveAliasRoutingInFlattenedAliases`, `hashAliasByName`, `stringIsJSONObject`) are duplicated in the new PF package; the SDK copies remain in place for `component_template.go` until it is migrated separately.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `elasticsearch-index-template`: clarifies that alias routing diff parity is achieved through semantic equality on the alias element rather than per-field plan-time diff suppression, and that index settings comparison is implemented via a custom type with semantic equality. The user-observable contract is preserved.
+
+## Impact
+
+- Affected code is centered in `internal/elasticsearch/index/template/` (new), `internal/utils/customtypes/index_settings_value.go` (new), `internal/clients/elasticsearch/index.go` (CRUD diags type change), `provider/plugin_framework.go`, and `provider/provider.go`. The shared `internal/elasticsearch/index/commons.go` and `internal/elasticsearch/index/component_template.go` continue to compile unchanged.
+- Affected interfaces are internal: the public Terraform schema, attribute paths, identity format, import behavior, and resource type name are unchanged. Plan diffs for routing-only alias configurations and dotted/nested `settings` JSON remain suppressed.
+- The change is intended to be backward compatible for existing state. The state schema version bump from `0` to `1` carries an upgrader that reshapes the six single-item collections to plain objects so existing tfstate continues to work without manual intervention or breaking HCL changes (block syntax `data_stream { … }` is preserved).
+- A dedicated SDK → Plugin Framework upgrade acceptance test (`TestAccResourceIndexTemplateFromSDK`) is required by REQ-042. It pins the last SDK-based provider release via `ExternalProviders`, applies a configuration that exercises every collapsed block plus the routing-only alias case, then re-applies the equivalent configuration with the in-tree Plugin Framework provider and asserts a no-op upgrade. This is the canonical regression guard for both the schema-shape change and the alias semantic equality contract.
+- Downstream resources that reference `elasticstack_elasticsearch_index_template` in acceptance tests (notably `elasticsearch_index_template_ilm_attachment`) are exercised as part of verification.

--- a/openspec/changes/migrate-index-template-to-plugin-framework/specs/elasticsearch-index-template/spec.md
+++ b/openspec/changes/migrate-index-template-to-plugin-framework/specs/elasticsearch-index-template/spec.md
@@ -1,0 +1,228 @@
+# Delta Spec: `elasticstack_elasticsearch_index_template` Plugin Framework migration
+
+Base spec: `openspec/specs/elasticsearch-index-template/spec.md`
+Last requirement in base spec: REQ-037
+This delta MODIFIES requirements REQ-024 (alias state mapping invariants), REQ-029 (read state mapping for routing), and REQ-031 (alias routing plan diff suppression), and ADDS requirements REQ-038 to REQ-042.
+
+---
+
+This delta defines the target behavior introduced by change `migrate-index-template-to-plugin-framework`. It keeps the user-observable contract for `elasticstack_elasticsearch_index_template` unchanged and clarifies the mechanism by which alias routing parity and index settings comparison are achieved under the Plugin Framework.
+
+## MODIFIED Requirements
+
+### Requirement: JSON and object mapping (REQ-018–REQ-025)
+
+`metadata` SHALL be validated as JSON by schema and parsed as JSON during create/update; if parsing fails, the resource SHALL return an error diagnostic and SHALL not call the Put API. `template.mappings` and `template.settings` SHALL be validated as JSON objects by schema and parsed into objects during create/update. `template.alias.filter` SHALL be validated as JSON by schema and parsed into an object when non-empty during create/update. `template.alias` SHALL be mapped as a set keyed by alias name in API payload/state conversion. Set membership SHALL be determined by the alias element's semantic equality (see REQ-031); two alias values that differ only in API-derived `index_routing` or `search_routing` SHALL be treated as the same set member. Alias routing and flag fields SHALL be copied directly between Terraform values and API model fields. `template.lifecycle` SHALL be mapped as at most one lifecycle object with `data_retention`. `data_stream.hidden` SHALL be sent when present. `data_stream.allow_custom_routing` SHALL be sent only when `true`, except that on updates it SHALL also be sent when prior state had `allow_custom_routing=true` (8.x workaround behavior).
+
+#### Scenario: Invalid metadata JSON
+
+- GIVEN invalid `metadata` JSON
+- WHEN create/update runs
+- THEN the provider SHALL error before calling Put
+
+#### Scenario: Routing-only alias remains a single set member
+
+- GIVEN an alias configured with only `routing = "x"` (no `index_routing` or `search_routing` in config)
+- WHEN refresh populates `index_routing = "x"` and `search_routing = "x"` from the API
+- THEN the alias set in state SHALL contain exactly one element for that `name`
+
+### Requirement: Read state mapping (REQ-026–REQ-030)
+
+On read, the resource SHALL set `name`, `composed_of`, `ignore_missing_component_templates`, `index_patterns`, `priority`, and `version` from the API response. On read, when API `metadata` is present, it SHALL be serialized into a JSON string and stored in state. On read, when API `template` is present, it SHALL be flattened into `template` state, including aliases, lifecycle, mappings, and settings. On read, when API `data_stream` is present, it SHALL be flattened into a single `data_stream` block and include only fields present in API response. The provider SHALL NOT post-process the flattened alias state to re-inject the user-configured `routing` value; equivalence between user-configured `routing` and API-derived `index_routing`/`search_routing` SHALL instead be preserved through the alias element's semantic equality (see REQ-031), so that a refreshed alias compares equal to the prior state value when only API-derived routing fields differ.
+
+#### Scenario: User routing preserved without state rewriting
+
+- GIVEN the user set alias `routing = "x"` and the API echoes `index_routing = "x"` / `search_routing = "x"`
+- WHEN read refreshes state
+- THEN the framework SHALL retain the prior state value for the alias element via semantic equality
+- AND no diff SHALL be produced for the routing-only alias
+
+### Requirement: Alias routing plan diff suppression (REQ-031)
+
+The provider SHALL treat a refreshed alias element as semantically equal to its prior state value when both elements have the same `name`, `is_hidden`, `is_write_index`, and `routing`, equivalent JSON `filter`, and:
+
+- For each of `index_routing` and `search_routing`: either the values are equal, or the prior state value is null/empty AND the new value equals the new value's `routing` field AND `routing` is non-empty.
+
+This semantic equality SHALL be implemented as an `ObjectValuableWithSemanticEquals` on the alias element type. As a consequence, plans SHALL NOT show diffs for `index_routing` or `search_routing` when those attributes are unset in configuration and their refreshed values equal the configured `routing`. The framework SHALL apply the same equivalence during refresh, plan, and post-apply state comparison, so the resource SHALL NOT produce "Provider produced inconsistent result after apply" errors for routing-only alias configurations.
+
+#### Scenario: Routing-only alias config
+
+- GIVEN a configuration which configures only the `routing` attribute on an alias
+- WHEN apply completes and state is refreshed
+- THEN `search_routing` and `index_routing` in state SHALL match the `routing` attribute as documented
+- AND no diff SHALL be reported on subsequent plans
+
+#### Scenario: Apply-time consistency
+
+- GIVEN a routing-only alias configuration that previously triggered SDK diff suppression
+- WHEN apply runs and Terraform compares the post-apply state to the planned state
+- THEN no inconsistency error SHALL be raised
+
+#### Scenario: Explicit override is honored
+
+- GIVEN an alias with `routing = "x"` and an explicit `index_routing = "y"` in configuration
+- WHEN refresh returns `index_routing = "y"`
+- THEN the prior state value `"y"` SHALL be retained AND no diff SHALL be reported
+
+## ADDED Requirements
+
+### Requirement: Plugin Framework implementation (REQ-038)
+
+The resource and data source SHALL be implemented on `terraform-plugin-framework`. The resource SHALL embed `*resourcecore.Core` constructed with `resourcecore.New(resourcecore.ComponentElasticsearch, "index_template")`. The data source SHALL implement `datasource.DataSourceWithConfigure` directly. Both SHALL be registered through `provider/plugin_framework.go`. The Terraform resource type name (`elasticstack_elasticsearch_index_template`), attribute paths, block HCL syntax (`data_stream { … }`, `template { … }`, etc.), computed-attribute set, identity format (`<cluster_uuid>/<template_name>`), and import behavior SHALL be unchanged from the previous Plugin SDK v2 implementation.
+
+The following blocks, previously declared as `MaxItems: 1` lists or sets in the SDK schema, SHALL be declared as `schema.SingleNestedBlock` in the Plugin Framework schema:
+
+- `data_stream`
+- `template`
+- `template.lifecycle`
+- `template.data_stream_options`
+- `template.data_stream_options.failure_store`
+- `template.data_stream_options.failure_store.lifecycle`
+
+The `template.alias` block SHALL remain a `schema.SetNestedBlock`.
+
+Plugin Framework `SingleNestedBlock` does not expose a `Required` flag. The previous SDK-side `Required: true` on `template.data_stream_options.failure_store` SHALL be enforced through `ValidateConfig` returning a plan-time error diagnostic when `data_stream_options` is configured and `failure_store` is null.
+
+#### Scenario: Type name and identity unchanged
+
+- WHEN the provider exposes the resource and data source
+- THEN both SHALL be registered as `elasticstack_elasticsearch_index_template`
+- AND the resource `id` attribute SHALL continue to use the format `<cluster_uuid>/<template_name>`
+
+#### Scenario: HCL block syntax preserved
+
+- GIVEN existing configuration that uses block syntax (e.g. `data_stream { hidden = true }`, `template { settings = "…" }`, `lifecycle { data_retention = "7d" }`)
+- WHEN the configuration is parsed against the Plugin Framework schema
+- THEN parsing SHALL succeed without modification
+
+#### Scenario: `data_stream_options` without `failure_store` rejected
+
+- GIVEN `template.data_stream_options` is configured and `failure_store` is null
+- WHEN Terraform validates the configuration
+- THEN the provider SHALL return a plan-time error diagnostic identifying the missing `failure_store` block
+
+### Requirement: Index settings semantic equality (REQ-039)
+
+`template.settings` SHALL be modeled with a custom Plugin Framework string type that implements `basetypes.StringValuableWithSemanticEquals`. The semantic equality comparator SHALL parse both sides as JSON, flatten nested objects to dotted keys, prefix any unprefixed keys with `index.`, stringify all values, and compare the resulting maps. Two `settings` strings SHALL be considered equal whenever they represent the same effective set of index settings, regardless of dotted-vs-nested key form or the presence of an `index.` prefix on individual keys.
+
+#### Scenario: Dotted vs nested keys equivalent
+
+- GIVEN configured settings `{"index": {"number_of_shards": 1}}` and a refreshed value `{"index.number_of_shards": "1"}`
+- WHEN plan runs after refresh
+- THEN no diff SHALL be reported for `template.settings`
+
+#### Scenario: `index.` prefix normalization
+
+- GIVEN configured settings `{"refresh_interval": "1s"}` and a refreshed value `{"index.refresh_interval": "1s"}`
+- WHEN plan runs after refresh
+- THEN no diff SHALL be reported for `template.settings`
+
+#### Scenario: Invalid JSON object rejected
+
+- GIVEN `template.settings` configured with a non-object JSON literal (e.g. an array)
+- WHEN Terraform validates the configuration
+- THEN the provider SHALL return a validation error diagnostic
+
+### Requirement: Client diagnostics use Plugin Framework types (REQ-040)
+
+The internal Elasticsearch client helpers `PutIndexTemplate`, `GetIndexTemplate`, and `DeleteIndexTemplate` SHALL return `terraform-plugin-framework/diag.Diagnostics`. Resource and data source code SHALL append these diagnostics to the response without conversion. The resource SHALL NOT introduce a Plugin SDK ↔ Plugin Framework diagnostics compatibility shim.
+
+#### Scenario: API error surfaced as Plugin Framework diagnostic
+
+- GIVEN an Elasticsearch API call returns a non-success status (other than 404 on read)
+- WHEN the resource processes the response
+- THEN the response diagnostics SHALL contain a Plugin Framework error diagnostic that surfaces the API error
+
+### Requirement: State schema version 0 → 1 upgrader (REQ-041)
+
+The Plugin Framework resource SHALL declare schema `Version` `1` and SHALL implement `resource.ResourceWithUpgradeState` registering an upgrader for prior schema version `0` (the version under which Plugin SDK v2 wrote state). The upgrader SHALL transform tfstate written by the SDK implementation into the Plugin Framework v1 shape by collapsing each of the following paths from a list-/set-shaped value to a single-object shape:
+
+- `data_stream`
+- `template`
+- `template.lifecycle`
+- `template.data_stream_options`
+- `template.data_stream_options.failure_store`
+- `template.data_stream_options.failure_store.lifecycle`
+
+For each listed path, after parent paths have already been collapsed, the upgrader SHALL apply the following rule:
+
+- If the value is null or absent, leave it unchanged.
+- If the value is an empty array (`[]`), set it to null.
+- If the value is a single-element array (`[obj]`), replace it with `obj`.
+- If the value is an array with more than one element, return an error diagnostic identifying the path; the upgrader SHALL NOT silently drop elements.
+
+All non-converted attributes (including JSON-string attributes such as `metadata`, `template.mappings`, `template.settings`, and `template.alias.filter`) SHALL be carried through unchanged. After the upgrader runs, Terraform SHALL be able to decode the resulting state against the v1 schema without further migration.
+
+#### Scenario: Upgrade single-element list to object
+
+- GIVEN tfstate written by Plugin SDK v2 with `data_stream = [{"hidden": true, "allow_custom_routing": false}]`
+- WHEN the v0 → v1 upgrader runs
+- THEN the upgraded state SHALL contain `data_stream = {"hidden": true, "allow_custom_routing": false}`
+
+#### Scenario: Upgrade empty list to null
+
+- GIVEN tfstate written by Plugin SDK v2 with `template.data_stream_options = []`
+- WHEN the v0 → v1 upgrader runs
+- THEN the upgraded state SHALL contain `template.data_stream_options = null`
+
+#### Scenario: Upgrade nested single-element collections
+
+- GIVEN tfstate written by Plugin SDK v2 with `template = [{"data_stream_options": [{"failure_store": [{"enabled": true, "lifecycle": [{"data_retention": "30d"}]}]}]}]`
+- WHEN the v0 → v1 upgrader runs
+- THEN the upgraded state SHALL contain `template = {"data_stream_options": {"failure_store": {"enabled": true, "lifecycle": {"data_retention": "30d"}}}}`
+
+#### Scenario: Upgrade preserves non-collapsed attributes
+
+- GIVEN tfstate written by Plugin SDK v2 that includes `metadata`, `composed_of`, `index_patterns`, and `template.alias` populated
+- WHEN the v0 → v1 upgrader runs
+- THEN those attributes SHALL be carried through byte-equivalent in the upgraded state
+
+#### Scenario: Refuse multi-element arrays at collapsed paths
+
+- GIVEN tfstate at one of the collapsed paths contains an array with two or more elements (a state corruption that should not occur because the SDK enforced `MaxItems: 1`)
+- WHEN the v0 → v1 upgrader runs
+- THEN it SHALL return an error diagnostic that identifies the offending path
+- AND the upgrader SHALL NOT silently discard elements
+
+#### Scenario: End-to-end upgrade from prior SDK release
+
+- GIVEN a resource created by the last Plugin SDK v2 release exercising every collapsed block
+- WHEN the same configuration is re-applied with the new Plugin Framework provider
+- THEN the v0 → v1 upgrader SHALL run automatically as part of refresh
+- AND the subsequent plan SHALL show no diff
+
+### Requirement: SDK → Plugin Framework upgrade acceptance test (REQ-042)
+
+The acceptance test suite for `elasticstack_elasticsearch_index_template` SHALL include a dedicated test (named `TestAccResourceIndexTemplateFromSDK`) that exercises upgrading state created by the last Plugin SDK v2 release of the provider to the new Plugin Framework implementation in a single Terraform run.
+
+The test SHALL be structured as a two-step `resource.TestCase`:
+
+- **Step 1** SHALL pin the prior provider release via `ExternalProviders` with the version constraint set to the last provider release in which `elasticstack_elasticsearch_index_template` was implemented on Plugin SDK v2. It SHALL apply a configuration that exercises every block converted to `SingleNestedBlock`: `data_stream`, `template` (including `template.alias`, `template.lifecycle`, `template.mappings`, `template.settings`), `template.data_stream_options`, `template.data_stream_options.failure_store`, and `template.data_stream_options.failure_store.lifecycle`. Step 1 SHALL also exercise the alias routing scenario (an alias with `routing` set and `index_routing`/`search_routing` unset) so that semantic equality (REQ-031) is validated across the upgrade.
+- **Step 2** SHALL switch to `ProtoV6ProviderFactories` pointing at the in-tree Plugin Framework implementation and re-apply the equivalent configuration. Step 2 SHALL assert that the apply is a no-op (no resource replacement, no destructive changes).
+
+The test SHALL be skipped or guarded for stack versions below `9.1.0` only when the test configuration includes `data_stream_options`; equivalent coverage for stack versions below `9.1.0` (without `data_stream_options`) SHALL still run.
+
+#### Scenario: Test exists and runs in CI
+
+- WHEN the acceptance test suite for `elasticstack_elasticsearch_index_template` runs
+- THEN `TestAccResourceIndexTemplateFromSDK` SHALL be present and SHALL be discovered by `go test`
+
+#### Scenario: No-op apply after provider switch
+
+- GIVEN Step 1 has applied a configuration that exercises every collapsed block using the last SDK-based provider release
+- WHEN Step 2 re-applies the equivalent configuration with the in-tree Plugin Framework provider
+- THEN apply SHALL succeed with no resource replacement or destructive change
+- AND the post-apply plan SHALL show no diff
+
+#### Scenario: Routing-only alias survives the upgrade
+
+- GIVEN Step 1 configured an alias with `routing` set and `index_routing`/`search_routing` unset
+- WHEN Step 2 re-applies the equivalent configuration with the Plugin Framework provider
+- THEN no diff SHALL be reported for the alias routing fields after apply
+
+#### Scenario: Collapsed-block state survives the upgrade
+
+- GIVEN Step 1 produced state containing list-shaped values for `data_stream`, `template`, `template.lifecycle`, `template.data_stream_options`, `template.data_stream_options.failure_store`, and `template.data_stream_options.failure_store.lifecycle`
+- WHEN Step 2 runs `terraform plan`
+- THEN the v0 → v1 upgrader SHALL collapse each of those values to its object/null shape
+- AND no diff SHALL be reported for any collapsed path

--- a/openspec/changes/migrate-index-template-to-plugin-framework/tasks.md
+++ b/openspec/changes/migrate-index-template-to-plugin-framework/tasks.md
@@ -1,0 +1,86 @@
+## 1. Custom types
+
+- [ ] 1.1 Add `internal/utils/customtypes/index_settings_value.go` implementing `IndexSettingsType` / `IndexSettingsValue` with `StringValuableWithSemanticEquals` (port `flattenMap` + `normalizeIndexSettings` from `internal/tfsdkutils/diffs.go`) and `xattr.ValidateableAttribute` for JSON-object validation.
+- [ ] 1.2 Add unit tests in `internal/utils/customtypes/index_settings_value_test.go`, lifting the cases from `internal/utils/utils_test.go` covering dotted-vs-nested keys, `index.` prefixing, and stringified value comparison.
+- [ ] 1.3 Implement the alias element custom type (`AliasObjectType` / `AliasObjectValue`) inside the new template package, satisfying `basetypes.ObjectValuable` and `basetypes.ObjectValuableWithSemanticEquals`. The `ObjectSemanticEquals` rule MUST match the strict predicate in design.md §2.
+- [ ] 1.4 Add unit tests for the alias element semantic equality covering: identical values, differing `name`, differing `routing`, derived `index_routing`/`search_routing` echoes, differing `filter` JSON whitespace, null vs empty string equivalence, and the asymmetric prior-vs-new direction.
+
+## 2. Client layer
+
+- [ ] 2.1 Change `internal/clients/elasticsearch.PutIndexTemplate`, `GetIndexTemplate`, and `DeleteIndexTemplate` to return `fwdiag.Diagnostics`. Use `diagutil.CheckErrorFromFW()` for HTTP responses and `diagutil.FrameworkDiagFromError()` for other errors.
+- [ ] 2.2 Confirm via grep that the only callers are `internal/elasticsearch/index/template.go` and `internal/elasticsearch/index/template_test.go`; both move in this change so no `SDKDiagsFromFramework` shim is needed.
+
+## 3. Plugin Framework package skeleton
+
+- [ ] 3.1 Create `internal/elasticsearch/index/template/` and add `resource.go` defining `Resource{*resourcecore.Core}` with `newResource()` / `NewResource()` / `ImportState` (passthrough on `id`).
+- [ ] 3.2 Add `data_source.go` with explicit `Configure` / `Metadata` / `Read`, registered as `<provider>_elasticsearch_index_template`.
+- [ ] 3.3 Wire interface assertions for `resource.ResourceWithConfigure`, `ResourceWithImportState`, `ResourceWithValidateConfig` (used for plan-time predicates that don't need the server version), `ResourceWithUpgradeState`, and `datasource.DataSourceWithConfigure`.
+
+## 4. Schema
+
+- [ ] 4.1 Add `internal/elasticsearch/index/template/schema.go` with the full resource schema mirroring `internal/elasticsearch/index/template.go`. Use `providerschema.GetEsFWConnectionBlock()` for the connection block. Set `Version: 1` on the resource schema.
+- [ ] 4.2 Declare each of the six single-item containers as `schema.SingleNestedBlock`: `data_stream`, `template`, `template.lifecycle`, `template.data_stream_options`, `template.data_stream_options.failure_store`, `template.data_stream_options.failure_store.lifecycle`. The `template.alias` collection remains a `SetNestedBlock`.
+- [ ] 4.3 Use `jsontypes.Normalized` for `metadata`, `template.mappings`, and `template.alias.filter`.
+- [ ] 4.4 Use `customtypes.IndexSettingsType` for `template.settings`.
+- [ ] 4.5 Use the alias `CustomType` on the `SetNestedBlock` `NestedBlockObject` for `template.alias`.
+- [ ] 4.6 Implement `ValidateConfig` enforcing the existing REQ-032 rule that `data_stream_options` configured without `failure_store` is rejected at plan time (replaces the SDK `Required: true` flag, which `SingleNestedBlock` does not expose).
+- [ ] 4.7 Add `data_source_schema.go` returning a Computed-only mirror schema (mirror the same `SingleNestedBlock` shape on the data source); share descriptions via constants in `descriptions.go`.
+
+## 5. Models, expand, flatten
+
+- [ ] 5.1 Add `internal/elasticsearch/index/template/models.go` with typed plan/state structs for the resource and the alias custom type.
+- [ ] 5.2 Add `expand.go` translating typed models into `models.IndexTemplate` (metadata JSON parse, mappings/settings JSON parse, alias map keyed by name, lifecycle, data_stream, data_stream_options).
+- [ ] 5.3 Add `flatten.go` translating Get response into the typed model. Drop the `extractAliasRoutingFromTemplateState`/`preserveAliasRoutingInFlattenedAliases` workarounds — semantic equality replaces them.
+- [ ] 5.4 Add `version_gating.go` with `validateIgnoreMissingComponentTemplatesVersion` and `validateDataStreamOptionsVersion` returning `fwdiag.Diagnostics`.
+
+## 6. CRUD
+
+- [ ] 6.1 `create.go`: load plan, fetch server version, run version gating, expand, call `PutIndexTemplate`, set `id` (`<cluster_uuid>/<name>`), call shared read to refresh state.
+- [ ] 6.2 `read.go`: extract a package-private `readIndexTemplate(ctx, client, name) (Model, fwdiag.Diagnostics)` used by the resource Read and the data source Read. Remove from state when not found (resource path) / leave defaulted (data source path, matching today's SDK behavior).
+- [ ] 6.3 `update.go`: load prior state and plan, fetch server version, run version gating, apply the 8.x `allow_custom_routing` workaround by inspecting prior state, expand, call `PutIndexTemplate`, refresh.
+- [ ] 6.4 `delete.go`: parse composite ID, call `DeleteIndexTemplate`.
+- [ ] 6.5 `data_source.go`: implement Read by calling `readIndexTemplate` with the configured `name` and setting `id`.
+
+## 7. State upgrade (v0 → v1)
+
+- [ ] 7.1 Add `state_upgrade.go` registering an `UpgradeState` map with version `0` mapped to a `StateUpgrader` that uses `RawState` JSON.
+- [ ] 7.2 Implement a JSON-tree walk that collapses each of the six `MaxItems: 1` paths from `[]`/`[obj]` to `null`/`obj`, applied top-down: `data_stream`, `template`, `template.lifecycle`, `template.data_stream_options`, `template.data_stream_options.failure_store`, `template.data_stream_options.failure_store.lifecycle`. The walker must collapse a parent before descending into it.
+- [ ] 7.3 Return an error diagnostic with the offending path if any of these paths is found with more than one element (defensive against corrupt prior state).
+- [ ] 7.4 Use a fresh PF state encode for the v1 schema (set the resulting `RawState` via the response so the framework re-decodes against the v1 schema).
+- [ ] 7.5 Add unit tests in `state_upgrade_test.go` covering, for each path: missing/null, empty list `[]`, single-element list `[obj]`, multi-element list (error), and round-trip encode→upgrade→decode against the v1 schema. Use the `ilm` package's `state_upgrade_test.go` as a structural reference.
+
+## 8. Provider wiring
+
+- [ ] 8.1 Register `template.NewResource` in `provider/plugin_framework.go` `resources()`.
+- [ ] 8.2 Register `template.NewDataSource` in `provider/plugin_framework.go` `dataSources()`.
+- [ ] 8.3 Remove `"elasticstack_elasticsearch_index_template"` entries from both `ResourcesMap` and `DataSourcesMap` in `provider/provider.go`.
+
+## 9. Acceptance tests
+
+- [ ] 9.1 Move `internal/elasticsearch/index/template_test.go` into `internal/elasticsearch/index/template/acc_test.go` (package `template_test`). Update imports and any helper references (`checkResourceDestroy`).
+- [ ] 9.2 Move `internal/elasticsearch/index/template_data_source_test.go` into the new package as `data_source_acc_test.go` (or merged into `acc_test.go`).
+- [ ] 9.3 Move test data: `internal/elasticsearch/index/testdata/TestAccResourceIndexTemplate*` into the new package's `testdata/`.
+- [ ] 9.4 Add `TestAccResourceIndexTemplateFromSDK` per REQ-042. Two-step `resource.TestCase`: Step 1 pins the last SDK-based provider release via `ExternalProviders` and `VersionConstraint` and applies a config exercising every collapsed block (`data_stream`, `template`, `template.alias`, `template.lifecycle`, `template.mappings`, `template.settings`, `template.data_stream_options`, `template.data_stream_options.failure_store`, `template.data_stream_options.failure_store.lifecycle`) plus the routing-only alias scenario; Step 2 switches to `ProtoV6ProviderFactories` and re-applies the equivalent configuration with `PlanOnly` / `ExpectNonEmptyPlan: false` (or equivalent) to assert a no-op upgrade. Guard the `data_stream_options` portion of the configuration with the `9.1.0` stack-version skip; keep the rest of the upgrade coverage running on older stacks. See `dev-docs/high-level/sdk-to-pf-migration.md` and the `internal/elasticsearch/security/user/` and `internal/elasticsearch/index/ilm/` precedents for the pattern.
+- [ ] 9.5 Resolve the `VersionConstraint` value used in 9.4 by inspecting the latest tagged provider release at the time of merge (e.g. `0.14.x`) and confirming that release still implemented `elasticstack_elasticsearch_index_template` on Plugin SDK v2. Capture the chosen version in the test source as a comment so future readers understand the pin.
+
+## 10. Schema coverage
+
+- [ ] 10.1 Run the `schema-coverage` skill against the new package and add tests for any attribute/block lacking coverage. Pay particular attention to `data_stream_options.failure_store.lifecycle.data_retention`, `composed_of`, `ignore_missing_component_templates`, `priority`, `version`, and the alias derived-routing edge cases.
+- [ ] 10.2 Add an explicit `TestAccResourceIndexTemplate_importState` if not already present.
+
+## 11. Cleanup
+
+- [ ] 11.1 Delete `internal/elasticsearch/index/template.go`.
+- [ ] 11.2 Delete `internal/elasticsearch/index/template_data_source.go`.
+- [ ] 11.3 Verify `internal/elasticsearch/index/component_template.go` still compiles unchanged. Confirm that the SDK helpers (`expandTemplate`, `flattenTemplateData`, `extractAliasRoutingFromTemplateState`, `preserveAliasRoutingInFlattenedAliases`, `hashAliasByName`, `stringIsJSONObject`) remain referenced exclusively by component template; do not delete them.
+- [ ] 11.4 Move `MinSupportedIgnoreMissingComponentTemplateVersion` and `MinSupportedDataStreamOptionsVersion` from `internal/elasticsearch/index/template.go` into the new package; if `templateilmattachment` references them, expose via a small constants file.
+
+## 12. Verification
+
+- [ ] 12.1 `make build`.
+- [ ] 12.2 `go test ./internal/elasticsearch/index/template/... -v`.
+- [ ] 12.3 `go test ./internal/utils/customtypes/... -v`.
+- [ ] 12.4 Acceptance tests: `go test ./internal/elasticsearch/index/template/... -v -count=1 -run TestAcc` against a live stack (see `dev-docs/high-level/testing.md`).
+- [ ] 12.5 Regression: `go test ./internal/elasticsearch/index/templateilmattachment/... -v -count=1 -run TestAcc` to exercise the downstream resource that references index templates.
+- [ ] 12.6 `make check-openspec`.
+- [ ] 12.7 Regenerate documentation if affected (`make docs-generate`); confirm the new resource and data source pages render correctly.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design proposal and task checklist for migrating `elasticsearch_index_template` to Plugin Framework
- Adds an OpenSpec proposal, design doc, delta spec, and task checklist for migrating the `elasticsearch_index_template` resource and data source from Terraform Plugin SDK v2 to Plugin Framework (PF).
- Key design decisions include converting nested attributes to `SingleNestedBlock`, introducing custom types for alias routing semantic equality and index settings, JSON normalization, a v0→v1 state upgrader, and switching client error handling to PF diagnostics.
- The delta spec mandates an acceptance test covering the SDK→PF upgrade path across provider versions.
- No production code is changed in this PR; it is documentation and planning only.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 593fba2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->