### PR TITLE
Remove explicit 7.x support

### DIFF
--- a/openspec/changes/remove-7x-support/.openspec.yaml
+++ b/openspec/changes/remove-7x-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/remove-7x-support/design.md
+++ b/openspec/changes/remove-7x-support/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The provider still advertises Elastic Stack `7.x+` support in `README.md` and runs acceptance tests against `7.17.13`. Several implementation paths and OpenSpec requirements preserve behavior for Elasticsearch versions below `8.0.0`, including transform setting gates, transform timeout handling, ILM `total_shards_per_node` gating, and Docker Fleet image fallback for `7.17.%`.
+
+Elastic Stack 7.x is now outside the intended support target. The change should remove intentional 7.x support without adding a blanket runtime rejection that would deliberately break incidental compatibility.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Set the documented minimum supported Elastic Stack version to `8.0.0`.
+- Remove `7.17.13` from the GitHub Actions acceptance matrix.
+- Remove 7.x-specific compatibility branches where the supported 8.0+ range makes them redundant.
+- Keep 8.x and 9.x feature gates intact where APIs or fields were introduced after `8.0.0`.
+- Regenerate generated artifacts that are expected to track source changes.
+
+**Non-Goals:**
+
+- Do not introduce a provider-wide runtime failure for all 7.x clusters.
+- Do not remove schema attributes solely because they existed before 8.0 if they remain valid in supported stack versions.
+- Do not rewrite unrelated historical changelog entries or archived OpenSpec changes.
+
+## Decisions
+
+### 1. Treat 8.0 as the support floor, not a global connection gate
+
+The provider documentation and tests will define the support floor. Resource logic will not add a broad `serverVersion < 8.0.0` diagnostic.
+
+Alternative considered: enforce `>= 8.0.0` centrally in provider configuration. That would be clearer but intentionally breaks users who may still have working 7.x workflows, which is outside the requested scope.
+
+### 2. Remove only pre-8.0 compatibility gates
+
+Version checks with minimums below `8.0.0` should be removed when they exist only to support 7.x behavior. Examples include transform feature minimum `7.2.0`, transform timeout minimum `7.17.0`, transform field gates below `8.0.0`, and ILM `total_shards_per_node` minimum `7.16.0`.
+
+Version gates at `8.x` or `9.x` should remain because they still describe feature boundaries inside the supported version range.
+
+### 3. Keep generated files in sync through repository generators
+
+The workflow source template is authoritative for the test workflow, so `.github/workflows-src/test/workflow.yml.tmpl` should be edited first and `.github/workflows/test.yml` regenerated with `make workflow-generate`. Terraform provider docs should be regenerated after schema description changes with `make docs-generate`.
+
+### 4. Leave historical records alone
+
+Historical changelog entries and archived OpenSpec changes may continue to mention 7.x because they describe past behavior. Current specs, docs, workflow sources, generated workflow output, and live implementation should reflect the new support floor.
+
+## Risks / Trade-offs
+
+- Removing 7.x matrix coverage may hide incidental regressions for users who still run 7.x. Mitigation: the change explicitly documents 8.0+ as the support floor rather than promising continued 7.x behavior.
+- Removing compatibility gates can change behavior when users connect to 7.x despite the unsupported status. Mitigation: avoid a global hard failure and only remove branches whose purpose is pre-8.0 support.
+- Generated workflow and docs can drift if only source files are edited. Mitigation: include generator and validation steps in the tasks.
+- Some 7.x strings are historical or test fixture values, not support promises. Mitigation: tasks should distinguish current support surface from historical records and unrelated literals.

