### PR TITLE
openspec: fix kibana-spec-impact checkout path

### DIFF
--- a/openspec/changes/fix-kibana-spec-impact-checkout/.openspec.yaml
+++ b/openspec/changes/fix-kibana-spec-impact-checkout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/fix-kibana-spec-impact-checkout/design.md
+++ b/openspec/changes/fix-kibana-spec-impact-checkout/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The `kibana-spec-impact` workflow is compiled from `.github/workflows-src/kibana-spec-impact/workflow.md.tmpl` into `.github/workflows/kibana-spec-impact.lock.yml` by `scripts/compile-workflow-sources`.
+
+The pre-activation `steps:` block in the template performs these actions:
+1. Check out the main repository (`fetch-depth: 0`)
+2. Set up Go
+3. **Check out the `memory/kibana-spec-impact` branch** to an absolute path: `path: /tmp/gh-aw/repo-memory/kibana-spec-impact`
+4. Run the `pre-activation` Go command with `--memory` pointing at that absolute path
+5. Upload the report as an artifact
+
+The `actions/checkout@v4` action validates that `path` is relative and under `$GITHUB_WORKSPACE`. An absolute `/tmp` path causes the step to fail with:
+```
+Error: Repository path is not under the workspace
+```
+
+This failure blocks the entire workflow because `activation` and `agent` jobs depend on `pre_activation` outputs (`run_agent`, `issue_cap`, etc.).
+
+The `agent` job itself already handles `/tmp` paths fine — it uses `clone_repo_memory_branch.sh` (a `run:` step) to clone the memory branch into `/tmp/gh-aw/repo-memory/kibana-spec-impact`. The `actions/checkout` restriction only applies to the pre-activation job.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the `pre_activation` job so the workflow completes successfully
+- Keep the existing deterministic `go run ... pre-activation` logic unchanged
+- Keep the artifact upload/download contract between pre-activation and the agent intact
+- Regenerate the compiled lockfile from the updated template
+
+**Non-Goals:**
+- Changing the `agent` job (it already works fine)
+- Changing the memory branch name or structure
+- Changing the `kibana-spec-impact` Go tool
+- Introducing new workflow behaviour (e.g. merging pre-activation into the agent job)
+
+## Decisions
+
+### Decision: Use workspace-relative checkout path in pre-activation
+
+**Chosen:** Change `path: /tmp/gh-aw/repo-memory/kibana-spec-impact` to a relative path under the workspace (e.g. `gh-aw-repo-memory/kibana-spec-impact`).
+
+**Rationale:**
+- Minimal change — only two lines in the template (checkout `path` and `--memory` flag value)
+- No new dependencies or scripts needed
+- The compiled workflow keeps the same structure; only the path changes
+- Pre-activation runs on a different runner (`ubuntu-slim`) than the agent (`ubuntu-latest`), so there is no conflict with the agent's own `/tmp` memory clone even if the paths differ
+
+**Alternatives considered:**
+
+| Approach | Why rejected |
+|----------|-------------|
+| Replace `actions/checkout` with a manual `git clone` run step | Works, but adds ~10 lines of shell and re-authentication boilerplate. Option C (relative path) is simpler. |
+| Fetch the memory file via GitHub API (`repos.getContent`) | API call overhead, must handle nested path encoding and branch-not-exists logic. Over-engineered for this problem. |
+| Move deterministic check into the agent job | Removes `pre_activation` entirely, which breaks the gh-aw framework (pre-activation also emits `activated`, `setup-trace-id`, team-membership gate). |
+
+### Decision: Keep `--memory` path in sync with checkout `path`
+
+**Chosen:** Update the `--memory` flag in the `go run pre-activation` command to match the new checkout location exactly.
+
+**Rationale:**
+- The Go command reads the memory file to resolve the baseline SHA and suppress duplicates
+- If the path is wrong, `ensurePreActivationMemory` will bootstrap from seed instead of loading the live branch, silently resetting state
+
+## Risks / Trade-offs
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Compiled lockfile is out of sync with template edit | Low | Include explicit `go run ./scripts/compile-workflow-sources` step and CI check |
+| Agent job and pre-activation job memory paths diverge silently | Very low | Paths are each self-contained; the agent downloads and re-closes its own memory. The report artifact is the only contract between jobs. |
+| `continue-on-error: true` on the checkout step is lost during copy-paste | Low | Review the template diff carefully; the new checkout step keeps the same `continue-on-error` attribute |

--- a/openspec/changes/fix-kibana-spec-impact-checkout/proposal.md
+++ b/openspec/changes/fix-kibana-spec-impact-checkout/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The `kibana-spec-impact` workflow's `pre_activation` job checks out the repo-memory branch (`memory/kibana-spec-impact`) to `/tmp/gh-aw/repo-memory/kibana-spec-impact`. GitHub Actions `actions/checkout@v4` requires the `path` input to be a **relative path under `$GITHUB_WORKSPACE`**. An absolute path to `/tmp` causes the pre-activation step to fail, which prevents the deterministic impact check from running and gates the entire agent workflow.
+
+This workflow is currently non-functional. Fixing it restores automated detection of Kibana OpenAPI/spec changes that may require Terraform provider updates.
+
+## What Changes
+
+- Change the pre-activation `actions/checkout` step for the repo-memory branch to use a **workspace-relative path** (e.g. `gh-aw-repo-memory/kibana-spec-impact` instead of `/tmp/gh-aw/repo-memory/kibana-spec-impact`)
+- Update the `--memory` flag path in the `go run ./scripts/kibana-spec-impact pre-activation` command to match the new checkout location
+- Re-generate the compiled lockfile (`.github/workflows/kibana-spec-impact.lock.yml`) via `scripts/compile-workflow-sources`
+
+## Capabilities
+
+### New Capabilities
+(none)
+
+### Modified Capabilities
+- `ci-kibana-spec-impact-issues`: adds a requirement that the pre-activation repo-memory checkout path must be workspace-relative to comply with `actions/checkout@v4` validation
+
+## Impact
+
+- **`.github/workflows-src/kibana-spec-impact/workflow.md.tmpl`** — source template for the pre-activation checkout path and `go run` command
+- **`.github/workflows/kibana-spec-impact.lock.yml`** — compiled/lockfile produced by the workflow compiler (must be regenerated)
+- **Scripts** — none; the `kibana-spec-impact` Go tool accepts any `--memory` path, no code changes needed

