### PR TITLE
More data source envelope usage

### DIFF
--- a/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/.openspec.yaml
+++ b/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/design.md
+++ b/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The `entitycore` package currently has two data source patterns:
+
+- `DataSourceBase`, which provides embedded Configure, Metadata, and client factory access for data sources that keep a concrete `Read` method.
+- `NewKibanaDataSource`, which wraps a schema factory and read callback with generic config decode, Kibana scoped client resolution, callback invocation, and state persistence.
+
+The Agent Builder agent data source currently uses neither pattern. It stores the provider client factory directly, implements `Metadata` and `Configure`, injects its own `kibana_connection` schema block, and performs the whole read flow locally.
+
+The read path has two version concerns. The Agent Builder agent API requires `minKibanaAgentBuilderAPIVersion` before the data source can operate at all. Workflow-type tool dependency export requires `minVersionAdvancedAgentConfig`, but only after reading the agent and discovering workflow-type tools.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Migrate the Agent Builder agent data source to the generic Kibana data source envelope.
+- Add optional model-specific pre-read version requirements to the Kibana envelope.
+- Preserve the Terraform type name `elasticstack_kibana_agentbuilder_agent`.
+- Preserve existing data source behavior for ID resolution, spaces, `kibana_connection`, dependency export, tool ordering, and workflow YAML export.
+- Keep conditional version checks that depend on fetched API data in entity-specific read logic.
+
+**Non-Goals:**
+
+- Do not migrate Agent Builder resources to a resource envelope.
+- Do not change the user-visible data source schema.
+- Do not make version requirements mandatory for every `KibanaDataSourceModel`.
+- Do not attempt to express post-fetch conditional requirements through the generic envelope in this change.
+
+## Decisions
+
+### 1. Use an optional interface for version requirements
+
+**Chosen:** Add an optional interface implemented by models that need static pre-read server version checks, for example:
+
+```go
+type DataSourceVersionRequirement struct {
+	MinVersion   *version.Version
+	ErrorMessage string
+}
+
+type KibanaDataSourceWithVersionRequirements interface {
+	GetVersionRequirements() ([]DataSourceVersionRequirement, diag.Diagnostics)
+}
+```
+
+The generic Kibana data source detects this with a type assertion on the decoded model.
+
+**Alternative:** Add `GetVersionRequirements` directly to `KibanaDataSourceModel`.
+
+**Rationale:** Most Kibana envelope data sources should not need to implement no-op version methods. Optional capabilities keep the base model contract focused on connection access while allowing model-specific behavior where needed.
+
+---
+
+### 2. Enforce static requirements after scoped client resolution
+
+**Chosen:** In `genericKibanaDataSource.Read`, enforce optional version requirements after `GetKibanaClient` succeeds and before `readFunc` is called.
+
+**Rationale:** Version enforcement needs a `*clients.KibanaScopedClient`, and failing before the entity callback prevents API calls against unsupported servers. This keeps the envelope responsible for the full pre-read gate.
+
+---
+
+### 3. Keep workflow-tool version gating local
+
+**Chosen:** Leave the `minVersionAdvancedAgentConfig` workflow-tool check inside the Agent Builder read callback.
+
+**Rationale:** The workflow API requirement is conditional on the returned agent's tool references and only matters when `include_dependencies` causes tool expansion. The generic envelope should not grow a post-fetch lifecycle hook solely for this data-dependent case.
+
+---
+
+### 4. Schema factory omits connection blocks
+
+**Chosen:** Convert the Agent Builder data source schema method into a factory that returns the entity attributes only, with no `kibana_connection` block. The envelope injects `kibana_connection`.
+
+**Rationale:** This matches the existing envelope contract and avoids duplicate connection block definitions.
+
+---
+
+### 5. Preserve model field tags unless embedding is clearly beneficial
+
+**Chosen:** Prefer adding `GetKibanaConnection() types.List` to `agentDataSourceModel` over embedding `entitycore.KibanaConnectionField`, unless implementation shows embedding produces a cleaner diff.
+
+**Rationale:** The data source model already has a `KibanaConnection types.List` field used by existing schema/tests. A simple accessor satisfies the envelope constraint with minimal state-model churn.
+
+## Risks / Trade-offs
+
+- **Envelope tests may be hard to make fully isolated from real client behavior.** The existing envelope tests already exercise unconfigured-client diagnostics. Version-hook tests should use the available test helpers where possible and focus on no-op behavior, interface detection, diagnostic propagation, and callback short-circuiting.
+- **Type assertion on a value model may miss pointer receiver implementations.** Implement `GetVersionRequirements` on the value type unless there is a strong reason not to. This matches the decoded model value passed through the envelope.
+- **Schema injection changes where `kibana_connection` is declared.** The final schema should remain equivalent because the envelope injects the same provider schema block. Tests should assert the block is still present.
+- **Static and conditional version checks split across layers.** This is intentional: static API requirements belong to the envelope, while data-dependent feature requirements remain in the callback.
+
+## Migration Plan
+
+1. Add the optional version-requirements types and enforcement path to `internal/entitycore/data_source_envelope.go`.
+2. Add or update entitycore tests for the optional hook and existing schema/metadata behavior.
+3. Convert Agent Builder data source construction to `entitycore.NewKibanaDataSource`.
+4. Convert the Agent Builder schema method to a schema factory without `kibana_connection`.
+5. Add `GetKibanaConnection` and `GetVersionRequirements` to `agentDataSourceModel`.
+6. Refactor `DataSource.Read` into `readAgentDataSource`, removing envelope-owned orchestration.
+7. Run focused unit tests and, where the environment supports it, relevant acceptance tests.

