### PR TITLE
openspec: propose elasticsearch resource envelope

### DIFF
--- a/openspec/changes/elasticsearch-resource-envelope/.openspec.yaml
+++ b/openspec/changes/elasticsearch-resource-envelope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/elasticsearch-resource-envelope/design.md
+++ b/openspec/changes/elasticsearch-resource-envelope/design.md
@@ -42,7 +42,7 @@ Create and Update flows in these resources diverge significantly (write-only pas
 
 ## Decisions
 
-### D1. Envelope owns Read + Delete + Schema; concrete owns Create + Update + ImportState
+### D1. Envelope owns Read + Delete + Schema + default ImportState; concrete owns Create + Update
 
 **Choice:** Wrap Read, Delete, Schema (with connection-block injection), Configure, Metadata, and provide a default ImportState that passes through `id`. Concrete resources keep Create and Update.
 
@@ -133,7 +133,7 @@ func deleteSystemUser(ctx context.Context, _ *clients.ElasticsearchScopedClient,
 
 ### D8. Envelope reuses `ResourceBase` rather than re-implementing Configure/Metadata
 
-**Choice:** `genericElasticsearchResource[T]` embeds `*ResourceBase` and uses its existing `Configure`, `Metadata`, and `Client()` methods. The envelope adds Schema, Read, Delete, and ImportState only.
+**Choice:** `ElasticsearchResource[T]` embeds `*ResourceBase` and uses its existing `Configure`, `Metadata`, and `Client()` methods. The envelope adds Schema, Read, Delete, and ImportState only.
 
 **Rationale:** Keeps the simple-base requirements (in `provider-framework-entity-core` spec) the single source of truth for Configure/Metadata behavior. The data source envelope today re-implements these — that's tolerable but slightly duplicative; resources have a chance to do better. Embedding also means the struct remains a `ResourceWithConfigure` automatically.
 

--- a/openspec/changes/elasticsearch-resource-envelope/design.md
+++ b/openspec/changes/elasticsearch-resource-envelope/design.md
@@ -1,0 +1,169 @@
+## Context
+
+`internal/entitycore` provides shared Plugin Framework wiring for resources and data sources. Today it has two layers:
+
+- **Simple base** (`resource_base.go`, `data_source_base.go`): shares Configure / Metadata / Client only. Concrete entities own Schema, Read, Delete, etc.
+- **Data source envelope** (`data_source_envelope.go`): a generic constructor `NewElasticsearchDataSource[T]` / `NewKibanaDataSource[T]` that adds connection-block schema injection, config decode, scoped-client resolution, and state persistence on top of the simple base. Concrete data sources only supply a schema factory and a pure read function.
+
+There is no resource analogue of the envelope. Issue #2555 found that the four Elasticsearch security resources duplicate the same Read/Delete prelude:
+
+```go
+// Repeated across user, systemuser, role, rolemapping (Read and Delete each)
+var data Data
+resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+if resp.Diagnostics.HasError() { return }
+
+compID, diags := clients.CompositeIDFromStrFw(data.ID.ValueString())
+resp.Diagnostics.Append(diags...)
+if resp.Diagnostics.HasError() { return }
+
+client, diags := r.Client().GetElasticsearchClient(ctx, data.ElasticsearchConnection)
+resp.Diagnostics.Append(diags...)
+if resp.Diagnostics.HasError() { return }
+```
+
+Create and Update flows in these resources diverge significantly (write-only passwords, server-version gating, JSON marshalling, post-write re-reads), so wrapping them is out of scope for this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide `entitycore.NewElasticsearchResource[T]` that owns Schema (with connection-block injection), Configure, Metadata, Read prelude, Delete prelude, and ImportState (passthrough).
+- Mirror the data source envelope's shape: type-parameter constraint, schema factory, pure callbacks.
+- Migrate the four Elasticsearch security resources to use it. No external behavior change.
+- Preserve existing acceptance tests verbatim.
+
+**Non-Goals:**
+
+- Wrapping Create or Update.
+- Adding a Kibana sibling (`NewKibanaResource[T]`) — deferred until we have at least one Kibana resource demanding it.
+- Migrating non-security resources (e.g., `api_key`, ingest processors, Fleet resources). Those can adopt the envelope incrementally under the same spec without re-proposal.
+- Changing what `*entitycore.ResourceBase` does. The simple base remains as-is for entities that don't fit the envelope.
+
+## Decisions
+
+### D1. Envelope owns Read + Delete + Schema; concrete owns Create + Update + ImportState
+
+**Choice:** Wrap Read, Delete, Schema (with connection-block injection), Configure, Metadata, and provide a default ImportState that passes through `id`. Concrete resources keep Create and Update.
+
+**Rationale:** Read and Delete have a uniform prelude across the four resources; Create and Update don't. Wrapping only what's actually duplicated avoids over-fitting the abstraction. Schema injection is included because connection-block declarations are also duplicated and the data source envelope already does this — symmetry keeps the entitycore API coherent.
+
+**Alternatives considered:**
+
+- *Read + Delete only, leave Schema alone.* Smaller blast radius but leaves the connection-block duplication in place and breaks symmetry with the data source envelope.
+- *Full CRUD wrapper.* Would force Create/Update into a single shape. The four resources each have meaningfully different update flows (write-only passwords, version gating, post-write re-read). Premature.
+
+### D2. Model interface requires `GetID()` and `GetElasticsearchConnection()`
+
+**Choice:** Define `ElasticsearchResourceModel` as
+
+```go
+type ElasticsearchResourceModel interface {
+    GetID() types.String
+    GetElasticsearchConnection() types.List
+}
+```
+
+Each concrete `Data` struct adds value-receiver methods:
+
+```go
+func (d Data) GetID() types.String { return d.ID }
+func (d Data) GetElasticsearchConnection() types.List { return d.ElasticsearchConnection }
+```
+
+**Rationale:** The envelope needs both fields and access through an interface lets the type parameter `T` stay concrete. Mirrors `ElasticsearchDataSourceModel`'s `GetElasticsearchConnection()` convention. Embedded helper structs (analogous to `ElasticsearchConnectionField`) aren't needed because the four `Data` types already declare both fields explicitly.
+
+**Alternatives considered:**
+
+- *Read attributes via `state.GetAttribute(path.Root("id"), …)` instead of an interface method.* Avoids changing every Data struct but bypasses the type system and has worse compile-time guarantees.
+- *Provide an embeddable `ElasticsearchResourceFields` helper.* Premature; only revisit if more migrations adopt it.
+
+### D3. Read callback returns `(T, bool, diag.Diagnostics)`
+
+**Choice:**
+
+```go
+type elasticsearchReadFunc[T ElasticsearchResourceModel] func(
+    ctx context.Context,
+    client *clients.ElasticsearchScopedClient,
+    resourceID string,
+    state T,
+) (T, bool, diag.Diagnostics)
+```
+
+The bool signals whether the entity exists. When `false` the envelope calls `resp.State.RemoveResource(ctx)`; when `true` it calls `resp.State.Set(ctx, model)`. Errors short-circuit before either branch.
+
+**Rationale:** The four resources all use the same pattern: API call → if nil/missing, log and remove from state; otherwise populate and persist. systemuser additionally checks `!user.IsSystemUser()`, which fits inside the `found` decision cleanly.
+
+**Alternatives considered:**
+
+- *Return `(*T, diag.Diagnostics)` with nil signalling not-found.* Awkward with non-pointer Data structs and value-typed `T`.
+- *A separate `notFoundError` sentinel diagnostic.* Indirect and easy to misuse.
+
+### D4. resourceID is a parsed string, not the full `*CompositeID`
+
+**Choice:** The envelope parses `clients.CompositeIDFromStrFw(model.GetID().ValueString())` itself and passes only `compID.ResourceID` to the callbacks.
+
+**Rationale:** Every current handler uses only `compID.ResourceID`. Pre-parsing keeps the callback surface narrow. If a future resource needs the full composite ID, broaden the signature later.
+
+### D5. Delete callback is required; system_user supplies a no-op
+
+**Choice:** `deleteFunc` is a non-nilable required parameter to the constructor. `systemuser.deleteSystemUser` is
+
+```go
+func deleteSystemUser(ctx context.Context, _ *clients.ElasticsearchScopedClient, resourceID string, _ Data) diag.Diagnostics {
+    tflog.Warn(ctx, fmt.Sprintf(`System user '%s' is not deletable, just removing from state`, resourceID))
+    return nil
+}
+```
+
+**Rationale:** A nilable callback hides intent at the envelope layer. Making it required forces each resource to express the delete behavior explicitly. The "no API call" case is a one-line function — clearer than a magic nil.
+
+### D6. ImportState defaults to passthrough on `id`; concrete may override
+
+**Choice:** The envelope implements `ImportState` as `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)`. Because the four security resources currently all do this, no overrides are needed in this migration. Concrete resources retain the ability to define their own `ImportState` on the embedded struct, which Plugin Framework will dispatch to (Go method-set rules give concrete methods precedence over promoted methods).
+
+**Rationale:** Captures the universal default; opt-out is free.
+
+### D7. Connection-block injection mirrors the data source envelope
+
+**Choice:** The schema factory returns `rschema.Schema` without an `elasticsearch_connection` block. The envelope's `Schema` method copies the user-provided blocks map and adds `elasticsearch_connection` via `providerschema.GetEsFWConnectionBlock()`.
+
+**Rationale:** Identical to the data source envelope's pattern in `data_source_envelope.go:191-198`. Concrete resources stop carrying their own copy of the connection block.
+
+### D8. Envelope reuses `ResourceBase` rather than re-implementing Configure/Metadata
+
+**Choice:** `genericElasticsearchResource[T]` embeds `*ResourceBase` and uses its existing `Configure`, `Metadata`, and `Client()` methods. The envelope adds Schema, Read, Delete, and ImportState only.
+
+**Rationale:** Keeps the simple-base requirements (in `provider-framework-entity-core` spec) the single source of truth for Configure/Metadata behavior. The data source envelope today re-implements these — that's tolerable but slightly duplicative; resources have a chance to do better. Embedding also means the struct remains a `ResourceWithConfigure` automatically.
+
+## Risks / Trade-offs
+
+- **Risk:** Method promotion ambiguity — a concrete resource that defines its own `Read` would silently override the envelope's. **Mitigation:** Each concrete resource is `type fooResource struct { *entitycore.ElasticsearchResource[Data] }` and declares only Create / Update. Reviewers (and the assertion `var _ resource.Resource = …`) catch any accidental Read/Delete overrides.
+
+- **Risk:** Generic type parameter `T` makes call sites verbose. **Mitigation:** Consistent naming (`type userResource struct { *entitycore.ElasticsearchResource[Data] }`) keeps the verbosity local to the constructor file. The data source envelope already proved this readable.
+
+- **Risk:** systemuser's no-op delete looks like dead code. **Mitigation:** Leave a one-line comment in `deleteSystemUser` explaining why it's a no-op (system users aren't deletable).
+
+- **Risk:** Default ImportState passthrough hides import behavior from a quick scan of the resource file. **Mitigation:** Document the default in the envelope's package comment alongside the existing data source envelope docs in `internal/entitycore/doc.go`.
+
+- **Trade-off:** Update flows aren't wrapped. Each resource still decodes plan, gets the client, reads state where needed, and writes state. Acceptable for now — wrapping later is a refinement, not a rewrite.
+
+## Migration Plan
+
+1. Add `internal/entitycore/resource_envelope.go` with the generic constructor and supporting types. Add tests mirroring `data_source_envelope_test.go`.
+2. For each of the four resources (`user`, `systemuser`, `role`, `rolemapping`), in independent commits:
+   - Add `GetID()` and `GetElasticsearchConnection()` to `Data`.
+   - Replace `*entitycore.ResourceBase` with `*entitycore.ElasticsearchResource[Data]` in the resource struct.
+   - Move `read` body into a package-level `readXxx` function with the new callback signature; delete the `Read` method.
+   - Move `delete` body into a package-level `deleteXxx` function; delete the `Delete` method.
+   - Strip the `elasticsearch_connection` block from the schema factory; the envelope injects it.
+   - Drop `ImportState` if and only if it was already plain passthrough on `id`.
+3. Update `internal/entitycore/doc.go` to document the resource envelope alongside the data source envelope.
+4. Run `make check-lint`, `make build`, `make check-openspec`, and the security acceptance tests.
+
+**Rollback:** Each resource migration is an independent commit; reverting any single one leaves the others functional. The envelope itself can be removed if no callers remain.
+
+## Open Questions
+
+None. All decisions are settled per the explore session.

--- a/openspec/changes/elasticsearch-resource-envelope/proposal.md
+++ b/openspec/changes/elasticsearch-resource-envelope/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Issue [#2555](https://github.com/elastic/terraform-provider-elasticstack/issues/2555) flags duplicated Read/Delete preludes across the four Elasticsearch security resources (user, system_user, role, role_mapping): each handler repeats the same state-load → composite-ID parse → scoped-client resolution → API call. The data sources already have a generic envelope (`entitycore.NewElasticsearchDataSource[T]`); a sibling envelope for resources will collapse the boilerplate, give Read/Delete a single canonical implementation, and prevent diagnostic-handling drift between resources.
+
+## What Changes
+
+- Add `entitycore.NewElasticsearchResource[T]`: a generic constructor that returns a Plugin Framework resource owning Configure, Metadata, Schema (with `elasticsearch_connection` block injection), Read, Delete, and ImportState (passthrough on `id`).
+- Add `entitycore.ElasticsearchResourceModel` type constraint requiring `GetID() types.String` and `GetElasticsearchConnection() types.List`.
+- Concrete resources supply: a schema factory (without the connection block), a read callback `func(ctx, *clients.ElasticsearchScopedClient, resourceID string, state T) (T, bool, diag.Diagnostics)` (bool = found), and a delete callback `func(ctx, *clients.ElasticsearchScopedClient, resourceID string, state T) diag.Diagnostics`.
+- Concrete resources continue to own Create and Update (their flows diverge — write-only passwords, server-version gating, JSON marshalling, post-write re-reads).
+- Migrate four Elasticsearch security resources to the envelope: `internal/elasticsearch/security/{user,systemuser,role,rolemapping}`. Each Data struct gains `GetID()` and `GetElasticsearchConnection()` getters.
+- system_user's delete callback is a no-op that returns nil diagnostics (system users aren't deletable). This is uniform with the required-callback contract.
+- Schema factories are split out so the connection block is added by the envelope rather than declared in each resource's schema.
+
+No external behavior, schema, generated docs, or acceptance test fixtures change. Existing resources that don't migrate (api_key, others outside security) are unaffected.
+
+## Capabilities
+
+### New Capabilities
+- `entitycore-resource-envelope`: Generic resource envelope (sibling to `entitycore-datasource-envelope`) that owns Configure, Metadata, Schema-with-connection-injection, Read prelude with composite-ID parsing and not-found removal, Delete prelude, and default ImportState passthrough.
+
+### Modified Capabilities
+<!-- None. The four security resource specs describe externally-observable behavior, which is preserved verbatim. The provider-framework-entity-core spec describes the simple ResourceBase substrate, which is unchanged; the envelope is an additional, separately-specified capability. -->
+
+## Impact
+
+- New code: `internal/entitycore/resource_envelope.go` (and matching tests).
+- Refactored code: `internal/elasticsearch/security/{user,systemuser,role,rolemapping}` — `resource.go`, `read.go`, `delete.go`, `schema.go`, `models.go`. `create.go` and `update.go` keep their existing logic (call sites for `r.Client()` continue to work via the embedded envelope).
+- Specs: new `openspec/specs/entitycore-resource-envelope/spec.md` (created on archive of this change).
+- No public API changes. No provider config changes. No Terraform schema changes.
+- Acceptance tests for the four resources must continue to pass without modification.

--- a/openspec/changes/elasticsearch-resource-envelope/specs/entitycore-resource-envelope/spec.md
+++ b/openspec/changes/elasticsearch-resource-envelope/specs/entitycore-resource-envelope/spec.md
@@ -1,0 +1,169 @@
+## ADDED Requirements
+
+### Requirement: Envelope constructor produces a valid Resource
+
+The system SHALL provide a generic constructor `NewElasticsearchResource[T]()` that returns a value satisfying `resource.Resource`.
+
+#### Scenario: Constructor returns valid resource
+
+- **WHEN** `NewElasticsearchResource[T](component, name, schemaFactory, readFunc, deleteFunc)` is called with non-nil callbacks
+- **THEN** the returned value SHALL satisfy `resource.Resource`
+- **AND** the returned value SHALL satisfy `resource.ResourceWithConfigure`
+- **AND** the returned value SHALL satisfy `resource.ResourceWithImportState`
+
+### Requirement: Envelope owns Configure and Metadata
+
+The system SHALL implement `Configure` and `Metadata` on the envelope using the same provider-data conversion and type-name composition rules as `ResourceBase`. The configured `*clients.ProviderClientFactory` SHALL be reachable from the envelope's Read and Delete preludes.
+
+#### Scenario: Configure stores the provider client factory
+
+- **WHEN** `Configure` receives provider data that converts successfully to `*clients.ProviderClientFactory`
+- **THEN** the envelope SHALL retain that factory for use by subsequent Read and Delete calls
+
+#### Scenario: Configure does not store a client after diagnostic failure
+
+- **WHEN** `Configure` has appended the conversion diagnostics and the response has error-level diagnostics
+- **THEN** the envelope SHALL not assign a factory from that conversion, and SHALL leave unchanged any factory previously stored by an earlier successful `Configure` call
+
+#### Scenario: Metadata builds the Terraform type name
+
+- **WHEN** an envelope is constructed via `NewElasticsearchResource[T](ComponentElasticsearch, "security_user", …)`
+- **THEN** its `Metadata` SHALL set the type name to `<provider_type_name>_elasticsearch_security_user`
+
+### Requirement: Envelope injects elasticsearch_connection block into schema
+
+The system SHALL inject the `elasticsearch_connection` block into the schema returned by the concrete schema factory before exposing it via the `Schema` method.
+
+#### Scenario: Schema includes injected connection block
+
+- **WHEN** an envelope is constructed with a schema factory that returns a schema lacking an `elasticsearch_connection` block
+- **THEN** calling `Schema` on the envelope SHALL return a schema that includes the `elasticsearch_connection` block produced by the canonical provider helper
+- **AND** the concrete schema attributes and other blocks SHALL remain unchanged
+
+### Requirement: Envelope owns the Read prelude
+
+The system SHALL implement `Read` by deserializing the prior state into the generic model `T`, parsing the composite ID with `clients.CompositeIDFromStrFw`, resolving the scoped Elasticsearch client from the model's connection block via `GetElasticsearchClient`, and invoking the concrete read function. The concrete read function SHALL be invoked with `(context, *clients.ElasticsearchScopedClient, resourceID string, T)` where `resourceID` is `compID.ResourceID`.
+
+#### Scenario: Successful read sets state from returned model
+
+- **WHEN** the concrete read function returns `(model, true, nil)` (entity found, no errors)
+- **THEN** `resp.State.Set` SHALL be called with the returned model `T`
+
+#### Scenario: Not-found read removes resource from state
+
+- **WHEN** the concrete read function returns `(_, false, nil)` (entity missing, no errors)
+- **THEN** `resp.State.RemoveResource` SHALL be called
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Read function error short-circuits state mutation
+
+- **WHEN** the concrete read function returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** neither `resp.State.Set` nor `resp.State.RemoveResource` SHALL be called
+
+#### Scenario: Composite ID parse failure short-circuits read
+
+- **WHEN** `CompositeIDFromStrFw` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete read function SHALL NOT be invoked
+- **AND** state SHALL remain untouched
+
+#### Scenario: Client resolution failure short-circuits read
+
+- **WHEN** `GetElasticsearchClient` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete read function SHALL NOT be invoked
+- **AND** state SHALL remain untouched
+
+### Requirement: Envelope owns the Delete prelude
+
+The system SHALL implement `Delete` by deserializing the prior state into the generic model `T`, parsing the composite ID with `clients.CompositeIDFromStrFw`, resolving the scoped Elasticsearch client from the model's connection block, and invoking the concrete delete function with `(context, *clients.ElasticsearchScopedClient, resourceID string, T)`.
+
+#### Scenario: Successful delete returns nil diagnostics
+
+- **WHEN** the concrete delete function returns no diagnostics
+- **THEN** the response diagnostics SHALL contain no errors and Plugin Framework SHALL remove the resource from state per its standard contract
+
+#### Scenario: Delete function error is appended to response diagnostics
+
+- **WHEN** the concrete delete function returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+
+#### Scenario: Composite ID parse failure short-circuits delete
+
+- **WHEN** `CompositeIDFromStrFw` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete delete function SHALL NOT be invoked
+
+#### Scenario: Client resolution failure short-circuits delete
+
+- **WHEN** `GetElasticsearchClient` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete delete function SHALL NOT be invoked
+
+### Requirement: Envelope requires a non-nil delete callback
+
+The system SHALL require concrete resources to supply a non-nil delete callback. Resources whose API has no delete operation SHALL pass a callback that returns `nil` diagnostics. The envelope SHALL NOT special-case a nil callback to mean "no API call".
+
+#### Scenario: Constructor accepts a no-op delete callback
+
+- **WHEN** the delete callback is supplied as a function that returns `nil` diagnostics without performing an API call
+- **THEN** the envelope SHALL invoke that callback during `Delete` and proceed normally, removing the resource from state
+
+### Requirement: Envelope provides a default ImportState passthrough
+
+The system SHALL implement `ImportState` as a passthrough on the `id` attribute equivalent to `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)`. Concrete resources MAY override `ImportState` by defining the method on the concrete type that embeds the envelope.
+
+#### Scenario: Default import passes through the id attribute
+
+- **WHEN** a Terraform import command is executed against a resource that uses the envelope without overriding `ImportState`
+- **THEN** the `id` attribute SHALL be set to the supplied import identifier
+- **AND** the subsequent Read SHALL receive that `id` in its prior state
+
+#### Scenario: Concrete resource overrides default import behavior
+
+- **WHEN** a concrete resource that embeds `*ElasticsearchResource[T]` defines its own `ImportState` method
+- **THEN** the concrete method SHALL be invoked instead of the envelope's default
+
+### Requirement: Model type constraint exposes ID and connection block
+
+The system SHALL define a type constraint `ElasticsearchResourceModel` requiring `GetID() types.String` and `GetElasticsearchConnection() types.List`. Concrete `Data` types SHALL satisfy this constraint by declaring value-receiver getter methods over their existing `ID` and `ElasticsearchConnection` fields.
+
+#### Scenario: Concrete model satisfies the constraint
+
+- **WHEN** a concrete `Data` struct declares `GetID() types.String` returning `d.ID` and `GetElasticsearchConnection() types.List` returning `d.ElasticsearchConnection`
+- **THEN** that struct SHALL satisfy `ElasticsearchResourceModel`
+- **AND** SHALL be usable as the type parameter to `NewElasticsearchResource[T]`
+
+### Requirement: Envelope preserves resource type names exactly
+
+The system SHALL allow concrete migrations to preserve their existing Terraform type name. Each migrated security resource SHALL initialize the envelope with the component namespace and literal name suffix that produce its current type name.
+
+#### Scenario: Migrated user resource preserves its type name
+
+- **WHEN** the user resource is migrated to the envelope using component `elasticsearch` and name `security_user`
+- **THEN** its Terraform type name SHALL remain `<provider_type_name>_elasticsearch_security_user`
+
+#### Scenario: Migrated system_user resource preserves its type name
+
+- **WHEN** the system user resource is migrated to the envelope using component `elasticsearch` and name `security_system_user`
+- **THEN** its Terraform type name SHALL remain `<provider_type_name>_elasticsearch_security_system_user`
+
+#### Scenario: Migrated role resource preserves its type name
+
+- **WHEN** the role resource is migrated to the envelope using component `elasticsearch` and name `security_role`
+- **THEN** its Terraform type name SHALL remain `<provider_type_name>_elasticsearch_security_role`
+
+#### Scenario: Migrated role_mapping resource preserves its type name
+
+- **WHEN** the role mapping resource is migrated to the envelope using component `elasticsearch` and name `security_role_mapping`
+- **THEN** its Terraform type name SHALL remain `<provider_type_name>_elasticsearch_security_role_mapping`
+
+### Requirement: Envelope coexists with ResourceBase-only entities
+
+The system SHALL NOT change the behavior of resources that embed `*ResourceBase` directly. Resources that do not migrate to the envelope SHALL continue to operate with their existing Configure, Metadata, and Client wiring.
+
+#### Scenario: ResourceBase-only resource continues to work
+
+- **WHEN** a resource that embeds `*ResourceBase` (without the envelope) is configured and used
+- **THEN** its Configure, Metadata, and Client behavior SHALL remain unchanged

--- a/openspec/changes/elasticsearch-resource-envelope/tasks.md
+++ b/openspec/changes/elasticsearch-resource-envelope/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Envelope implementation
 
-- [ ] 1.1 Add `internal/entitycore/resource_envelope.go` defining `ElasticsearchResourceModel` constraint (`GetID() types.String` + `GetElasticsearchConnection() types.List`), `genericElasticsearchResource[T]` struct embedding `*ResourceBase`, and the constructor `NewElasticsearchResource[T](component Component, name string, schemaFactory func() rschema.Schema, readFunc, deleteFunc) *genericElasticsearchResource[T]`.
+- [ ] 1.1 Add `internal/entitycore/resource_envelope.go` defining `ElasticsearchResourceModel` constraint (`GetID() types.String` + `GetElasticsearchConnection() types.List`), exported `ElasticsearchResource[T]` struct embedding `*ResourceBase`, and the constructor `NewElasticsearchResource[T](component Component, name string, schemaFactory func() rschema.Schema, readFunc, deleteFunc) *ElasticsearchResource[T]`.
 - [ ] 1.2 Implement `Schema` on the envelope: copy the user-supplied blocks map and inject `elasticsearch_connection` via `providerschema.GetEsFWConnectionBlock()`, mirroring the data source envelope.
 - [ ] 1.3 Implement `Read` on the envelope: state.Get into `T`, parse composite ID via `clients.CompositeIDFromStrFw`, resolve scoped client via `Client().GetElasticsearchClient(ctx, model.GetElasticsearchConnection())`, invoke `readFunc`, then either `state.Set` (found=true) or `state.RemoveResource` (found=false). Short-circuit on every diagnostic gate.
 - [ ] 1.4 Implement `Delete` on the envelope: same prelude as Read, invoke `deleteFunc`, append diagnostics.
 - [ ] 1.5 Implement default `ImportState` on the envelope as `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)`.
-- [ ] 1.6 Add interface assertions: `var _ resource.Resource = (*genericElasticsearchResource[…])(nil)` etc., to fail compile if any method is missing.
+- [ ] 1.6 Add interface assertions: `var _ resource.Resource = (*ElasticsearchResource[…])(nil)` etc., to fail compile if any method is missing.
 - [ ] 1.7 Update `internal/entitycore/doc.go` to document the resource envelope alongside the data source envelope (mention the model constraint, callback signatures, and the default ImportState).
 - [ ] 1.8 Add `internal/entitycore/resource_envelope_test.go` covering: constructor returns valid resource, Metadata type-name composition, Schema injects connection block, Read happy path, Read not-found removes state, Read short-circuits on each diagnostic gate, Delete happy path, Delete short-circuits on each diagnostic gate, default ImportState passthrough.
 

--- a/openspec/changes/elasticsearch-resource-envelope/tasks.md
+++ b/openspec/changes/elasticsearch-resource-envelope/tasks.md
@@ -1,0 +1,58 @@
+## 1. Envelope implementation
+
+- [ ] 1.1 Add `internal/entitycore/resource_envelope.go` defining `ElasticsearchResourceModel` constraint (`GetID() types.String` + `GetElasticsearchConnection() types.List`), `genericElasticsearchResource[T]` struct embedding `*ResourceBase`, and the constructor `NewElasticsearchResource[T](component Component, name string, schemaFactory func() rschema.Schema, readFunc, deleteFunc) *genericElasticsearchResource[T]`.
+- [ ] 1.2 Implement `Schema` on the envelope: copy the user-supplied blocks map and inject `elasticsearch_connection` via `providerschema.GetEsFWConnectionBlock()`, mirroring the data source envelope.
+- [ ] 1.3 Implement `Read` on the envelope: state.Get into `T`, parse composite ID via `clients.CompositeIDFromStrFw`, resolve scoped client via `Client().GetElasticsearchClient(ctx, model.GetElasticsearchConnection())`, invoke `readFunc`, then either `state.Set` (found=true) or `state.RemoveResource` (found=false). Short-circuit on every diagnostic gate.
+- [ ] 1.4 Implement `Delete` on the envelope: same prelude as Read, invoke `deleteFunc`, append diagnostics.
+- [ ] 1.5 Implement default `ImportState` on the envelope as `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)`.
+- [ ] 1.6 Add interface assertions: `var _ resource.Resource = (*genericElasticsearchResource[…])(nil)` etc., to fail compile if any method is missing.
+- [ ] 1.7 Update `internal/entitycore/doc.go` to document the resource envelope alongside the data source envelope (mention the model constraint, callback signatures, and the default ImportState).
+- [ ] 1.8 Add `internal/entitycore/resource_envelope_test.go` covering: constructor returns valid resource, Metadata type-name composition, Schema injects connection block, Read happy path, Read not-found removes state, Read short-circuits on each diagnostic gate, Delete happy path, Delete short-circuits on each diagnostic gate, default ImportState passthrough.
+
+## 2. Migrate `elasticsearch_security_user`
+
+- [ ] 2.1 Add value-receiver methods `GetID() types.String` and `GetElasticsearchConnection() types.List` on `securityuser.Data`.
+- [ ] 2.2 Replace `*entitycore.ResourceBase` with `*entitycore.ElasticsearchResource[Data]` in `userResource`. Update `newUserResource()` to call `NewElasticsearchResource[Data]` with the schema factory, `readUser`, and `deleteUser` callbacks.
+- [ ] 2.3 Convert the existing `Read` body into a package-level `readUser(ctx, client, resourceID, state Data) (Data, bool, diag.Diagnostics)`. Remove the `Read` method from the resource type.
+- [ ] 2.4 Convert the existing `Delete` body into a package-level `deleteUser(ctx, client, resourceID, state Data) diag.Diagnostics`. Remove the `Delete` method from the resource type.
+- [ ] 2.5 Drop the `elasticsearch_connection` block from the schema factory; the envelope injects it.
+- [ ] 2.6 Remove the explicit `ImportState` method (envelope provides the same passthrough).
+- [ ] 2.7 Verify Create and Update still compile and use `r.Client()` correctly via the embedded envelope.
+- [ ] 2.8 Run `go test ./internal/elasticsearch/security/user/...` and the user acceptance tests; confirm no behavior change.
+
+## 3. Migrate `elasticsearch_security_system_user`
+
+- [ ] 3.1 Add `GetID()` and `GetElasticsearchConnection()` getters on `systemuser.Data`.
+- [ ] 3.2 Replace `*entitycore.ResourceBase` with `*entitycore.ElasticsearchResource[Data]` in `systemUserResource`.
+- [ ] 3.3 Convert `Read` body into `readSystemUser(ctx, client, resourceID, state Data) (Data, bool, diag.Diagnostics)`. The not-found path SHALL include `user == nil || !user.IsSystemUser()` returning `(_, false, nil)`.
+- [ ] 3.4 Convert `Delete` body into `deleteSystemUser(ctx, _ *clients.ElasticsearchScopedClient, resourceID string, _ Data) diag.Diagnostics`. Body logs the existing tflog warning and returns nil. Add a one-line comment explaining why no API call is made.
+- [ ] 3.5 Strip the `elasticsearch_connection` block from the schema factory.
+- [ ] 3.6 Run `go test ./internal/elasticsearch/security/systemuser/...`.
+
+## 4. Migrate `elasticsearch_security_role`
+
+- [ ] 4.1 Add `GetID()` and `GetElasticsearchConnection()` getters on `role.Data`.
+- [ ] 4.2 Replace `*entitycore.ResourceBase` with `*entitycore.ElasticsearchResource[Data]` in `roleResource`.
+- [ ] 4.3 Refactor the existing `read(ctx, data Data) (*Data, diag.Diagnostics)` into `readRole(ctx, client, resourceID, state Data) (Data, bool, diag.Diagnostics)`. Return `(_, false, nil)` for the not-found branch. Update `update.go`'s post-write re-read site to call this new function (it currently calls `r.read(ctx, data)`); a thin local helper bridging the new signature is acceptable.
+- [ ] 4.4 Convert `Delete` body into `deleteRole(ctx, client, resourceID, state Data) diag.Diagnostics`.
+- [ ] 4.5 Strip the `elasticsearch_connection` block from the schema factory.
+- [ ] 4.6 Preserve the `UpgradeState` method on the concrete resource (envelope does not provide it).
+- [ ] 4.7 Run `go test ./internal/elasticsearch/security/role/...` plus the role acceptance test.
+
+## 5. Migrate `elasticsearch_security_role_mapping`
+
+- [ ] 5.1 Add `GetID()` and `GetElasticsearchConnection()` getters on `rolemapping.Data`.
+- [ ] 5.2 Replace `*entitycore.ResourceBase` with `*entitycore.ElasticsearchResource[Data]` in `roleMappingResource`.
+- [ ] 5.3 Convert `Read` body into `readRoleMappingResource(ctx, client, resourceID, state Data) (Data, bool, diag.Diagnostics)` that wraps the existing `readRoleMapping` helper. Map `nil` return to `(_, false, nil)`.
+- [ ] 5.4 Convert `Delete` body into `deleteRoleMapping(ctx, client, resourceID, state Data) diag.Diagnostics`.
+- [ ] 5.5 Strip the `elasticsearch_connection` block from the schema factory.
+- [ ] 5.6 Run `go test ./internal/elasticsearch/security/rolemapping/...`.
+
+## 6. Verification
+
+- [ ] 6.1 `make build` passes.
+- [ ] 6.2 `make check-lint` passes (golangci-lint + revive + openspec validate).
+- [ ] 6.3 `make check-openspec` passes.
+- [ ] 6.4 Acceptance test sweep against the running stack: `user`, `systemuser`, `role`, `rolemapping` (per `dev-docs/high-level/testing.md`).
+- [ ] 6.5 Generated docs unchanged: confirm `terraform-docs` / `tfplugindocs` produces no diff for the four security resources.
+- [ ] 6.6 Ensure `openspec validate elasticsearch-resource-envelope --strict` passes.


### PR DESCRIPTION
## Summary

- Adds OpenSpec change `elasticsearch-resource-envelope` proposing a generic `entitycore.NewElasticsearchResource[T]` (sibling to the existing data source envelope) that owns Configure / Metadata / Schema-with-connection-injection / Read prelude / Delete prelude / default ImportState passthrough.
- Plans migration of the four Elasticsearch security resources (`user`, `system_user`, `role`, `role_mapping`) onto the envelope. Concrete resources keep `Create` / `Update` (their flows diverge — write-only passwords, server-version gating).
- Addresses the duplicated Read/Delete prelude flagged in #2555.

This PR contains the proposal artifacts only (`proposal.md`, `design.md`, `specs/entitycore-resource-envelope/spec.md`, `tasks.md`). Implementation will land in a follow-up PR.

## Test plan

- [ ] `make check-openspec` passes (`openspec validate elasticsearch-resource-envelope --strict`)
- [ ] Reviewers confirm the design decisions (D1–D8 in `design.md`) are the right shape before implementation begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propose Elasticsearch resource envelope spec for Plugin Framework resources
> - Adds an OpenSpec proposal and design document for a new Elasticsearch resource envelope that wraps `schema.Schema` with automatic connection-block injection, reducing boilerplate duplicated across security resources.
> - Defines constructor contracts, `Configure`/`Metadata` behavior, Read/Delete preludes with diagnostic short-circuiting, a required non-nil delete callback, default `ImportState` passthrough, and a model constraint with typed getters.
> - Includes a [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2563/files#diff-8c952e3319e6e4d1da891ff34a34fe47f2deae534637a269158806bdac012b4e) covering implementation steps and migration of four Elasticsearch security resources.
> - No external behavior changes are introduced by this proposal itself.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22b54fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->