--- a/openspec/changes/remove-7x-support/proposal.md
+++ b/openspec/changes/remove-7x-support/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Elastic Stack 7.x is no longer a supported target for this provider. Keeping 7.x in the documented support floor and acceptance test matrix adds CI cost and preserves compatibility branches that are only relevant to unsupported stack versions.
+
+## What Changes
+
+- **BREAKING**: Update the documented minimum supported Elastic Stack version from 7.x to 8.0.
+- Remove Elastic Stack 7.x from the acceptance test matrix.
+- Remove 7.x-only compatibility checks and test skips where the behavior is only needed for stack versions below 8.0.
+- Keep existing version gates for 8.x and 9.x feature boundaries.
+- Do not add a global runtime block for 7.x; the provider may continue to work incidentally where APIs remain compatible, but 7.x is no longer documented or intentionally tested.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `ci-build-lint-test`: The matrix acceptance test coverage no longer includes Elastic Stack 7.x.
+- `makefile-workflows`: Fleet Docker image selection no longer needs a 7.17-specific fallback.
+- `elasticsearch-transform`: Transform behavior no longer needs compatibility gates for Elasticsearch versions below 8.0.
+- `elasticsearch-index-lifecycle`: ILM behavior no longer needs compatibility gates or documentation for Elasticsearch 7.16-only support boundaries.
+
+## Impact
+
+- `README.md` and generated Terraform docs will advertise Elastic Stack 8.0 or higher.
+- `.github/workflows-src/test/workflow.yml.tmpl` and generated `.github/workflows/test.yml` will drop the 7.17 acceptance matrix entry.
+- `Makefile` will keep Docker Hub Fleet image fallback only for 8.0 and 8.1 stack lines.
+- Resource and data source code may be simplified where pre-8.0 version checks only guarded unsupported 7.x behavior.
+- OpenSpec specs and generated docs will be updated to match the 8.0+ support floor, including stale 7.x references in processor descriptions.

--- a/openspec/changes/remove-7x-support/specs/ci-build-lint-test/spec.md
+++ b/openspec/changes/remove-7x-support/specs/ci-build-lint-test/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Acceptance test job structure (REQ-009–REQ-014)
+
+The matrix acceptance test job SHALL depend on successful completion of the `build` job and the change-classification job. The acceptance test job SHALL run with a non-fail-fast matrix covering configured stack versions and included version-specific overrides. The configured stack versions SHALL NOT include Elastic Stack versions below `8.0.0`. The acceptance test job SHALL configure required environment variables for Elastic credentials and experimental provider behavior. The acceptance test job SHALL execute only when the preflight gate outputs `should_run=true` and the change-classification job reports `provider_changes=true`.
+
+For each matrix entry, the job SHALL free disk space, set up Go and Terraform, run `make vendor`, start the stack via Docker Compose, and wait for Elasticsearch and Kibana readiness. Fleet setup and forced synthetics installation SHALL run only for configured version subsets. Acceptance tests SHALL run via `make testacc`, with snapshot versions allowed to fail (`continue-on-error`) while non-snapshot versions remain blocking.
+
+The stack-start step SHALL have a step-level timeout so that a hung container image pull fails fast instead of consuming the full job timeout.
+
+#### Scenario: Provider change runs stack and tests
+
+- **GIVEN** a matrix version and runner
+- **AND** the preflight gate allows execution
+- **AND** the change-classification job reports `provider_changes=true`
+- **WHEN** the test job executes
+- **THEN** the stack SHALL be provisioned, readiness waits SHALL pass, and `make testacc` SHALL run with the documented policy for snapshots
+
+#### Scenario: OpenSpec-only change skips matrix acceptance
+
+- **GIVEN** a workflow run whose changed files are all under `openspec/`
+- **WHEN** the acceptance test job evaluates its execution conditions
+- **THEN** the matrix acceptance `test` job SHALL be skipped
+
+#### Scenario: Compose step timeout prevents hung pull
+
+- **GIVEN** Docker Compose is starting the stack for a matrix entry
+- **AND** a container image pull or stack startup hangs
+- **WHEN** the configured step timeout is reached
+- **THEN** the step SHALL fail and the job SHALL exit early
+
+#### Scenario: Matrix excludes 7.x stack versions
+
+- **WHEN** the acceptance matrix is evaluated
+- **THEN** every configured stack version SHALL be `8.0.0` or higher, except snapshot labels that represent later unreleased stack versions

--- a/openspec/changes/remove-7x-support/specs/elasticsearch-index-lifecycle/spec.md
+++ b/openspec/changes/remove-7x-support/specs/elasticsearch-index-lifecycle/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Version-gated ILM settings (REQ-022–REQ-025)
+
+For ILM action settings that are only supported on newer Elasticsearch versions, the provider SHALL compare the connected server version to the setting's minimum supported version during expansion. If the configured value is non-default on an unsupported server, the provider SHALL return an error diagnostic. If the configured value equals the default, the provider SHALL omit that unsupported setting from the payload instead of failing.
+
+The following minimum versions SHALL apply:
+
+- `rollover.max_primary_shard_docs`: Elasticsearch `8.2.0`
+- `rollover.min_age`, `rollover.min_docs`, `rollover.min_size`, `rollover.min_primary_shard_docs`, `rollover.min_primary_shard_size`: Elasticsearch `8.4.0`
+- `shrink.allow_write_after_shrink` when `true`: Elasticsearch `8.14.0`
+
+ILM settings available throughout the supported `8.x` and later range SHALL NOT have pre-8.0 compatibility gates.
+
+#### Scenario: Unsupported rollover min condition
+
+- GIVEN `rollover.min_docs` is configured with a non-default value
+- AND the connected Elasticsearch server is below `8.4.0`
+- WHEN the policy is expanded
+- THEN the provider SHALL return an unsupported-setting diagnostic
+
+#### Scenario: Unsupported shrink allow-write-after-shrink
+
+- GIVEN the connected Elasticsearch server is below `8.14.0`
+- WHEN `shrink.allow_write_after_shrink = true` is configured
+- THEN the provider SHALL return an unsupported-setting diagnostic
+
+#### Scenario: Supported-range allocate setting is sent
+
+- GIVEN `allocate.total_shards_per_node` is configured with a value other than `-1`
+- WHEN the policy is expanded against a supported Elasticsearch server version
+- THEN the provider SHALL include `total_shards_per_node` in the API payload