--- a/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/proposal.md
+++ b/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The `elasticstack_kibana_agentbuilder_agent` data source still implements Plugin Framework boilerplate locally: provider data conversion, client storage, metadata naming, config decode, scoped Kibana client resolution, and state persistence. The `entitycore` package already provides a generic Kibana data source envelope that centralizes this outer flow, but it does not yet own static per-model server version gates.
+
+Migrating this data source to the envelope reduces bespoke data source wiring and makes the static Agent Builder API version requirement a reusable concern of the generic data source pipeline. The Agent Builder data source still needs local read logic for its entity-specific behavior: composite ID and space resolution, optional dependency export, tool expansion, and workflow lookup.
+
+## What Changes
+
+- Add an optional Kibana data source version-requirements interface to `internal/entitycore/data_source_envelope.go`.
+- Teach the generic Kibana data source envelope to enforce model-provided minimum version requirements after resolving the Kibana scoped client and before invoking the entity read callback.
+- Migrate the Agent Builder agent data source constructor to `entitycore.NewKibanaDataSource`.
+- Refactor the current Agent Builder data source `Read` method into an envelope read callback.
+- Move the unconditional Agent Builder API minimum version check into `agentDataSourceModel` via the optional version-requirements interface.
+- Keep the conditional workflow-tool version check in the Agent Builder callback because it depends on API data discovered during the read.
+- Convert the Agent Builder data source schema method into a schema factory and let the envelope inject `kibana_connection`.
+- Update tests to cover the new envelope version hook and preserve the data source's Terraform type name and schema behavior.
+
+## Capabilities
+
+### New Capabilities
+
+_(none - this is an internal implementation migration and shared data source envelope enhancement, not a user-visible Terraform capability)_
+
+### Modified Capabilities
+
+_(none - the `elasticstack_kibana_agentbuilder_agent` data source should preserve its existing user-visible schema and read behavior)_
+
+## Impact
+
+- **Shared implementation:** `internal/entitycore/data_source_envelope.go` gains optional pre-read version requirement enforcement for Kibana-backed envelope data sources.
+- **Migrated data source:** `internal/kibana/agentbuilderagent/data_source.go`, `data_source_schema.go`, `data_source_read.go`, and `models.go` move from local data source orchestration to the generic Kibana envelope.
+- **Tests:** `internal/entitycore/data_source_envelope_test.go` and Agent Builder data source tests should cover the new version hook and confirm schema/type-name compatibility.
+- **No Terraform behavior change intended:** existing acceptance coverage for default space, explicit space, `kibana_connection`, `include_dependencies`, and workflow-tool export should continue to pass.

