### PR TITLE
Fix runtime_field_map consistency issue

### DIFF
--- a/openspec/changes/fix-dataview-runtime-field-map-state/.openspec.yaml
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/fix-dataview-runtime-field-map-state/design.md
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The `elasticstack_kibana_data_view` resource manages Kibana data views through Kibana's Data Views HTTP API. Kibana's update endpoint follows a partial-update contract: only the properties provided in the request body are modified; omitted properties remain unchanged in Kibana's persisted state.
+
+Terraform's Plugin Framework distinguishes between:
+- **Optional only**: Terraform expects the attribute in state to exactly match the config (whether set or null). If the provider returns a different value, Terraform raises a consistency error.
+- **Optional + Computed**: Terraform allows the provider to return a value that differs from config, because the real value is determined by the external system.
+
+Currently `data_view.runtime_field_map` is `Optional` but not `Computed`. When a user removes `runtime_field_map` from their Terraform configuration, Kibana preserves the existing runtime fields, the provider reads them back on refresh, and Terraform rejects the state because `null (plan) ≠ non-null (state)`.
+
+This same risk exists for other collection attributes (`source_filters`, `field_formats`), but the issue reporter only hit `runtime_field_map`. The Kibana API docs claim all unspecified fields stay persisted, yet the current acceptance tests pass for those other attributes. That suggests either:
+- The test currently masks the issue because `field_attrs` removal forces resource replacement, so the "update" path is never exercised, or
+- Kibana's preservation behavior is field-specific despite the generic docs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the Terraform state consistency error for `runtime_field_map` when it is omitted from config but Kibana preserves it
+- Update the acceptance test to assert true in-place update (not replacement) behavior for the data view resource
+- Document the expected behavior for `runtime_field_map` persistence in requirements
+
+**Non-Goals:**
+- Changing `source_filters` or `field_formats` to `Computed` — only if acceptance tests reveal they have the same problem after the test fix
+- Adding new provider functionality (e.g., dedicated runtime field sub-resource)
+- Changing how Kibana's API works (we work with its partial-update semantics)
+
+## Decisions
+
+### Decision 1: Add `Computed: true` to `runtime_field_map`
+
+**Rationale:** This is the minimal, correct fix. Terraform's semantics say: if an external system can produce a value different from what the user configured, the attribute must be `Computed`. Kibana's partial-update contract means the persisted `runtime_field_map` can diverge from config when omitted, so `Computed` is semantically correct.
+
+**Alternative considered:** Send an explicit empty map `{}` when config omits `runtime_field_map`. Rejected because it would change behavior — users who explicitly omit the field would see their Kibana runtime fields deleted, which is a breaking change and contrary to the current documented/tested behavior.
+
+### Decision 2: Keep `field_attrs` in `basic_updated` testdata
+
+**Rationale:** `field_attrs` has a `RequiresReplace()` plan modifier. Removing it from config in `basic_updated` forces replacement, which masks the `runtime_field_map` bug because the new resource starts with no runtime fields. To test the true update path, the step must avoid any attribute that triggers replacement.
+
+### Decision 3: Assert `runtime_field_map` is still present in the update step
+
+**Rationale:** Because Kibana preserves the field, and now it's `Computed`, Terraform will accept the non-null value into state even when config omits it. The test should assert this preservation rather than asserting absence.
+
+## Risks / Trade-offs
+
+- **[Risk]** Setting `Computed: true` means Terraform will silently accept drift between config and state. If a user genuinely wants to remove all runtime fields, they must explicitly set `runtime_field_map = {}`. `TestCheckNoResourceAttr` is replaced with `TestCheckResourceAttr`.
+  - **Mitigation**: This is already how the system behaves (Kibana preserves the field). `Computed` only makes Terraform stop complaining about the existing behavior. The `runtime_field_map = {}` workaround is already documented in issue #2135.
+
+- **[Risk]** The change to `Computed` could cause import verification to fail if `runtime_field_map` is not present in config but present in imported state.
+  - **Mitigation**: Add `ImportStateVerifyIgnore` for `data_view.runtime_field_map` in the import test step.
+
+## Open Questions
+
+- Do `source_filters` and `field_formats` also require `Computed: true`? The Kibana docs suggest yes, but current tests don't exercise true update for those fields. This will be resolved by running the fixed acceptance test; if those fields also produce consistency errors, they can be added to a follow-up change.

