### PR TITLE
docs: add envelope-datasource-generics change proposal

### DIFF
--- a/openspec/changes/envelope-datasource-generics/.openspec.yaml
+++ b/openspec/changes/envelope-datasource-generics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/envelope-datasource-generics/design.md
+++ b/openspec/changes/envelope-datasource-generics/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The provider's `DataSourceBase` (in `internal/entitycore`) currently provides `Configure` and `Metadata` wiring, but every data source still rewrites its entire `Read()` method. Agent Builder data sources (`agentbuilderagent`, `agentbuildertool`, `agentbuilderworkflow`) repeat a full pipeline: config decode, scoped Kibana client resolution, version enforcement, composite ID resolution, space ID fallback, API fetch, and state set. This is the duplication identified in #2511.
+
+Existing struct-based data sources (`spaces`, `enrollment_tokens`, `index_template`) all follow the same shape but vary in client type (Kibana vs Elasticsearch). The provider already has typed scoped clients (`KibanaScopedClient`, `ElasticsearchScopedClient`) and factory methods (`GetKibanaClient`, `GetElasticsearchClient`). The gap is at the orchestration layer.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate Read() orchestration boilerplate for simple Kibana and Elasticsearch data sources.
+- Allow concrete packages to provide only schema + entity logic (no connection field, no Read method).
+- Keep the change fully opt-in; existing struct-based data sources continue to work.
+- Migrate the three Agent Builder data sources from #2511 as reference implementations.
+
+**Non-Goals:**
+- Changing resource patterns (Create/Read/Update/Delete). Resources remain struct-based.
+- Migrating SDK-based data sources.
+- Changing any Terraform schema or observable behavior.
+- Complex data sources with conditional early returns or custom state manipulation (e.g., `agentbuilder_agent` with its tool-dependency graph) are not forced into the envelope; they stay struct-based or use local helpers.
+
+## Decisions
+
+### 1. Envelope struct with anonymous field embed
+
+**Decision:** `kibanaEnvelope[T any]` wraps the concrete model via anonymous field `T`, plus the connection block field `KibanaConnection types.List`.
+
+**Rationale:** Go's `tfsdk` struct tag support now handles embedded structs (terraform-plugin-framework PR #667, #1021). This means `Config.Get(ctx, &envelope)` reads both the connection block and the promoted concrete fields into one struct. The concrete model remains clean—no connection field, no interface method.
+
+**Alternative considered:** Interface constraint `M interface { GetKibanaConnection() types.List }` on the generic parameter. Rejected because it requires every concrete model to add a method or embed a helper struct with a method. The anonymous field approach requires no changes to the concrete model at all.
+
+**Alternative considered:** Named field `Body T` instead of anonymous embed. Rejected because it breaks Terraform's struct-to-schema matching unless the schema namespacing changes, which would be a breaking schema change.
+
+### 2. Schema injection at construction time
+
+**Decision:** The generic constructor accepts a schema factory `func() datasource.Schema`, calls it internally to obtain a fresh schema value, defensively clones the `Blocks` map, and injects `kibana_connection` (or `elasticsearch_connection`) before returning.
+
+**Rationale:** The concrete package defines its schema without connection blocks and passes a factory function. The base obtains an isolated schema copy, clones the `Blocks` map to avoid mutating the caller's shared state, and adds the connection block. A function parameter eliminates the shared-mutation footgun because the constructor controls when the schema is built and owns the resulting instance. Defensive cloning of the `Blocks` map inside the constructor provides defense-in-depth regardless of what the schema function does.
+
+**Alternative considered:** Pass `datasource.Schema` as a value parameter. Rejected because `Schema.Blocks` is a `map[string]datasource.Block` (reference type). Mutating the map in the constructor would surprise callers who reuse the same schema value across multiple data sources or hold it in package-level variables.
+
+**Alternative considered:** Require the concrete package to include the connection block in its schema manually. Rejected because it defeats the purpose—the concrete package should not need to think about connections at all.
+
+### 3. Two constructors: Kibana and Elasticsearch
+
+**Decision:** Provide `NewKibanaDataSource[T]()` and `NewElasticsearchDataSource[T]()` as separate top-level functions.
+
+**Rationale:** The connection block type, scoped client type, and factory method differ. A single generic constructor would need an extra type parameter for the client type and a way to dispatch the factory call, which adds complexity without reducing code. Two constructors are explicit and zero-cost.
+
+**Alternative considered:** Single `NewDataSource[T, C any](...)` with a constraint that maps `C` to the right factory. Rejected as over-abstracted for two cases.
+
+### 4. Pure read function signature
+
+**Decision:** `readFunc func(context.Context, *clients.KibanaScopedClient, T) (T, diag.Diagnostics)`
+
+**Rationale:** The function receives the scoped client and the decoded model, performs entity work, and returns the populated model. Diagnostics accumulate naturally. State setting is owned by the base.
+
+**Alternative considered:** Callback with access to `*datasource.ReadResponse` for direct diagnostic append. Rejected because it leaks the Terraform contract into the entity logic, re-creating the coupling we're trying to eliminate.
+
+### 5. No version enforcement in the generic base
+
+**Decision:** `EnforceMinVersion` calls stay in the concrete read function, not the generic base.
+
+**Rationale:** Not all Kibana data sources need version gating. Adding it to the base would require a way to opt out or pass a version parameter, which complicates the simple cases. The Agent Builder datasources can share a domain-local version helper.
+
+## Risks / Trade-offs
+
+- **[Risk]** `tfsdk` embedded struct support may not work identically for `Config.Get()` vs `State.Set()` in all framework versions. → **Mitigation:** Validate with a spike before full migration. If embedding fails, fall back to typed `KibanaDataSource` embeddable (no generics) plus local helpers.
+- **[Risk]** Schema injection could mutate shared map state if the concrete package holds a reference to the `Blocks` map. → **Mitigation:** The constructor accepts a factory function (callers pass `getDataSourceSchema`, not a `schema.Schema` value) and defensively clones the `Blocks` map before injecting the connection block. The resulting schema instance is fully owned by the generic base.
+- **[Risk]** Data sources with unusual `Read` patterns (no state set, conditional early return, manual state removal) can't use the envelope. → **Mitigation:** The envelope is opt-in. Complex data sources stay struct-based. We'll document the envelope's limitations.
+- **[Risk]** Future framework versions may change `Config.Get()` reflection behavior. → **Mitigation:** The envelope code is centralized; a fix is one place. Existing struct-based data sources are unaffected.
+
+## Migration Plan
+
+1. Add `NewKibanaDataSource[T]()` and `NewElasticsearchDataSource[T]()` to `internal/entitycore`.
+2. Add connection block helpers for datasource schema types.
+3. Migrate `agentbuilderworkflow` data source (simplest of the three—no conditional workflow fetch).
+4. Migrate `agentbuildertool` data source (medium—conditional workflow fetch).
+5. Migrate `agentbuilderagent` data source if it fits; otherwise leave it struct-based with a local helper.
+6. Acceptance tests for migrated data sources must pass unchanged.
+7. Document the pattern for future data sources.
+
+## Open Questions
+
+- Does the framework's embedded struct support work identically for `Config.Get` across all supported framework versions in `go.mod`?
+- Should we also migrate `kibana/spaces` and `fleet/enrollmenttokens` (simple cases) as part of this change, or keep the scope to Agent Builder only?