--- a/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/specs/entitycore-datasource-envelope/spec.md
+++ b/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/specs/entitycore-datasource-envelope/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Kibana envelope enforces optional model version requirements
+
+The Kibana data source envelope SHALL allow a decoded model to optionally declare pre-read server version requirements. When the model implements the optional version-requirements interface, the envelope SHALL evaluate those requirements after resolving the scoped Kibana client and before invoking the concrete read function.
+
+Version requirements SHALL remain optional. A Kibana data source model that only satisfies the base `KibanaDataSourceModel` contract SHALL continue through the existing read flow without defining no-op version requirements.
+
+#### Scenario: Model without version requirements reads normally
+
+- **GIVEN** a Kibana envelope data source whose model does not implement the optional version-requirements interface
+- **WHEN** `Read` successfully decodes config and resolves the scoped Kibana client
+- **THEN** the envelope SHALL invoke the concrete read function without attempting model-specific version enforcement
+- **AND** state persistence SHALL follow the existing envelope behavior
+
+#### Scenario: Supported server invokes read function
+
+- **GIVEN** a Kibana envelope data source whose model declares a minimum server version requirement
+- **AND** the scoped Kibana client reports that the server satisfies that minimum version
+- **WHEN** `Read` evaluates the version requirement
+- **THEN** the envelope SHALL invoke the concrete read function
+- **AND** the read result SHALL be used for state persistence according to existing envelope behavior
+
+#### Scenario: Unsupported server stops before read function
+
+- **GIVEN** a Kibana envelope data source whose model declares a minimum server version requirement with an error message
+- **AND** the scoped Kibana client reports that the server does not satisfy that minimum version
+- **WHEN** `Read` evaluates the version requirement
+- **THEN** the envelope SHALL add an `Unsupported server version` diagnostic using the model-provided error message
+- **AND** the concrete read function SHALL NOT be invoked
+- **AND** Terraform state SHALL NOT be set from a read result
+
+#### Scenario: Version requirement diagnostics stop read
+
+- **GIVEN** a Kibana envelope data source whose model implements the optional version-requirements interface
+- **AND** collecting or enforcing the requirements returns error diagnostics
+- **WHEN** `Read` evaluates version requirements
+- **THEN** the envelope SHALL append those diagnostics to the read response
+- **AND** the concrete read function SHALL NOT be invoked
+- **AND** Terraform state SHALL NOT be set from a read result

