### PR TITLE
Proposal to validate examples

### DIFF
--- a/openspec/changes/examples-config-validation/.openspec.yaml
+++ b/openspec/changes/examples-config-validation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/examples-config-validation/design.md
+++ b/openspec/changes/examples-config-validation/design.md
@@ -50,15 +50,11 @@ The user explicitly preferred per-file failure attribution. To make per-file iso
 
 Today, only one directory violates this: `examples/resources/elasticstack_kibana_alerting_rule/`. Its `resource-index-rule.tf` and `resource_rule_action_frequency.tf` both reference `elasticstack_kibana_action_connector.index_example` and `elasticstack_elasticsearch_data_stream.my_data_stream` defined in the directory's `resource.tf`. We will inline those dependencies into each file. The cost is some duplication in the generated docs; the benefit is that every documented snippet is independently usable.
 
-### 4. Strip embedded provider configuration from examples
+### 4. Leave embedded provider configuration in examples alone
 
-Around twenty examples currently include `provider "elasticstack" { elasticsearch {} }`, and a handful include per-resource `elasticsearch_connection {}` blocks with hardcoded `localhost:9200` / `changeme` credentials. Both patterns:
+An earlier version of this design considered stripping every embedded `provider "elasticstack" { ... }` block and per-resource `elasticsearch_connection { ... }` block from existing examples. That cleanup is unnecessary for the validate-based harness: `terraform validate` accepts those blocks as schema-conformant input and does not require the harness to inject its own provider configuration. The blocks are also stylistic choices in the rendered docs (some users prefer the explicit setup, others prefer it implicit), and stripping them would produce a large, behaviourally-irrelevant docs diff.
 
-- Conflict with the provider configuration the harness needs to inject.
-- Bake test-environment defaults into the rendered docs.
-- Encourage users to copy stale credentials into real configurations.
-
-We will strip both patterns from existing examples in a single cleanup pass. Going forward, the validation test itself enforces the convention: any new example that re-introduces a `provider` block will fail validation against the harness-injected provider configuration. No additional lint tool is needed.
+This change therefore leaves embedded provider and connection blocks in place. The harness itself does not write a provider configuration into the per-test working directory; it only writes the `terraform { required_providers { ... } }` pin needed for `terraform init` to discover the locally built provider. If a future change wants to standardise example docs (e.g. for stylistic consistency), it can do so as a separate, focused cleanup with its own justification.
 
 ### 5. Static skip-list for non-validatable directories
 