--- a/openspec/changes/fix-kibana-spec-impact-checkout/specs/ci-kibana-spec-impact-issues/spec.md
+++ b/openspec/changes/fix-kibana-spec-impact-checkout/specs/ci-kibana-spec-impact-issues/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Pre-activation repo-memory checkout path
+
+The workflow's pre-activation repo-memory initialization step SHALL use a workspace-relative checkout path that is accepted by `actions/checkout`. The checkout path SHALL be co-located within the workflow workspace so that the deterministic helper can read the memory file from that path without requiring an absolute path outside the workspace.
+
+#### Scenario: Workspace-relative repo-memory checkout succeeds
+- **GIVEN** the workflow pre-activation job checks out the repo-memory branch for Kibana spec-impact baseline state
+- **WHEN** the checkout step runs
+- **THEN** it SHALL complete successfully using a workspace-relative path
+- **AND** the subsequent deterministic helper SHALL be able to read the memory file from that path
+
+## MODIFIED Requirements
+
+(none)
+
+## REMOVED Requirements
+
+(none)

--- a/openspec/changes/fix-kibana-spec-impact-checkout/tasks.md
+++ b/openspec/changes/fix-kibana-spec-impact-checkout/tasks.md
@@ -1,0 +1,17 @@
+## 1. Fix pre-activation checkout path in workflow template
+
+- [ ] 1.1 Edit `.github/workflows-src/kibana-spec-impact/workflow.md.tmpl`
+  - Change the `Checkout repo-memory branch` step `path` from `/tmp/gh-aw/repo-memory/kibana-spec-impact` to a workspace-relative path (`gh-aw-repo-memory/kibana-spec-impact`)
+  - Update the `--memory` flag in the `Compute kibana spec impact` step to match the new relative path
+  - Preserve `continue-on-error: true` on the checkout step
+- [ ] 1.2 Verify the template compiles cleanly by running the workflow compiler
+
+## 2. Regenerate compiled lockfile
+
+- [ ] 2.1 Run `go run ./scripts/compile-workflow-sources` to regenerate `.github/workflows/kibana-spec-impact.lock.yml`
+- [ ] 2.2 Inspect the diff to confirm only the pre-activation checkout path and `--memory` flag changed; no other jobs or steps were altered
+
+## 3. Verify agent steps remain untouched
+
+- [ ] 3.1 Confirm the `agent` job's `Download kibana spec impact report` and `Clone repo-memory branch` steps still reference `/tmp/gh-aw/...` paths (these are correct and must not change)
+- [ ] 3.2 Confirm the repo-memory tool config (`branch-name: memory/kibana-spec-impact`) matches the checkout `ref` in pre-activation


### PR DESCRIPTION
}
## Summary

Fixes the `kibana-spec-impact` workflow by changing the pre-activation repo-memory checkout from an absolute `/tmp` path to a workspace-relative path, which `actions/checkout@v4` accepts.

## Change Proposal

| Artifact | Description |
|----------|-------------|
| **proposal.md** | `actions/checkout@v4` rejects absolute `/tmp` paths. Changes the repo-memory checkout in pre-activation to a workspace-relative path. |
| **design.md** | Option C: workspace-relative checkout. Rejected alternatives: manual git clone, GitHub API fetch, merging pre-activation into agent job. |
| **specs.md** | No Terraform provider behaviour changes (infrastructure-only fix). |
| **tasks.md** | 1) Edit template, 2) Regenerate lockfile, 3) Verify agent steps untouched. |

## Why

The `pre_activation` job checks out the `memory/kibana-spec-impact` branch to `/tmp/gh-aw/repo-memory/kibana-spec-impact`. GitHub Actions `actions/checkout@v4` requires the `path` input to be a **relative path under `$GITHUB_WORKSPACE`**. An absolute path to `/tmp` causes the pre-activation step to fail, preventing the deterministic impact check from running and gating the entire agent workflow.

## What Changes

- Change the pre-activation `actions/checkout` step for the repo-memory branch to use a **workspace-relative path** (`gh-aw-repo-memory/kibana-spec-impact`)
- Update the `--memory` flag path in the `go run ./scripts/kibana-spec-impact pre-activation` command to match
- Regenerate the compiled lockfile via `scripts/compile-workflow-sources`

## Impact

- `.github/workflows-src/kibana-spec-impact/workflow.md.tmpl`
- `.github/workflows/kibana-spec-impact.lock.yml` (regenerated)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `kibana-spec-impact` pre-activation checkout path to be workspace-relative
> The `kibana-spec-impact` CI workflow fails because the pre-activation repo-memory checkout path is not workspace-relative, preventing the helper from accessing it. This PR adds openspec design, proposal, specification, and task documents outlining the fix: switching to a workspace-relative checkout path, updating the matching `--memory` flag, and regenerating the compiled lockfile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a376ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->