--- a/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/tasks.md
+++ b/openspec/changes/migrate-agentbuilder-agent-datasource-envelope/tasks.md
@@ -1,0 +1,42 @@
+## 1. Entitycore Version Requirements
+
+- [ ] 1.1 Add `DataSourceVersionRequirement` to `internal/entitycore/data_source_envelope.go` with `MinVersion *version.Version` and `ErrorMessage string`.
+- [ ] 1.2 Add optional interface `KibanaDataSourceWithVersionRequirements` with `GetVersionRequirements() ([]DataSourceVersionRequirement, diag.Diagnostics)`.
+- [ ] 1.3 Update `genericKibanaDataSource.Read` to detect the optional interface after scoped Kibana client resolution and before `readFunc`.
+- [ ] 1.4 For each returned requirement, call `client.EnforceMinVersion`, append converted SDK diagnostics, and add `Unsupported server version` with the requirement's error message when unsupported.
+- [ ] 1.5 Ensure data sources whose models do not implement the optional interface continue through the existing read path unchanged.
+
+## 2. Entitycore Tests
+
+- [ ] 2.1 Add tests proving `NewKibanaDataSource` still works when the model does not implement version requirements.
+- [ ] 2.2 Add tests for models that implement version requirements, including successful enforcement and short-circuit behavior when diagnostics/errors occur where feasible with existing test helpers.
+- [ ] 2.3 Verify existing envelope tests for schema injection, metadata, configure, and unconfigured-client diagnostics still pass.
+
+## 3. Agent Builder Data Source Constructor and Schema
+
+- [ ] 3.1 Replace the concrete `DataSource` implementation in `internal/kibana/agentbuilderagent/data_source.go` with `entitycore.NewKibanaDataSource[agentDataSourceModel](entitycore.ComponentKibana, "agentbuilder_agent", getDataSourceSchema, readAgentDataSource)`.
+- [ ] 3.2 Remove local data source `client` storage, `Configure`, and `Metadata` methods.
+- [ ] 3.3 Convert `Schema` in `internal/kibana/agentbuilderagent/data_source_schema.go` into `getDataSourceSchema() dsschema.Schema`.
+- [ ] 3.4 Remove the explicit `kibana_connection` block from the Agent Builder schema factory so the envelope owns connection block injection.
+
+## 4. Agent Builder Model and Read Callback
+
+- [ ] 4.1 Add `GetKibanaConnection() types.List` to `agentDataSourceModel`, or embed `entitycore.KibanaConnectionField` if that produces a cleaner implementation.
+- [ ] 4.2 Add `GetVersionRequirements()` to `agentDataSourceModel`, returning the static `minKibanaAgentBuilderAPIVersion` requirement with the current Agent Builder unsupported-version message.
+- [ ] 4.3 Refactor `func (d *DataSource) Read(...)` into `readAgentDataSource(ctx context.Context, kbClient *clients.KibanaScopedClient, config agentDataSourceModel) (agentDataSourceModel, diag.Diagnostics)`.
+- [ ] 4.4 Remove config decode, `GetKibanaClient`, static `minKibanaAgentBuilderAPIVersion` enforcement, and `resp.State.Set` from the callback because the envelope owns those steps.
+- [ ] 4.5 Preserve composite ID parsing, default-space handling, agent fetch, model population, `include_dependencies` normalization, tool expansion, workflow lookup, and conditional `minVersionAdvancedAgentConfig` enforcement.
+
+## 5. Agent Builder Tests
+
+- [ ] 5.1 Add or update tests confirming `NewDataSource()` implements `datasource.DataSource` and `datasource.DataSourceWithConfigure` through the envelope.
+- [ ] 5.2 Add or update tests confirming metadata remains `elasticstack_kibana_agentbuilder_agent`.
+- [ ] 5.3 Add or update tests confirming the final data source schema still includes `kibana_connection` and the existing Agent Builder attributes.
+- [ ] 5.4 Keep existing acceptance coverage for default space, explicit space, explicit `kibana_connection`, `include_dependencies`, and workflow-tool export unchanged.
+
+## 6. Verification
+
+- [ ] 6.1 Run `go test ./internal/entitycore ./internal/kibana/agentbuilderagent`.
+- [ ] 6.2 Run `make check-openspec` once the OpenSpec CLI is available.
+- [ ] 6.3 If an Elastic Stack test environment is available, run the targeted Agent Builder data source acceptance tests.
+- [ ] 6.4 Run `make build` before considering implementation complete.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add OpenSpec design for migrating Agent Builder data source to Kibana envelope
- Adds proposal, design, spec, and task documents for migrating the Agent Builder agent data source to the generic Kibana data source envelope.
- Introduces an optional `version-requirements` interface on data source models, with enforcement in the envelope's read flow to handle unsupported server versions and propagate diagnostics.
- Outlines schema factory adjustments and refactoring of read logic as part of the migration plan.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26ee964.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->