--- a/openspec/changes/remove-7x-support/specs/elasticsearch-transform/spec.md
+++ b/openspec/changes/remove-7x-support/specs/elasticsearch-transform/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Timeout parameter (REQ-016–REQ-017)
+
+The `timeout` attribute SHALL accept a Go duration string and SHALL default to `"30s"`. The resource SHALL pass the parsed `timeout` value as the API operation timeout parameter to the Put Transform, Update Transform, Start Transform, and Stop Transform APIs.
+
+#### Scenario: Timeout passed to API
+
+- GIVEN `timeout = "60s"`
+- WHEN create or update runs
+- THEN the API call SHALL include a 60-second timeout parameter
+
+### Requirement: Version-gated settings (REQ-020–REQ-032)
+
+Settings and capabilities that require a minimum supported Elasticsearch version later than `8.0.0` SHALL be silently omitted from API calls (with a log warning) when the server version is below the minimum. The version requirements are:
+
+- `destination.aliases`: requires Elasticsearch >= `8.8.0`
+- `deduce_mappings`: requires Elasticsearch >= `8.1.0`
+- `num_failure_retries`: requires Elasticsearch >= `8.4.0`
+- `unattended`: requires Elasticsearch >= `8.5.0`
+
+Transform settings and capabilities that are available throughout the supported `8.x` and later range SHALL NOT have pre-8.0 compatibility gates.
+
+#### Scenario: Version-gated setting silently omitted
+
+- GIVEN `deduce_mappings = true` and an Elasticsearch server version below `8.1.0`
+- WHEN create or update runs
+- THEN `deduce_mappings` SHALL be omitted from the API request body and a warning SHALL be logged
+
+#### Scenario: Supported-range setting is always sent
+
+- GIVEN `align_checkpoints = true`
+- WHEN create or update runs against a supported Elasticsearch server version
+- THEN `align_checkpoints` SHALL be included in the API request body
+
+### Requirement: JSON field mapping — pivot, latest, metadata (REQ-038–REQ-040)
+
+The `pivot` and `latest` fields SHALL be validated as JSON strings and SHALL apply JSON-normalized diff suppression. On create, the resource SHALL decode `pivot` or `latest` (whichever is set) into an `any` value for the API request. The `metadata` field SHALL be validated as a JSON string and SHALL apply JSON-normalized diff suppression. On create and update, when `metadata` is set, the resource SHALL decode it into a `map[string]any` for the API request.
+
+#### Scenario: Invalid pivot JSON rejected
+
+- GIVEN `pivot` contains invalid JSON
+- WHEN create runs
+- THEN the provider SHALL return an error and SHALL not call the Put Transform API
+
+#### Scenario: Metadata decoded on supported versions
+
+- GIVEN `metadata` is configured with a valid JSON object
+- WHEN create or update runs against a supported Elasticsearch server version
+- THEN the provider SHALL decode `metadata` into the API request body
+
+## REMOVED Requirements
+
+### Requirement: Minimum server version for transforms (REQ-006)
+
+**Reason**: The provider's supported Elastic Stack floor is now `8.0.0`, so an explicit transform feature gate for Elasticsearch versions below `7.2.0` is redundant.
+
+**Migration**: Users running Elastic Stack 7.x should upgrade to Elastic Stack 8.0 or higher before relying on supported transform resource behavior.

