### PR TITLE
Data sources use envelope

### DIFF
--- a/openspec/changes/migrate-pf-datasources-to-envelope/.openspec.yaml
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/migrate-pf-datasources-to-envelope/design.md
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/design.md
@@ -1,0 +1,119 @@
+## Context
+
+The `entitycore` package currently provides two data source patterns:
+
+1. **Envelope generics** — `NewKibanaDataSource[T]` and `NewElasticsearchDataSource[T]` — which own `Configure`, `Metadata`, `Schema` (with connection block injection), and `Read` orchestration (config decode → scoped client resolution → optional version gate → callback invocation → state persistence). This pattern has been proven by three Agent Builder data sources (`agentbuilder_agent`, `agentbuilder_tool`, `agentbuilder_workflow`).
+
+2. **Struct-based embedding** — `DataSourceBase` — which provides `Configure`, `Metadata`, and client factory access, but requires the concrete data source to implement `Schema` and `Read` manually. Nine data sources still use this or fully bespoke wiring.
+
+Additionally, `agentbuilder_agent` currently satisfies the envelope contract through hand-rolled accessor methods (`GetKibanaConnection`, `GetVersionRequirements`) rather than embedding `KibanaConnectionField`, making it inconsistent with the other envelope data sources.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Migrate all remaining Plugin Framework data sources to the envelope pattern.
+- Unify PF data source implementation so every one follows the same pattern.
+- Remove `DataSourceBase` and all `entitycore_contract_test.go` files that assert its embedding, since it will have zero consumers.
+- Update `agentbuilder_agent` to embed `entitycore.KibanaConnectionField` for consistency.
+- Preserve every existing Terraform type name, schema attribute, and read behavior.
+- Zero acceptance test breakage.
+
+**Non-Goals:**
+
+- Do not migrate SDK v2 data sources (ingest processors, cluster info, snapshot repository, etc.).
+- Do not migrate resources to resource envelopes.
+- Do not add `DataSourceVersionRequirement` support to any data source that doesn't already have static version gating (only `agentbuilder_agent` currently uses this).
+- Do not change user-visible schemas or add/remove attributes.
+- Do not introduce new envelope features (e.g., retry logic, caching, post-read hooks).
+
+## Decisions
+
+### 1. Use model embedding for all migrations
+
+**Chosen:** All migrated data sources shall embed `entitycore.KibanaConnectionField` or `entitycore.ElasticsearchConnectionField` in their models.
+
+**Rationale:** The envelope's doc.go already prescribes this as the canonical pattern. Embedding provides the `GetKibanaConnection()` / `GetElasticsearchConnection()` method automatically, eliminates hand-rolled accessors, and keeps models self-describing. For `agentbuilder_agent`, this replaces the current accessor-method approach with embedding.
+
+**Alternative considered:** Keep existing explicit `KibanaConnection` / `ElasticsearchConnection` fields and add accessor methods. Rejected because it perpetuates inconsistency and the embedding pattern is already proven across `agentbuildertool` and `agentbuilderworkflow`.
+
+### 2. Schema factory omits connection blocks
+
+**Chosen:** Extract the current `Schema` method body into a package-level `func() dsschema.Schema` that returns entity attributes only, with no `kibana_connection` or `elasticsearch_connection` block.
+
+**Rationale:** Matches the existing envelope contract. The envelope injects the connection block via `maps.Copy` in its `Schema` method. This avoids duplicate block definitions and ensures all connection blocks use the same schema definition from `providerschema`.
+
+### 3. Read callback signature: `(ctx, client, model) (model, diag.Diagnostics)`
+
+**Chosen:** Each data source's current `Read` method is stripped of envelope-owned orchestration and converted to a pure callback with this signature.
+
+**Rationale:** The envelope owns config decode, client resolution, optional version enforcement, and state persistence. The callback owns only the entity-specific API call and model population. This is the exact contract already used by the Agent Builder POC.
+
+### 4. Remove DataSourceBase as part of this change
+
+**Chosen:** Once all `DataSourceBase` consumers are migrated, delete `internal/entitycore/data_source_base.go` and `data_source_base_test.go`.
+
+**Rationale:** `DataSourceBase` exists solely for struct-based data sources. Once none remain, keeping it creates dead code and invites future inconsistency. If a future data source genuinely needs custom `Read` orchestration, it can still implement `datasource.DataSource` directly without `DataSourceBase`.
+
+**Alternative considered:** Deprecate but keep `DataSourceBase`. Rejected because it has no callers and the envelope is strictly more powerful for the uniform case.
+
+### 5. Fleet data sources use `NewKibanaDataSource` with `ComponentFleet`
+
+**Chosen:** `fleet_integration`, `fleet_output`, and `enrollment_tokens` use `NewKibanaDataSource[T]` even though their Terraform type names use the `"fleet"` component.
+
+**Rationale:** `Component` controls only the Terraform type name prefix (`elasticstack_fleet_*`). The envelope's `GetKibanaClient` resolves a Kibana scoped client, which is exactly what Fleet data sources need (they subsequently call `GetFleetClient()` on it). There is no `ComponentFleet` envelope variant because client resolution is driven by the connection type, not the component string.
+
+### 6. Batch execution order
+
+**Chosen:** Execute in three batches based on complexity and client backing:
+
+1. **Batch 1 (Kibana-backed)**: `spaces`, `export_saved_objects` — simplest models, warm up on pattern.
+2. **Batch 2 (Fleet-backed)**: `fleet_integration`, `fleet_output`, `enrollment_tokens` — moderate complexity, prove `ComponentFleet` + Kibana client combination.
+3. **Batch 3 (ES-backed)**: `indices`, `index_template`, `enrich_policy`, `security_role_mapping` — heaviest schemas, includes one legacy not-found behavior (`index_template`).
+
+**Rationale:** Risk increases with schema size and special-case behavior. Starting with smaller data sources validates the mechanical refactoring before tackling the complex ones. Each batch can be committed independently if CI passes.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|-----------|
+| Schema block injection changes where `kibana_connection` / `elasticsearch_connection` is declared in source, but the final runtime schema should be identical. | Acceptance tests verify schema correctness. Unit tests in `entitycore` already assert block injection. Spot-check each migrated data source's schema response in a unit test if acceptance coverage is sparse. |
+| `index_template` has legacy not-found behavior: when the template is missing, it sets an empty model with only `name` and `elasticsearch_connection`. In the envelope, the callback returns the model and the envelope calls `resp.State.Set`. Need to verify this preserves behavior. | Review the `index_template` callback carefully. The empty model still carries the connection block from config decode (embedded field), so `resp.State.Set` should produce the same state. Targeted acceptance test for missing template confirms this. |
+| Large schema moves (`indices` has 50+ attributes, `index_template` has nested blocks with custom types) create noisy diffs that are hard to review. | Keep mechanical moves in dedicated commits separate from logic changes. Use `git diff --stat` to monitor line counts. |
+| Removing `DataSourceBase` might break in-flight PRs that add new struct-based data sources. | This is a short window risk. Coordinate with team. Any future data source should use the envelope from the start. |
+| `agentbuilder_agent` model change from accessors to embedding shifts the `KibanaConnection` field's position in the struct, which could affect struct tag-based reflection or test assertions. | `agentbuilder_agent` tests do not use reflection on the model for the connection field. Manual verification of unit and acceptance tests. |
+| `enrich_policy` shares its `PolicyData` model between the data source and the resource. Embedding `ElasticsearchConnectionField` adds a field the resource doesn't need. | The resource uses `PolicyDataWithExecute`, which embeds `PolicyData`. The extra field is harmless (it's a Terraform framework type, not an API field). Alternatively, define a separate data-source-only model if the resource tests complain. |
+
+## Migration Plan
+
+1. **Batch 1 — Kibana-backed simple data sources**
+   - Refactor `spaces` (embed `KibanaConnectionField`, schema factory, read callback, remove `entitycore_contract_test.go`).
+   - Refactor `export_saved_objects` similarly.
+   - Run targeted acceptance tests.
+
+2. **Batch 2 — Fleet-backed data sources**
+   - Refactor `fleet_integration`, `fleet_output`, `enrollment_tokens`.
+   - Run targeted acceptance tests.
+
+3. **Batch 3 — Elasticsearch-backed data sources**
+   - Refactor `security_role_mapping`, `enrich_policy`, `indices`, `index_template`.
+   - Pay special attention to `index_template` not-found handling.
+   - Run targeted acceptance tests.
+
+4. **Agent Builder agent model cleanup**
+   - Update `agentbuilderagent/models.go` to embed `KibanaConnectionField`.
+   - Remove `GetKibanaConnection` and `GetVersionRequirements` methods (the envelope's type constraint is now satisfied by embedding).
+   - Run existing acceptance tests.
+
+5. **Remove dead code**
+   - Delete `internal/entitycore/data_source_base.go`.
+   - Delete `internal/entitycore/data_source_base_test.go`.
+
+6. **Final verification**
+   - `go build` passes.
+   - All acceptance tests for migrated data sources pass.
+   - `make check-openspec` passes (no spec changes needed, but structural checks should succeed).
+
+## Open Questions
+
+- None. The pattern is proven and mechanical.

--- a/openspec/changes/migrate-pf-datasources-to-envelope/proposal.md
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The provider has two parallel data source wiring patterns: the generic `entitycore` envelope (`NewKibanaDataSource` / `NewElasticsearchDataSource`) and manual struct-based wiring (`DataSourceBase` embedding or fully bespoke `Configure`/`Metadata`/`Read`). The envelope eliminates duplicated boilerplate (config decode, scoped client resolution, state persistence, connection block schema injection) and is already proven by the Agent Builder POC. Migrating all remaining Plugin Framework data sources to the envelope unifies the codebase, reduces maintenance surface, and makes `DataSourceBase` — which will have zero consumers — removable.
+
+## What Changes
+
+- **Migrate 9 remaining PF data sources** to the generic envelope:
+  - **Kibana-backed** (use `NewKibanaDataSource`): `spaces`, `export_saved_objects`
+  - **Fleet-backed Kibana client** (use `NewKibanaDataSource` with `ComponentFleet`): `fleet_integration`, `fleet_output`, `enrollment_tokens`
+  - **Elasticsearch-backed** (use `NewElasticsearchDataSource`): `indices`, `index_template`, `enrich_policy`, `security_role_mapping`
+- **Update `agentbuilder_agent` model** to embed `entitycore.KibanaConnectionField` instead of a hand-rolled accessor, aligning it with the other envelope data sources.
+- **Remove `DataSourceBase`** from `internal/entitycore/data_source_base.go` and all dependent `entitycore_contract_test.go` files, since every PF data source will use the envelope.
+- **Convert schema methods to schema factories** for all migrated data sources: extract the current `Schema` method body into a package-level `func() dsschema.Schema` that omits the connection block (the envelope injects it).
+- **Convert `Read` methods to pure read callbacks** for all migrated data sources: strip envelope-owned orchestration (`req.Config.Get`, client resolution, `resp.State.Set`) and keep only the entity-specific API call and model population logic.
+- **Preserve all existing Terraform type names and schemas** — no user-visible breaking changes.
+
+## Capabilities
+
+### New Capabilities
+_(none — this is an internal refactoring with no new user-visible capabilities)_
+
+### Modified Capabilities
+_(none — no spec-level requirements change; all migrated data sources preserve their existing schemas and read behavior)_
+
+## Impact
+
+- **`internal/entitycore/`**: `data_source_envelope.go` gains the sole PF data source pattern. `data_source_base.go` and `data_source_base_test.go` are removed.
+- **`internal/kibana/spaces/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope. `entitycore_contract_test.go` removed.
+- **`internal/kibana/exportsavedobjects/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope.
+- **`internal/fleet/integrationds/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope.
+- **`internal/fleet/outputds/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope.
+- **`internal/fleet/enrollmenttokens/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope. `entitycore_contract_test.go` removed.
+- **`internal/elasticsearch/index/indices/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope.
+- **`internal/elasticsearch/index/template/`**: `data_source.go`, `data_source_schema.go`, `read.go`, and `models.go` refactored to envelope.
+- **`internal/elasticsearch/enrich/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope. `entitycore_contract_test.go` removed.
+- **`internal/elasticsearch/security/rolemapping/`**: `data_source.go`, `schema.go`, `read.go`, and `models.go` refactored to envelope.
+- **`internal/kibana/agentbuilderagent/`**: `models.go` updated to embed `KibanaConnectionField`; accessor methods removed.
+- **Provider registration** (`provider/plugin_framework.go`): No changes needed — `NewDataSource` constructors remain stable.
+- **Tests**: All existing acceptance tests should pass without modification. Unit tests that assert on schema block presence may need minor updates since the block is now injected by the envelope.

--- a/openspec/changes/migrate-pf-datasources-to-envelope/specs/entitycore-datasource-envelope/spec.md
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/specs/entitycore-datasource-envelope/spec.md
@@ -1,0 +1,36 @@
+## REMOVED Requirements
+
+### Requirement: Existing struct-based data sources remain functional
+**Reason**: The `DataSourceBase` struct and struct-based embedding pattern have been removed. All Plugin Framework data sources now use the generic envelope constructors. Removing `DataSourceBase` eliminates the dual-pattern maintenance burden and unifies the codebase on the envelope.
+**Migration**: Any new or in-flight Plugin Framework data sources should use `entitycore.NewKibanaDataSource[T]` or `entitycore.NewElasticsearchDataSource[T]` instead of embedding `*entitycore.DataSourceBase`.
+
+## ADDED Requirements
+
+### Requirement: Envelope is the sole supported Plugin Framework data source pattern
+The system SHALL provide only the generic envelope constructors for Plugin Framework data source wiring. No struct-based alternative SHALL exist within `internal/entitycore`. All existing Plugin Framework data sources SHALL be constructed via `NewKibanaDataSource` or `NewElasticsearchDataSource`.
+
+#### Scenario: All PF data sources use envelope constructor
+- **WHEN** the provider enumerates its Plugin Framework data sources
+- **THEN** every data source SHALL be constructed via `entitycore.NewKibanaDataSource[T]` or `entitycore.NewElasticsearchDataSource[T]`
+- **AND** no data source SHALL embed `*entitycore.DataSourceBase`
+
+#### Scenario: DataSourceBase is not present in the entitycore package
+- **WHEN** developers inspect `internal/entitycore` for data source base types
+- **THEN** `DataSourceBase` SHALL NOT exist
+- **AND** only envelope constructors and connection field embeddable structs SHALL be available
+
+### Requirement: Kibana data source models embed KibanaConnectionField
+Kibana-backed envelope data source models SHALL embed `entitycore.KibanaConnectionField` (or an equivalent struct field with the `GetKibanaConnection` accessor) so the envelope can decode the `kibana_connection` block alongside entity attributes.
+
+#### Scenario: Model embedding satisfies KibanaDataSourceModel
+- **WHEN** a data source model embeds `KibanaConnectionField`
+- **THEN** the model SHALL satisfy the `KibanaDataSourceModel` type constraint
+- **AND** the envelope SHALL decode the `kibana_connection` block into that field during `Read`
+
+### Requirement: Elasticsearch data source models embed ElasticsearchConnectionField
+Elasticsearch-backed envelope data source models SHALL embed `entitycore.ElasticsearchConnectionField` (or an equivalent struct field with the `GetElasticsearchConnection` accessor) so the envelope can decode the `elasticsearch_connection` block alongside entity attributes.
+
+#### Scenario: Model embedding satisfies ElasticsearchDataSourceModel
+- **WHEN** a data source model embeds `ElasticsearchConnectionField`
+- **THEN** the model SHALL satisfy the `ElasticsearchDataSourceModel` type constraint
+- **AND** the envelope SHALL decode the `elasticsearch_connection` block into that field during `Read`

--- a/openspec/changes/migrate-pf-datasources-to-envelope/specs/no-op.md
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/specs/no-op.md
@@ -1,0 +1,9 @@
+# No Requirements Changes
+
+This change is a pure internal refactoring. All existing data source schemas,
+attributes, and read behaviors are preserved. No new capabilities are introduced
+and no existing capability requirements are modified.
+
+The migration from struct-based/`DataSourceBase` wiring to the generic envelope
+is an implementation detail only; the Terraform user-visible contract remains
+unchanged for every migrated data source.

--- a/openspec/changes/migrate-pf-datasources-to-envelope/specs/no-op.md
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/specs/no-op.md
@@ -1,9 +1,0 @@
-# No Requirements Changes
-
-This change is a pure internal refactoring. All existing data source schemas,
-attributes, and read behaviors are preserved. No new capabilities are introduced
-and no existing capability requirements are modified.
-
-The migration from struct-based/`DataSourceBase` wiring to the generic envelope
-is an implementation detail only; the Terraform user-visible contract remains
-unchanged for every migrated data source.

--- a/openspec/changes/migrate-pf-datasources-to-envelope/tasks.md
+++ b/openspec/changes/migrate-pf-datasources-to-envelope/tasks.md
@@ -1,0 +1,40 @@
+## 1. Kibana-backed data sources (Batch 1)
+
+- [ ] 1.1 Migrate `spaces` data source to envelope: embed `KibanaConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`, remove `entitycore_contract_test.go`
+- [ ] 1.2 Migrate `export_saved_objects` data source to envelope: embed `KibanaConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`
+- [ ] 1.3 Run acceptance tests for `spaces` and `export_saved_objects`; verify no regressions
+
+## 2. Fleet-backed data sources (Batch 2)
+
+- [ ] 2.1 Migrate `fleet_integration` data source to envelope: embed `KibanaConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`
+- [ ] 2.2 Migrate `fleet_output` data source to envelope: embed `KibanaConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`
+- [ ] 2.3 Migrate `enrollment_tokens` data source to envelope: embed `KibanaConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`, remove `entitycore_contract_test.go`
+- [ ] 2.4 Run acceptance tests for `fleet_integration`, `fleet_output`, and `enrollment_tokens`; verify no regressions
+
+## 3. Elasticsearch-backed data sources (Batch 3)
+
+- [ ] 3.1 Migrate `security_role_mapping` data source to envelope: embed `ElasticsearchConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewRoleMappingDataSource`
+- [ ] 3.2 Migrate `enrich_policy` data source to envelope: embed `ElasticsearchConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewEnrichPolicyDataSource`, remove `entitycore_contract_test.go`
+- [ ] 3.3 Migrate `indices` data source to envelope: embed `ElasticsearchConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`
+- [ ] 3.4 Migrate `index_template` data source to envelope: embed `ElasticsearchConnectionField` in model, extract schema factory, convert `Read` to callback, update `NewDataSource`, verify not-found empty-model behavior is preserved
+- [ ] 3.5 Run acceptance tests for all Batch 3 data sources; verify no regressions
+
+## 4. Agent Builder agent model cleanup
+
+- [ ] 4.1 Update `agentbuilderagent/models.go` to embed `entitycore.KibanaConnectionField` instead of explicit `KibanaConnection` field
+- [ ] 4.2 Remove `GetKibanaConnection()` and `GetVersionRequirements()` methods from `agentDataSourceModel`
+- [ ] 4.3 Update any test or struct literal that references the old field name or methods
+- [ ] 4.4 Run `agentbuilder_agent` acceptance tests; verify no regressions
+
+## 5. Remove dead code
+
+- [ ] 5.1 Delete `internal/entitycore/data_source_base.go`
+- [ ] 5.2 Delete `internal/entitycore/data_source_base_test.go`
+- [ ] 5.3 Verify `go build` passes with no references to `DataSourceBase`
+
+## 6. Final verification
+
+- [ ] 6.1 Run `make build` successfully
+- [ ] 6.2 Run `make check-openspec` successfully
+- [ ] 6.3 Run `make check-lint` successfully
+- [ ] 6.4 Confirm all PF data source constructors in `provider/plugin_framework.go` still return valid `datasource.DataSource` values


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design spec and migration plan for Plugin Framework data sources to use envelope constructors
- Adds an OpenSpec change bundle (metadata, design doc, proposal, spec, and task list) under [`openspec/changes/migrate-pf-datasources-to-envelope/`](https://github.com/elastic/terraform-provider-elasticstack/pull/2591/files#diff-abb7a211ba694277b3ae44d4e1aed8adab83bd5532747e897d0538b385ff6038) to plan the migration of all Plugin Framework data sources to the entitycore envelope pattern.
- The spec mandates envelope constructors as the sole PF data source pattern, deprecates and removes struct-based `DataSourceBase`, and requires model embedding of Kibana/Elasticsearch connection fields to satisfy envelope constraints.
- The task list outlines a batch-wise migration covering Kibana, Fleet, and Elasticsearch data sources, agent model cleanup, and dead code removal.
- This PR contains only planning and specification documents; no production code is changed yet.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 218431c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->