### PR TITLE
Speed up acceptance tests

### DIFF
--- a/openspec/changes/speed-up-dashboard-acceptance-tests/.openspec.yaml
+++ b/openspec/changes/speed-up-dashboard-acceptance-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/speed-up-dashboard-acceptance-tests/design.md
+++ b/openspec/changes/speed-up-dashboard-acceptance-tests/design.md
@@ -1,0 +1,114 @@
+## Context
+
+The matrix acceptance test workflow runs ~21 entries in parallel; the longest entry (`9.4.0-SNAPSHOT`) gates merge time. Within that entry, `make testacc` invokes:
+
+```
+TF_ACC=1 go tool gotestsum --format testname \
+  --rerun-fails=$(RERUN_FAILS) --rerun-fails-max-failures=$(RERUN_FAILS_MAX_FAILURES) \
+  --packages="./..." -- -v -count $(ACCTEST_COUNT) -parallel $(ACCTEST_PARALLELISM) \
+  $(TESTARGS) -timeout $(ACCTEST_TIMEOUT)
+```
+
+Two go-test scheduling knobs apply:
+
+- `-parallel N` (currently `10` via `ACCTEST_PARALLELISM`): cap for `t.Parallel()` tests **inside one package**.
+- `-p N` (currently unset → `GOMAXPROCS` → `4` on the standard 4‑vCPU public-runner): how many test **binaries** run concurrently.
+
+`go test ./...` schedules packages roughly in source order, so on the snapshot matrix entry `internal/kibana/dashboard` (the package that carries 89.5 minutes of serial test CPU and the 561 s longest test) sat in the queue for ~10 minutes while four earlier-alphabetical packages occupied the four `-p` slots. The dashboard package only began at 05:35 of a test phase that started at 05:25 and ended at 05:48.
+
+Inside the dashboard package, every `TestAcc*` function uses `resource.ParallelTest` (which calls `t.Parallel()`), so all 55 dashboard acceptance tests are eligible to run concurrently up to `-parallel 10`. The 89.5 min ÷ 10 floor is `~537 s`; the actual wall is `~690 s`. The remaining gap is the single longest test (`TestAccResourceDashboardXYChart`, 561 s, 10 sequential steps) — Amdahl's law made visible.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Cut snapshot-matrix wall-clock by addressing both head-of-line scheduling (`-p`) and the longest single test (split monoliths).
+- Eliminate test bodies that re-create dashboards a sibling test has already created+destroyed.
+- Keep total test coverage equivalent: every `ConfigDirectory` exercised today must still be exercised after the change.
+- Make the package-parallelism choice explicit in the Makefile so it is reproducible across runner configurations.
+
+**Non-Goals:**
+- Changing the `kibana-dashboard` resource implementation or its spec.
+- Reducing Elastic Stack matrix coverage or skipping versions.
+- Caching docker images / pre-warming Kibana / changing the stack startup phase.
+- Restructuring tests in any package other than `internal/kibana/dashboard`.
+- Tuning `-parallel` (in-package) above 10 — kept as a follow-up once the new test shape lands.
+
+## Decisions
+
+### 1. Use `-p 8` rather than `-p 4` (default), `-p 12`, or "as high as possible"
+
+Three options were considered:
+
+- `-p 4` (status quo): preserves the head-of-line stall; we already know its wall-clock cost.
+- `-p 8`: enough to ensure `internal/kibana/dashboard` is in the first parallel batch alongside the other long packages (`security_detection_rule` 990 s serial, `ingest` 732 s, `index/template` 467 s, `agentpolicy` 293 s). Peak in-flight tests rise from 40 → 80, sharing one Kibana + ES instance on 4 vCPUs.
+- `-p 12` or higher: head-of-line is solved at `-p 8`; adding more slots beyond the long-package count only increases Kibana contention without scheduling benefit.
+
+We choose `-p 8` because it is the smallest value that resolves the observed scheduling problem.
+
+The value is exposed as a new Make variable `ACCTEST_PACKAGE_PARALLELISM ?= 8`, parallel to `ACCTEST_PARALLELISM` (which controls in-package `-parallel`). Contributors and CI may override it without editing the recipe.
+
+### 2. Do not change `GOMAXPROCS`
+
+`GOMAXPROCS` defaults to `runtime.NumCPU()`, which already matches the runner. Setting it explicitly would risk drift if Actions later changes the runner spec, and a lower value would starve the Go scheduler. The relevant decision is `-p`, not `GOMAXPROCS`. The proposal records this so future contributors don't conflate the two.
+
+### 3. Splitting strategy: one function per `ConfigDirectory`, not per `Check`
+
+The longest monolithic tests sequence multiple full create/replace cycles against the same resource address with **independent** config directories (e.g. `axis`, `decorations`, `filters`, …). Each cycle pays a full Kibana create + delete and is logically a different scenario. Splitting at the `ConfigDirectory` boundary keeps each new test small and parallelisable, and preserves a 1:1 mapping with the existing `testdata/` fixtures so reviewers can audit coverage by looking at directory listings.
+
+We deliberately do **not** split at the `Check` level — that would force testdata duplication or shared fixtures and add review burden without wall-clock benefit.
+
+ImportState steps for split tests stay paired with their producing test: each split function ends with its own ImportState step against the same `ConfigDirectory` so import is exercised against the exact shape that test produces. This matches the current pattern in `TestAccResourceDashboardXYChart`'s final step (which imports against `layers_reference`).
+
+### 4. Initial scope: only the heaviest monoliths
+
+Splitting every multi-step `ParallelTest` is unnecessary; the wall-clock floor is set by the single longest test, so we only need to bring the longest down to the level of the next-longest until diminishing returns kick in. The plan is iterative:
+
+- Round 1 (this change): `XYChart` (561 s), `Panels` (242 s), `ESQLControl` (232 s) — three obvious wins, each with cleanly independent steps.
+- Round 2 (this change, if scope allows): `LensDashboardAppByValue*` (~190 s each), `SloBurnRateDisplayOptions` (151 s), and any redundancy uncovered during the lens audit (§5).
+- Future: tests below ~120 s — addressed when a new bottleneck emerges.
+
+The acceptance criterion is "max single dashboard test ≤ 120 s on the snapshot matrix entry", not "no test has more than one step".
+
+### 5. Duplicate-test deletions
+
+Two known duplicates:
+
+- `TestAccResourceDashboardSloBurnRateSloInstanceIDNullPreservation` (127 s) re-applies `required_only` then `PlanOnly: true`. Its assertion is `slo_instance_id` stays null after read-back. **Action:** delete the function, add a third step (`PlanOnly: true`, same `ConfigDirectory`) plus a `TestCheckNoResourceAttr` to `TestAccResourceDashboardSloBurnRate`'s existing Steps slice.
+- `TestAccResourceDashboardSloErrorBudgetSloInstanceIDNullPreservation` (143 s): same pattern, same fix against `TestAccResourceDashboardSloErrorBudget*`.
+
+The `acc_lens_dashboard_app_panels_test.go` audit (22 `ConfigDirectory` references across multiple functions) will surface any further duplicates of this shape; the action for each will be the same: append-as-step, delete the standalone function.
+
+### 6. Audit method for `acc_lens_dashboard_app_panels_test.go`
+
+Mechanical, not exploratory:
+
+1. Tabulate every `(test_function, config_directory, step_intent)` triple in the file.
+2. Group by `config_directory`. Any directory referenced by more than one test function is a candidate.
+3. Within each candidate group, classify each occurrence as one of:
+   - First creator (`Steps[0]` apply)
+   - ImportState (uses `ResourceName` + `ImportState: true`)
+   - PlanOnly assertion / null-preservation (uses `PlanOnly: true`)
+   - Update-from-prior (relies on a prior step's state)
+4. Fold (2)+(3) into the corresponding (1) test as additional Steps; delete the now-empty wrappers. Update steps that depend on prior state cannot be folded across function boundaries and stay where they are.
+
+This audit MAY surface zero foldable duplicates — that is an acceptable outcome and is not a failure of the change. The goal is correctness, not a quota.
+
+## Risks / Trade-offs
+
+- **Kibana saturation at `-p 8`** — Mitigation: keep `-parallel 10` (no increase in per-package concurrency); rely on the existing `--rerun-fails=5 --rerun-fails-max-failures=20` budget to absorb transient failures during rollout; revert to `-p 4` is a one-line change.
+- **More test functions to maintain** — Mitigation: splits sit next to their parents in the same `acc_*_panels_test.go` file; helper-extracting common preamble (`PreCheck`, `SkipFunc`, `ProtoV6ProviderFactories`, `ConfigVariables`) is a follow-up if duplication becomes painful, but is out of scope for this change to keep diffs reviewable.
+- **`testdata/` directory churn** — None expected. Existing directories continue to be referenced from the new function names.
+- **Merging the duplicate-deletion and split-monolith work in one change** — Reviewers will see a large diff in `acc_xy_panels_test.go`, `acc_panels_test.go`, `acc_esql_control_panels_test.go`, `acc_slo_burn_rate_panels_test.go`, `acc_slo_error_budget_panels_test.go`, and `acc_lens_dashboard_app_panels_test.go`. We accept that because the wins compound (one CI run validates both buckets).
+
+## Migration Plan
+
+1. Land the Makefile change (`ACCTEST_PACKAGE_PARALLELISM`, default `8`) and the `makefile-workflows` spec update first; this can be exercised on its own and produces an immediate ~10‑minute saving on the snapshot matrix entry.
+2. Split `TestAccResourceDashboardXYChart` and the next two heaviest tests in a single follow-up commit; verify locally with `make testacc-vs-docker TESTARGS='-run ^TestAccResourceDashboardXY...'`.
+3. Apply the duplicate-deletion fixes for `*SloInstanceIDNullPreservation`.
+4. Run the lens audit and apply its findings.
+5. Validate on a real PR run; capture the new snapshot matrix entry wall-clock for the change description.
+
+## Open Questions
+
+- **Is `-p 8` enough or should we go to `-p 6`?** The 6‑slot configuration would cover the four long packages (`dashboard`, `security_detection_rule`, `ingest`, `index/template`) plus two more, with peak in-flight = 60. Worth measuring after the split lands; out of scope for this change.
+- **Should `-parallel` rise from 10 once the longest dashboard test is below ~120 s?** Possibly to `16`; deferred to a follow-up because tuning that knob is independent of this change's correctness story.

--- a/openspec/changes/speed-up-dashboard-acceptance-tests/proposal.md
+++ b/openspec/changes/speed-up-dashboard-acceptance-tests/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The matrix acceptance job for the snapshot stack version (currently the matrix critical path) takes ~27 minutes, of which ~22 minutes is the test phase. Profiling the [`Matrix Acceptance Test (9.4.0-SNAPSHOT)` job in run 25035397726](https://github.com/elastic/terraform-provider-elasticstack/actions/runs/25035397726/job/73325928002) shows two compounding root causes that both live in our control:
+
+1. **The `internal/kibana/dashboard` package waits ~10 minutes before its first test runs.** `make testacc` invokes `go test` without an explicit `-p`, so the test scheduler defaults to `GOMAXPROCS` (4 on the standard 4‑vCPU runner) and `kibana/dashboard` queues behind earlier alphabetical packages. Once it does start, it runs for ~11.5 minutes and gates wall-clock for the whole job.
+2. **Inside the dashboard package, a few monolithic `ParallelTest` functions dominate the floor.** `TestAccResourceDashboardXYChart` alone is 561 s with 10 sequential steps, each fully replacing the dashboard with an independent config (basic, axis, decorations, filters, fitting, two legend variants, two layer variants, ImportState). Several other tests follow the same shape (`TestAccResourceDashboardPanels` 242 s, `TestAccResourceDashboardESQLControl` 232 s, `LensDashboardAppByValue*` ~190 s, `SloBurnRateDisplayOptions` 151 s).
+
+There are also two pure duplicate-work test functions whose body could be a single extra step in an existing test: `TestAccResourceDashboardSloBurnRateSloInstanceIDNullPreservation` (127 s) and `TestAccResourceDashboardSloErrorBudgetSloInstanceIDNullPreservation` (143 s) re-create the same `required_only` dashboard that their corresponding base tests have already created and torn down.
+
+`acc_lens_dashboard_app_panels_test.go` carries 22 `ConfigDirectory` references across multiple test functions and is the most likely place for the same redundancy patterns to recur.
+
+## What Changes
+
+- Set an explicit package parallelism (`-p 8`) for the `testacc` Make target so the dashboard package starts in the first parallel batch on 4‑vCPU GitHub-hosted runners instead of queueing behind alphabetical predecessors. Document the value via a `?=`-style Makefile variable so contributors can override it locally without editing the recipe.
+- Split the longest monolithic `resource.ParallelTest` functions in `internal/kibana/dashboard/` into per-facet `TestAcc*` functions so each test exercises a single configuration shape rather than 4–10 sequential, independent shapes. Initial scope:
+  - `TestAccResourceDashboardXYChart` → 1 function per facet (basic, axis, decorations, filters, fitting, legend_outside, legend_inside, layers, layers_reference, ImportState).
+  - `TestAccResourceDashboardPanels` → 1 function per facet (basic, multiple_panels, with_sections, multi_sections_*, panels_and_sections).
+  - `TestAccResourceDashboardESQLControl` → 1 function per facet equivalent to its sequential steps.
+- Delete the duplicated `*SloInstanceIDNullPreservation` test functions and instead append a `PlanOnly: true` re-apply step to their corresponding base tests.
+- Audit `acc_lens_dashboard_app_panels_test.go` and apply the same two patterns (split monoliths, fold duplicates) wherever they appear.
+- Update the `makefile-workflows` capability spec to require that the `testacc` target sets package parallelism explicitly rather than relying on `GOMAXPROCS`.
+
+This change is purely test- and tooling-side; the `kibana-dashboard` resource implementation and its spec are not touched. Test coverage is preserved — every `ConfigDirectory` exercised today will still be exercised after the split.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `makefile-workflows`: the `testacc` target gains an explicit, contributor-overridable package parallelism input distinct from the existing `ACCTEST_PARALLELISM` (which controls `-parallel`, the in-package `t.Parallel()` cap).
+
+## Impact
+
+- `Makefile`: new `ACCTEST_PACKAGE_PARALLELISM` variable (defaulting to `8`), threaded into `go tool gotestsum -- ... -p $(ACCTEST_PACKAGE_PARALLELISM)`.
+- `internal/kibana/dashboard/`: net more test functions, fewer steps per function. No new `testdata/` config directories are added; existing ones are re-targeted from sequential steps to parallel functions.
+- CI wall-clock for the snapshot matrix entry: expected reduction of ~10 minutes from the `-p` change alone, with a further ~5–8 minutes once the longest dashboard tests are split. Other matrix entries skip dashboard tests via `minDashboardAPISupport` and are not affected.
+- Risk: peak in-flight tests rise from `4 × 10 = 40` to `8 × 10 = 80`, increasing load on the colocated single Kibana + Elasticsearch instance. Mitigated by leaving `-parallel` at 10 and watching the existing `--rerun-fails` budget. No spec contract change for any resource.

--- a/openspec/changes/speed-up-dashboard-acceptance-tests/specs/makefile-workflows/spec.md
+++ b/openspec/changes/speed-up-dashboard-acceptance-tests/specs/makefile-workflows/spec.md
@@ -1,0 +1,26 @@
+# `makefile-workflows` — Makefile Requirements (delta)
+
+Implementation: [`Makefile`](../../../../../Makefile)
+
+## MODIFIED Requirements
+
+### Requirement: Acceptance tests (REQ-023–REQ-024)
+
+The `testacc` target SHALL enable Terraform acceptance testing for the module tree, using gotestsum with rerun-of-fails behavior, a configurable rerun max-failures cap, and tunable in-package and cross-package parallelism, timeout, and count via the acceptance-test variables. It SHALL invoke the repository-wide package scope `./...` and pass verbose Go test output through to the underlying test run. The `testacc-vs-docker` target SHALL run acceptance tests against a local Docker stack on default localhost ports with the configured Elasticsearch credentials.
+
+The `testacc` recipe SHALL set `go test`'s package-level parallelism (the `-p` flag) explicitly via a Makefile-defined variable rather than relying on the Go default of `GOMAXPROCS`. The variable SHALL be overridable by contributors and CI through the standard `make VAR=value` mechanism, and the in-package `t.Parallel()` cap (the `-parallel` flag) SHALL remain a separate, independently-overridable variable.
+
+#### Scenario: Acceptance tests with defaults
+
+- GIVEN `make testacc`
+- WHEN the recipe runs
+- THEN `TF_ACC` SHALL be set for acceptance mode and tests SHALL run across `./...` with the Makefile’s timeout and parallelism defaults unless overridden
+- AND gotestsum reruns SHALL honor both the configured rerun count and the configured max-failures cap
+- AND the underlying `go test` invocation SHALL include both an explicit `-p` value (cross-package parallelism) and an explicit `-parallel` value (in-package `t.Parallel()` cap), each taken from a distinct Makefile variable
+
+#### Scenario: Contributor overrides package parallelism
+
+- GIVEN `make testacc` invoked with the package-parallelism Make variable overridden on the command line
+- WHEN the recipe runs
+- THEN the underlying `go test` invocation SHALL use the overridden value for `-p` without requiring any change to the recipe itself
+- AND the in-package `-parallel` value SHALL remain unchanged unless a separate, dedicated variable is also overridden

--- a/openspec/changes/speed-up-dashboard-acceptance-tests/tasks.md
+++ b/openspec/changes/speed-up-dashboard-acceptance-tests/tasks.md
@@ -1,0 +1,31 @@
+## 1. Make `testacc` package-parallelism explicit
+
+- [ ] 1.1 Add `ACCTEST_PACKAGE_PARALLELISM ?= 8` near the existing `ACCTEST_PARALLELISM` block in `Makefile`.
+- [ ] 1.2 Thread the variable into the `testacc` recipe as `-p $(ACCTEST_PACKAGE_PARALLELISM)`, placed alongside `-parallel $(ACCTEST_PARALLELISM)`.
+- [ ] 1.3 Update the `makefile-workflows` capability spec to require explicit, contributor-overridable package parallelism for `testacc`, with a `MODIFIED` requirement and accompanying scenarios.
+- [ ] 1.4 Verify locally that `make testacc TESTARGS='-run ^TestAccResourceDashboardEmptyDashboard$$' ACCTEST_PACKAGE_PARALLELISM=2` honors the override (smoke test only; no behavioral assertion needed beyond observing the flag in the printed command).
+
+## 2. Split the longest monolithic dashboard tests
+
+- [ ] 2.1 Replace `TestAccResourceDashboardXYChart` with one `TestAccResourceDashboardXYChart_<facet>` function per existing `ConfigDirectory` (`basic`, `axis`, `decorations`, `filters`, `fitting`, `legend_outside`, `legend_inside`, `layers`, `layers_reference`), each carrying its own `Check` block from the original Steps slice. Pair `layers_reference` with the existing ImportState step inside its own function. Keep `TestAccResourceDashboardXYChartMinimalConfig` as-is.
+- [ ] 2.2 Replace `TestAccResourceDashboardPanels` with one `TestAccResourceDashboardPanels_<facet>` function per existing `ConfigDirectory` (`basic`, `multiple_panels`, `with_sections`, `multi_sections_single_panel_each`, `multi_sections_multi_panels_each`, `panels_and_sections`).
+- [ ] 2.3 Apply the same split to `TestAccResourceDashboardESQLControl` (the 232 s test in `acc_esql_control_panels_test.go`).
+- [ ] 2.4 If wall-clock measurements after 2.1–2.3 still show a single dashboard test ≥ 120 s, apply the same split to `TestAccResourceDashboardLensDashboardAppByValue`, `TestAccResourceDashboardLensDashboardAppByValueTypedMetric`, and `TestAccResourceDashboardSloBurnRateDisplayOptions`; otherwise mark this task done and stop.
+
+## 3. Delete duplicate dashboard tests
+
+- [ ] 3.1 Append a `PlanOnly: true` re-apply step (with a `TestCheckNoResourceAttr` for `panels.0.slo_burn_rate_config.slo_instance_id`) to `TestAccResourceDashboardSloBurnRate`'s Steps slice; delete `TestAccResourceDashboardSloBurnRateSloInstanceIDNullPreservation` from `acc_slo_burn_rate_panels_test.go`.
+- [ ] 3.2 Append the equivalent `PlanOnly: true` re-apply step to `TestAccResourceDashboardSloErrorBudget` (the base test in `acc_slo_error_budget_panels_test.go`); delete `TestAccResourceDashboardSloErrorBudgetSloInstanceIDNullPreservation`.
+
+## 4. Audit `acc_lens_dashboard_app_panels_test.go`
+
+- [ ] 4.1 Tabulate every `(test_function, ConfigDirectory, step_intent)` triple in `acc_lens_dashboard_app_panels_test.go`. Record the table in the PR description.
+- [ ] 4.2 For each `ConfigDirectory` referenced by more than one function, classify each occurrence as one of: first creator, ImportState, PlanOnly assertion, or update-from-prior. Note any cases where two functions create-then-destroy the same `ConfigDirectory`.
+- [ ] 4.3 Fold ImportState-only and PlanOnly-only duplicate functions into their first creator as additional Steps; delete the now-empty wrappers. Leave update-from-prior cases untouched.
+- [ ] 4.4 If the audit also surfaces a monolithic ParallelTest in this file with ≥ 4 independent `ConfigDirectory` steps and a wall-clock ≥ 120 s in the most recent CI run, apply the §2 split to it. Otherwise note the file is already acceptably structured.
+
+## 5. Verify and document
+
+- [ ] 5.1 Run `make testacc TESTARGS='-run ^TestAccResourceDashboard'` against a local 9.4 stack (`testacc-vs-docker`) and confirm the suite passes with the new shape.
+- [ ] 5.2 Run `openspec validate --specs` and `openspec validate --change speed-up-dashboard-acceptance-tests` (when available) to confirm the spec delta is well-formed.
+- [ ] 5.3 Open the PR with the latest snapshot matrix wall-clock recorded in the description (before/after, captured from the failing-CI run linked in `proposal.md` and the new CI run on this branch). Confirm peak `--rerun-fails` usage did not increase materially.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add parallelism controls and test splits to speed up dashboard acceptance tests
- Introduces `ACCTEST_PACKAGE_PARALLELISM` variable wired to `go test -p` (defaulting to 8) in the `testacc` Makefile target, enabling cross-package parallel execution.
- Splits the heaviest dashboard acceptance tests into per-facet functions and removes duplicate tests by folding them into base tests.
- Adds an audit of lens dashboard panel tests and documents contributor override behavior for the `-p` flag.
- Behavioral Change: `testacc` now runs up to 8 packages concurrently by default instead of sequentially; contributors can override via `ACCTEST_PACKAGE_PARALLELISM`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c754c93.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->