--- a/openspec/changes/envelope-datasource-generics/proposal.md
+++ b/openspec/changes/envelope-datasource-generics/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Agent Builder data sources repeat the same read pipeline—config decode, scoped client resolution, version enforcement, composite ID splitting, space ID fallback, and state setting—with only the final API call and model mapping varying (#2511). This duplication is repeated to a lesser degree across all Kibana and Elasticsearch data sources. Existing `DataSourceBase` eliminates `Configure` and `Metadata` duplication, but every data source still rewrites its entire `Read()` method from scratch.
+
+## What Changes
+
+- Introduce generic `entitycore.NewKibanaDataSource[T]()` and `entitycore.NewElasticsearchDataSource[T]()` constructors that own the full Terraform contract (`Configure`, `Metadata`, `Schema`, `Read`) via an envelope pattern.
+- The base injects the scoped connection block (`kibana_connection` / `elasticsearch_connection`) into the schema automatically.
+- The concrete package provides only:
+  1. **Schema** (without connection block)
+  2. **Model** (without connection field)
+  3. **A pure read function** — entity-specific API call and state mapping
+- Migrate the three Agent Builder data sources identified in #2511 to the new pattern as reference implementations.
+- No changes to resource patterns or SDK-based data sources.
+
+## Capabilities
+
+### New Capabilities
+- `entitycore-datasource-envelope`: Generic envelope constructor for Plugin Framework data sources that eliminates Read() orchestration boilerplate by owning config decode, scoped client resolution, and state persistence. Concrete implementations supply only schema and a pure read function.
+
+### Modified Capabilities
+<!-- No spec-level requirement changes. Agent builder data sources, kibana spaces, and fleet enrollment tokens change only implementation architecture, not observable behavior. -->
+
+## Impact
+
+- **Package**: `internal/entitycore` — new generic constructors and envelope types.
+- **Packages**: `internal/kibana/agentbuilderagent`, `internal/kibana/agentbuildertool`, `internal/kibana/agentbuilderworkflow` — migrated to envelope pattern.
+- **No breaking changes** to Terraform schemas, state shapes, or provider API.
+- Existing struct-based data sources remain fully functional.

--- a/openspec/changes/envelope-datasource-generics/specs/entitycore-datasource-envelope/spec.md
+++ b/openspec/changes/envelope-datasource-generics/specs/entitycore-datasource-envelope/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Envelope constructor produces a valid DataSource
+The system SHALL provide a generic constructor `NewKibanaDataSource[T]()` (and `NewElasticsearchDataSource[T]()`) that returns a value satisfying `datasource.DataSource`.
+
+#### Scenario: Constructor returns valid data source
+- **WHEN** `NewKibanaDataSource[T](component, name, schema, readFunc)` is called
+- **THEN** the returned value SHALL satisfy `datasource.DataSource`
+- **AND** the returned value SHALL satisfy `datasource.DataSourceWithConfigure`
+
+### Requirement: Envelope injects connection block into schema
+The system SHALL inject the scoped connection block (`kibana_connection` or `elasticsearch_connection`) into the schema before exposing it via the `Schema` method.
+
+#### Scenario: Schema includes injected connection block
+- **WHEN** a data source is constructed with `NewKibanaDataSource[T]` and a schema that lacks a `kibana_connection` block
+- **THEN** calling `Schema` on the resulting data source SHALL return a schema that includes the `kibana_connection` block
+- **AND** the concrete schema attributes SHALL remain unchanged
+
+### Requirement: Envelope owns config deserialization
+The system SHALL deserialize the Terraform config into an internal envelope struct that holds both the connection block and the concrete model.
+
+#### Scenario: Config decode populates concrete model fields
+- **WHEN** `Read` is invoked with a Terraform config containing both `kibana_connection` and concrete attributes
+- **THEN** the concrete model SHALL be deserialized into the generic type parameter `T`
+- **AND** the connection block value SHALL be captured separately
+
+### Requirement: Envelope owns scoped client resolution
+The system SHALL resolve the scoped client from the provider factory using the captured connection block value.
+
+#### Scenario: Scoped client resolved from connection block
+- **WHEN** `Read` captures a non-empty `kibana_connection` block
+- **THEN** the system SHALL call `GetKibanaClient` with that connection value
+- **AND** pass the resulting `*KibanaScopedClient` to the concrete read function
+
+#### Scenario: Scoped client resolved from provider defaults
+- **WHEN** `Read` captures an empty or null `kibana_connection` block
+- **THEN** the system SHALL call `GetKibanaClient` with an empty list
+- **AND** the factory SHALL return the provider-default scoped client
+
+### Requirement: Envelope delegates entity logic to read function
+The system SHALL invoke the concrete read function with the scoped client and deserialized model, then capture the returned model and diagnostics.
+
+#### Scenario: Read function receives client and model
+- **WHEN** `Read` has successfully deserialized config and resolved the client
+- **THEN** the concrete read function SHALL be called with `(context, *KibanaScopedClient, T)`
+- **AND** its returned `(T, diag.Diagnostics)` SHALL be used for state setting
+
+### Requirement: Envelope owns state persistence
+The system SHALL set the Terraform state from the model returned by the concrete read function, preserving the connection block value from the original config.
+
+#### Scenario: State set after successful read
+- **WHEN** the concrete read function returns a model without error diagnostics
+- **THEN** `resp.State.Set` SHALL be called with the envelope containing the returned model and the original connection block
+
+#### Scenario: State not set on read function error
+- **WHEN** the concrete read function returns error diagnostics
+- **THEN** `resp.State.Set` SHALL NOT be called
+- **AND** the error diagnostics SHALL be appended to `resp.Diagnostics`
+
+### Requirement: Existing struct-based data sources remain functional
+The system SHALL NOT break existing data sources that embed `*DataSourceBase` and implement `Read` directly.
+
+#### Scenario: Struct-based data source continues to work
+- **WHEN** an existing data source uses struct-based embedding without the generic constructor
+- **THEN** its `Configure`, `Metadata`, and `Read` behavior SHALL remain unchanged

--- a/openspec/changes/envelope-datasource-generics/specs/entitycore-datasource-envelope/spec.md
+++ b/openspec/changes/envelope-datasource-generics/specs/entitycore-datasource-envelope/spec.md
@@ -34,8 +34,8 @@ The system SHALL resolve the scoped client from the provider factory using the c
 
 #### Scenario: Scoped client resolved from provider defaults
 - **WHEN** `Read` captures an empty or null `kibana_connection` block
-- **THEN** the system SHALL call `GetKibanaClient` with an empty list
-- **AND** the factory SHALL return the provider-default scoped client
+- **THEN** the system SHALL call `GetKibanaClient` with the captured connection block value
+- **AND** when that captured value is null or empty, the factory SHALL return the provider-default scoped client
 
 ### Requirement: Envelope delegates entity logic to read function
 The system SHALL invoke the concrete read function with the scoped client and deserialized model, then capture the returned model and diagnostics.

--- a/openspec/changes/envelope-datasource-generics/tasks.md
+++ b/openspec/changes/envelope-datasource-generics/tasks.md
@@ -7,7 +7,7 @@
 - [ ] 1.5 Implement schema injection for `elasticsearch_connection` block into datasource schema
 - [ ] 1.6 Implement generic `Read()` on `genericKibanaDataSource[T]` (config decode → client resolve → callback → state set)
 - [ ] 1.7 Implement generic `Read()` on `genericElasticsearchDataSource[T]`
-- [ ] 1.8 Add datasource-schema-specific connection block helpers (adapt `GetKbFWConnectionBlock` / `GetEsFWConnectionBlock` to `datasource.Block` types)
+- [ ] 1.8 Reuse existing datasource-compatible connection block helpers where possible (e.g., `GetKbFWConnectionBlock` / `GetEsFWConnectionBlock`), and if any changes are needed, ensure they target `github.com/hashicorp/terraform-plugin-framework/datasource/schema` block types (typically `dsschema.Block`), not `datasource.Block`
 - [ ] 1.9 Write unit tests for envelope config decode, client resolution, and state set
 
 ## 2. Agent Builder data source migrations

--- a/openspec/changes/envelope-datasource-generics/tasks.md
+++ b/openspec/changes/envelope-datasource-generics/tasks.md
@@ -1,0 +1,34 @@
+## 1. Envelope generics constructor — `internal/entitycore`
+
+- [ ] 1.1 Add `kibanaEnvelope[T any]` and `elasticsearchEnvelope[T any]` types with anonymous field embed
+- [ ] 1.2 Add `NewKibanaDataSource[T]()` constructor returning `datasource.DataSource`
+- [ ] 1.3 Add `NewElasticsearchDataSource[T]()` constructor returning `datasource.DataSource`
+- [ ] 1.4 Implement schema injection for `kibana_connection` block into datasource schema
+- [ ] 1.5 Implement schema injection for `elasticsearch_connection` block into datasource schema
+- [ ] 1.6 Implement generic `Read()` on `genericKibanaDataSource[T]` (config decode → client resolve → callback → state set)
+- [ ] 1.7 Implement generic `Read()` on `genericElasticsearchDataSource[T]`
+- [ ] 1.8 Add datasource-schema-specific connection block helpers (adapt `GetKbFWConnectionBlock` / `GetEsFWConnectionBlock` to `datasource.Block` types)
+- [ ] 1.9 Write unit tests for envelope config decode, client resolution, and state set
+
+## 2. Agent Builder data source migrations
+
+- [ ] 2.1 Migrate `kibana/agentbuilderworkflow` data source to `NewKibanaDataSource[workflowDataSourceModel]`
+- [ ] 2.2 Remove `data_source.go` and `data_source_read.go` orchestration from `agentbuilderworkflow`
+- [ ] 2.3 Migrate `kibana/agentbuildertool` data source to `NewKibanaDataSource[toolDataSourceModel]`
+- [ ] 2.4 Remove `data_source.go` and `data_source_read.go` orchestration from `agentbuildertool`
+- [ ] 2.5 Evaluate `kibana/agentbuilderagent` data source for envelope fit; migrate if straightforward, otherwise extract domain-local read pipeline helper
+- [ ] 2.6 Extract shared Agent Builder read pipeline helpers (version enforcement, composite ID resolution, space ID fallback) if multiple Agent Builder datasources remain struct-based
+
+## 3. Verification
+
+- [ ] 3.1 Run `make build` — no compilation errors
+- [ ] 3.2 Run `make check-openspec` — OpenSpec validation passes
+- [ ] 3.3 Run acceptance tests for migrated Agent Builder data sources
+- [ ] 3.4 Verify existing struct-based data sources (`spaces`, `enrollment_tokens`) remain unaffected
+- [ ] 3.5 Add `entitycore` unit test covering envelope `Read` with mocked client and config
+
+## 4. Documentation
+
+- [ ] 4.1 Add package-level GoDoc for `NewKibanaDataSource` / `NewElasticsearchDataSource` with usage example
+- [ ] 4.2 Update `internal/entitycore/doc.go` to describe the envelope pattern alongside struct-based embedding
+- [ ] 4.3 Add ADR or dev-docs note on when to use envelope vs struct-based pattern


### PR DESCRIPTION
Adds OpenSpec change artifacts for generic envelope data source constructors.

The envelope pattern lets concrete data sources provide only schema + entity logic while the generic base owns config decode, scoped client resolution, and state persistence.

Relates: https://github.com/elastic/terraform-provider-elasticstack/issues/2511

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add envelope-datasource-generics change proposal to OpenSpec
> Adds a full change proposal under [openspec/changes/envelope-datasource-generics/](https://github.com/elastic/terraform-provider-elasticstack/pull/2543/files#diff-cccab55f5b4f0778129c044f77a5eb391aa6f1445cc5748e94e097c2a1cdb9ce) covering generic envelope-based Terraform data sources for Kibana and Elasticsearch.
>
> - [proposal.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2543/files#diff-87d64d471c70f128af6dc759c30e54210dfe6b3ceb296bb2b5317b94c8894d12) describes the motivation and planned changes, including new generic constructors that own the Terraform data source contract and migration of select Agent Builder data sources.
> - [design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2543/files#diff-7565251ae1322468f9991cbe652b44513bdd461fee6448a077c64c0f4bbb0def) documents key decisions: envelope struct with anonymous embed, schema injection, dual constructors, read function signature, and version enforcement.
> - [specs/entitycore-datasource-envelope/spec.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2543/files#diff-7a67e5a6634edb1773bffec739273970f0b02e8f53f66a2781d66b7def0f7c12) defines requirements and scenarios for constructor behavior, schema injection, config deserialization, and state persistence.
> - [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2543/files#diff-103c46ae5b119d10a0241dd0c1c2d51222a42532f53c632ab120047c31c32a24) lists implementation steps covering constructors, schema injection, unit tests, migrations, and documentation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4548e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->