### PR TITLE
Ingest process DS -> PF

### DIFF
--- a/openspec/changes/migrate-ingest-processor-ds-pf-remaining/.openspec.yaml
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-remaining/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/migrate-ingest-processor-ds-pf-remaining/design.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-remaining/design.md
@@ -1,0 +1,72 @@
+## Context
+
+PR #1 (`migrate-ingest-processor-ds-pf-shared-base`) established the shared generic base and validated it with 4 representative processors. This PR scales the pattern to the remaining 35 processors and performs cleanup. The shared base artifacts are:
+- `ProcessorModel` interface
+- `processorDataSource[T ProcessorModel]` generic struct
+- `CommonProcessorModel` + `CommonProcessorSchemaAttributes()`
+- `marshalAndHash()` helper
+
+## Goals / Non-Goals
+
+**Goals:**
+- Migrate all remaining 35 processor data sources to Plugin Framework using the PR #1 pattern
+- Add missing common processor fields to `geoip` and `user_agent` (non-breaking enhancement)
+- Clean up old SDK data source files and test files
+- Move processor model structs from `internal/models/ingest.go` to `internal/elasticsearch/ingest/processor_models.go`
+
+**Non-Goals:**
+- Changing the shared base architecture (established in PR #1)
+- Migrating the `ingest_pipeline` resource
+- Changing any processor's JSON output format or attribute names (except geoip/user_agent additions)
+
+## Decisions
+
+### 1. Scale the Established Pattern Without Changes
+
+**Decision:** The remaining 35 processors use the exact same pattern as the 4 representatives. Each processor defines:
+1. A schema factory returning `schema.Schema`
+2. A model struct implementing `ProcessorModel`
+3. A `MarshalBody()` converting model to `map[string]any`
+4. A `NewDataSource()` constructor returning `datasource.DataSource`
+
+**Rationale:** PR #1 validated the pattern with edge cases (validators, JSON blobs, common-only). Scaling is purely mechanical.
+
+### 2. Geoip and User-Agent: Add Common Fields
+
+**Decision:** Include `description`, `if`, `ignore_failure`, `on_failure`, `tag` in schemas and models for `geoip` and `user_agent`, making them consistent with all other processors.
+
+**Rationale:** All Elasticsearch processors support these fields per official documentation. The SDK omission is a gap, not intentional design. Adding optional fields is non-breaking.
+
+### 3. Move Models Local, Then Delete from `internal/models`
+
+**Decision:** Copy processor model structs from `internal/models/ingest.go` to `internal/elasticsearch/ingest/processor_models.go` as part of migration. Delete from `internal/models/ingest.go` once all SDK references are gone.
+
+**Rationale:** These structs have no consumers outside the `ingest` package. Co-location eliminates an unnecessary dependency on the shared `models` package.
+
+### 4. Preserve Existing Tests, Remove Old Files
+
+**Decision:** Keep existing acceptance tests as-is (they already use `ProtoV6ProviderFactories`). Delete old SDK implementation and test files after migration.
+
+**Rationale:** Acceptance tests validate behavior via JSON output assertions. Since JSON output is preserved, tests pass unchanged. The test harness is muxed — PF data sources are exercised transparently.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| One processor in the bulk migration has an unanticipated edge case (complex `TypeSet` handling, pointer semantics, etc.) | Acceptance tests for each processor catch regressions. The PR #1 representatives covered the primary edge cases |
+| Deleting `internal/models/ingest.go` structs while still referenced by SDK files | Only delete after all old SDK files are removed. `go build` catches dangling references |
+| `on_failure` JSON parsing differs between SDK and PF | Use `jsontypes.NormalizedType` which enforces JSON validity and semantic equality. Parse identically in `MarshalBody` |
+
+## Migration Plan
+
+1. Create 35 new PF processor data source files using the established pattern
+2. Migrate `geoip` and `user_agent` with common fields included
+3. Register all new constructors in `provider/plugin_framework.go`
+4. Remove all old SDK registrations from `provider/provider.go`
+5. Delete old SDK implementation files and test files
+6. Move processor structs to `processor_models.go`; delete from `internal/models/ingest.go`
+7. `make build` + acceptance tests
+
+## Open Questions
+
+- Should `commons_test.go` be updated or deleted? Assess after migration — if the ingest pipeline resource tests still need `CheckResourceJSON`, keep it.

--- a/openspec/changes/migrate-ingest-processor-ds-pf-remaining/proposal.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-remaining/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+The shared generic base introduced in PR #1 (`migrate-ingest-processor-ds-pf-shared-base`) proves the pattern. Now the remaining 35 processor data sources must be migrated from the Terraform Plugin SDK to the Plugin Framework to complete the migration. Additionally, two processors (`geoip`, `user_agent`) currently omit common processor fields that Elasticsearch supports — this is corrected as part of the migration.
+
+## What Changes
+
+- **Migrate** the remaining 35 processor data sources to Plugin Framework using the established shared base pattern:
+  - `bytes`, `circle`, `community_id`, `convert`, `csv`, `date`, `date_index_name`, `dissect`, `dot_expander`, `enrich`, `fail`, `fingerprint`, `grok`, `gsub`, `html_strip`, `inference`, `join`, `json`, `kv`, `lowercase`, `network_direction`, `pipeline`, `registered_domain`, `remove`, `rename`, `reroute`, `set`, `set_security_user`, `sort`, `split`, `trim`, `uppercase`, `uri_parts`, `urldecode`
+- **Migrate** `geoip` and `user_agent` with added common processor fields (`description`, `if`, `ignore_failure`, `on_failure`, `tag`)
+- **Register** all 35 new constructors in `provider/plugin_framework.go`
+- **Remove** all 35 old SDK registrations from `provider/provider.go`
+- **Delete** old SDK data source implementation files (`processor_*_data_source.go`)
+- **Delete** old SDK data source test files (`processor_*_data_source_test.go`)
+- **Delete** `commons_test.go` if no longer referenced
+- **Move** processor model structs from `internal/models/ingest.go` to `internal/elasticsearch/ingest/processor_models.go`
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is an implementation migration._
+
+### Modified Capabilities
+
+The following existing capabilities are migrated from Plugin SDK to Plugin Framework with identical behavior (no requirement changes):
+
+- `elasticsearch-ingest-processor-bytes`
+- `elasticsearch-ingest-processor-circle`
+- `elasticsearch-ingest-processor-community-id`
+- `elasticsearch-ingest-processor-convert`
+- `elasticsearch-ingest-processor-csv`
+- `elasticsearch-ingest-processor-date`
+- `elasticsearch-ingest-processor-date-index-name`
+- `elasticsearch-ingest-processor-dissect`
+- `elasticsearch-ingest-processor-dot-expander`
+- `elasticsearch-ingest-processor-enrich`
+- `elasticsearch-ingest-processor-fail`
+- `elasticsearch-ingest-processor-fingerprint`
+- `elasticsearch-ingest-processor-foreach` (already migrated in PR #1, will be cleaned up here)
+- `elasticsearch-ingest-processor-grok`
+- `elasticsearch-ingest-processor-gsub`
+- `elasticsearch-ingest-processor-html-strip`
+- `elasticsearch-ingest-processor-inference`
+- `elasticsearch-ingest-processor-join`
+- `elasticsearch-ingest-processor-json`
+- `elasticsearch-ingest-processor-kv`
+- `elasticsearch-ingest-processor-lowercase`
+- `elasticsearch-ingest-processor-network-direction`
+- `elasticsearch-ingest-processor-pipeline`
+- `elasticsearch-ingest-processor-registered-domain`
+- `elasticsearch-ingest-processor-remove`
+- `elasticsearch-ingest-processor-rename`
+- `elasticsearch-ingest-processor-reroute`
+- `elasticsearch-ingest-processor-script` (already migrated in PR #1, will be cleaned up here)
+- `elasticsearch-ingest-processor-set`
+- `elasticsearch-ingest-processor-set-security-user`
+- `elasticsearch-ingest-processor-sort`
+- `elasticsearch-ingest-processor-split`
+- `elasticsearch-ingest-processor-trim`
+- `elasticsearch-ingest-processor-uppercase`
+- `elasticsearch-ingest-processor-uri-parts`
+- `elasticsearch-ingest-processor-urldecode`
+
+The following capabilities have **true requirement changes** (new optional attributes):
+
+- `elasticsearch-ingest-processor-geoip`
+- `elasticsearch-ingest-processor-user-agent`
+
+## Impact
+
+- `internal/elasticsearch/ingest/`: +35 new PF files, deletion of 39 old SDK files and tests, +local model structs moved
+- `provider/plugin_framework.go`: +35 data source registrations
+- `provider/provider.go`: -35 data source registrations
+- `internal/models/ingest.go`: processor structs removed
+- Acceptance tests: all existing tests transparently exercise PF implementation (already use `ProtoV6ProviderFactories`)

--- a/openspec/changes/migrate-ingest-processor-ds-pf-remaining/specs/elasticsearch-ingest-processor-geoip/spec.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-remaining/specs/elasticsearch-ingest-processor-geoip/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Common processor fields
+The geoip processor data source SHALL expose `description`, `if`, `ignore_failure`, `on_failure`, and `tag` as optional attributes. When configured, each SHALL be included in the serialized JSON. When not configured, each SHALL be omitted from the JSON (except `ignore_failure`, which defaults to `false` and is always included).
+
+#### Scenario: Common fields in schema
+- GIVEN the data source schema definition
+- WHEN inspecting available attributes
+- THEN `description`, `if`, `ignore_failure`, `on_failure`, and `tag` SHALL be valid optional attributes
+
+#### Scenario: Common fields included in JSON when configured
+- GIVEN a configuration that sets `description = "geoip lookup"`, `if = "ctx.ip != null"`, `ignore_failure = true`, `on_failure = ['{"set":{"field":"error.message","value":"geoip failed"}}']`, and `tag = "geoip-tag"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"description": "geoip lookup"`, `"if": "ctx.ip != null"`, `"ignore_failure": true`, `"on_failure": [{"set":{"field":"error.message","value":"geoip failed"}}]`, and `"tag": "geoip-tag"`
+
+#### Scenario: Common fields omitted when not configured
+- GIVEN a configuration that does not set `description`, `if`, `on_failure`, or `tag`
+- WHEN the data source is read
+- THEN `json` SHALL omit `"description"`, `"if"`, `"on_failure"`, and `"tag"` keys
+- AND `json` SHALL include `"ignore_failure": false`
+
+## ADDED Requirements
+
+### Requirement: description field
+The data source SHALL accept an optional `description` string attribute. When configured, it SHALL be included in the serialized JSON under the `"description"` key. When not configured, the key SHALL be omitted.
+
+#### Scenario: description configured
+- GIVEN `description = "Lookup geoip for client IP"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"description": "Lookup geoip for client IP"`
+
+### Requirement: if field
+The data source SHALL accept an optional `if` string attribute. When configured, it SHALL be included in the serialized JSON under the `"if"` key. When not configured, the key SHALL be omitted.
+
+#### Scenario: if configured
+- GIVEN `if = "ctx.ip != null"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"if": "ctx.ip != null"`
+
+### Requirement: on_failure field
+The data source SHALL accept an optional `on_failure` list of JSON string attributes. When configured with one or more elements, each element SHALL be parsed as JSON and included in the serialized JSON under the `"on_failure"` key as an array of objects. When not configured, the key SHALL be omitted.
+
+#### Scenario: on_failure configured
+- GIVEN `on_failure = ['{"set":{"field":"error.message","value":"geoip failed"}}']`
+- WHEN the data source is read
+- THEN `json` SHALL include `"on_failure": [{"set":{"field":"error.message","value":"geoip failed"}}]`
+
+### Requirement: tag field
+The data source SHALL accept an optional `tag` string attribute. When configured, it SHALL be included in the serialized JSON under the `"tag"` key. When not configured, the key SHALL be omitted.
+
+#### Scenario: tag configured
+- GIVEN `tag = "geoip-lookup"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"tag": "geoip-lookup"`

--- a/openspec/changes/migrate-ingest-processor-ds-pf-remaining/specs/elasticsearch-ingest-processor-user-agent/spec.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-remaining/specs/elasticsearch-ingest-processor-user-agent/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Common processor fields
+The `elasticstack_elasticsearch_ingest_processor_user_agent` data source SHALL expose `description`, `if`, `ignore_failure`, `on_failure`, and `tag` as optional attributes. When configured, each SHALL be included in the serialized JSON. When not configured, each SHALL be omitted from the JSON (except `ignore_failure`, which defaults to `false` and is always included).
+
+#### Scenario: Common fields in schema
+- GIVEN the data source schema definition
+- WHEN inspecting available attributes
+- THEN `description`, `if`, `ignore_failure`, `on_failure`, and `tag` SHALL be valid optional attributes
+
+#### Scenario: Common fields included in JSON when configured
+- GIVEN a configuration that sets `description = "parse user agent"`, `if = "ctx.agent != null"`, `ignore_failure = true`, `on_failure = ['{"set":{"field":"error.message","value":"ua failed"}}']`, and `tag = "ua-tag"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"description": "parse user agent"`, `"if": "ctx.agent != null"`, `"ignore_failure": true`, `"on_failure": [{"set":{"field":"error.message","value":"ua failed"}}]`, and `"tag": "ua-tag"`
+
+#### Scenario: Common fields omitted when not configured
+- GIVEN a configuration that does not set `description`, `if`, `on_failure`, or `tag`
+- WHEN the data source is read
+- THEN `json` SHALL omit `"description"`, `"if"`, `"on_failure"`, and `"tag"` keys
+- AND `json` SHALL include `"ignore_failure": false`
+
+## ADDED Requirements
+
+### Requirement: description field
+The data source SHALL accept an optional `description` string attribute. When configured, it SHALL be included in the serialized JSON under the `"description"` key. When not configured, the key SHALL be omitted.
+
+#### Scenario: description configured
+- GIVEN `description = "Parse user agent string"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"description": "Parse user agent string"`
+
+### Requirement: if field
+The data source SHALL accept an optional `if` string attribute. When configured, it SHALL be included in the serialized JSON under the `"if"` key. When not configured, the key SHALL be omitted.
+
+#### Scenario: if configured
+- GIVEN `if = "ctx.agent != null"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"if": "ctx.agent != null"`
+
+### Requirement: on_failure field
+The data source SHALL accept an optional `on_failure` list of JSON string attributes. When configured with one or more elements, each element SHALL be parsed as JSON and included in the serialized JSON under the `"on_failure"` key as an array of objects. When not configured, the key SHALL be omitted.
+
+#### Scenario: on_failure configured
+- GIVEN `on_failure = ['{"set":{"field":"error.message","value":"user agent failed"}}']`
+- WHEN the data source is read
+- THEN `json` SHALL include `"on_failure": [{"set":{"field":"error.message","value":"user agent failed"}}]`
+
+### Requirement: tag field
+The data source SHALL accept an optional `tag` string attribute. When configured, it SHALL be included in the serialized JSON under the `"tag"` key. When not configured, the key SHALL be omitted.
+
+#### Scenario: tag configured
+- GIVEN `tag = "user-agent-parse"`
+- WHEN the data source is read
+- THEN `json` SHALL include `"tag": "user-agent-parse"`

--- a/openspec/changes/migrate-ingest-processor-ds-pf-remaining/tasks.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-remaining/tasks.md
@@ -1,0 +1,57 @@
+## 1. Migrate Remaining 35 Processors
+
+- [ ] 1.1 Migrate `bytes` processor to PF
+- [ ] 1.2 Migrate `circle` processor to PF
+- [ ] 1.3 Migrate `community_id` processor to PF
+- [ ] 1.4 Migrate `convert` processor to PF
+- [ ] 1.5 Migrate `csv` processor to PF
+- [ ] 1.6 Migrate `date` processor to PF
+- [ ] 1.7 Migrate `date_index_name` processor to PF
+- [ ] 1.8 Migrate `dissect` processor to PF
+- [ ] 1.9 Migrate `dot_expander` processor to PF
+- [ ] 1.10 Migrate `enrich` processor to PF
+- [ ] 1.11 Migrate `fail` processor to PF
+- [ ] 1.12 Migrate `fingerprint` processor to PF
+- [ ] 1.13 Migrate `grok` processor to PF
+- [ ] 1.14 Migrate `gsub` processor to PF
+- [ ] 1.15 Migrate `html_strip` processor to PF
+- [ ] 1.16 Migrate `inference` processor to PF
+- [ ] 1.17 Migrate `join` processor to PF
+- [ ] 1.18 Migrate `json` processor to PF
+- [ ] 1.19 Migrate `kv` processor to PF
+- [ ] 1.20 Migrate `lowercase` processor to PF
+- [ ] 1.21 Migrate `network_direction` processor to PF
+- [ ] 1.22 Migrate `pipeline` processor to PF
+- [ ] 1.23 Migrate `registered_domain` processor to PF
+- [ ] 1.24 Migrate `remove` processor to PF
+- [ ] 1.25 Migrate `rename` processor to PF
+- [ ] 1.26 Migrate `reroute` processor to PF
+- [ ] 1.27 Migrate `set` processor to PF
+- [ ] 1.28 Migrate `set_security_user` processor to PF
+- [ ] 1.29 Migrate `sort` processor to PF
+- [ ] 1.30 Migrate `split` processor to PF
+- [ ] 1.31 Migrate `trim` processor to PF
+- [ ] 1.32 Migrate `uppercase` processor to PF
+- [ ] 1.33 Migrate `uri_parts` processor to PF
+- [ ] 1.34 Migrate `urldecode` processor to PF
+- [ ] 1.35 Migrate `geoip` processor to PF (adds common fields: description, if, ignore_failure, on_failure, tag)
+- [ ] 1.36 Migrate `user_agent` processor to PF (adds common fields: description, if, ignore_failure, on_failure, tag)
+
+## 2. Provider Wiring
+
+- [ ] 2.1 Register all 35 new constructors in `provider/plugin_framework.go`
+- [ ] 2.2 Remove all 35 old SDK registrations from `provider/provider.go`
+
+## 3. Cleanup
+
+- [ ] 3.1 Delete old SDK data source implementation files (`processor_*_data_source.go`) for all 39 processors
+- [ ] 3.2 Delete old SDK data source test files (`processor_*_data_source_test.go`) for all 39 processors
+- [ ] 3.3 Delete `internal/elasticsearch/ingest/commons_test.go` if no longer needed
+- [ ] 3.4 Move remaining processor structs from `internal/models/ingest.go` to `internal/elasticsearch/ingest/processor_models.go`
+- [ ] 3.5 Delete processor structs from `internal/models/ingest.go`
+
+## 4. Verification
+
+- [ ] 4.1 Run `make build` and verify no compilation errors
+- [ ] 4.2 Run full acceptance test suite for all migrated processor data sources
+- [ ] 4.3 Run `make check-openspec` and verify the change passes validation

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/.openspec.yaml
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/design.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The `internal/elasticsearch/ingest/` package contains 39 processor data sources. Every one follows the same boilerplate pattern: schema definition, `ReadContext` that populates a `models.ProcessorX`, marshals `{"<name>": processor}` JSON, hashes it for `id`, and sets the `json` attribute. There is no external API call. The provider already runs as a muxed provider (SDK + PF), so PF data sources can be registered alongside SDK resources.
+
+This PR establishes the shared generic base and validates it with 4 processors chosen to exercise different aspects of the base:
+- `drop` — minimal surface (common fields only)
+- `append` — specific scalar + list fields with defaults
+- `script` — PF validators (`ExactlyOneOf`) and a JSON blob attribute (`params`)
+- `foreach` — a JSON string field (`processor`) parsed to `map[string]any`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create a generic `processorDataSource[T ProcessorModel]` that owns `Read` entirely
+- Extract `CommonProcessorModel` and `CommonProcessorSchemaAttributes()` for the 37 processors that use common fields
+- Preserve byte-identical JSON output and hash-based ID for the 4 representatives
+- Prove the pattern works in CI before scaling
+
+**Non-Goals:**
+- Migrating the remaining 35 processors
+- Changing `geoip` or `user_agent` schemas (those come in PR #2)
+- Moving `internal/models/ingest.go` structs yet (PR #2)
+- Deleting old SDK files yet (PR #2)
+
+## Decisions
+
+### 1. Generic `processorDataSource[T ProcessorModel]`
+
+**Decision:** A Go generic struct parameterized by a `ProcessorModel` interface owns `Read`. The generic `Read` decodes config, calls `model.MarshalBody()`, wraps as `{"name": body}`, marshals with `json.MarshalIndent(..., "", " ")`, hashes via `schemautil.StringToHash`, and sets state.
+
+**Rationale:** Eliminates the identical `Read` function repeated 39 times. The interface is minimal and does not assume common fields exist.
+
+### 2. `CommonProcessorModel` Embedded Struct
+
+**Decision:** A `CommonProcessorModel` struct with `tfsdk` tags embeds into the 37 processors that use common fields. `CommonProcessorSchemaAttributes()` returns the common `schema.Attribute` map.
+
+**Rationale:** Schema and model composition in PF is straightforward. Embedding reduces duplication without forcing processors that don't need common fields (none in this PR, but the design must accommodate it).
+
+### 3. Local Inner Structs with `json` Tags
+
+**Decision:** Lightweight local structs (mirroring the existing `models.ProcessorX` shapes) are constructed inside `MarshalBody`, marshaled to bytes, then `json.Unmarshal` to `map[string]any`.
+
+**Rationale:** Reuses existing `omitempty` semantics. Clean compile-time field names. The struct is an implementation detail of `MarshalBody`.
+
+### 4. `jsontypes.NormalizedType` for JSON Strings
+
+**Decision:** `on_failure` and any JSON blob fields use `jsontypes.NormalizedType{}` as the element/attribute type.
+
+**Rationale:** Gives JSON validation and semantic diff suppression in one type. Already used elsewhere in the provider.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|---|---|
+| JSON output differs from SDK, causing `id` hash churn | Use identical `json.MarshalIndent` params and `json` tags; acceptance tests validate exact JSON match |
+| `on_failure` parsing from `jsontypes.Normalized` fails | Parse with `json.Unmarshal` in `MarshalBody`; errors become `diag.Diagnostics` |
+| Old SDK data sources left registered | Delete from `DataSourcesMap` in same PR that adds to `plugin_framework.go`. `make build` catches duplicates |
+
+## Migration Plan
+
+1. Create shared base files (`processor_datasource_base.go`, `processor_common.go`, `processor_models.go`)
+2. Create 4 PF processor files
+3. Wire in `provider/plugin_framework.go`; remove from `provider/provider.go`
+4. `make build` + acceptance tests for the 4 processors
+
+## Open Questions
+
+- Should `ListAttribute` or `SetAttribute` be used for historically-set fields? The shared base is agnostic — each processor schema factory decides. `SetAttribute` + explicit sort in `MarshalBody` for fields that were `TypeSet` in SDK.

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/proposal.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+All 39 `elasticstack_elasticsearch_ingest_processor_*` data sources are implemented using the Terraform Plugin SDK. They follow identical patterns: define a schema, read config into a model, marshal JSON, hash it for the computed `id`. This repetition makes the package unnecessarily large and hard to maintain. Before migrating the bulk of processors, we need to establish a shared generic base that eliminates per-processor `Read` duplication and validates the pattern with representative processors spanning different complexity levels.
+
+## What Changes
+
+- **Add** `internal/elasticsearch/ingest/processor_datasource_base.go` with:
+  - `ProcessorModel` interface (`TypeName()`, `MarshalBody()`, `SetID()`, `SetJSON()`)
+  - Generic `processorDataSource[T ProcessorModel]` struct owning `Metadata`, `Read`, `Configure`
+  - `marshalAndHash()` helper wrapping body as `{"<name>": body}`, indent-marshaling, and hashing
+- **Add** `internal/elasticsearch/ingest/processor_common.go` with:
+  - `CommonProcessorModel` (PF struct for `description`, `if`, `ignore_failure`, `on_failure`, `tag`)
+  - `CommonProcessorSchemaAttributes()` factory
+  - `appendCommonFields()` helper for `MarshalBody()` reuse
+- **Add** `internal/elasticsearch/ingest/processor_models.go` with local inner structs for the 4 representatives
+- **Migrate** 4 representative processor data sources to Plugin Framework:
+  - `drop` — simplest possible (only common fields, no specific attributes)
+  - `append` — medium complexity (specific fields + common, `ListAttribute`, defaults)
+  - `script` — validators (`ExactlyOneOf` on `script_id` vs `source`), JSON blob `params`
+  - `foreach` — JSON blob field `processor` parsing
+- **Register** the 4 new constructors in `provider/plugin_framework.go`
+- **Remove** the 4 old SDK registrations from `provider/provider.go`
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is an internal implementation refactor._
+
+### Modified Capabilities
+
+_None — no user-facing requirements change for the 4 representative processors._
+
+## Impact
+
+- `internal/elasticsearch/ingest/`: +3 shared base files, +4 new PF data source files
+- `provider/plugin_framework.go`: +4 data source registrations
+- `provider/provider.go`: -4 data source registrations
+- `internal/models/ingest.go`: unaffected in this PR (structs remain in place)

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/specs/processor-datasource-shared-base/spec.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/specs/processor-datasource-shared-base/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Generic processor data source base
+The system SHALL provide a generic `processorDataSource[T ProcessorModel]` struct that implements `datasource.DataSource` and `datasource.DataSourceWithConfigure`. It SHALL own the `Metadata`, `Read`, and `Configure` methods, eliminating the need for per-processor `Read` implementations.
+
+#### Scenario: Generic Read executes without per-processor code
+- GIVEN a processor data source constructed with a concrete type `T` satisfying `ProcessorModel`
+- WHEN `Read` is invoked with a Terraform configuration
+- THEN the data source SHALL decode the config into `T`, call `T.MarshalBody()`, wrap the result as `{"<name>": body}`, marshal to indented JSON, hash the JSON for `id`, and set state
+- AND no processor-specific `Read` function SHALL be required
+
+### Requirement: ProcessorModel interface
+The system SHALL define a `ProcessorModel` interface that is satisfied by any struct providing `TypeName() string`, `MarshalBody() (map[string]any, diag.Diagnostics)`, `SetID(string)`, and `SetJSON(string)`.
+
+#### Scenario: Model implements ProcessorModel
+- GIVEN a processor model struct implementing all four methods
+- WHEN the model is used as the type parameter `T` for `processorDataSource[T]`
+- THEN it SHALL compile and satisfy the generic constraint
+
+### Requirement: Common processor fields helper
+The system SHALL provide `CommonProcessorModel` (a struct with `tfsdk` tags for `description`, `if`, `ignore_failure`, `on_failure`, `tag`), `CommonProcessorSchemaAttributes()` returning the common schema attributes, and `appendCommonFields()` for use within `MarshalBody()`.
+
+#### Scenario: Common fields merged into processor schema
+- GIVEN a processor schema factory that merges its specific attributes with `CommonProcessorSchemaAttributes()`
+- WHEN the schema is returned by the data source
+- THEN it SHALL include `id`, `json`, `description`, `if`, `ignore_failure`, `on_failure`, and `tag`
+
+### Requirement: No Elasticsearch connection required
+Processor data sources SHALL NOT require or expose an `elasticsearch_connection` block. The generic `Configure` method SHALL be a no-op.
+
+#### Scenario: Processor data source read without connection
+- GIVEN a processor data source configured without any connection block
+- WHEN the data source is read
+- THEN it SHALL succeed and produce valid `json` and `id` outputs

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/specs/spec.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/specs/spec.md
@@ -1,0 +1,1 @@
+No spec changes required for this change. The 4 representative processor data sources (`append`, `drop`, `foreach`, `script`) are migrated from Plugin SDK to Plugin Framework with identical schema attributes, types, defaults, validation rules, JSON output format, and hash-based ID generation. No user-facing requirements change.

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/specs/spec.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/specs/spec.md
@@ -1,1 +1,0 @@
-No spec changes required for this change. The 4 representative processor data sources (`append`, `drop`, `foreach`, `script`) are migrated from Plugin SDK to Plugin Framework with identical schema attributes, types, defaults, validation rules, JSON output format, and hash-based ID generation. No user-facing requirements change.

--- a/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/tasks.md
+++ b/openspec/changes/migrate-ingest-processor-ds-pf-shared-base/tasks.md
@@ -1,0 +1,23 @@
+## 1. Shared Base Infrastructure
+
+- [ ] 1.1 Create `internal/elasticsearch/ingest/processor_datasource_base.go` with `ProcessorModel` interface, generic `processorDataSource[T]` struct, and `marshalAndHash()` helper
+- [ ] 1.2 Create `internal/elasticsearch/ingest/processor_common.go` with `CommonProcessorModel`, `CommonProcessorSchemaAttributes()`, and `appendCommonFields()` helper
+- [ ] 1.3 Create `internal/elasticsearch/ingest/processor_models.go` with local inner structs for `drop`, `append`, `script`, `foreach` (keep `json` tags identical to existing `models.ProcessorX`)
+
+## 2. Representative Processor Migrations
+
+- [ ] 2.1 Create `internal/elasticsearch/ingest/processor_drop_data_source.go` (PF schema + model + `MarshalBody()` + constructor)
+- [ ] 2.2 Create `internal/elasticsearch/ingest/processor_append_data_source.go` (PF schema + model + `MarshalBody()` + constructor)
+- [ ] 2.3 Create `internal/elasticsearch/ingest/processor_script_data_source.go` (PF schema + model + `MarshalBody()` + constructor; include `ExactlyOneOf` validator for `script_id` vs `source`)
+- [ ] 2.4 Create `internal/elasticsearch/ingest/processor_foreach_data_source.go` (PF schema + model + `MarshalBody()` + constructor; handle `processor` JSON string → map parsing)
+
+## 3. Provider Wiring
+
+- [ ] 3.1 Register the 4 new constructors in `provider/plugin_framework.go`
+- [ ] 3.2 Remove the 4 old SDK registrations from `provider/provider.go` `DataSourcesMap`
+
+## 4. Verification
+
+- [ ] 4.1 Run `make build` and verify no compilation errors
+- [ ] 4.2 Run targeted acceptance tests for the 4 migrated processors
+- [ ] 4.3 Run `make check-openspec` and verify the change passes validation


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add design specs for migrating 35 ingest processor data sources to Plugin Framework
- Adds OpenSpec documentation for two changesets: establishing a shared Plugin Framework base for processor data sources, and migrating the remaining 35 ingest processors to that base.
- The shared base changeset ([design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2595/files#diff-f8584c51e5af791ebaa73de5328033a2738ce85fb5aefab298d538cee696addc)) defines a generic `processorDataSource`, common model/attributes, and JSON marshaling helpers, with 4 representative processors migrated first.
- The remaining processors changeset ([design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2595/files#diff-e84cda39221ae9f792d2eed98231fc7100e3c3267ef7693ce6ed167a38285fbc)) covers migrating all 35 remaining processors, adding common fields (`description`, `if`, `ignore_failure`, `on_failure`, `tag`) to `geoip` and `user_agent`, and cleaning up old SDK files and tests.
- Specs for `geoip` and `user_agent` add scenarios validating presence/omission and JSON serialization of the new common fields.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e227c2.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->