### PR TITLE
Proposal to automatically adopt existing indices

### DIFF
--- a/openspec/changes/elasticsearch-index-use-existing/.openspec.yaml
+++ b/openspec/changes/elasticsearch-index-use-existing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/elasticsearch-index-use-existing/design.md
+++ b/openspec/changes/elasticsearch-index-use-existing/design.md
@@ -1,0 +1,129 @@
+## Context
+
+`elasticstack_elasticsearch_index` currently has a single "create" path: build the API model from the plan and call the Create Index API. If the index already exists in Elasticsearch, the API returns `resource_already_exists_exception` and the apply fails.
+
+Two production scenarios surface this:
+
+1. **Replacement race ([#966](https://github.com/elastic/terraform-provider-elasticstack/issues/966))** — A change to a static setting (e.g. `mapping_coerce`) forces replacement. Terraform destroys the old index, but indexing load or `auto_create_index` template behavior can recreate the same name before the provider's create call lands. Maintainer triage on #966 noted there is "not much the provider can do" without an opt-in mechanism. `use_existing` is that mechanism.
+2. **Adopt-without-import** — Practitioners want to manage an index that was created by another tool, a bootstrap job, or a matching index template, without taking it out of state with `terraform import` first.
+
+Both reduce to the same primitive: an opt-in fallback that, on create, tolerates an already-existing index by reconciling the resource state against it.
+
+The resource already has all the building blocks needed:
+
+- `Get Index` helper that returns `nil` for 404.
+- An update flow that reconciles aliases, dynamic settings, and mappings against any prior state, and that already understands template-injected mapping supersets.
+- A `staticSettingsKeys` list defining which settings cannot be changed on an existing index.
+- A composite `id` derived from cluster UUID + concrete name.
+
+The design reuses these to keep the new code path small and predictable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide an explicit, opt-in mechanism to tolerate an already-existing index at create time.
+- Reuse the existing update-time reconciliation for aliases, dynamic settings, and mappings — including the existing template-aware mapping semantics.
+- Fail loudly and refuse to mutate the cluster when adoption would silently lie about static settings.
+- Be a no-op at the schema and behavioral level when `use_existing = false`, preserving full backward compatibility.
+- Keep the surface area auditable: a single new attribute, a single new branch in `Create`, and a single new requirement in the spec.
+
+**Non-Goals:**
+
+- Tolerating "already exists" errors when `use_existing = false` (no implicit fallback).
+- Closing the `Get Index → 404 → Create Index → 409` TOCTOU race that can still occur if the index appears between the existence check and the create call. The existing 409 error keeps surfacing in that narrow window.
+- Adopt by date math expression, wildcard, or alias.
+- A non-destructive-destroy / "release without delete" mode. Adoption implies full Terraform ownership; `deletion_protection` (already true by default) remains the safety net.
+- Coercing static-setting values silently between config and the existing index.
+
+## Decisions
+
+### A new opt-in boolean attribute, no plan modifier
+
+A single optional boolean `use_existing` is added to the schema with default `false`. It has no `RequiresReplace` plan modifier and no `UseStateForUnknown` modifier — flipping it after the resource exists is a no-op (the resource is already in state, so there is no "create" to short-circuit).
+
+Alternative considered: making `use_existing` `ForceNew`. Rejected because that would force replacement (which can fail again for the same reasons that motivated the feature) when the user is simply correcting documentation of intent.
+
+Alternative considered: making the create flow always tolerate `resource_already_exists_exception`. Rejected because adoption is a meaningful state change with surprising consequences; it must be opt-in and visible.
+
+### Pre-flight existence check, not catch-on-409
+
+The adopt path uses a `Get Index` call before the `Create Index` call. If the index exists, the create call is skipped entirely; if it does not, the provider falls through to the normal create path.
+
+Alternative considered: try `Create Index` first and on `resource_already_exists_exception` fall back to adopt. This would close the TOCTOU window, but it produces uglier error paths (the provider has to distinguish 409s caused by adoption-eligible existence from 409s caused by other races) and the body of an Elasticsearch 409 is not always shaped consistently across versions. The pre-flight check is simpler and the residual race is acceptable for v1; it can be tightened in a follow-up by adding a 409 fallback layered on top of the pre-flight check.
+
+### Adopt by reusing the update flow over a synthetic prior state
+
+When the existence check succeeds, the create handler builds a synthetic `tfModel` from the Get Index API response (the same code path that powers `Read`) and treats it as the "prior state" passed to the existing update helpers. Concretely:
+
+- Aliases are reconciled by the existing `updateAliases` helper, which deletes aliases that are in synthetic state but not in the plan and upserts aliases present in the plan. This keeps adoption symmetric with normal update behavior — adopted aliases not in config are removed.
+- Dynamic settings are reconciled by the existing `updateSettings` helper, which only sends the diff and explicitly nulls dynamic settings present on the existing index but absent from config.
+- Mappings are reconciled by the existing `updateMappings` helper, which already treats template-injected mapping supersets as semantically equal to user intent.
+
+After reconciliation, the create handler computes `id` from the cluster UUID and the existing concrete index name, sets `concrete_name`, and performs the standard post-create read.
+
+Alternative considered: write a fresh "merge" implementation that compares the plan against the API response inline. Rejected because it would duplicate behavior already encoded in the update helpers, including the template-injected mapping semantics. Reusing the update flow keeps adoption semantics tied to normal update semantics by construction.
+
+### Static settings are strict — error, do not mutate
+
+Before any reconciliation, the adopt path compares each static setting attribute that is *explicitly* set in config (i.e. `Known()` and not null) against the value reported by Get Index for the same key, with light normalization (string-or-typed equality, since Elasticsearch returns most settings as strings).
+
+If any explicitly-configured static setting differs from the existing index, the provider:
+
+1. Collects every mismatch into a single error diagnostic listing the attribute name, the configured value, and the actual value.
+2. Returns immediately. No alias, setting, or mapping changes are applied.
+
+Static setting attributes that are not explicitly set in config are not compared — the user has no opinion, so any value on the existing index is acceptable.
+
+Alternative considered: warn and adopt anyway, persisting the existing index's values in state. Rejected because it produces permanent silent drift between config and state for static fields, surprising users when they re-read their own config months later.
+
+Alternative considered: delete the existing index and recreate. Rejected because adoption may target indices with real data; destructive mutation must never be implicit.
+
+The strict list mirrors the existing `staticSettingsKeys` slice in `models.go`: `number_of_shards`, `number_of_routing_shards`, `codec`, `routing_partition_size`, `load_fixed_bitset_filters_eagerly`, `shard.check_on_startup`, `sort.field`, `sort.order`, `mapping.coerce`. Analysis settings (`analysis_*`) are also create-only at the API level but are not in `staticSettingsKeys` and are not mass-comparable through the existing settings map; they are out of scope for the strict comparison and are simply not sent on adopt (mirroring the current update flow which also does not send them).
+
+### Date math interaction — runtime skip with a warning
+
+When `use_existing = true` and the configured `name` matches `DateMathIndexNameRe`, the existence check is skipped, a warning diagnostic is emitted explaining that `use_existing` does not apply to date math names, and the create proceeds along the normal path.
+
+Alternative considered: a plan-time configuration validator that errors on `use_existing = true` + date-math `name`. Rejected because the user explicitly requested the more lenient runtime-skip behavior, which keeps configurations portable when `name` switches between static and date math values across environments.
+
+### Adoption is observable via a warning diagnostic
+
+Whenever the adopt branch executes (the existence check returns the index), the provider adds a warning diagnostic on the resource indicating that the index was adopted rather than created, and including the concrete name. This makes adoption visible in `terraform apply` output without raising an error and without requiring users to dig into trace logs.
+
+### Destroy semantics — full ownership after adopt
+
+After adoption the resource state is identical to a freshly-created resource: same `id`, same `concrete_name`, same fields populated. `terraform destroy` calls the Delete Index API, gated by `deletion_protection` (default `true`). No new attribute or knob is introduced for adoption-specific destroy behavior.
+
+Alternative considered: a `delete_on_destroy` flag so adopted indices can be released without deletion. Rejected for v1 because it complicates state semantics and `deletion_protection = true` (the default) already protects accidental deletion. The flag can be added later if there is demand.
+
+## Risks / Trade-offs
+
+- [Risk] **TOCTOU race between existence check and create.** If the index appears between Get Index returning 404 and Create Index returning, the existing 409 still surfaces. Mitigation: explicitly documented as a known limitation; can be closed in a follow-up by chaining a 409 fallback after the pre-flight check.
+- [Risk] **Static-setting comparison may be overly strict for value normalization edge cases** (e.g. `"1"` vs `1`, `null` vs absent, ES-server-side defaults like `index.number_of_shards = "1"` filling in unspecified config values). Mitigation: normalize to the same JSON-ish representation used by the existing settings round-trip (`map[string]any`), include focused unit tests for each static setting type.
+- [Risk] **Adoption deletes aliases on the existing index that aren't in config** (because it reuses the update flow's symmetric semantics). Mitigation: this matches normal update semantics, is documented in the design, and is the principle-of-least-surprise choice — users who want to keep an alias must declare it.
+- [Risk] **Users may expect `use_existing` to also adopt during failed `Update` runs**, e.g. when an update somehow targets a missing index. Mitigation: scope is explicitly create-time-only; document the limitation in the attribute description.
+- [Risk] **Operators may flip `use_existing` to `true` on already-managed resources thinking it changes runtime behavior.** Mitigation: the attribute is no-op after create (the resource is already in state), and the design accepts this. Documentation should call this out.
+- [Risk] **Static-setting strictness can block legitimate adoption** of an index with extra non-configured settings the user did not anticipate. Mitigation: the strict comparison only fires for settings the user explicitly set, not for any static setting that happens to be set on the existing index. Users can drop the offending attribute from config to adopt and let the existing value pass through.
+
+## Migration Plan
+
+1. Add the schema attribute, its documentation, and the model field; rebuild docs.
+2. Add the existence-check + adopt branch in `Create`, reusing the existing update helpers behind a small refactor that exposes them as package-private functions taking the relevant arguments.
+3. Add the static-setting strict comparison helper and wire it into the adopt branch ahead of any update calls.
+4. Add the date-math runtime-skip + warning logic at the top of the `use_existing = true` path.
+5. Add unit tests for the static-setting comparison helper across all `staticSettingsKeys`.
+6. Add acceptance tests:
+   - adopt an empty index (template-injected only) and verify a clean apply with the warning;
+   - adopt with config matching existing → success, idempotent second apply;
+   - adopt with a static-setting mismatch → error diagnostic, no mutation;
+   - `use_existing = true` + date math name → warning + normal create.
+7. Add a `CHANGELOG.md` entry referencing #966.
+
+## Open Questions
+
+- None. The TOCTOU window after the pre-flight existence check is intentionally left open in v1, with a clear path to close it in a follow-up if needed.
+
+## Testing: `use_existing` create-branch coverage
+
+Acceptance tests exercise the full Create branching semantics end-to-end: `TestAccResourceIndexUseExistingDateMath` (date-math gate + normal create), `TestAccResourceIndexUseExistingFallthrough` (404 fall-through to Create Index), `TestAccResourceIndexUseExistingMismatch` (static mismatch + no cluster mutation), `TestAccResourceIndexUseExistingAdopt` / `TestAccResourceIndexUseExistingAdoptAliasReconcile` / `TestAccResourceIndexUseExistingTemplateNoMappingDrift` (successful adoption, symmetric aliases, template mapping superset tolerance). Unit tests cover extractable helpers (`compareStaticSettings`, `formatStaticSettingMismatchesDetail`, the date-math regex gate, and `populateFromAPI` synthetic state). Direct unit tests of each `Create` branch would need an injectable Elasticsearch client in this package; that refactor is intentionally deferred.

--- a/openspec/changes/elasticsearch-index-use-existing/proposal.md
+++ b/openspec/changes/elasticsearch-index-use-existing/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`elasticstack_elasticsearch_index` always treats create as "create a brand-new index". When an index with the same name already exists at create time, the Create Index API returns `resource_already_exists_exception` and the resource fails. This affects two real scenarios:
+
+- **Replacement race (issue [#966](https://github.com/elastic/terraform-provider-elasticstack/issues/966))** — Changing a static setting like `mapping_coerce` forces replacement. Between the destroy and the subsequent create, the index can be re-created out-of-band by indexing load or by an `auto_create_index` template, so the create then fails. Today there is no provider-side mitigation.
+- **Adopting an existing index** — Operators sometimes want to manage an index that was created out-of-band (bootstrap scripts, a different team, or an index template that pre-creates the concrete index) without first running `terraform import`.
+
+Both cases need the same primitive: an opt-in fallback during create that detects an existing index and brings it under management instead of failing.
+
+## What Changes
+
+- Add a new optional boolean attribute `use_existing` to `elasticstack_elasticsearch_index` (defaults to `false`).
+- When `use_existing = true` and the configured `name` is a static index name, the create flow SHALL look up the index by name and, if it exists, adopt it: build a synthetic prior state from the Get Index API response and run the resource's existing update logic to reconcile aliases, dynamic settings, and mappings against the plan.
+- Adoption SHALL be strict on static settings: if the existing index's static settings differ from any static setting explicitly set in config, the resource SHALL fail with an error diagnostic listing every mismatch and SHALL NOT mutate the cluster.
+- Adoption SHALL surface a warning diagnostic whenever it occurs, so practitioners can see in apply output that an existing index was adopted rather than created.
+- When `use_existing = true` but the configured `name` is a date math expression, the resource SHALL skip the existence check, emit a warning explaining `use_existing` is ignored for date math names, and fall through to the normal create path.
+- When `use_existing = false` (the default), the resource SHALL behave exactly as it does today.
+- After adoption the resource is fully managed by Terraform: subsequent reads, updates, and deletes follow the existing flows (including `deletion_protection` semantics).
+
+Out of scope:
+
+- Tolerating `resource_already_exists_exception` when `use_existing = false` (no implicit fallback).
+- Race-window handling between the existence check and the subsequent create call (the existing 409 surfaces unchanged).
+- A separate "release on destroy" / non-destructive removal mode — adopt implies full ownership.
+- Adopting indices via wildcards, aliases, or date math expressions.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `elasticsearch-index`: extend the create flow to optionally adopt an existing index by name, gated by the new `use_existing` attribute.
+
+## Impact
+
+- `internal/elasticsearch/index/index/schema.go` for the new `use_existing` attribute.
+- `internal/elasticsearch/index/index/models.go` to track `use_existing` on the Terraform model.
+- `internal/elasticsearch/index/index/create.go` for the new pre-create existence check and adopt branch, including static-setting strict validation, mapping/alias/dynamic-setting reconciliation via the existing update helpers, and warning diagnostics.
+- `internal/elasticsearch/index/index/update.go` to expose its dynamic-settings, mappings, and aliases reconciliation helpers (or share them) so the create-time adopt path can reuse them.
+- `internal/elasticsearch/index/index/acc_test.go` and `testdata/` for acceptance coverage of adopt success, static-setting mismatch error, and the date-math warning fallback.
+- `internal/elasticsearch/index/index/models_test.go` (or new unit tests) for static-setting comparison behavior.
+- `openspec/specs/elasticsearch-index/spec.md` via the delta spec for the new requirement and the modified create-flow requirement.
+- `docs/resources/elasticsearch_index.md` regenerated to document the new attribute.
+- `CHANGELOG.md` entry referencing issue #966.

--- a/openspec/changes/elasticsearch-index-use-existing/specs/elasticsearch-index/spec.md
+++ b/openspec/changes/elasticsearch-index-use-existing/specs/elasticsearch-index/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Opt-in adoption of existing indices via `use_existing`
+
+The resource SHALL expose an optional boolean attribute `use_existing` (default `false`) on `elasticstack_elasticsearch_index`. The attribute SHALL NOT have any plan modifier that triggers replacement when its value changes; flipping it on an already-managed resource SHALL be a planning no-op. When `use_existing` is `false` or unset, the resource SHALL NOT perform any pre-create existence check and SHALL behave exactly as it does today.
+
+When `use_existing` is `true` and the configured `name` is a static index name (i.e. it does not match the date-math regex), the create flow SHALL, before issuing the Create Index API call, query the Get Index API for that name. If Get Index returns no matching index (HTTP 404 or absent from the response body), the resource SHALL fall through to the normal create path without emitting any extra diagnostic.
+
+If Get Index returns an existing index, the resource SHALL adopt it. Adoption SHALL:
+
+1. Build a synthetic prior state from the Get Index API response using the same response-to-state mapping used by the Read flow.
+2. Compare each static index setting attribute that is explicitly set in the plan (i.e. neither null nor unknown) against the value reported by the Get Index API for the same setting key. The static settings compared are those listed in `staticSettingsKeys` (currently: `number_of_shards`, `number_of_routing_shards`, `codec`, `routing_partition_size`, `load_fixed_bitset_filters_eagerly`, `shard.check_on_startup`, `sort.field`, `sort.order`, `mapping.coerce`). Static settings not explicitly set in config SHALL NOT be compared.
+3. If any explicitly-configured static setting differs from the existing index, the resource SHALL return an error diagnostic naming every mismatched attribute together with its configured and actual values, SHALL NOT call any Put Settings, Put Mapping, Put Alias, or Delete Alias APIs, and SHALL NOT update Terraform state.
+4. Otherwise, reconcile the existing index against the plan by reusing the same alias, dynamic-setting, and mappings reconciliation logic used by the resource's update flow. Aliases present on the existing index but absent from the plan SHALL be deleted via the Delete Alias API; aliases present in the plan SHALL be upserted via the Put Alias API. Dynamic-setting differences SHALL be applied via Put Settings, with dynamic settings present on the existing index but absent from the plan sent as `null`. Mapping differences SHALL be applied via Put Mapping using the resource's existing mapping semantic-equality logic, including the existing template-aware superset handling.
+5. Compute `id` from the current cluster UUID and the concrete index name returned by Get Index, set `concrete_name` to that concrete index name, and perform the standard post-create read to refresh state.
+6. Emit a warning diagnostic stating that the existing index was adopted, including the concrete index name in the message.
+
+When `use_existing` is `true` and the configured `name` is a plain date math expression (i.e. it matches `DateMathIndexNameRe`), the resource SHALL skip the existence check, emit a warning diagnostic explaining that `use_existing` has no effect for date math names, and proceed along the normal create path without further changes in behavior.
+
+After adoption, the resource SHALL be fully managed by Terraform: subsequent reads, updates, and deletes SHALL follow the existing flows. In particular, a subsequent destroy SHALL call the Delete Index API for the adopted concrete index, gated by `deletion_protection` according to its existing semantics.
+
+#### Scenario: `use_existing = false` keeps the create path unchanged
+
+- **GIVEN** `use_existing` is `false` (or unset) on an `elasticstack_elasticsearch_index` resource
+- **WHEN** create runs
+- **THEN** the resource SHALL NOT call the Get Index API before the Create Index API
+- **AND** the create flow SHALL behave exactly as it does without this attribute
+
+#### Scenario: `use_existing = true` adopts an existing static-named index
+
+- **GIVEN** `use_existing = true`, `name` is a static index name, and an index with that name already exists in Elasticsearch
+- **AND** every static setting explicitly set in the plan matches the existing index's static settings
+- **WHEN** create runs
+- **THEN** the resource SHALL NOT call the Create Index API
+- **AND** the resource SHALL reconcile aliases, dynamic settings, and mappings against the existing index using the same logic as a normal update
+- **AND** `id` SHALL be set from the cluster UUID and the existing concrete index name
+- **AND** `concrete_name` SHALL be set to the existing concrete index name
+- **AND** a warning diagnostic indicating that the index was adopted (including the concrete name) SHALL be emitted
+- **AND** a subsequent Terraform plan against the same configuration SHALL be empty
+
+#### Scenario: `use_existing = true` falls through to create when the index does not exist
+
+- **GIVEN** `use_existing = true`, `name` is a static index name, and no index with that name exists in Elasticsearch
+- **WHEN** create runs
+- **THEN** the resource SHALL call the Create Index API as it does today
+- **AND** SHALL NOT emit an adoption warning
+
+#### Scenario: Adoption with mismatched static settings fails without mutating the cluster
+
+- **GIVEN** `use_existing = true`, an existing index whose static settings differ from at least one static setting explicitly set in the plan
+- **WHEN** create runs
+- **THEN** the resource SHALL return an error diagnostic listing every mismatched static setting with its configured and actual values
+- **AND** the resource SHALL NOT call Put Settings, Put Mapping, Put Alias, or Delete Alias on the existing index
+- **AND** Terraform state SHALL NOT be updated
+
+#### Scenario: Adopting an index reconciles aliases symmetrically with normal updates
+
+- **GIVEN** `use_existing = true` and an existing index that has alias `legacy_alias`
+- **AND** the plan defines alias `new_alias` and does not declare `legacy_alias`
+- **WHEN** create runs and adoption proceeds
+- **THEN** the resource SHALL call the Delete Alias API for `legacy_alias`
+- **AND** SHALL call the Put Alias API for `new_alias`
+
+#### Scenario: Adopting an index tolerates template-injected mapping supersets
+
+- **GIVEN** `use_existing = true` and an existing index whose mappings are a non-drifting superset of the plan's mappings due to a matching index template
+- **WHEN** create runs and adoption proceeds
+- **THEN** the resource SHALL NOT call the Put Mapping API solely for the template-owned differences
+- **AND** Terraform SHALL produce an empty plan for the unchanged configuration on the next refresh
+
+#### Scenario: `use_existing = true` with a date math name emits a warning and falls through to create
+
+- **GIVEN** `use_existing = true` and `name` is a plain Elasticsearch date math expression
+- **WHEN** create runs
+- **THEN** the resource SHALL NOT call the Get Index API for that name
+- **AND** the resource SHALL emit a warning diagnostic explaining that `use_existing` has no effect for date math names
+- **AND** the resource SHALL proceed with the normal create path (URI-encoded date math name, capture concrete name from response, etc.)
+
+#### Scenario: Flipping `use_existing` after adoption is a planning no-op
+
+- **GIVEN** an `elasticstack_elasticsearch_index` resource has been created via adoption with `use_existing = true`
+- **WHEN** the configuration changes `use_existing` from `true` to `false` (or back) without any other changes
+- **THEN** Terraform SHALL plan an in-place update with no API calls
+- **AND** the resource SHALL NOT be marked for replacement
+
+## MODIFIED Requirements
+
+### Requirement: Create flow (REQ-013–REQ-014)
+
+On create, the resource SHALL build an API model from the plan (including settings, mappings, and aliases) and submit a Create Index request using the configured `name` together with the configured `wait_for_active_shards`, `master_timeout`, and `timeout` parameters. When the configured `name` is a validated date math expression, the provider SHALL URI-encode it before sending the Create Index API request path. After a successful create, the resource SHALL capture the concrete index name returned by the Create Index API response, store it in `concrete_name`, compute `id` from the cluster UUID and that concrete name, and then perform a read to refresh all computed attributes in state. That post-create read SHALL preserve the configured `name` value in state rather than replacing it with the concrete index name.
+
+When `use_existing` is `true` and the configured `name` is a static index name, the resource SHALL first call the Get Index API for that name. If the index already exists, the resource SHALL adopt it as defined by the "Opt-in adoption of existing indices via `use_existing`" requirement, in which case the Create Index API SHALL NOT be called. If the index does not exist, the resource SHALL proceed with the normal create path described above. When `use_existing` is `true` and the configured `name` is a date math expression, the resource SHALL emit a warning diagnostic and proceed with the normal create path without performing any existence check.
+
+#### Scenario: Serverless — master_timeout and wait_for_active_shards omitted
+
+- **GIVEN** the Elasticsearch server flavor is `serverless`
+- **WHEN** a create request is issued
+- **THEN** `master_timeout` and `wait_for_active_shards` SHALL be omitted from the API call parameters
+
+#### Scenario: Date math create stores configured and concrete names separately
+
+- **WHEN** the configuration uses a plain date math index name and Elasticsearch creates a concrete index from it
+- **THEN** state SHALL preserve the configured expression in `name` and store the concrete created index in `concrete_name`
+
+#### Scenario: `use_existing = true` short-circuits the Create Index API for an existing index
+
+- **GIVEN** `use_existing = true`, `name` is a static index name, and the index already exists in Elasticsearch
+- **WHEN** create runs
+- **THEN** the resource SHALL NOT call the Create Index API
+- **AND** the resource SHALL run the adoption flow
+
+#### Scenario: `use_existing = true` falls through to the normal create when the index does not exist
+
+- **GIVEN** `use_existing = true`, `name` is a static index name, and no index with that name exists in Elasticsearch
+- **WHEN** create runs
+- **THEN** the resource SHALL call the Create Index API as it would when `use_existing = false`

--- a/openspec/changes/elasticsearch-index-use-existing/tasks.md
+++ b/openspec/changes/elasticsearch-index-use-existing/tasks.md
@@ -1,0 +1,37 @@
+## 1. Schema and model
+
+- [ ] 1.1 Add the optional `use_existing` boolean attribute (default `false`, no plan modifiers) to `internal/elasticsearch/index/index/schema.go` with a description that explains: opt-in, create-time-only, static names only, strict on static settings, full ownership after adopt.
+- [ ] 1.2 Add the corresponding `UseExisting types.Bool` field to `tfModel` in `internal/elasticsearch/index/index/models.go`.
+- [ ] 1.3 Regenerate `docs/resources/elasticsearch_index.md` so the new attribute is documented.
+
+## 2. Static-setting strict comparison helper
+
+- [ ] 2.1 Add a helper that, given a plan `tfModel` and a `models.Index` returned by Get Index, walks `staticSettingsKeys` and reports a list of mismatches for static settings that are explicitly set in the plan (`Known()` and not null) and differ from the existing index value.
+- [ ] 2.2 Normalize comparison values so Elasticsearch's stringly-typed responses (`"1"`, `"true"`) compare equal to the typed plan values (`int64(1)`, `true`) for each `staticSettingsKeys` attribute type used in the schema.
+- [ ] 2.3 Add unit tests for the helper covering: no mismatches, single mismatch, multiple mismatches, plan attribute null/unknown, value-type normalization for ints, bools, strings, and the list/set typed static settings (`sort.field`, `sort.order`).
+
+## 3. Adopt branch in Create
+
+- [ ] 3.1 Refactor `Update` in `internal/elasticsearch/index/index/update.go` so the alias, dynamic-setting, and mapping reconciliation logic is callable as package-private helpers taking explicit arguments (synthetic state vs plan). Preserve all existing semantics.
+- [ ] 3.2 In `internal/elasticsearch/index/index/create.go`, when `use_existing = true`:
+  - [ ] 3.2.1 If the configured `name` matches `esclient.DateMathIndexNameRe`, add a warning diagnostic explaining `use_existing` is ignored for date math names and fall through to the existing create path.
+  - [ ] 3.2.2 Otherwise call `elasticsearch.GetIndex` for the configured `name`. If the response is `nil` (404), fall through to the existing create path.
+  - [ ] 3.2.3 If the response returns an existing index, build a synthetic `tfModel` from the API response using the existing `populateFromAPI` flow.
+  - [ ] 3.2.4 Run the static-setting strict comparison; on any mismatch, return an error diagnostic listing each mismatch and stop without mutating the cluster.
+  - [ ] 3.2.5 Otherwise call the alias, dynamic-setting, and mapping reconciliation helpers with the synthetic state vs the plan.
+  - [ ] 3.2.6 Compute `id` from the cluster UUID and the existing concrete index name, set `ConcreteName`, perform a final read, and add a warning diagnostic stating that the existing index was adopted (including the concrete name).
+- [ ] 3.3 When `use_existing = false`, ensure the create path is byte-for-byte the same as today (no warning, no extra API call).
+
+## 4. Acceptance and unit coverage
+
+- [ ] 4.1 Add an acceptance test that creates an index out-of-band (or via an index template that pre-creates a concrete index), then applies a Terraform configuration with `use_existing = true` and verifies: success, the warning diagnostic, no spurious follow-up plan, and that subsequent updates run through the normal update path.
+- [ ] 4.2 Add an acceptance test where the existing index has a different `number_of_shards` than config and verify the apply fails with an error diagnostic listing the mismatch and no mutation occurs (existing index settings remain unchanged).
+- [ ] 4.3 Add an acceptance test for `use_existing = true` plus a date math `name` that asserts the warning is emitted and the create proceeds normally.
+- [ ] 4.4 Add unit tests covering the create handler's branching (existence check skipped for date math, 404 falls through, 200 with mismatching static settings errors, 200 with matching static settings runs reconciliation and emits the warning).
+
+  Branches in **task 4.4** are fully covered in acceptance tests (`TestAccResourceIndexUseExistingDateMath`, `TestAccResourceIndexUseExistingFallthrough`, `TestAccResourceIndexUseExistingMismatch`, `TestAccResourceIndexUseExistingAdopt`, plus `…AdoptAliasReconcile`, `…TemplateNoMappingDrift`); unit tests cover helper extraction only—injectable ES client for `Create` is deferred (see change `design.md`, section “Testing: use_existing create-branch coverage”).
+
+## 5. Changelog and references
+
+- [ ] 5.1 Add a `CHANGELOG.md` entry under "Unreleased" describing the new `use_existing` attribute and referencing issue #966.
+- [ ] 5.2 Cross-link the new attribute in the resource description / schema docs so practitioners encountering the "already exists" error during replacement can discover the workaround.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `use_existing` adoption path for `elasticstack_elasticsearch_index` at create time
- Adds a design proposal and spec for a new `use_existing` boolean attribute on `elasticstack_elasticsearch_index` that allows Terraform to adopt a pre-existing index rather than failing or recreating it.
- At create time, if `use_existing` is set, the provider performs a pre-flight `GET` index check; if the index exists, it synthesizes prior state and runs the normal update reconciliation path instead of creating a new index.
- Static settings (e.g. number of shards) are compared strictly — mismatches surface as warning diagnostics rather than errors, and date-math index names are skipped during the existence check.
- This PR is a spec/design-only change; implementation tasks are tracked in [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2588/files#diff-d2a6f41780df1ba8533da4d63d9013d163c68ff4655c4928af65c31213086a38).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4568fd0.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->