--- a/openspec/changes/remove-7x-support/specs/makefile-workflows/spec.md
+++ b/openspec/changes/remove-7x-support/specs/makefile-workflows/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Fleet Server image for older stack versions (REQ-017)
+
+When `STACK_VERSION` matches `8.0.%` or `8.1.%`, the Makefile SHALL set the Fleet agent image to **`elastic/elastic-agent` on Docker Hub** so Compose can pull an image that is not published to `docker.elastic.co` for those lines. For other versions, Compose SHALL use the default image source from the Compose files unless overridden elsewhere.
+
+#### Scenario: Older 8.0 / 8.1 line
+
+- GIVEN `STACK_VERSION` matches `8.0.%` or `8.1.%`
+- WHEN Compose runs Fleet
+- THEN `FLEET_IMAGE` SHALL resolve to Docker Hub's `elastic/elastic-agent` so pulls can succeed
+
+#### Scenario: Unsupported 7.x line has no special fallback
+
+- GIVEN `STACK_VERSION` matches `7.%`
+- WHEN Compose runs Fleet
+- THEN the Makefile SHALL NOT select Docker Hub's `elastic/elastic-agent` because of the 7.x version alone

--- a/openspec/changes/remove-7x-support/tasks.md
+++ b/openspec/changes/remove-7x-support/tasks.md
@@ -1,0 +1,33 @@
+## 1. Documentation and CI Matrix
+
+- [ ] 1.1 Update `README.md` so the documented minimum supported Elastic Stack version is `8.0` or higher.
+- [ ] 1.2 Remove the `7.17.13` entry from `.github/workflows-src/test/workflow.yml.tmpl`.
+- [ ] 1.3 Regenerate `.github/workflows/test.yml` with `make workflow-generate`.
+- [ ] 1.4 Verify the generated workflow acceptance matrix contains no Elastic Stack 7.x entries.
+
+## 2. Docker Workflow Support Floor
+
+- [ ] 2.1 Update `Makefile` Fleet image fallback logic so it matches `8.0.%` and `8.1.%`, but not `7.17.%`.
+- [ ] 2.2 Update comments and current OpenSpec wording for Makefile workflow behavior so older-version fallback language no longer mentions 7.17.
+
+## 3. Remove Redundant Pre-8.0 Runtime Gates
+
+- [ ] 3.1 Remove the transform minimum feature gate for Elasticsearch versions below `7.2.0`.
+- [ ] 3.2 Always pass transform API operation timeouts for supported versions; remove the `7.17.0` timeout branch.
+- [ ] 3.3 Remove transform setting gates whose minimum versions are below `8.0.0`, while preserving gates for `8.1.0`, `8.4.0`, `8.5.0`, and `8.8.0`.
+- [ ] 3.4 Always decode configured transform `metadata` on create and update for supported versions.
+- [ ] 3.5 Remove the ILM `allocate.total_shards_per_node` `7.16.0` compatibility gate while preserving later 8.x ILM gates.
+- [ ] 3.6 Review acceptance tests with explicit 7.x-only skips or minimums and remove or update only those that are redundant under the 8.0+ support floor.
+
+## 4. Generated Documentation and Stale References
+
+- [ ] 4.1 Update live schema descriptions that advertise 7.15, 7.16, or 7.x support boundaries where those boundaries are no longer relevant.
+- [ ] 4.2 Regenerate Terraform docs with `make docs-generate`.
+- [ ] 4.3 Search current docs, workflow sources, Makefile, live OpenSpec specs, and implementation code for remaining current-support 7.x references; leave historical changelog entries and archived OpenSpec changes unchanged.
+
+## 5. Verification
+
+- [ ] 5.1 Run `openspec validate remove-7x-support --strict`.
+- [ ] 5.2 Run `make check-workflows`.
+- [ ] 5.3 Run focused Go tests for changed transform, ILM, and version-related acceptance helper code where unit coverage exists.
+- [ ] 5.4 Run `make build`.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Remove explicit Elastic Stack 7.x support and set 8.0.0 as minimum version
- Sets 8.0.0 as the documented support floor, removing 7.x from the CI acceptance test matrix and all pre-8.0 compatibility gates in the transform and ILM resources.
- Fleet Server image fallback logic in the Makefile is narrowed to 8.0.x and 8.1.x stack lines only; no fallback for 7.x.
- Version-gated settings in ILM and transform now enforce 8.x minimums (e.g. 8.1.0, 8.2.0, 8.4.0) with silent omission or warnings below the minimum.
- Design, proposal, and task documents are added under `openspec/changes/remove-7x-support/` to track the change.
- Risk: this is a breaking change for any users running against Elastic Stack 7.x.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc376d3.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->