### PR TITLE
feat(openspec): fleet space-aware import unification

### DIFF
--- a/openspec/changes/fleet-space-aware-import-unification/.openspec.yaml
+++ b/openspec/changes/fleet-space-aware-import-unification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/fleet-space-aware-import-unification/design.md
+++ b/openspec/changes/fleet-space-aware-import-unification/design.md
@@ -1,0 +1,92 @@
+## Context
+
+Six Fleet resources implement `resource.ResourceWithImportState`. Two (`fleet_output`, `fleet_server_host`) use `resource.ImportStatePassthroughID` and are broken for non-default spaces. The other four each have a hand-written `ImportState` method using `clients.CompositeIDFromStrFw` — but with slight behavioral variations (strict vs. lenient empty-segment validation, whether to also set `id`, whether to hardcode `"default"` on plain IDs).
+
+All six resources embed `*resourcecore.Core` for Configure/Metadata wiring. That precedent motivates the same embedding pattern for import.
+
+The `internal/fleet` package already owns `GetOperationalSpaceFromState` in `space_utils.go`. Adding `SpaceImporter` there keeps all fleet-space utilities co-located.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the import bug in `fleet_output` and `fleet_server_host`
+- Eliminate bespoke `ImportState` methods from all six resources via a shared embedding
+- Establish a single canonical import behavior for all Fleet resources with `space_ids`
+- Update OpenSpec requirements to match implementation across all four specs that are currently incorrect or incomplete
+
+**Non-Goals:**
+- Changing import behavior for resources without `space_ids` (non-Fleet resources)
+- Adding import support to `fleet_integration` or `fleet_custom_integration` (they don't support import today)
+- Changing how `space_ids` is written back during Read (unchanged)
+
+## Decisions
+
+### Decision 1: Embeddable struct over shared function
+
+**Chosen:** `SpaceImporter` struct with promoted `ImportState` method, embedded in resource structs alongside `*resourcecore.Core`.
+
+**Alternative:** A standalone function `fleet.HandleSpaceAwareImportState(ctx, req, resp, idField)` called from each resource's own `ImportState`.
+
+**Rationale:** The embedding pattern is already established by `resourcecore.Core`. Embedding promotes the method directly, so resources that embed `*SpaceImporter` need no `ImportState` method at all — the interface is satisfied automatically. The standalone function approach still requires each resource to declare an `ImportState` method, keeping the boilerplate.
+
+---
+
+### Decision 2: `SpaceImporter` lives in `internal/fleet/`, not `internal/resourcecore/`
+
+**Chosen:** `internal/fleet/space_importer.go`
+
+**Alternative:** `internal/resourcecore/` alongside `Core`.
+
+**Rationale:** `space_ids` as a schema field is specific to Fleet resources. Non-Fleet resources (Kibana, Elasticsearch) use different identity patterns. Putting this in `resourcecore` would give it false generality. The `internal/fleet` package already has `space_utils.go` — this is a natural neighbor.
+
+---
+
+### Decision 3: Variadic `idFields ...path.Path` constructor
+
+**Chosen:** `NewSpaceImporter(fields ...path.Path)` — accepts one or more paths, all set to the resource ID on import.
+
+**Alternative:** Single required `idField path.Path`.
+
+**Rationale:** Needed for `agentdownloadsource`, which historically set both `id` and `source_id`. Even though `id` is the Terraform resource ID that Read will repopulate, the variadic form keeps the constructor uniform and avoids a special case. In practice all resources except `agentdownloadsource` use a single field.
+
+---
+
+### Decision 4: Plain import ID → `space_ids` NOT set (nil)
+
+**Chosen:** When `CompositeIDFromStrFw` fails (no `/`), treat the whole string as the resource ID and leave `space_ids` unset.
+
+**Alternative (current `agentdownloadsource` behavior):** Hardcode `space_ids = ["default"]`.
+
+**Rationale:** `GetOperationalSpaceFromState` returns `""` for both nil and empty `space_ids`, and `""` routes to the default space in all Fleet API calls. The behaviors are observationally equivalent for resources in the default space. Not setting `space_ids` is more honest — "you didn't specify a space" vs. "I'm asserting default" — and avoids permanently writing `["default"]` into state for resources the user may later move or whose space scoping they haven't declared. This is a minor behavioral change for `agentdownloadsource` only; it does not affect any currently working import flow.
+
+---
+
+### Decision 5: `agentdownloadsource` drops `id` field assignment on import
+
+**Chosen:** `NewSpaceImporter(path.Root("source_id"))` only; `id` is not set during `ImportState`.
+
+**Rationale:** `id` is the Terraform resource ID (computed, managed by the framework). It is repopulated from `source_id` during the Read that immediately follows import. Setting it explicitly in `ImportState` was redundant. Dropping it removes a dual-path special case from `SpaceImporter`.
+
+---
+
+### Decision 6: Remove `integration_policy` strict empty-segment validation
+
+**Chosen:** Align with the lenient behavior of `agent_policy` and `elastic_defend`: if `CompositeIDFromStrFw` parses successfully, use the result; if not, fall back to plain ID. Do not add explicit empty-segment checks.
+
+**Rationale:** `CompositeIDFromStrFw` wraps `CompositeIDFromStr`, which splits on `/` and requires exactly two parts. An ID like `"space/"` or `"/resource"` produces two parts with an empty element — `CompositeIDFromStr` accepts these and returns `ClusterID=""` or `ResourceID=""`. The stricter validation in `integration_policy` was inconsistent with the other resources and adds complexity to `SpaceImporter`. Empty `ClusterID` routes to default space (harmless); empty `ResourceID` results in a 404 from the API, which produces a clear error. The extra validation is not worth the inconsistency.
+
+## Risks / Trade-offs
+
+- **`agentdownloadsource` plain-ID behavior change** — After migration, a plain import ID produces `space_ids = nil` instead of `space_ids = ["default"]`. Anyone who currently imports `agentdownloadsource` with a plain ID and relies on the post-import state having `space_ids = ["default"]` will see a difference in intermediate import state. The Read call converges correctly regardless, so this is not a regression in practice. → _Mitigation: document in changelog; update spec scenario._
+
+- **`integration_policy` strict validation removal** — A degenerate ID like `"space/"` previously returned a clear diagnostic; after migration it returns a 404 from the API. The error is still clear, just at a different layer. → _Mitigation: acceptable trade-off for consistency._
+
+- **Method promotion ambiguity** — If a future resource embeds both `*SpaceImporter` and another struct that also has `ImportState`, Go will require an explicit disambiguation method. This is a distant risk given no such struct exists. → _No mitigation needed now._
+
+## Migration Plan
+
+1. Add `internal/fleet/space_importer.go` with `SpaceImporter` and unit tests
+2. Fix `fleet_output` and `fleet_server_host` (embed, wire, add acceptance tests) — bug fix scope
+3. Migrate remaining four resources — cleanup scope
+4. Update four delta specs
+5. `make build && make lint` gate throughout; acceptance tests run in CI

--- a/openspec/changes/fleet-space-aware-import-unification/proposal.md
+++ b/openspec/changes/fleet-space-aware-import-unification/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`elasticstack_fleet_output` and `elasticstack_fleet_server_host` use `ImportStatePassthroughID`, which passes the raw import string through as the resource ID. When a user imports from a non-default Kibana space using `<space_id>/<resource_id>`, the composite string lands in `output_id`/`host_id` and `space_ids` is never set — causing the subsequent Read to query the wrong ID against the wrong space (404). Additionally, the four Fleet resources that already handle space-aware import each do so with bespoke logic, creating fragmentation and subtle behavioral inconsistencies.
+
+## What Changes
+
+- Introduce `fleet.SpaceImporter`, an embeddable struct in `internal/fleet/` that provides a canonical `ImportState` implementation for resources with `space_ids`
+- `SpaceImporter` accepts one or more `path.Path` values (the resource-specific ID fields to seed), parses composite `<space_id>/<resource_id>` import IDs via `clients.CompositeIDFromStrFw`, and falls back to a plain ID with no `space_ids` set
+- Fix `fleet_output` by embedding `*SpaceImporter` wired to `path.Root("output_id")`
+- Fix `fleet_server_host` by embedding `*SpaceImporter` wired to `path.Root("host_id")`
+- Migrate `fleet_agent_policy`, `fleet_integration_policy`, `fleet_elastic_defend_integration_policy`, and `fleet_agent_binary_download_source` to use `*SpaceImporter`, removing their bespoke `ImportState` methods
+- Normalize `fleet_agent_binary_download_source` behavior: plain import ID leaves `space_ids` unset (was: hardcoded to `["default"]`); plain ID no longer also sets `id` (Terraform resource ID is repopulated by Read)
+- Add acceptance tests for `fleet_output` and `fleet_server_host` space-aware import
+- Update OpenSpec requirement docs for all four specs whose import REQs change
+
+## Capabilities
+
+### New Capabilities
+
+_(none — `SpaceImporter` is internal implementation scaffolding, not a user-visible capability)_
+
+### Modified Capabilities
+
+- `fleet-output`: REQ-008 currently documents `ImportStatePassthroughID` semantics; replace with composite ID import behavior matching `fleet-integration-policy` REQ-006
+- `fleet-server-host`: REQ-007 currently documents `ImportStatePassthroughID` semantics; replace with composite ID import behavior
+- `fleet-agent-download-source`: "Terraform import" requirement currently documents hardcoded `["default"]` fallback and dual `id`+`source_id` assignment; align with standard behavior (no `space_ids` set on plain ID, `source_id` only)
+- `fleet-elastic-defend-integration-policy`: REQ-004 says "import passthrough semantics" but the implementation already supports composite IDs; update spec to document actual behavior
+
+## Impact
+
+- **Fixed resources**: `internal/fleet/output/resource.go`, `internal/fleet/serverhost/resource.go`
+- **Migrated resources**: `internal/fleet/agentpolicy/resource.go`, `internal/fleet/integration_policy/resource.go`, `internal/fleet/elastic_defend_integration_policy/resource.go`, `internal/fleet/agentdownloadsource/resource.go`
+- **New file**: `internal/fleet/space_importer.go`
+- **Specs updated**: `fleet-output`, `fleet-server-host`, `fleet-agent-download-source`, `fleet-elastic-defend-integration-policy`
+- **No breaking changes**: composite import ID was not previously supported for `output` and `server_host`, so adding it is purely additive; `agentdownloadsource` plain-ID behavior change is observable only in intermediate import state (Read converges correctly either way)

--- a/openspec/changes/fleet-space-aware-import-unification/specs/fleet-agent-download-source/spec.md
+++ b/openspec/changes/fleet-space-aware-import-unification/specs/fleet-agent-download-source/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Terraform import
+
+The resource SHALL support `terraform import` by accepting either `<space_id>/<source_id>` or `<source_id>`. The Fleet download source ID SHALL populate `source_id` in state. When a space is provided, the space ID SHALL populate `space_ids` as a single-entry collection. When only `<source_id>` is provided (no `/` separator), `space_ids` SHALL NOT be set from the import ID; the subsequent read cycle SHALL populate all remaining attributes using the default space.
+
+#### Scenario: Import by composite ID
+
+- **WHEN** the practitioner runs import with a valid `<space_id>/<source_id>` identifier
+- **THEN** state SHALL contain the parsed resource ID in `source_id`, and `space_ids` SHALL contain exactly the provided `space_id`
+
+#### Scenario: Import by source ID only
+
+- **WHEN** the practitioner runs import with `<source_id>` and no explicit space prefix
+- **THEN** state SHALL contain `source_id` set to the provided value, and `space_ids` SHALL NOT be set from the import ID

--- a/openspec/changes/fleet-space-aware-import-unification/specs/fleet-elastic-defend-integration-policy/spec.md
+++ b/openspec/changes/fleet-space-aware-import-unification/specs/fleet-elastic-defend-integration-policy/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Identity and import (REQ-004)
+
+The resource SHALL expose computed `id` and `policy_id` attributes whose values are set from the Kibana package policy id returned by the API. `policy_id` SHALL be the import key. Changes to a configured `policy_id` SHALL require replacement.
+
+The resource SHALL support import with both plain and composite import IDs.
+
+When the import ID is a composite string in the format `<space_id>/<policy_id>`, the resource SHALL set `policy_id` to the parsed resource ID and `space_ids` to `[<space_id>]` in state, so that Defend integration policies in non-default Kibana spaces can be imported successfully.
+
+When the import ID is a plain (non-composite) string — i.e. it contains no `/` that can be parsed as a composite ID — the resource SHALL treat the entire string as `policy_id` and SHALL NOT set `space_ids` from the import ID. This preserves existing behaviour for default-space imports.
+
+On the subsequent read after import (regardless of ID form), the resource SHALL use the space from state to query the Fleet API and populate all remaining attributes, including validating that the resolved package policy belongs to the `endpoint` package.
+
+#### Scenario: Import by composite space/policy ID
+
+- GIVEN an existing Elastic Defend package policy in Kibana space `"my-space"` with policy ID `"abc-123"`
+- WHEN `terraform import` is run with the composite ID `"my-space/abc-123"`
+- THEN `policy_id` SHALL be `"abc-123"` and `space_ids` SHALL contain `"my-space"`
+
+#### Scenario: Import by plain policy ID (default space)
+
+- GIVEN an existing Elastic Defend package policy in the default Kibana space with policy ID `"abc-123"`
+- WHEN `terraform import` is run with the plain ID `"abc-123"` (no `/` separator)
+- THEN `policy_id` SHALL be `"abc-123"` and `space_ids` SHALL NOT be set from the import ID
+
+#### Scenario: Import by policy id (read-back)
+
+- GIVEN an existing Elastic Defend package policy id
+- WHEN `terraform import` is run for `elasticstack_fleet_elastic_defend_integration_policy`
+- THEN a subsequent read SHALL populate the modeled schema fields from the API response

--- a/openspec/changes/fleet-space-aware-import-unification/specs/fleet-output/spec.md
+++ b/openspec/changes/fleet-space-aware-import-unification/specs/fleet-output/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Import (REQ-008)
+
+The resource SHALL support import with both plain and composite import IDs.
+
+When the import ID is a composite string in the format `<space_id>/<output_id>`, the resource SHALL set `output_id` to the parsed resource ID and `space_ids` to `[<space_id>]` in state, so that outputs in non-default Kibana spaces can be imported successfully.
+
+When the import ID is a plain (non-composite) string — i.e. it contains no `/` that can be parsed as a composite ID — the resource SHALL treat the entire string as `output_id` and SHALL NOT set `space_ids` from the import ID. This preserves existing behaviour for default-space imports.
+
+On the subsequent read after import (regardless of ID form), the resource SHALL use the space from state to query the Fleet API and populate all remaining attributes.
+
+#### Scenario: Import by composite space/output ID
+
+- GIVEN an existing Fleet output in Kibana space `"my-space"` with output ID `"abc-123"`
+- WHEN `terraform import` is run with the composite ID `"my-space/abc-123"`
+- THEN `output_id` SHALL be `"abc-123"` and `space_ids` SHALL contain `"my-space"`
+
+#### Scenario: Import by plain output ID (default space)
+
+- GIVEN an existing Fleet output in the default Kibana space with output ID `"abc-123"`
+- WHEN `terraform import` is run with the plain ID `"abc-123"` (no `/` separator)
+- THEN `output_id` SHALL be `"abc-123"` and `space_ids` SHALL NOT be set from the import ID

--- a/openspec/changes/fleet-space-aware-import-unification/specs/fleet-server-host/spec.md
+++ b/openspec/changes/fleet-space-aware-import-unification/specs/fleet-server-host/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Import (REQ-007)
+
+The resource SHALL support import with both plain and composite import IDs.
+
+When the import ID is a composite string in the format `<space_id>/<host_id>`, the resource SHALL set `host_id` to the parsed resource ID and `space_ids` to `[<space_id>]` in state, so that server hosts in non-default Kibana spaces can be imported successfully.
+
+When the import ID is a plain (non-composite) string — i.e. it contains no `/` that can be parsed as a composite ID — the resource SHALL treat the entire string as `host_id` and SHALL NOT set `space_ids` from the import ID. This preserves existing behaviour for default-space imports.
+
+On the subsequent read after import (regardless of ID form), the resource SHALL use the space from state to query the Fleet API and populate all remaining attributes.
+
+#### Scenario: Import by composite space/host ID
+
+- GIVEN an existing Fleet server host in Kibana space `"my-space"` with host ID `"abc-123"`
+- WHEN `terraform import` is run with the composite ID `"my-space/abc-123"`
+- THEN `host_id` SHALL be `"abc-123"` and `space_ids` SHALL contain `"my-space"`
+
+#### Scenario: Import by plain host ID (default space)
+
+- GIVEN an existing Fleet server host in the default Kibana space with host ID `"abc-123"`
+- WHEN `terraform import` is run with the plain ID `"abc-123"` (no `/` separator)
+- THEN `host_id` SHALL be `"abc-123"` and `space_ids` SHALL NOT be set from the import ID

--- a/openspec/changes/fleet-space-aware-import-unification/tasks.md
+++ b/openspec/changes/fleet-space-aware-import-unification/tasks.md
@@ -1,0 +1,31 @@
+## 1. Shared SpaceImporter
+
+- [ ] 1.1 Create `internal/fleet/space_importer.go`: define `SpaceImporter` struct with `idFields []path.Path`, `NewSpaceImporter(fields ...path.Path) *SpaceImporter`, and `ImportState` method that parses composite IDs via `clients.CompositeIDFromStrFw`, sets each `idField` to the resource ID, and sets `space_ids` when a space prefix is present
+- [ ] 1.2 Add unit tests for `SpaceImporter.ImportState` in `internal/fleet/space_importer_test.go`: composite ID sets resource ID and space_ids; plain ID sets resource ID and leaves space_ids nil; multiple idFields all receive the resource ID
+
+## 2. Bug Fix — fleet_output
+
+- [ ] 2.1 Embed `*SpaceImporter` in `outputResource`, wire `NewSpaceImporter(path.Root("output_id"))` in `newOutputResource()`, remove the explicit `ImportState` method
+- [ ] 2.2 Add acceptance test `TestAccResourceFleetOutput_importFromSpace` in `internal/fleet/output/acc_test.go` mirroring the pattern from `TestAccResourceIntegrationPolicy_importFromSpace`: create a Kibana space, deploy an output into it, import using composite ID, verify `space_ids` is populated
+
+## 3. Bug Fix — fleet_server_host
+
+- [ ] 3.1 Embed `*SpaceImporter` in `serverHostResource`, wire `NewSpaceImporter(path.Root("host_id"))` in `newServerHostResource()`, remove the explicit `ImportState` method
+- [ ] 3.2 Add acceptance test `TestAccResourceFleetServerHost_importFromSpace` in `internal/fleet/serverhost/acc_test.go` mirroring the same pattern
+
+## 4. Migration — existing resources
+
+- [ ] 4.1 Migrate `fleet_agent_policy`: embed `*SpaceImporter` wired to `path.Root("policy_id")`, remove the bespoke `ImportState` method from `internal/fleet/agentpolicy/resource.go`
+- [ ] 4.2 Migrate `fleet_integration_policy`: embed `*SpaceImporter` wired to `path.Root("policy_id")`, remove the bespoke `ImportState` method from `internal/fleet/integration_policy/resource.go` (removes strict empty-segment validation, aligning with standard behavior)
+- [ ] 4.3 Migrate `fleet_elastic_defend_integration_policy`: embed `*SpaceImporter` wired to `path.Root("policy_id")`, remove the bespoke `ImportState` method from `internal/fleet/elastic_defend_integration_policy/resource.go` (also removes the extra `ImportStatePassthroughID` call for `id`)
+- [ ] 4.4 Migrate `fleet_agent_binary_download_source`: embed `*SpaceImporter` wired to `path.Root("source_id")`, remove the bespoke `ImportState` method and `setImportStateAttributes` helper from `internal/fleet/agentdownloadsource/resource.go` (removes hardcoded `"default"` fallback and `strings.SplitN` usage)
+
+## 5. Spec Updates
+
+- [ ] 5.1 Verify `make check-openspec` passes with the four delta specs in this change
+
+## 6. Verification
+
+- [ ] 6.1 `make build` passes
+- [ ] 6.2 `make lint` passes (check for unused imports left behind after `ImportState` method removals)
+- [ ] 6.3 Existing import acceptance tests for `fleet_agent_policy`, `fleet_integration_policy`, `fleet_elastic_defend_integration_policy`, and `fleet_agent_binary_download_source` continue to pass


### PR DESCRIPTION
## Summary

- Proposes a new `fleet.SpaceImporter` embeddable struct in `internal/fleet/` that provides a canonical `ImportState` implementation for all Fleet resources with `space_ids`
- Fixes the broken space-aware import bug in `elasticstack_fleet_output` and `elasticstack_fleet_server_host` (both currently use `ImportStatePassthroughID`, which passes the raw composite `<space_id>/<resource_id>` string as the resource ID and never sets `space_ids` — causing 404 on the subsequent Read)
- Migrates all four existing importable Fleet resources to use the shared embedding, removing bespoke `ImportState` methods and normalising subtle behavioural inconsistencies
- Updates OpenSpec delta specs for `fleet-output`, `fleet-server-host`, `fleet-agent-download-source`, and `fleet-elastic-defend-integration-policy`

## Change

`openspec/changes/fleet-space-aware-import-unification/`

Ready for implementation via `/opsx:apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add design proposal for unified space-aware import handling across Fleet resources
> - Adds an OpenSpec change descriptor, proposal, design doc, and task list for consolidating Fleet resource import behavior into a shared `SpaceImporter` struct in `internal/fleet`.
> - The proposal identifies inconsistencies in how `fleet_output` and `fleet_server_host` handle space-aware imports and defines a unified approach: accept both `<space_id>/<resource_id>` and plain `<resource_id>` formats, setting `space_ids` only when a space is provided.
> - Spec change documents are added for `fleet-agent-download-source`, `fleet-elastic-defend-integration-policy`, `fleet-output`, and `fleet-server-host` to capture the new import requirements and scenarios.
> - This PR is documentation and planning only — no implementation code is included.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7739f82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->