@@ -82,7 +78,6 @@ The harness still depends on the locally built provider being available to the `
 ## Risks / Trade-offs
 
 - **`terraform init` per subtest is slow.** With ~115 examples and a fresh init per directory, naive sequential execution may add several minutes to `go test`. Mitigation: run subtests in parallel (`t.Parallel()`), which is safe because each writes to its own tempdir; share the provider plugin cache across subtests via `TF_PLUGIN_CACHE_DIR`. Measure before optimizing further.
-- **Strip-provider-blocks changes generated docs.** The doc regeneration will produce a large diff. Mitigation: treat docs regeneration as part of this change and review the diff in the same PR. Users who depended on the old in-snippet provider config will need to provide their own — same as for ~80% of existing examples that already omit it.
 - **Self-contained example files inflate `alerting_rule` docs slightly.** Each of the three rule snippets will redefine the connector and data stream prerequisites. Mitigation: accept the duplication; it is a one-time cost confined to one resource and matches what users actually need to copy.
 - **Latent broken examples may be more numerous than expected.** Mitigation: the WIP commit referenced by the task already proves the harness pattern works; we will run it locally during implementation to enumerate and fix all surfaced failures before the change is ready for review.
 - **`terraform validate` may not catch every schema bug Plugin Framework providers can express.** Some validations only run during plan (e.g. `Validators` on attributes that compare across blocks). Mitigation: treat this test as a floor, not a ceiling. Per-resource acceptance tests continue to cover apply-time behaviour.
@@ -94,13 +89,12 @@ The work is naturally staged:
 
 1. Add the embed FS in `examples/examples.go` and the validation harness in `internal/acctest/`.
 2. Run the harness locally; collect the list of failing example files.
-3. Strip embedded `provider` and `elasticsearch_connection` blocks across all examples.
-4. Restructure `examples/resources/elasticstack_kibana_alerting_rule/` for self-containment.
-5. Fix `delayed_data_check_config` (#2523) and every other example surfaced as broken by step 2.
-6. Regenerate provider docs (`make docs-generate` or equivalent).
-7. Land the harness, the cleanups, and the regenerated docs in a single change.
+3. Restructure `examples/resources/elasticstack_kibana_alerting_rule/` for self-containment.
+4. Fix `delayed_data_check_config` (#2523) and every other example surfaced as broken by step 2.
+5. Regenerate provider docs only for the example files actually changed.
+6. Land the harness, the targeted cleanups, and any regenerated docs in a single change.
 
-No external data migration is required. No state-format changes. Users who relied on in-example provider blocks will need to provide their own provider configuration after this change — which they typically already do.
+No external data migration is required. No state-format changes. Embedded provider and connection blocks in existing examples remain valid input to the harness and are deliberately left untouched.
 
 ## Open Questions
 

--- a/openspec/changes/examples-config-validation/design.md
+++ b/openspec/changes/examples-config-validation/design.md
@@ -1,0 +1,109 @@
+## Context
+
+The provider ships ~115 example `.tf` files under `examples/resources/` and `examples/data-sources/`. They are consumed two ways:
+
+1. `terraform-plugin-docs` embeds them into the generated reference docs at `docs/resources/<name>.md` and `docs/data-sources/<name>.md`.
+2. End users copy them into their own configurations as starting points.
+
+Today there is no automated check that these snippets parse against the provider's actual schema. Schema drift between the provider and its documented examples (e.g. a block-form attribute being changed to an object attribute) is silent until a user reports a broken copy-paste, as in issue #2523.
+
+This change introduces a single Go test that validates every example against the locally built provider. The design favours keeping the test cheap, fast, and correct over catching every possible bug class — `terraform validate` is the right tool for "does this snippet match the schema", and going further (PlanOnly, full Apply) trades dramatically more execution cost and infrastructure dependency for a small marginal gain in coverage.
+
+## Goals / Non-Goals
+
+**Goals**:
+- Catch schema-mismatch bugs in example `.tf` files (block vs. attribute, wrong attribute names, type errors, missing required attributes) before they reach users.
+- Attribute failures to a specific example file so the fix is obvious.
+- Run as part of the normal `go test ./...` suite without requiring a live Elastic stack.
+- Make example files self-contained so users can copy any single snippet and have it parse.
+- Establish "examples must validate" as an enforceable convention going forward.
+
+**Non-Goals**:
+- Verify that examples produce a valid plan (would force a third of data-source examples to depend on a live stack).
+- Verify that examples can be applied successfully (different and much more expensive guarantee, already partially covered by per-resource acceptance tests).
+- Lint examples for stylistic concerns (formatting, comment quality).
+- Test combinations of examples that span multiple resource directories.
+
+## Decisions
+
+### 1. Use `terraform validate` rather than `PlanOnly`
+
+`terraform validate` parses the configuration and checks it against the provider schema, including block-vs-attribute, attribute names, types, required attributes, and intra-config references. It does **not** call data sources or refresh state, so it has no live-backend dependency.
+
+`PlanOnly` via `terraform-plugin-testing` would additionally evaluate data sources and resolve computed cross-resource references. In this repo, only a small minority of resource examples reference data sources at all, and most data-source examples are local-compute (`elasticstack_elasticsearch_ingest_processor_*`). The marginal coverage `PlanOnly` would add over `validate` is small — and would require a live Elastic and Kibana stack for a meaningful subset of examples, pushing the test out of unit-test territory.
+
+The bug class motivating this change (#2523, block vs. attribute) is squarely in `validate`'s wheelhouse.
+
+### 2. Drive the harness via `terraform-exec`, not `terraform-plugin-testing`
+
+`terraform-plugin-testing` does not expose a "validate-only" step; its lifecycle starts at plan. Using `terraform-exec` (`tfexec.NewTerraform(...).Init(...).Validate(...)`) keeps the harness aligned with what is actually being tested and avoids dragging in lifecycle behaviour the test does not want.
+
+The harness will:
+1. Embed the contents of `examples/resources/` and `examples/data-sources/` via `embed.FS` in `examples/examples.go`.
+2. For each example `.tf` file, write it to a temporary directory together with a generated `terraform.tf` that pins the locally built provider via `dev_overrides` (or the existing acceptance-test provider factory if cleaner — see open question 1).
+3. Run `terraform init` and `terraform validate`, surfacing structured diagnostics if validation fails.
+4. Use `t.Run("<relative-path>", ...)` so the failing file is named in the test output and matches `-run` filters.
+
+### 3. One subtest per example file
+
+The user explicitly preferred per-file failure attribution. To make per-file isolation work, every example `.tf` file must be **self-contained**: it cannot reference resources or data sources defined only in sibling files. This is also a usability improvement — readers of the generated docs see one snippet at a time and reasonably expect each to be runnable on its own.
+
+Today, only one directory violates this: `examples/resources/elasticstack_kibana_alerting_rule/`. Its `resource-index-rule.tf` and `resource_rule_action_frequency.tf` both reference `elasticstack_kibana_action_connector.index_example` and `elasticstack_elasticsearch_data_stream.my_data_stream` defined in the directory's `resource.tf`. We will inline those dependencies into each file. The cost is some duplication in the generated docs; the benefit is that every documented snippet is independently usable.
+
+### 4. Strip embedded provider configuration from examples
+
+Around twenty examples currently include `provider "elasticstack" { elasticsearch {} }`, and a handful include per-resource `elasticsearch_connection {}` blocks with hardcoded `localhost:9200` / `changeme` credentials. Both patterns:
+
+- Conflict with the provider configuration the harness needs to inject.
+- Bake test-environment defaults into the rendered docs.
+- Encourage users to copy stale credentials into real configurations.
+
+We will strip both patterns from existing examples in a single cleanup pass. Going forward, the validation test itself enforces the convention: any new example that re-introduces a `provider` block will fail validation against the harness-injected provider configuration. No additional lint tool is needed.
+
+### 5. Static skip-list for non-validatable directories
+
+Two directories under `examples/` cannot be validated by this harness:
+
+- `examples/cloud/`: uses the `ec` (Elastic Cloud) provider, not `elasticstack`. Out of scope for this test.
+- `examples/provider/`: contains snippets demonstrating provider configuration itself. They are intentionally partial and not standalone configurations.
+
+We will hard-code these paths in the harness skip-list. We considered an in-file sentinel comment (`# acctest:skip reason=...`) for richer per-file metadata, but with "fix everything" as the policy (see decision 6) the only legitimate skips are these two structural cases, and a static list keeps the mechanism trivial to audit.
+
+### 6. Fix every example the harness flags
+
+Rather than landing the test in a partially-disabled state, this change fixes every example that the new harness reports as broken. We expect the `delayed_data_check_config` bug from #2523 plus a small number of latent issues — most likely a handful of block-vs-attribute or attribute-rename mistakes that have accumulated since the relevant resources were last touched.
+
+### 7. Run alongside the regular `go test` suite
+
+Because `terraform validate` does not need a live stack, this test does not need the `TF_ACC=1` gating used for true acceptance tests. It can be a standard `*_test.go` test in `internal/acctest/` (or a new lightweight package) that runs in `make test`. CI will catch broken examples on every PR, not only on full acceptance runs.
+
+The harness still depends on the locally built provider being available to the `terraform` CLI. We will use the same `dev_overrides`-style configuration the existing development workflow already supports.
+
+## Risks / Trade-offs
+
+- **`terraform init` per subtest is slow.** With ~115 examples and a fresh init per directory, naive sequential execution may add several minutes to `go test`. Mitigation: run subtests in parallel (`t.Parallel()`), which is safe because each writes to its own tempdir; share the provider plugin cache across subtests via `TF_PLUGIN_CACHE_DIR`. Measure before optimizing further.
+- **Strip-provider-blocks changes generated docs.** The doc regeneration will produce a large diff. Mitigation: treat docs regeneration as part of this change and review the diff in the same PR. Users who depended on the old in-snippet provider config will need to provide their own — same as for ~80% of existing examples that already omit it.
+- **Self-contained example files inflate `alerting_rule` docs slightly.** Each of the three rule snippets will redefine the connector and data stream prerequisites. Mitigation: accept the duplication; it is a one-time cost confined to one resource and matches what users actually need to copy.
+- **Latent broken examples may be more numerous than expected.** Mitigation: the WIP commit referenced by the task already proves the harness pattern works; we will run it locally during implementation to enumerate and fix all surfaced failures before the change is ready for review.
+- **`terraform validate` may not catch every schema bug Plugin Framework providers can express.** Some validations only run during plan (e.g. `Validators` on attributes that compare across blocks). Mitigation: treat this test as a floor, not a ceiling. Per-resource acceptance tests continue to cover apply-time behaviour.
+- **Provider `Configure` may still be invoked by `terraform validate` in some Terraform versions.** Mitigation: confirm during implementation that the elasticstack provider's `Configure` does not require live connectivity (most providers defer client construction). If it does, document the requirement and consider running with `TF_SKIP_PROVIDER_VERIFY` or split the harness into stack-required and stack-free buckets.
+
+## Migration Plan
+
+The work is naturally staged:
+
+1. Add the embed FS in `examples/examples.go` and the validation harness in `internal/acctest/`.
+2. Run the harness locally; collect the list of failing example files.
+3. Strip embedded `provider` and `elasticsearch_connection` blocks across all examples.
+4. Restructure `examples/resources/elasticstack_kibana_alerting_rule/` for self-containment.
+5. Fix `delayed_data_check_config` (#2523) and every other example surfaced as broken by step 2.
+6. Regenerate provider docs (`make docs-generate` or equivalent).
+7. Land the harness, the cleanups, and the regenerated docs in a single change.
+
+No external data migration is required. No state-format changes. Users who relied on in-example provider blocks will need to provide their own provider configuration after this change — which they typically already do.
+
+## Open Questions
+
+- **Provider availability mechanism**: should the harness use `dev_overrides` (matching the local development workflow) or build the provider once at test setup and inject it via a filesystem mirror? `dev_overrides` is simpler but emits a stderr warning each invocation; a filesystem mirror is cleaner but more setup. Default plan: `dev_overrides`, revisit if the warnings make output hard to read.
+- **Test location**: place the new test alongside existing acceptance tests in `internal/acctest/` for consistency, or in a new `internal/examples/` package to signal it is a different class of test (no `TF_ACC=1` gating, no live stack). Default plan: `internal/acctest/` with a clear filename like `examples_validate_test.go`; revisit if the lighter dependencies make a separate package worth the split.
+- **Parallelism limit**: how aggressively to parallelise. Default plan: full `t.Parallel()` with the standard `go test -parallel` cap; tune if init contention shows up under high parallelism.

--- a/openspec/changes/examples-config-validation/proposal.md
+++ b/openspec/changes/examples-config-validation/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Examples under `examples/resources/` and `examples/data-sources/` are surfaced verbatim in the generated provider docs, but nothing currently verifies that they parse against the provider schema. Issue [#2523](https://github.com/elastic/terraform-provider-elasticstack/issues/2523) is a recent instance of this: the `elasticsearch_ml_datafeed` example uses `delayed_data_check_config` as a block when the schema declares it as an attribute, so the documented snippet fails immediately when a user copies it into their configuration. This class of bug is mechanical, easy to introduce during refactors, and only ever caught by user reports.
+
+A test that runs `terraform validate` against every example file closes that gap and turns the schema itself into the lint rule for examples going forward.
+
+## What Changes
+
+- Add a Go test that, for every `*.tf` file under `examples/resources/` and `examples/data-sources/`, runs the file through `terraform init` + `terraform validate` against the locally built provider, with one subtest per file so failures attribute to the offending snippet.
+- Establish a convention that each example `.tf` file is **self-contained**: it must not reference resources or data sources defined only in sibling files. Restructure `examples/resources/elasticstack_kibana_alerting_rule/` (currently the only directory that violates this) so each `.tf` file stands on its own.
+- Strip embedded `provider "elasticstack" {}` blocks and per-resource `elasticsearch_connection {}` overrides from existing example files. The validation harness injects provider configuration; duplicate provider blocks in a snippet would conflict with that and are also confusing for documentation readers.
+- Skip `examples/cloud/` (uses the `ec` provider) and `examples/provider/` (provider-config snippets, not standalone configs) from the harness via a static path skip-list.
+- Fix every example surfaced as broken by the new test on first run, including the `delayed_data_check_config` bug from #2523 and any other latent schema mismatches.
+
+## Capabilities
+
+### New Capabilities
+
+- `examples-validation`: a harness that validates every example file against the provider schema, run as part of the standard `go test` suite.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Affected code**: new `examples/examples.go` (embed FS), new `internal/acctest/examples_validate_test.go` (or equivalent location), updates to most `.tf` files under `examples/resources/` and `examples/data-sources/` to remove provider blocks and fix latent schema bugs.
+- **Affected interfaces**: no provider schema changes. Documentation regeneration may produce diffs because example contents change.
+- **Backward compatibility**: stripped provider blocks change the rendered docs. Users who copy an example will now also need to provide their own provider configuration (which they typically already do), so this is a docs-quality improvement rather than a regression.
+- **CI**: the new test runs without a live Elastic stack (`terraform validate` does not call data sources or refresh state) and integrates into the existing `go test` invocation. Expected wall-clock impact is single-digit minutes for ~115 example files; can be parallelised via `t.Parallel()` since each subtest uses its own working directory.

--- a/openspec/changes/examples-config-validation/proposal.md
+++ b/openspec/changes/examples-config-validation/proposal.md
@@ -8,7 +8,6 @@ A test that runs `terraform validate` against every example file closes that gap
 
 - Add a Go test that, for every `*.tf` file under `examples/resources/` and `examples/data-sources/`, runs the file through `terraform init` + `terraform validate` against the locally built provider, with one subtest per file so failures attribute to the offending snippet.
 - Establish a convention that each example `.tf` file is **self-contained**: it must not reference resources or data sources defined only in sibling files. Restructure `examples/resources/elasticstack_kibana_alerting_rule/` (currently the only directory that violates this) so each `.tf` file stands on its own.
-- Strip embedded `provider "elasticstack" {}` blocks and per-resource `elasticsearch_connection {}` overrides from existing example files. The validation harness injects provider configuration; duplicate provider blocks in a snippet would conflict with that and are also confusing for documentation readers.
 - Skip `examples/cloud/` (uses the `ec` provider) and `examples/provider/` (provider-config snippets, not standalone configs) from the harness via a static path skip-list.
 - Fix every example surfaced as broken by the new test on first run, including the `delayed_data_check_config` bug from #2523 and any other latent schema mismatches.
 
@@ -24,7 +23,7 @@ None.
 
 ## Impact
 
-- **Affected code**: new `examples/examples.go` (embed FS), new `internal/acctest/examples_validate_test.go` (or equivalent location), updates to most `.tf` files under `examples/resources/` and `examples/data-sources/` to remove provider blocks and fix latent schema bugs.
-- **Affected interfaces**: no provider schema changes. Documentation regeneration may produce diffs because example contents change.
-- **Backward compatibility**: stripped provider blocks change the rendered docs. Users who copy an example will now also need to provide their own provider configuration (which they typically already do), so this is a docs-quality improvement rather than a regression.
+- **Affected code**: new `examples/examples.go` (embed FS), new `internal/acctest/examples_validate_test.go` (or equivalent location), targeted updates to `.tf` files under `examples/resources/` to fix latent schema bugs and to make the `elasticstack_kibana_alerting_rule` examples self-contained.
+- **Affected interfaces**: no provider schema changes. Documentation regeneration may produce diffs only for the example files actually changed by this work (alerting-rule restructuring and any examples whose schema bugs are fixed).
+- **Backward compatibility**: no behaviour change for users who copy existing examples. Embedded `provider` and `elasticsearch_connection` blocks in examples remain valid input to the harness — `terraform validate` accepts them — so they are deliberately left in place to keep the diff minimal.
 - **CI**: the new test runs without a live Elastic stack (`terraform validate` does not call data sources or refresh state) and integrates into the existing `go test` invocation. Expected wall-clock impact is single-digit minutes for ~115 example files; can be parallelised via `t.Parallel()` since each subtest uses its own working directory.

--- a/openspec/changes/examples-config-validation/specs/examples-validation/spec.md
+++ b/openspec/changes/examples-config-validation/specs/examples-validation/spec.md
@@ -4,6 +4,8 @@
 
 For every `*.tf` file under `examples/resources/` and `examples/data-sources/` that is not in the skip-list defined by this capability, the project SHALL provide an automated test that runs `terraform init` and `terraform validate` against the locally built `elasticstack` provider for that file in isolation.
 
+Before invoking `terraform validate`, the harness SHALL inject a provider configuration for the `elasticstack` provider into the per-test working directory so that examples can reference provider-managed resources without declaring their own provider block. The injected configuration SHALL pin the locally built `elasticstack` provider and SHALL be the single source of provider configuration during validation.
+
 The test SHALL fail when `terraform validate` reports any diagnostic of severity `error` for a covered file. The test SHALL surface the offending file path, validate diagnostic text, and source location in the failure message.
 
 #### Scenario: Schema-conformant example passes
@@ -59,15 +61,23 @@ This requirement is enforced by REQ-001 and REQ-002: the harness validates each 
 
 ### Requirement: Example files SHALL NOT embed provider configuration (REQ-004)
 
-`*.tf` files under `examples/resources/` and `examples/data-sources/` SHALL NOT contain a top-level `provider "elasticstack" { ... }` block. They SHALL NOT contain per-resource `elasticsearch_connection { ... }` blocks with hardcoded credentials.
+`*.tf` files under `examples/resources/` and `examples/data-sources/` SHALL NOT contain a top-level `provider "elasticstack" { ... }` block. They SHALL NOT contain per-resource `elasticsearch_connection { ... }` blocks, regardless of whether those blocks contain hardcoded credentials, environment-variable references, or are otherwise empty.
 
-This requirement is enforced by REQ-001: the validation harness injects provider configuration, and a duplicate provider block in an example produces a `terraform validate` error.
+The top-level `provider` ban is enforced by REQ-001: the validation harness injects provider configuration, and a duplicate top-level provider block in an example produces a `terraform validate` error.
+
+The per-resource `elasticsearch_connection` ban SHALL additionally be enforced by an explicit content check in the harness, because `elasticsearch_connection` is a valid schema block on individual resources and would not by itself cause `terraform validate` to fail. The harness SHALL scan each covered file and SHALL fail the corresponding subtest if any `elasticsearch_connection` block is present, regardless of its contents.
 
 #### Scenario: Embedded provider block is rejected
 
 - **GIVEN** an example file that contains `provider "elasticstack" { elasticsearch {} }`
 - **WHEN** the validation harness runs against that file with provider configuration injected by the harness
 - **THEN** the subtest SHALL fail with the duplicate-provider-configuration diagnostic from `terraform validate`
+
+#### Scenario: Per-resource `elasticsearch_connection` block is rejected
+
+- **GIVEN** an example file that contains an `elasticsearch_connection { ... }` block on any resource, including blocks that use environment-variable references or contain no attributes
+- **WHEN** the validation harness runs against that file
+- **THEN** the subtest SHALL fail with a content-check diagnostic identifying the offending block, independently of any `terraform validate` outcome
 
 ### Requirement: The harness SHALL skip non-validatable example directories (REQ-005)
 
@@ -93,7 +103,7 @@ The harness SHALL NOT exclude any other directory by default. New skips SHALL re
 
 ### Requirement: The harness SHALL run without a live Elastic stack (REQ-006)
 
-The validation harness SHALL be executable as part of the standard `go test ./...` invocation. It SHALL NOT require `TF_ACC=1`, `ES_ENDPOINTS`, `KIBANA_ENDPOINT`, or any other live-stack environment variable. It SHALL NOT depend on Elasticsearch or Kibana being reachable from the host running the test.
+The validation harness SHALL be executable as part of the standard `go test ./...` invocation. It SHALL NOT require `TF_ACC=1`, `ELASTICSEARCH_ENDPOINTS`, `ELASTICSEARCH_USERNAME`, `ELASTICSEARCH_PASSWORD`, `ELASTICSEARCH_API_KEY`, `KIBANA_ENDPOINT`, `KIBANA_USERNAME`, `KIBANA_PASSWORD`, `KIBANA_API_KEY`, or any other live-stack environment variable consumed by the provider's acceptance-test harness. It SHALL NOT depend on Elasticsearch or Kibana being reachable from the host running the test.
 
 #### Scenario: Test runs in a clean environment
 

--- a/openspec/changes/examples-config-validation/specs/examples-validation/spec.md
+++ b/openspec/changes/examples-config-validation/specs/examples-validation/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: Every example file SHALL validate against the provider schema (REQ-001)
+
+For every `*.tf` file under `examples/resources/` and `examples/data-sources/` that is not in the skip-list defined by this capability, the project SHALL provide an automated test that runs `terraform init` and `terraform validate` against the locally built `elasticstack` provider for that file in isolation.
+
+The test SHALL fail when `terraform validate` reports any diagnostic of severity `error` for a covered file. The test SHALL surface the offending file path, validate diagnostic text, and source location in the failure message.
+
+#### Scenario: Schema-conformant example passes
+
+- **GIVEN** an example file whose configuration matches the current `elasticstack` provider schema
+- **WHEN** the validation harness runs against that file
+- **THEN** the corresponding subtest SHALL pass with no error diagnostics
+
+#### Scenario: Block-vs-attribute mismatch is rejected
+
+- **GIVEN** an example file that configures a schema attribute using HCL block syntax (or vice versa) — for example `delayed_data_check_config { ... }` where the schema declares an attribute
+- **WHEN** the validation harness runs against that file
+- **THEN** the corresponding subtest SHALL fail and the failure message SHALL include the validate diagnostic identifying the offending construct
+
+#### Scenario: Unknown attribute name is rejected
+
+- **GIVEN** an example file that uses an attribute name that does not exist on the referenced resource or data source
+- **WHEN** the validation harness runs against that file
+- **THEN** the corresponding subtest SHALL fail with the unknown-attribute diagnostic from `terraform validate`
+
+### Requirement: Example failures SHALL be attributed to a single file (REQ-002)
+
+The validation harness SHALL run each covered `.tf` file in its own subtest, named so that a `go test -run` filter can target an individual example. The subtest name SHALL include the file's path relative to the `examples/` root.
+
+#### Scenario: Subtest name identifies the example
+
+- **WHEN** an example at `examples/resources/elasticstack_elasticsearch_ml_datafeed/resource.tf` fails validation
+- **THEN** the failing subtest name SHALL include `elasticsearch_ml_datafeed/resource.tf` (or the equivalent relative path) so the failing example is identifiable from CI output alone
+
+#### Scenario: Failures do not cascade across files
+
+- **GIVEN** two example files in the same directory, only one of which is broken
+- **WHEN** the harness runs both
+- **THEN** only the subtest for the broken file SHALL fail; the subtest for the well-formed file SHALL pass
+
+### Requirement: Example files SHALL be self-contained (REQ-003)
+
+Each `*.tf` file under `examples/resources/` and `examples/data-sources/` SHALL be valid in isolation. An example file SHALL NOT depend on resources, data sources, locals, or variables that are defined only in sibling files within the same directory.
+
+This requirement is enforced by REQ-001 and REQ-002: the harness validates each file independently, so any cross-file reference produces an unresolved-reference error.
+
+#### Scenario: Cross-file references are rejected
+
+- **GIVEN** an example file that references `elasticstack_kibana_action_connector.shared` defined only in a sibling file
+- **WHEN** the validation harness runs against that file in isolation
+- **THEN** the subtest SHALL fail with an unresolved-reference diagnostic
+
+#### Scenario: Inlined dependencies pass
+
+- **GIVEN** an example file that references its own definitions of every resource and data source it depends on
+- **WHEN** the validation harness runs against it in isolation
+- **THEN** the subtest SHALL pass
+
+### Requirement: Example files SHALL NOT embed provider configuration (REQ-004)
+
+`*.tf` files under `examples/resources/` and `examples/data-sources/` SHALL NOT contain a top-level `provider "elasticstack" { ... }` block. They SHALL NOT contain per-resource `elasticsearch_connection { ... }` blocks with hardcoded credentials.
+
+This requirement is enforced by REQ-001: the validation harness injects provider configuration, and a duplicate provider block in an example produces a `terraform validate` error.
+
+#### Scenario: Embedded provider block is rejected
+
+- **GIVEN** an example file that contains `provider "elasticstack" { elasticsearch {} }`
+- **WHEN** the validation harness runs against that file with provider configuration injected by the harness
+- **THEN** the subtest SHALL fail with the duplicate-provider-configuration diagnostic from `terraform validate`
+
+### Requirement: The harness SHALL skip non-validatable example directories (REQ-005)
+
+The validation harness SHALL exclude `examples/cloud/` and `examples/provider/` from coverage. The skip-list SHALL be expressed as repository-relative path prefixes in the harness source code and SHALL be documented inline.
+
+The harness SHALL NOT exclude any other directory by default. New skips SHALL require explicit code changes to the harness, with a documented justification, rather than being controlled by data files or environment variables.
+
+#### Scenario: `examples/cloud/` is not validated
+
+- **WHEN** the validation harness walks `examples/`
+- **THEN** files under `examples/cloud/` SHALL NOT produce subtests
+
+#### Scenario: `examples/provider/` is not validated
+
+- **WHEN** the validation harness walks `examples/`
+- **THEN** files under `examples/provider/` SHALL NOT produce subtests
+
+#### Scenario: Other directories are not implicitly skipped
+
+- **GIVEN** a new `*.tf` file added under any path beneath `examples/resources/` or `examples/data-sources/`
+- **WHEN** the validation harness next runs
+- **THEN** that file SHALL be covered by a subtest without further configuration
+
+### Requirement: The harness SHALL run without a live Elastic stack (REQ-006)
+
+The validation harness SHALL be executable as part of the standard `go test ./...` invocation. It SHALL NOT require `TF_ACC=1`, `ES_ENDPOINTS`, `KIBANA_ENDPOINT`, or any other live-stack environment variable. It SHALL NOT depend on Elasticsearch or Kibana being reachable from the host running the test.
+
+#### Scenario: Test runs in a clean environment
+
+- **GIVEN** a host with no Elastic stack reachable and no acceptance-test environment variables set
+- **WHEN** `go test ./...` runs
+- **THEN** the validation harness SHALL execute and SHALL pass for all covered, well-formed example files
+
+#### Scenario: Test runs alongside acceptance tests
+
+- **GIVEN** a CI run with `TF_ACC=1` and a live stack configured
+- **WHEN** the full test suite runs
+- **THEN** the validation harness SHALL still execute exactly once per covered example and SHALL NOT additionally call data sources or apply resources

--- a/openspec/changes/examples-config-validation/specs/examples-validation/spec.md
+++ b/openspec/changes/examples-config-validation/specs/examples-validation/spec.md
@@ -4,8 +4,6 @@
 
 For every `*.tf` file under `examples/resources/` and `examples/data-sources/` that is not in the skip-list defined by this capability, the project SHALL provide an automated test that runs `terraform init` and `terraform validate` against the locally built `elasticstack` provider for that file in isolation.
 
-Before invoking `terraform validate`, the harness SHALL inject a provider configuration for the `elasticstack` provider into the per-test working directory so that examples can reference provider-managed resources without declaring their own provider block. The injected configuration SHALL pin the locally built `elasticstack` provider and SHALL be the single source of provider configuration during validation.
-
 The test SHALL fail when `terraform validate` reports any diagnostic of severity `error` for a covered file. The test SHALL surface the offending file path, validate diagnostic text, and source location in the failure message.
 
 #### Scenario: Schema-conformant example passes
@@ -58,26 +56,6 @@ This requirement is enforced by REQ-001 and REQ-002: the harness validates each 
 - **GIVEN** an example file that references its own definitions of every resource and data source it depends on
 - **WHEN** the validation harness runs against it in isolation
 - **THEN** the subtest SHALL pass
-
-### Requirement: Example files SHALL NOT embed provider configuration (REQ-004)
-
-`*.tf` files under `examples/resources/` and `examples/data-sources/` SHALL NOT contain a top-level `provider "elasticstack" { ... }` block. They SHALL NOT contain per-resource `elasticsearch_connection { ... }` blocks, regardless of whether those blocks contain hardcoded credentials, environment-variable references, or are otherwise empty.
-
-The top-level `provider` ban is enforced by REQ-001: the validation harness injects provider configuration, and a duplicate top-level provider block in an example produces a `terraform validate` error.
-
-The per-resource `elasticsearch_connection` ban SHALL additionally be enforced by an explicit content check in the harness, because `elasticsearch_connection` is a valid schema block on individual resources and would not by itself cause `terraform validate` to fail. The harness SHALL scan each covered file and SHALL fail the corresponding subtest if any `elasticsearch_connection` block is present, regardless of its contents.
-
-#### Scenario: Embedded provider block is rejected
-
-- **GIVEN** an example file that contains `provider "elasticstack" { elasticsearch {} }`
-- **WHEN** the validation harness runs against that file with provider configuration injected by the harness
-- **THEN** the subtest SHALL fail with the duplicate-provider-configuration diagnostic from `terraform validate`
-
-#### Scenario: Per-resource `elasticsearch_connection` block is rejected
-
-- **GIVEN** an example file that contains an `elasticsearch_connection { ... }` block on any resource, including blocks that use environment-variable references or contain no attributes
-- **WHEN** the validation harness runs against that file
-- **THEN** the subtest SHALL fail with a content-check diagnostic identifying the offending block, independently of any `terraform validate` outcome
 
 ### Requirement: The harness SHALL skip non-validatable example directories (REQ-005)
 

--- a/openspec/changes/examples-config-validation/tasks.md
+++ b/openspec/changes/examples-config-validation/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Add `examples/examples.go` exporting `embed.FS` instances for `examples/resources` and `examples/data-sources`
 - [ ] 1.2 Add a Go test (e.g. `internal/acctest/examples_validate_test.go`) that walks both embedded filesystems and runs each `.tf` file as a subtest named after its repo-relative path
-- [ ] 1.3 In each subtest, write the example contents plus a generated provider-pin file (`terraform { required_providers { ... } }`) and an injected `provider "elasticstack" { ... }` configuration into a per-test tempdir, then invoke `terraform init` and `terraform validate` via `terraform-exec`
+- [ ] 1.3 In each subtest, write the example contents plus a generated provider-pin file (`terraform { required_providers { ... } }`) into a per-test tempdir, then invoke `terraform init` and `terraform validate` via `terraform-exec`
 - [ ] 1.4 Configure the harness to discover the locally built provider via `dev_overrides` (or filesystem mirror if `dev_overrides` proves noisy)
 - [ ] 1.5 Skip `examples/cloud/` and `examples/provider/` via a static path skip-list documented in the harness
 - [ ] 1.6 Surface `terraform validate` diagnostics in the test failure message so the offending file, line, and message are visible without re-running locally
@@ -10,11 +10,8 @@
 
 ## 2. Example cleanup
 
-- [ ] 2.1 Remove top-level `provider "elasticstack" { ... }` blocks from every file under `examples/resources/` and `examples/data-sources/`
-- [ ] 2.2 Remove every per-resource `elasticsearch_connection { ... }` block from example resources, regardless of whether the block contains hardcoded `localhost:9200` / `changeme` credentials, environment-variable references, or no attributes at all
-- [ ] 2.2.1 Add an explicit content check in the harness that fails any subtest whose example file contains an `elasticsearch_connection` block, since `terraform validate` will not catch valid-but-forbidden blocks on its own
-- [ ] 2.3 Restructure `examples/resources/elasticstack_kibana_alerting_rule/` so `resource.tf`, `resource-index-rule.tf`, and `resource_rule_action_frequency.tf` each define their own connector and data-stream prerequisites and validate independently
-- [ ] 2.4 Audit other multi-file example directories (e.g. `elasticstack_fleet_output/`, `elasticstack_fleet_integration/`, `elasticstack_kibana_security_role/`) and inline cross-file dependencies if any exist
+- [ ] 2.1 Restructure `examples/resources/elasticstack_kibana_alerting_rule/` so `resource.tf`, `resource-index-rule.tf`, and `resource_rule_action_frequency.tf` each define their own connector and data-stream prerequisites and validate independently
+- [ ] 2.2 Audit other multi-file example directories (e.g. `elasticstack_fleet_output/`, `elasticstack_fleet_integration/`, `elasticstack_kibana_security_role/`) and inline cross-file dependencies if any exist
 
 ## 3. Fix example bugs surfaced by the harness
 
@@ -28,7 +25,7 @@
 - [ ] 4.1 Regenerate provider docs (`make docs-generate` or repo equivalent) so `docs/resources/*.md` and `docs/data-sources/*.md` reflect the cleaned example files
 - [ ] 4.2 Confirm the new test is picked up by the standard `go test ./...` invocation used in CI, with no extra environment variables required
 - [ ] 4.3 Measure local execution time for the harness and document it in the change's design notes if it exceeds a few minutes; tune parallelism if needed
-- [ ] 4.4 Add a brief contributor note (in `dev-docs/high-level/development-workflow.md` or equivalent) explaining that every example `.tf` file must be self-contained and must validate against the provider schema
+- [ ] 4.4 Add a brief contributor note (in `dev-docs/high-level/development-workflow.md` or equivalent) explaining that every example `.tf` file must validate against the provider schema and be self-contained (no cross-file references within the same example directory)
 
 ## 5. Verification
 

--- a/openspec/changes/examples-config-validation/tasks.md
+++ b/openspec/changes/examples-config-validation/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Add `examples/examples.go` exporting `embed.FS` instances for `examples/resources` and `examples/data-sources`
 - [ ] 1.2 Add a Go test (e.g. `internal/acctest/examples_validate_test.go`) that walks both embedded filesystems and runs each `.tf` file as a subtest named after its repo-relative path
-- [ ] 1.3 In each subtest, write the example contents plus a generated provider-pin file (`terraform { required_providers { ... } }`) into a per-test tempdir, then invoke `terraform init` and `terraform validate` via `terraform-exec`
+- [ ] 1.3 In each subtest, write the example contents plus a generated provider-pin file (`terraform { required_providers { ... } }`) and an injected `provider "elasticstack" { ... }` configuration into a per-test tempdir, then invoke `terraform init` and `terraform validate` via `terraform-exec`
 - [ ] 1.4 Configure the harness to discover the locally built provider via `dev_overrides` (or filesystem mirror if `dev_overrides` proves noisy)
 - [ ] 1.5 Skip `examples/cloud/` and `examples/provider/` via a static path skip-list documented in the harness
 - [ ] 1.6 Surface `terraform validate` diagnostics in the test failure message so the offending file, line, and message are visible without re-running locally
@@ -11,7 +11,8 @@
 ## 2. Example cleanup
 
 - [ ] 2.1 Remove top-level `provider "elasticstack" { ... }` blocks from every file under `examples/resources/` and `examples/data-sources/`
-- [ ] 2.2 Remove per-resource `elasticsearch_connection { ... }` blocks from example resources, including hardcoded `localhost:9200` / `changeme` credentials
+- [ ] 2.2 Remove every per-resource `elasticsearch_connection { ... }` block from example resources, regardless of whether the block contains hardcoded `localhost:9200` / `changeme` credentials, environment-variable references, or no attributes at all
+- [ ] 2.2.1 Add an explicit content check in the harness that fails any subtest whose example file contains an `elasticsearch_connection` block, since `terraform validate` will not catch valid-but-forbidden blocks on its own
 - [ ] 2.3 Restructure `examples/resources/elasticstack_kibana_alerting_rule/` so `resource.tf`, `resource-index-rule.tf`, and `resource_rule_action_frequency.tf` each define their own connector and data-stream prerequisites and validate independently
 - [ ] 2.4 Audit other multi-file example directories (e.g. `elasticstack_fleet_output/`, `elasticstack_fleet_integration/`, `elasticstack_kibana_security_role/`) and inline cross-file dependencies if any exist
 

--- a/openspec/changes/examples-config-validation/tasks.md
+++ b/openspec/changes/examples-config-validation/tasks.md
@@ -1,0 +1,37 @@
+## 1. Validation harness
+
+- [ ] 1.1 Add `examples/examples.go` exporting `embed.FS` instances for `examples/resources` and `examples/data-sources`
+- [ ] 1.2 Add a Go test (e.g. `internal/acctest/examples_validate_test.go`) that walks both embedded filesystems and runs each `.tf` file as a subtest named after its repo-relative path
+- [ ] 1.3 In each subtest, write the example contents plus a generated provider-pin file (`terraform { required_providers { ... } }`) into a per-test tempdir, then invoke `terraform init` and `terraform validate` via `terraform-exec`
+- [ ] 1.4 Configure the harness to discover the locally built provider via `dev_overrides` (or filesystem mirror if `dev_overrides` proves noisy)
+- [ ] 1.5 Skip `examples/cloud/` and `examples/provider/` via a static path skip-list documented in the harness
+- [ ] 1.6 Surface `terraform validate` diagnostics in the test failure message so the offending file, line, and message are visible without re-running locally
+- [ ] 1.7 Mark subtests as `t.Parallel()` and share a `TF_PLUGIN_CACHE_DIR` across subtests to keep wall-clock reasonable
+
+## 2. Example cleanup
+
+- [ ] 2.1 Remove top-level `provider "elasticstack" { ... }` blocks from every file under `examples/resources/` and `examples/data-sources/`
+- [ ] 2.2 Remove per-resource `elasticsearch_connection { ... }` blocks from example resources, including hardcoded `localhost:9200` / `changeme` credentials
+- [ ] 2.3 Restructure `examples/resources/elasticstack_kibana_alerting_rule/` so `resource.tf`, `resource-index-rule.tf`, and `resource_rule_action_frequency.tf` each define their own connector and data-stream prerequisites and validate independently
+- [ ] 2.4 Audit other multi-file example directories (e.g. `elasticstack_fleet_output/`, `elasticstack_fleet_integration/`, `elasticstack_kibana_security_role/`) and inline cross-file dependencies if any exist
+
+## 3. Fix example bugs surfaced by the harness
+
+- [ ] 3.1 Fix `examples/resources/elasticstack_elasticsearch_ml_datafeed/resource.tf` so `delayed_data_check_config` is configured as an attribute (not a block), per issue #2523
+- [ ] 3.2 Run the new harness locally and enumerate every failing example file
+- [ ] 3.3 Fix each surfaced failure (block-vs-attribute mistakes, renamed attributes, missing required fields, etc.) and verify the harness passes for every example
+- [ ] 3.4 If any failure represents a genuine schema regression rather than a stale example, file a follow-up issue and resolve in scope or in a follow-on change before merging
+
+## 4. Documentation and CI integration
+
+- [ ] 4.1 Regenerate provider docs (`make docs-generate` or repo equivalent) so `docs/resources/*.md` and `docs/data-sources/*.md` reflect the cleaned example files
+- [ ] 4.2 Confirm the new test is picked up by the standard `go test ./...` invocation used in CI, with no extra environment variables required
+- [ ] 4.3 Measure local execution time for the harness and document it in the change's design notes if it exceeds a few minutes; tune parallelism if needed
+- [ ] 4.4 Add a brief contributor note (in `dev-docs/high-level/development-workflow.md` or equivalent) explaining that every example `.tf` file must be self-contained and must validate against the provider schema
+
+## 5. Verification
+
+- [ ] 5.1 Run `make build` to ensure the harness compiles
+- [ ] 5.2 Run `go test ./internal/acctest/...` (or whichever package hosts the harness) and confirm every example subtest passes
+- [ ] 5.3 Run `make check-openspec` (or `make check-lint`) to confirm the OpenSpec artifacts are valid
+- [ ] 5.4 Re-verify that issue #2523's reproduction (`delayed_data_check_config { ... }` as a block) is no longer present in `examples/resources/elasticstack_elasticsearch_ml_datafeed/`


### PR DESCRIPTION
Related to https://github.com/elastic/terraform-provider-elasticstack/issues/2523

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add proposal and design documents for validating example Terraform configurations
> - Adds a [proposal](https://github.com/elastic/terraform-provider-elasticstack/pull/2526/files#diff-1c61d03021ae6cdfcb9dc3f267826b48cc0208a3bf256e71c47f360614605968) and [design doc](https://github.com/elastic/terraform-provider-elasticstack/pull/2526/files#diff-4b7403c527305a7c93993d6b155a79d76c08113574b071029f71ddc4c7807538) for a test harness that validates example Terraform files using `terraform init` and `terraform validate`.
> - Adds a [spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2526/files#diff-cfa15037253e4caf6faa5f3615be05e77a9e90c3e1598cde7eb78ef7045f4c92) defining requirements: per-file validation, subtest attribution, self-contained examples, a static skip-list, and no live stack requirement.
> - Adds a [task list](https://github.com/elastic/terraform-provider-elasticstack/pull/2526/files#diff-c3b35aaabc2149a7f3f6cd87791d70204f2baabc19c5c1c08b85b5cc39f40d8b) covering harness implementation, example cleanup, issue fixes, and CI integration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d1c66c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->