### PR TITLE
Proposed shareded acceptance tests

### DIFF
--- a/openspec/changes/shard-acceptance-tests-modulo/.openspec.yaml
+++ b/openspec/changes/shard-acceptance-tests-modulo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/shard-acceptance-tests-modulo/design.md
+++ b/openspec/changes/shard-acceptance-tests-modulo/design.md
@@ -1,0 +1,106 @@
+## Context
+
+`speed-up-dashboard-acceptance-tests` (PR #2539) reduced the snapshot matrix entry from ~27 min to ~25 min by adding explicit cross-package parallelism (`-p 6`) and splitting monolithic test functions. The remaining bottleneck is `internal/kibana/dashboard` (~11.6 min), which sets a floor that no amount of in-process parallelism can move.
+
+Package-level timing data from PR #2539 (9.4.0-SNAPSHOT, `-p 6`, 88 first-run packages):
+
+| Group | Pkgs | Sum | Est. wall-clock (`-p 6`) |
+|---|---|---|---|
+| `internal/kibana/...` | 28 | 38.6 m | **11.6 m** (critical path) |
+| `internal/elasticsearch/...` + other | 48 | 25.0 m | 4.2 m |
+| `internal/fleet/...` | 12 | 15.6 m | 6.1 m |
+
+The ~4 m elasticsearch and ~6 m fleet work queues behind the 11.6 m kibana work on the same runner. Splitting the suite across two concurrent runners with independent stacks breaks this coupling.
+
+Two consistently flaky packages — `internal/fleet/integration` and `internal/fleet/integration_policy` — fail on first run and require gotestsum reruns in nearly every matrix version. Today both run on the same runner; separating them allows each to rerun independently.
+
+## Goals / Non-Goals
+
+**Goals**:
+- Halve the snapshot matrix wall-clock from ~25 min to ~12 min by running two parallel shards per version.
+- Separate the two known-flaky fleet packages onto different shards.
+- Guarantee that all packages are covered without hardcoding package names.
+- Keep `make testacc` (no shard variables) fully backwards-compatible for local use.
+
+**Non-Goals**:
+- Further splitting beyond two shards (a third shard does not reduce the critical path).
+- Duration-aware shard balancing (alphabetical modulo is sufficient; the imbalance is bounded by the longest single package).
+- Changing per-package parallelism (`-parallel`) or rerun settings.
+
+## Decisions
+
+### 1. Modulo bucketing over sorted `go list ./...` output, not named shards
+
+Two approaches were compared using actual timing data:
+
+- **Named shards** (`internal/kibana/...` | `internal/elasticsearch/...` | `internal/fleet/...`): deterministic but requires updating shard filter rules when new product namespaces are added. Produces imbalanced shards (11.6 m / 4.2 m / 6.1 m at N=3). Does not separate the two flaky fleet packages — they would both land in the fleet shard.
+- **Modulo on alphabetical `go list ./...`**: zero-maintenance. Coverage is mathematically guaranteed (every index 0–N appears in exactly one shard, and all N shards together cover the full list). Alphabetically, `internal/fleet/integration` (index 42) and `internal/fleet/integration_policy` (index 43) are adjacent, so modulo-2 puts them in different shards — a useful side effect.
+
+Modulo is chosen because it requires no ongoing maintenance and improves fleet flakiness isolation compared to named shards.
+
+### 2. N=2 shards to start
+
+Measured wall-clock estimates from PR #2539 CI data:
+
+| N shards | Shard 0 | Shard 1 | Shard 2 | Critical path |
+|---|---|---|---|---|
+| 1 (today) | 21.4 m | — | — | 21.4 m |
+| **2 (modulo-2)** | **11.6 m** | **6.1 m** | — | **11.6 m** |
+| 3 (modulo-3) | 11.6 m | 6.1 m | 3.2 m | 11.6 m |
+
+`kibana/dashboard` (11.6 m) sets the floor regardless. A third shard moves work that is already finishing before the kibana shard completes; it adds runner cost without reducing wall-clock. Two shards is the minimum effective split; three can be revisited if the non-critical shard later exceeds ~10 min due to new packages.
+
+### 3. Makefile implementation
+
+```makefile
+ACCTEST_TOTAL_SHARDS ?= 1
+ACCTEST_SHARD_INDEX  ?= 0
+
+.PHONY: testacc
+testacc:
+	TF_ACC=1 go tool gotestsum \
+	  --format testname \
+	  --rerun-fails=$(RERUN_FAILS) \
+	  --rerun-fails-max-failures=$(RERUN_FAILS_MAX_FAILURES) \
+	  --packages="$(shell go list ./... \
+	    | sort \
+	    | awk '(NR-1) % $(ACCTEST_TOTAL_SHARDS) == $(ACCTEST_SHARD_INDEX)')" \
+	  -- -p $(ACCTEST_PACKAGE_PARALLELISM) \
+	     -v \
+	     -count $(ACCTEST_COUNT) \
+	     -parallel $(ACCTEST_PARALLELISM) \
+	     $(TESTARGS) \
+	     -timeout $(ACCTEST_TIMEOUT)
+```
+
+When `ACCTEST_TOTAL_SHARDS=1` (default), `awk 'NR % 1 == 0'` matches every line — identical to `./...` behaviour today. `$(shell go list ./...)` is evaluated at recipe expansion time, so it reflects the actual module state at invocation (~1 s overhead on warm cache).
+
+The existing `TEST ?= ./...` variable is deliberately not repurposed for sharding; `TEST` is already used by contributors to run individual packages, and overloading it would create confusing semantics.
+
+### 4. GitHub Actions workflow change
+
+A `shard: [0, 1]` dimension is added to the existing version matrix so each `(version, shard)` pair runs as an independent job. The `make testacc` step becomes:
+
+```yaml
+make testacc ACCTEST_TOTAL_SHARDS=2 ACCTEST_SHARD_INDEX=${{ matrix.shard }}
+```
+
+Stack startup, fleet setup, and teardown are unchanged and run per-shard (each shard has its own isolated Elastic stack). Changes MUST be authored in the `workflows-src/` template system and compiled via `make workflow-generate`.
+
+### 5. Coverage guarantee
+
+For `ACCTEST_TOTAL_SHARDS=N`, the set of packages in shard `k` is `{ p_i : i % N == k }`. The union over k=0…N−1 equals `{ p_i : 0 ≤ i < len }` = all packages. CI requires all shards to pass; branch protection enforces this, so a missing shard job leaves the workflow non-green.
+
+## Risks / Trade-offs
+
+- **Runner cost**: 2 runners × ~12 min ≈ 24 runner-min vs 1 runner × ~25 min ≈ 25 runner-min. Near cost-neutral.
+- **Index drift**: adding or removing packages shifts modulo assignments by one. Not a correctness concern (coverage is always complete); worst-case impact is a temporarily imbalanced run.
+- **`go list` in recipe**: ~1 s on warm cache, ~5 s cold. Acceptable overhead for an acceptance-test target.
+- **Stack startup cost paid twice**: each shard starts its own ES + Kibana + Fleet stack (~2 min). This is already inside the 25-min baseline and not on the critical path.
+
+## Migration Plan
+
+1. Land Makefile changes (`ACCTEST_TOTAL_SHARDS`, `ACCTEST_SHARD_INDEX`) with default no-op values; verify local backwards compatibility.
+2. Update the `makefile-workflows` spec and run `make check-lint`.
+3. Update the workflow source template to add the shard matrix dimension; regenerate and verify with `make check-workflows`.
+4. Open PR; capture actual shard wall-clocks from the first CI run.

--- a/openspec/changes/shard-acceptance-tests-modulo/proposal.md
+++ b/openspec/changes/shard-acceptance-tests-modulo/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+After `speed-up-dashboard-acceptance-tests` (PR #2539) the matrix snapshot entry runs in ~25 minutes, with `internal/kibana/dashboard` as the undisputed critical path at ~11.5 minutes of wall clock. The test splits and `-p 6` change reduce total time from ~27 min to ~25 min, but further gains within a single runner are bounded: `kibana/dashboard` sets an ~11.5 min floor that no amount of in-process parallelism can move.
+
+Package-level timing data from the PR #2539 CI run (9.4.0-SNAPSHOT, `-p 6`):
+
+| Package group | Packages | Sum | Est. wall-clock (with `-p 6`) |
+|---|---|---|---|
+| `internal/kibana/...` | 28 | 38.6 m | **11.6 m** (critical path) |
+| `internal/elasticsearch/...` + other | 48 | 25.0 m | 4.2 m |
+| `internal/fleet/...` | 12 | 15.6 m | 6.1 m |
+
+Running all 88 packages serially through `-p 6` slots forces the ~4 m elasticsearch work and ~6 m fleet work to queue behind the 11.6 m kibana work. Splitting the suite across two concurrent runners with independent stacks breaks this coupling and delivers roughly a **halving of wall-clock**: max(11.6, 6.1) = **~12 min** (down from ~25 min), using the same runner hardware already provisioned per-version by the matrix strategy.
+
+There are also two consistently flaky packages — `internal/fleet/integration` and `internal/fleet/integration_policy` — that fail on first run and require gotestsum reruns in nearly every matrix version. Today both land on the same runner; separating them onto different shards gives each its own rerun budget and prevents one package's retries from delaying the other's shard completion.
+
+## What Changes
+
+- Add two new Makefile variables — `ACCTEST_TOTAL_SHARDS` (default `1`) and `ACCTEST_SHARD_INDEX` (default `0`) — that control which subset of packages the `testacc` target runs.
+- When `ACCTEST_TOTAL_SHARDS=1` (the default), behaviour is identical to today: all packages run, no filtering applied. Contributors and existing CI jobs that do not set these variables are unaffected.
+- When `ACCTEST_TOTAL_SHARDS > 1`, the `testacc` recipe narrows `--packages` to those packages whose position in the sorted `go list ./...` output satisfies `index % ACCTEST_TOTAL_SHARDS == ACCTEST_SHARD_INDEX`. Sorting is alphabetical, which is stable across runs.
+- Update the GitHub Actions acceptance-test workflow to add a `shard` dimension (`[0, 1]`) to the version matrix. Each (version, shard) combination starts its own runner, spins up its own isolated Elastic stack, and runs `make testacc ACCTEST_TOTAL_SHARDS=2 ACCTEST_SHARD_INDEX=${{ matrix.shard }}`.
+- Update the `makefile-workflows` capability spec to require sharding support in `testacc`.
+
+This change is purely test-infrastructure; no resource implementation or provider spec is touched.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `makefile-workflows`: the `testacc` target gains shard-selection inputs (`ACCTEST_TOTAL_SHARDS`, `ACCTEST_SHARD_INDEX`) that are no-ops at their defaults and enable modulo-based package sharding when set.
+
+## Impact
+
+- `Makefile`: two new `?=`-defaulted variables; `testacc` recipe gains a conditional `--packages` filter using `go list ./... | awk`.
+- `.github/workflows/`: the matrix acceptance-test workflow gains a `shard: [0, 1]` matrix dimension, doubling the number of runners per stack version.
+- CI wall-clock for the snapshot matrix entry: expected reduction from ~25 min to ~12 min (~52% improvement).
+- Runner cost: doubles the runner-minutes per version (2 runners × ~12 min vs 1 runner × ~25 min = ~24 min vs ~25 min), near cost-neutral.
+- Fleet flakiness isolation: `internal/fleet/integration` (alphabetical index 42, shard 0) and `internal/fleet/integration_policy` (index 43, shard 1) land on separate runners. Each can rerun independently without delaying the other shard.
+- Coverage guarantee: the union of all shards is exactly `go list ./...`. No new package can be silently excluded — any package added to the module is automatically assigned to a shard by the modulo rule.

--- a/openspec/changes/shard-acceptance-tests-modulo/specs/makefile-workflows/spec.md
+++ b/openspec/changes/shard-acceptance-tests-modulo/specs/makefile-workflows/spec.md
@@ -1,0 +1,39 @@
+# `makefile-workflows` — Makefile Requirements (delta)
+
+Implementation: [`Makefile`](../../../../../Makefile)
+
+## MODIFIED Requirements
+
+### Requirement: Acceptance tests (REQ-023–REQ-024)
+
+The `testacc` target SHALL enable Terraform acceptance testing for the module tree, using gotestsum with rerun-of-fails behavior, a configurable rerun max-failures cap, and tunable in-package and cross-package parallelism, timeout, and count via the acceptance-test variables. It SHALL invoke the repository-wide package scope `./...` by default, and pass verbose Go test output through to the underlying test run. The `testacc-vs-docker` target SHALL run acceptance tests against a local Docker stack on default localhost ports with the configured Elasticsearch credentials.
+
+The `testacc` recipe SHALL support modulo-based package sharding via two independently-overridable Makefile variables: `ACCTEST_TOTAL_SHARDS` (total number of shards) and `ACCTEST_SHARD_INDEX` (zero-based index of the shard to run). When `ACCTEST_TOTAL_SHARDS=1` (the default), `testacc` SHALL run all packages identically to the unsharded behaviour — no packages are excluded. When `ACCTEST_TOTAL_SHARDS > 1`, `testacc` SHALL run only those packages whose zero-based position in the sorted `go list ./...` output satisfies `position % ACCTEST_TOTAL_SHARDS == ACCTEST_SHARD_INDEX`. The sorted package list SHALL be derived from `go list ./...` at recipe invocation time so that any package added to the module is automatically assigned to a shard without requiring a configuration change. The union of all shards (indices 0 through ACCTEST_TOTAL_SHARDS−1) SHALL cover every package in `go list ./...` exactly once.
+
+#### Scenario: Acceptance tests with defaults
+
+- GIVEN `make testacc`
+- WHEN the recipe runs
+- THEN `TF_ACC` SHALL be set for acceptance mode and tests SHALL run across all packages with the Makefile's timeout and parallelism defaults unless overridden
+- AND gotestsum reruns SHALL honor both the configured rerun count and the configured max-failures cap
+- AND the underlying `go test` invocation SHALL include both an explicit `-p` value (cross-package parallelism) and an explicit `-parallel` value (in-package `t.Parallel()` cap), each taken from a distinct Makefile variable
+
+#### Scenario: Contributor overrides package parallelism
+
+- GIVEN `make testacc` invoked with the package-parallelism Make variable overridden on the command line
+- WHEN the recipe runs
+- THEN the underlying `go test` invocation SHALL use the overridden value for `-p` without requiring any change to the recipe itself
+- AND the in-package `-parallel` value SHALL remain unchanged unless a separate, dedicated variable is also overridden
+
+#### Scenario: CI runs a specific shard
+
+- GIVEN `make testacc` invoked with `ACCTEST_TOTAL_SHARDS=2` and `ACCTEST_SHARD_INDEX=0`
+- WHEN the recipe runs
+- THEN only packages at even positions in the sorted `go list ./...` output SHALL be passed to gotestsum
+- AND packages at odd positions SHALL not be executed in this invocation
+
+#### Scenario: Shard coverage is complete
+
+- GIVEN `make testacc` run twice with `ACCTEST_TOTAL_SHARDS=2 ACCTEST_SHARD_INDEX=0` and `ACCTEST_TOTAL_SHARDS=2 ACCTEST_SHARD_INDEX=1`
+- WHEN both runs complete
+- THEN the union of packages executed SHALL equal the full output of `go list ./...` with no package appearing in both shards and no package omitted

--- a/openspec/changes/shard-acceptance-tests-modulo/tasks.md
+++ b/openspec/changes/shard-acceptance-tests-modulo/tasks.md
@@ -1,0 +1,20 @@
+## 1. Makefile sharding variables
+
+- [ ] 1.1 Add `ACCTEST_TOTAL_SHARDS ?= 1` and `ACCTEST_SHARD_INDEX ?= 0` near the existing `ACCTEST_PARALLELISM` / `ACCTEST_PACKAGE_PARALLELISM` block in `Makefile`.
+- [ ] 1.2 Replace the `--packages="./..."` argument in the `testacc` recipe with `--packages="$(shell go list ./... | sort | awk '(NR-1) % $(ACCTEST_TOTAL_SHARDS) == $(ACCTEST_SHARD_INDEX)')"`.
+- [ ] 1.3 Verify that `make testacc` without shard variables is equivalent to today (smoke-test: run `make testacc TESTARGS='-run ^TestAccResourceDashboardEmptyDashboard$$'` and confirm the single test runs).
+- [ ] 1.4 Verify that `make testacc ACCTEST_TOTAL_SHARDS=2 ACCTEST_SHARD_INDEX=0` and `ACCTEST_SHARD_INDEX=1` together cover all packages: `diff <(go list ./... | sort) <(cat <(go list ./... | sort | awk '(NR-1)%2==0') <(go list ./... | sort | awk '(NR-1)%2==1') | sort)` should produce no output.
+- [ ] 1.5 Update the `makefile-workflows` capability spec (REQ-023–REQ-024 or a new requirement) to require that `testacc` supports `ACCTEST_TOTAL_SHARDS` / `ACCTEST_SHARD_INDEX` with modulo-based package selection and backwards-compatible defaults.
+
+## 2. GitHub Actions workflow change
+
+- [ ] 2.1 Locate the workflow source template(s) in `workflows-src/` that define the acceptance-test matrix job.
+- [ ] 2.2 Add `shard: [0, 1]` as a matrix dimension so each `(version, shard)` pair runs as an independent job with its own runner and Elastic stack.
+- [ ] 2.3 Thread `ACCTEST_TOTAL_SHARDS=2 ACCTEST_SHARD_INDEX=${{ matrix.shard }}` into the `make testacc` step in the template.
+- [ ] 2.4 Regenerate the compiled workflow files via `make workflow-generate` and confirm `make check-workflows` passes.
+- [ ] 2.5 Confirm `make check-lint` passes with the updated workflow sources and Makefile.
+
+## 3. Verify and document
+
+- [ ] 3.1 Open the PR. Record in the PR description: (a) the estimated wall-clock for each shard derived from the timing data in `speed-up-dashboard-acceptance-tests` PR #2539; (b) the modulo split of the two known-flaky fleet packages (`integration` → shard 0, `integration_policy` → shard 1).
+- [ ] 3.2 Capture the actual wall-clock for both shards from the first successful CI run and update the PR description with the before/after comparison.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design proposal for modulo-based sharding of acceptance tests
Adds an OpenSpec change record, design document, proposal, capability spec, and implementation task checklist for splitting acceptance tests into shards using modulo bucketing.

- Tests are split into N shards (defaulting to 2) via `ACCTEST_TOTAL_SHARDS` and `ACCTEST_SHARD_INDEX` Makefile variables; default values preserve existing no-op behavior.
- CI workflow gains a shard matrix dimension so both shards run in parallel, reducing wall-clock time.
- The spec formalizes coverage guarantees: running all shard indices together must execute every test exactly once.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e300b6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->