--- a/openspec/changes/fix-dataview-runtime-field-map-state/proposal.md
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Kibana's Data Views update API preserves unspecified fields (documented as "Only the specified properties are updated in the data view. Unspecified fields stay as they are persisted."). When a Terraform configuration omits `data_view.runtime_field_map` after previously defining it, Kibana keeps the runtime fields. The provider then reads them back into state, but because `runtime_field_map` is `Optional` and not `Computed`, Terraform rejects the post-apply state with:
+
+```
+produced an unexpected new value: .data_view.runtime_field_map: was null, but now ...
+```
+
+This prevents clean updates when users remove `runtime_field_map` from configuration (reported in #2135). Adding `Computed: true` to the schema attribute aligns Terraform's expectations with Kibana's partial-update semantics.
+
+## What Changes
+
+- **Schema change**: Add `Computed: true` to `data_view.runtime_field_map` in `internal/kibana/dataview/schema.go`
+- **Acceptance test fix**: Update `TestAccResourceDataView` so the `basic → basic_updated` transition exercises a true in-place update rather than a resource replacement:
+  - Keep `field_attrs` in `basic_updated` testdata to avoid `RequiresReplace`
+  - Add `captureID` / `checkIDUnchanged` assertions across update steps
+  - Update expectations for `runtime_field_map` in the update step to assert the fields are still present (because Kibana preserves them)
+  - Add `ImportStateVerifyIgnore` for `data_view.runtime_field_map` in the import step
+- **Requirements update**: Update REQ-011 in `kibana-data-view` spec to cover the preserved-null behavior for `runtime_field_map` when the attribute is omitted from config
+
+## Capabilities
+
+### New Capabilities
+*(none)*
+
+### Modified Capabilities
+
+- `kibana-data-view`: REQ-011 (State mapping for empty collections) must be updated to specify that `runtime_field_map` is `Computed`. When the attribute is omitted from config and Kibana preserves a non-empty `runtime_field_map`, the provider SHALL accept the API response into state without raising a consistency error.
+
+## Impact
+
+- `internal/kibana/dataview/schema.go` — add `Computed: true` to `runtime_field_map`
+- `internal/kibana/dataview/acc_test.go` — add ID stability checks, adjust runtime_field_map assertions, add import ignore
+- `internal/kibana/dataview/testdata/TestAccResourceDataView/basic_updated/data_view.tf` — keep `field_attrs` to avoid replacement
+- `openspec/specs/kibana-data-view/spec.md` — update REQ-011 requirements

--- a/openspec/changes/fix-dataview-runtime-field-map-state/specs/kibana-data-view/spec.md
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/specs/kibana-data-view/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: State mapping for empty collections (REQ-011)
+
+When mapping API responses back to Terraform state, empty `source_filters`, `field_attrs`, `runtime_field_map`, and `field_formats` returned by Kibana SHALL preserve a prior null value instead of forcing an empty list or map into state. If a field format entry has no `params`, the resource SHALL store `params` as a null object in state. `runtime_field_map` SHALL be marked `Computed` so that Terraform accepts a persisted non-empty value when the attribute is omitted from configuration.
+
+#### Scenario: Empty API collection preserves null
+- GIVEN prior state where `data_view.source_filters` is null
+- WHEN Kibana returns an empty `source_filters` collection
+- THEN the provider SHALL keep `data_view.source_filters` null in state
+
+#### Scenario: Omitted runtime_field_map with persisted API value
+- GIVEN prior state where `data_view.runtime_field_map` contains entries
+- WHEN the configuration removes `data_view.runtime_field_map` and update runs
+- AND Kibana preserves the existing runtime fields in its response
+- THEN the provider SHALL accept the persisted `runtime_field_map` into state without raising a consistency error

--- a/openspec/changes/fix-dataview-runtime-field-map-state/specs/kibana-data-view/spec.md
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/specs/kibana-data-view/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: State mapping for empty collections (REQ-011)
 
-When mapping API responses back to Terraform state, empty `source_filters`, `field_attrs`, `runtime_field_map`, and `field_formats` returned by Kibana SHALL preserve a prior null value instead of forcing an empty list or map into state. If a field format entry has no `params`, the resource SHALL store `params` as a null object in state. `runtime_field_map` SHALL be marked `Computed` so that Terraform accepts a persisted non-empty value when the attribute is omitted from configuration.
+When mapping API responses back to Terraform state, empty `source_filters`, `field_attrs`, `runtime_field_map`, and `field_formats` returned by Kibana SHALL preserve a prior null value instead of forcing an empty list or map into state. If a field format entry has no `params`, the resource SHALL store `params` as a null object in state. `runtime_field_map` SHALL be marked `Optional` and `Computed` so that it remains user-settable while Terraform also accepts a persisted non-empty value when the attribute is omitted from configuration.
 
 #### Scenario: Empty API collection preserves null
 - GIVEN prior state where `data_view.source_filters` is null

--- a/openspec/changes/fix-dataview-runtime-field-map-state/tasks.md
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Acceptance Test Fix
 
-- [ ] 2.1 Update `internal/kibana/dataview/testdata/TestAccResourceDataView/basic_updated/data_view.tf` to include `field_attrs` so the step no longer triggers `RequiresReplace()`
+- [ ] 2.1 Update `internal/kibana/dataview/testdata/TestAccResourceDataView/basic_updated/data_view.tf` to include `field_attrs` with the same values as in `internal/kibana/dataview/testdata/TestAccResourceDataView/basic/data_view.tf`, so the step no longer triggers `RequiresReplace()`
 - [ ] 2.2 Add `captureID` and `checkIDUnchanged` helper functions in `internal/kibana/dataview/acc_test.go` (same pattern used in `TestAccResourceDataViewNamespaces`)
 - [ ] 2.3 Attach `captureID` to the `basic` step's Check and `checkIDUnchanged` to the `basic_updated` step's Check in `TestAccResourceDataView`
 - [ ] 2.4 Update the `basic_updated` step assertions: replace `TestCheckNoResourceAttr(..., "data_view.runtime_field_map")` with `TestCheckResourceAttr(..., "data_view.runtime_field_map.runtime_shape_name.script_source", "emit(doc['shape_name'].value)")` to assert that Kibana preserves the runtime field

--- a/openspec/changes/fix-dataview-runtime-field-map-state/tasks.md
+++ b/openspec/changes/fix-dataview-runtime-field-map-state/tasks.md
@@ -1,0 +1,22 @@
+## 1. Schema Fix
+
+- [ ] 1.1 Add `Computed: true` to `data_view.runtime_field_map` in `internal/kibana/dataview/schema.go`
+- [ ] 1.2 Run `make build` to verify the schema change compiles
+
+## 2. Acceptance Test Fix
+
+- [ ] 2.1 Update `internal/kibana/dataview/testdata/TestAccResourceDataView/basic_updated/data_view.tf` to include `field_attrs` so the step no longer triggers `RequiresReplace()`
+- [ ] 2.2 Add `captureID` and `checkIDUnchanged` helper functions in `internal/kibana/dataview/acc_test.go` (same pattern used in `TestAccResourceDataViewNamespaces`)
+- [ ] 2.3 Attach `captureID` to the `basic` step's Check and `checkIDUnchanged` to the `basic_updated` step's Check in `TestAccResourceDataView`
+- [ ] 2.4 Update the `basic_updated` step assertions: replace `TestCheckNoResourceAttr(..., "data_view.runtime_field_map")` with `TestCheckResourceAttr(..., "data_view.runtime_field_map.runtime_shape_name.script_source", "emit(doc['shape_name'].value)")` to assert that Kibana preserves the runtime field
+- [ ] 2.5 Update the import step to add `ImportStateVerifyIgnore: []string{"data_view.runtime_field_map"}` so that import verification succeeds when the imported state contains a preserved `runtime_field_map` that is absent from config
+
+## 3. Requirements Update
+
+- [ ] 3.1 Update REQ-011 in `openspec/specs/kibana-data-view/spec.md` to match the modified requirement in the change delta spec (mark `runtime_field_map` as `Computed`, add scenario for omitted config with persisted API value)
+
+## 4. Validation
+
+- [ ] 4.1 Run unit tests: `go test ./internal/kibana/dataview/...`
+- [ ] 4.2 Run `make check-lint` to ensure lint passes
+- [ ] 4.3 If a Kibana stack is available, run acceptance tests: `TF_ACC=1 go test -v -run TestAccResourceDataView ./internal/kibana/dataview/... -timeout 20m`


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Mark `runtime_field_map` as Computed in the Kibana data view Terraform provider schema
- Marks `runtime_field_map` as `Optional` and `Computed` in the data view schema so that API-persisted values are accepted into state without causing drift.
- Updates acceptance tests to assert in-place update behavior, ID stability, and to ignore `runtime_field_map` during import verification.
- Behavioral Change: Previously, omitting `runtime_field_map` in config would cause a plan diff if the API returned a non-empty value; after this change, the API value is preserved in state silently.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 697dd99.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->