### PR TITLE
openspec: fleet integration space-aware behavior

### DIFF
--- a/openspec/changes/fleet-integration-space-aware/.openspec.yaml
+++ b/openspec/changes/fleet-integration-space-aware/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/fleet-integration-space-aware/design.md
+++ b/openspec/changes/fleet-integration-space-aware/design.md
@@ -1,0 +1,100 @@
+## Context
+
+The `elasticstack_fleet_integration` resource manages Fleet integration packages via `POST /api/fleet/epm/packages/{pkg}/{version}` (install) and `DELETE /api/fleet/epm/packages/{pkg}/{version}` (uninstall). Fleet treats the package installation record as a global saved object, but Kibana assets (dashboards, visualizations, saved searches) are space-scoped.
+
+When a user installs `tcp@1.16.0` in Space A and then tries to install the same package in Space B, Kibana's install endpoint returns success immediately because the package is already installed *globally*. The target space never receives assets. Terraform's wait loop also succeeds because `GET /api/fleet/epm/packages/{pkg}/{version}` returns `status: installed` regardless of which space queried it.
+
+Kibana 8.15.0 resolved this with:
+- `POST /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` — installs Kibana assets into a specific space for an already-installed package.
+- `DELETE /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` — removes Kibana assets from the current space.
+- `PackageInfo.InstallationInfo.AdditionalSpacesInstalledKibana` — tracks which spaces have assets beyond the primary install space.
+- `PackageInfo.InstallationInfo.InstalledKibanaSpaceId` — tracks the primary install space.
+
+The provider must bridge the gap between Terraform's per-resource model (one resource = one space) and Fleet's global install model.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `elasticstack_fleet_integration` correctly represent and manage space-scoped Kibana assets when `space_id` is configured on Kibana >= 8.15.0.
+- Ensure `Create` installs assets in the target space even when the package is already installed elsewhere.
+- Ensure `Delete` only removes assets from the target space when the package is installed in multiple spaces, and fully uninstalls when it's the only remaining space.
+- Ensure `Read` accurately reflects whether assets exist in the target space (drift detection).
+- Maintain backward compatibility: on Kibana < 8.15.0 or when `space_id` is not set, behavior is unchanged.
+
+**Non-Goals:**
+- Supporting installation of the *same* package version in the same space via multiple Terraform resources (this is already prevented by API behavior).
+- Managing `additional_spaces_installed_kibana` as a Terraform-managed list (the resource remains a single-space abstraction).
+- Auto-installing assets into all spaces referenced by agent policies (out of scope; Kibana issue #237658).
+- Changing the resource schema.
+- Supporting Kibana spaces experimental feature flags (the provider assumes the APIs are available if the version check passes).
+
+## Decisions
+
+### Decision 1: Version gate at 8.15.0 for space-aware behavior
+**Rationale:** The `installed_kibana_space_id` field exists since Kibana 8.1.0, but the `kibana_assets` endpoints did not arrive until 8.15.0. If we used field presence as a capability signal, a provider running against Kibana 8.1–8.14 would detect "not installed in target space" but have no way to install assets there, causing a perpetual diff → create → wait → diff loop.
+
+**Alternatives considered:**
+- **Field presence only** — rejected due to the perpetual diff risk on 8.1–8.14.
+- **Endpoint probe (call kibana_assets, fall back on 404)** — viable but adds a spurious failed API call on every create. Version check is cleaner and matches existing patterns in the codebase (`MinVersionIgnoreMappingUpdateErrors`).
+
+### Decision 2: `fleetPackageInstalled` accepts `spaceID` and `spaceAware` parameters
+**Rationale:** The helper is used in `Read`, the Create wait loop, and the Create pre-flight check. It needs to know both which space to check and whether the server supports strict space checks. When `spaceAware` is false, the existing global check is preserved.
+
+**Signature:**
+```go
+func fleetPackageInstalled(pkg *kbapi.PackageInfo, spaceID string, spaceAware bool) bool
+```
+
+**Alternatives considered:**
+- **Always strict when `space_id` is set** — rejected because it breaks on Kibana < 8.15.0 (field may exist but endpoint doesn't).
+- **Check version inside the helper** — rejected because it would require passing a `*KibanaScopedClient` into a pure function, complicating testing and the wait-loop callback.
+
+### Decision 3: Create pre-flights with `GetPackage` before deciding install vs. kibana_assets
+**Rationale:** There are three distinct states on create:
+1. Package not installed anywhere → `InstallPackage` (full install).
+2. Package installed in target space already → `InstallPackage` (upgrade or no-op).
+3. Package installed in a *different* space → `InstallKibanaAssets` (space-scoped asset install).
+
+A single `GetPackage` call before the install operation resolves which path to take. This avoids guessing or relying on install API response codes.
+
+**Alternatives considered:**
+- **Always call InstallPackage, then check if assets are missing and lazily call kibana_assets** — rejected because the install API returns success (no-op) with no signal that assets are missing, so we can't trigger the fallback without another read.
+- **Call kibana_assets first, then InstallPackage on failure** — rejected because `kibana_assets` requires the package to already be installed globally; it would fail on first install.
+
+### Decision 4: Delete checks `isInstalledInMultipleSpaces` to choose between asset removal and full uninstall
+**Rationale:** A user declares one resource per space. When destroying the resource for Space B, if Space A still holds assets, we must not call the global `Uninstall` API (that would orphan Space A's Terraform state and remove A's assets). We only call `Uninstall` when the package is installed in *only* the target space.
+
+**Multi-space detection logic:**
+```go
+func isInstalledInMultipleSpaces(pkg *kbapi.PackageInfo, spaceID string) bool {
+    if pkg.InstallationInfo == nil { return false }
+    otherSpaces := 0
+    if pkg.InstallationInfo.AdditionalSpacesInstalledKibana != nil {
+        otherSpaces = len(*pkg.InstallationInfo.AdditionalSpacesInstalledKibana)
+    }
+    // If target is the primary space, additional spaces = multi
+    // If target is in additional spaces, primary + (additional minus self) = multi
+    isPrimary := pkg.InstallationInfo.InstalledKibanaSpaceId != nil &&
+                 *pkg.InstallationInfo.InstalledKibanaSpaceId == spaceID
+    if isPrimary {
+        return otherSpaces > 0
+    }
+    return otherSpaces > 1 || pkg.InstallationInfo.InstalledKibanaSpaceId != nil
+}
+```
+
+### Decision 5: Fleet client helpers sit in `internal/clients/fleet/fleet.go`
+**Rationale:** This is the existing convention for all Fleet API wrappers. The helpers wrap the generated `kbapi` client and handle status-code translation, error formatting, and space-aware path injection via `kibanautil.SpaceAwarePathRequestEditor`.
+
+### Decision 6: `space_id` stays Optional+Computed with RequiresReplace
+**Rationale:** No schema changes are needed. The existing `space_id` semantics already express "install in this space". The behavioral change is entirely in how the resource interacts with the API.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| **[Risk]** Kibana 8.15.x may have bugs in the `kibana_assets` endpoints (e.g., issue #210141). | **[Mitigation]** The 404/400 fallback on `kibana_assets` errors routes back to `InstallPackage` / `Uninstall`, preserving current behavior if the endpoint is unexpectedly unavailable. |
+| **[Risk]** `AdditionalSpacesInstalledKibana` may be empty or missing on some Kibana configurations even at 8.15+. | **[Mitigation]** `fleetPackageInstalled` falls back to returning `true` (treating as installed) when `InstallationInfo` is nil, avoiding false negatives that would cause unnecessary reinstalls. When `InstallationInfo` is present but no space match is found, it returns `false`, which is the conservative (correct) behavior for drift detection. |
+| **[Risk]** Version check adds a `/api/status` call per resource operation on `space_id`-configured resources. | **[Mitigation]** Cached version checks could be added to `KibanaScopedClient` later without changing resource logic. For now, the cost is one lightweight status call per CRUD operation, which is already done in `create.go` for `ignore_mapping_update_errors` / `skip_data_stream_rollover` gates. |
+| **[Risk]** Serverless behavior differs from stateful. | **[Mitigation]** `EnforceMinVersion` returns `true` for serverless, so the space-aware path is always attempted. If serverless does not expose the endpoint, the 404 fallback activates. This is consistent with other serverless/version-gated features in the provider. |
+| **[Risk]** Concurrent `create` calls for the same package in different spaces may race. | **[Mitigation]** Kibana handles the global install object. If Space A's create is mid-install when Space B's create starts, Space B's pre-flight may see "not installed" and call `InstallPackage`. On Kibana 8.15+, that is still a no-op (global install), but the wait loop will eventually see the installed state and then the subsequent `kibana_assets` call (if needed) will succeed. In practice, Terraform plans are deterministic and this race is unlikely. |

--- a/openspec/changes/fleet-integration-space-aware/proposal.md
+++ b/openspec/changes/fleet-integration-space-aware/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Fleet treats integration package installation as global (one saved object), but Kibana assets (dashboards, visualizations, saved searches) are space-scoped. After installing a package in Space A, installing the *same* package in Space B is a silent no-op because Kibana's `POST /api/fleet/epm/packages/{pkg}/{version}` checks global install status and returns "already installed". Terraform sees `status: installed`, wait succeeds, but the target space never receives assets.
+
+Kibana 8.15 introduced `POST/DELETE /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` endpoints and `additional_spaces_installed_kibana` tracking, enabling proper multi-space asset management. We need the provider to leverage these APIs so that `elasticstack_fleet_integration` correctly installs and removes space-scoped assets.
+
+## What Changes
+
+- **Modify `fleetPackageInstalled` helper** to be space-aware on Kibana >= 8.15.0. A package is considered installed in a target space only when:
+  - `InstallStatus` is `installed` (or legacy `Status` is `installed`), **AND**
+  - `InstalledKibanaSpaceId` matches the target space, **OR**
+  - the target space is present in `AdditionalSpacesInstalledKibana`.
+  On older Kibana (< 8.15.0) or when `space_id` is not configured, behavior falls back to the current global check.
+
+- **Modify `Create`/`Update`** to detect when a package is already installed in a *different* space. When Kibana >= 8.15.0, instead of calling the regular install API (which no-ops), the resource calls `POST /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` scoped to the target space to install Kibana assets there. When the package is not installed at all (or already in target), the regular install API is used as before.
+
+- **Modify `Delete`** to detect whether the package is installed in only the target space or in multiple spaces. When Kibana >= 8.15.0 and the package is installed in multiple spaces, the resource calls `DELETE /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` scoped to the target space to remove only that space's assets. When the package is only in the target space, the existing `Uninstall` API is used to remove the package globally.
+
+- **Add Kibana version gate at 8.15.0** for the new space-aware behavior. The resource checks `EnforceMinVersion` when `space_id` is configured; on older versions it falls back to current behavior.
+
+- **Add Fleet client helpers** (`InstallKibanaAssets`, `DeleteKibanaAssets`) in `internal/clients/fleet/fleet.go`.
+
+- **Add acceptance tests** covering multi-space install, partial destroy (assets removed from one space but package kept in others), and version-gated fallback behavior.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this is a behavioral fix within an existing capability. -->
+
+### Modified Capabilities
+- `fleet-integration`: Requirements for `Read`, `Create`/`Update`, and `Delete` are changing to support space-aware asset installation and removal via Kibana 8.15+ Fleet APIs, with graceful fallback on older versions.
+
+## Impact
+
+- `internal/fleet/integration/create.go` — space-aware install logic, version gate, kibana_assets fallback.
+- `internal/fleet/integration/read.go` — `fleetPackageInstalled` signature+logic change.
+- `internal/fleet/integration/delete.go` — space-aware uninstall logic, multi-space detection.
+- `internal/fleet/integration/resource.go` — new minimum version constant (`MinVersionSpaceAwareIntegration = 8.15.0`).
+- `internal/clients/fleet/fleet.go` — new `InstallKibanaAssets` and `DeleteKibanaAssets` helpers.
+- `internal/fleet/integration/acc_test.go` — new acceptance tests for multi-space scenarios.
+- No breaking schema changes.

--- a/openspec/changes/fleet-integration-space-aware/specs/fleet-integration/spec.md
+++ b/openspec/changes/fleet-integration-space-aware/specs/fleet-integration/spec.md
@@ -1,0 +1,95 @@
+## MODIFIED Requirements
+
+### Requirement: Fleet package read API (REQ-004–REQ-005)
+
+The resource SHALL use the Kibana Fleet get package API to refresh state on read, supplying the `name` and `version` from state. When `space_id` is configured, the get package API call SHALL be scoped to that Kibana space. The data source SHALL use the Kibana Fleet list packages API to retrieve available packages, filtered by the `prerelease` parameter.
+
+When `space_id` is configured and the Kibana server version is at least 8.15.0, the resource SHALL determine that a package is "installed" only when its installation status is "installed" AND the package has Kibana assets installed in the target space, as indicated by `InstalledKibanaSpaceId` or `AdditionalSpacesInstalledKibana` in the Fleet API response. On Kibana versions below 8.15.0, or when `space_id` is not configured, the resource SHALL retain the existing behavior of treating global install status as sufficient.
+
+#### Scenario: Package not found on resource read
+
+- GIVEN the integration package is not present (status not "installed") or nil in the Fleet API response
+- WHEN read runs on the resource
+- THEN the resource SHALL be removed from Terraform state
+
+#### Scenario: Package installed in a different space on resource read
+
+- GIVEN the integration package is installed globally but its Kibana assets are in a different space than the resource's `space_id`
+- AND the Kibana server version is at least 8.15.0
+- WHEN read runs on the resource
+- THEN the resource SHALL be removed from Terraform state
+
+#### Scenario: Data source package lookup
+
+- GIVEN a valid `name` and optional `prerelease` flag
+- WHEN read runs on the data source
+- THEN the data source SHALL set `version` to the version returned by the Fleet list packages API for the matching package name, or null if not found
+
+#### Scenario: Data source with space_id
+
+- GIVEN `space_id` is set to a non-default Kibana space
+- WHEN read runs on the data source
+- THEN the list packages API SHALL be called with that space ID as context (i.e. via the `/s/{space_id}/api/fleet/epm/packages` path)
+
+### Requirement: Create/Update — install options (REQ-011)
+
+On create and update, the resource SHALL pass `force`, `prerelease`, and `ignore_constraints` as install options to the Fleet install package API when configured. When `ignore_mapping_update_errors` and `skip_data_stream_rollover` pass the server version check, they SHALL also be included in the install options. When `space_id` is a known value, the resource SHALL pass it as the space context for installation.
+
+When `space_id` is configured, the Kibana server version is at least 8.15.0, and the package is already installed globally but not in the target space, the resource SHALL call the Fleet `POST /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` API scoped to the target space instead of the regular install API.
+
+#### Scenario: space-aware installation
+
+- GIVEN `space_id` is set to a known string
+- WHEN create or update runs
+- THEN the install API SHALL be called with that space ID as context
+
+#### Scenario: Package already installed in another space
+
+- GIVEN `space_id` is set to a known string
+- AND the Kibana server version is at least 8.15.0
+- AND the integration package is already installed in a different space
+- WHEN create or update runs
+- THEN the resource SHALL call the Fleet kibana_assets API scoped to the target space to install Kibana assets there
+- AND the resource SHALL NOT call the regular install API
+
+### Requirement: Delete — space-aware uninstall (REQ-015)
+
+On delete, when `space_id` is a known value in state, the resource SHALL determine whether the package is installed in multiple spaces. When the Kibana server version is at least 8.15.0 and the package is installed in multiple spaces, the resource SHALL call the Fleet `DELETE /api/fleet/epm/packages/{pkg}/{version}/kibana_assets` API scoped to the target space to remove Kibana assets from that space only. When the package is installed in only the target space, or when the Kibana server version is below 8.15.0, the resource SHALL pass `space_id` as the space context to the Fleet uninstall API. The `force` flag from state SHALL be passed to whichever API is called.
+
+#### Scenario: Delete with space context — single space installation
+
+- GIVEN `space_id` is set to a known string in state
+- AND the package is installed in only that space (or the Kibana server is below 8.15.0)
+- WHEN destroy runs
+- THEN the Fleet uninstall API SHALL be called with that space ID and the `force` flag from state
+
+#### Scenario: Delete with space context — multi-space installation
+
+- GIVEN `space_id` is set to a known string in state
+- AND the Kibana server version is at least 8.15.0
+- AND the package is installed in multiple spaces
+- WHEN destroy runs
+- THEN the Fleet delete kibana_assets API SHALL be called scoped to the target space
+- AND the global package installation SHALL remain intact
+- AND the `force` flag from state SHALL be passed to the API
+
+## ADDED Requirements
+
+### Requirement: Compatibility — space-aware behavior version gate (REQ-018)
+
+When `space_id` is configured with a known value, the resource SHALL verify the server version before enabling space-aware behavior. If the Kibana server version is at least 8.15.0, the resource SHALL use space-aware install and uninstall logic. If the Kibana server version is below 8.15.0, the resource SHALL fall back to the existing non-space-aware behavior.
+
+#### Scenario: space-aware behavior on supported server
+
+- GIVEN `space_id` is set to a known string
+- AND the Kibana server version is at least 8.15.0
+- WHEN create or delete runs
+- THEN the resource SHALL use space-aware logic (kibana_assets endpoints for cross-space installs, multi-space detection on delete)
+
+#### Scenario: space-aware behavior falls back on old server
+
+- GIVEN `space_id` is set to a known string
+- AND the Kibana server version is below 8.15.0
+- WHEN create or delete runs
+- THEN the resource SHALL use the existing non-space-aware behavior (regular install and uninstall APIs)
+- AND no error diagnostic SHALL be returned solely due to the server version being below 8.15.0

--- a/openspec/changes/fleet-integration-space-aware/tasks.md
+++ b/openspec/changes/fleet-integration-space-aware/tasks.md
@@ -1,0 +1,50 @@
+## 1. Fleet Client Helpers
+
+- [ ] 1.1 Add `InstallKibanaAssets` helper in `internal/clients/fleet/fleet.go` using `PostFleetEpmPackagesPkgnamePkgversionKibanaAssetsWithResponse` with space-aware path injection
+- [ ] 1.2 Add `DeleteKibanaAssets` helper in `internal/clients/fleet/fleet.go` using `DeleteFleetEpmPackagesPkgnamePkgversionKibanaAssetsWithResponse` with space-aware path injection
+- [ ] 1.3 Handle `http.StatusOK`, `http.StatusNotFound`, and default error cases in both helpers following existing `reportUnknownError` pattern
+- [ ] 1.4 Verify helpers compile with `make build`
+
+## 2. Resource Logic — Read (`internal/fleet/integration/read.go`)
+
+- [ ] 2.1 Add `spaceAware` boolean parameter to `fleetPackageInstalled` signature: `func fleetPackageInstalled(pkg *kbapi.PackageInfo, spaceID string, spaceAware bool) bool`
+- [ ] 2.2 Implement strict space check in `fleetPackageInstalled`: match against `InstalledKibanaSpaceId` and `AdditionalSpacesInstalledKibana`
+- [ ] 2.3 Preserve fallback behavior: when `spaceAware` is false or `spaceID` is empty, use existing global install status check
+- [ ] 2.4 Update `Read` method to call `fleetPackageInstalled` with `spaceID` from state and `spaceAware=false` (Read will gain version awareness in task 3.2)
+
+## 3. Resource Logic — Version Gating (`internal/fleet/integration/resource.go`, `create.go`)
+
+- [ ] 3.1 Add `MinVersionSpaceAwareIntegration = version.Must(version.NewVersion("8.15.0"))` constant in `resource.go`
+- [ ] 3.2 In `Read`, call `client.EnforceMinVersion(ctx, MinVersionSpaceAwareIntegration)` when `space_id` is known to determine `spaceAware`, then pass to `fleetPackageInstalled`
+- [ ] 3.3 In `create`, call `apiClient.EnforceMinVersion(ctx, MinVersionSpaceAwareIntegration)` when `space_id` is known to determine `spaceAware` before install decision
+
+## 4. Resource Logic — Create/Update (`internal/fleet/integration/create.go`)
+
+- [ ] 4.1 Add pre-flight `GetPackage` call when `spaceAware` is true to determine `installedInTarget` and `installedElsewhere`
+- [ ] 4.2 When `installedElsewhere` is true, call `fleet.InstallKibanaAssets` scoped to target space instead of `fleet.InstallPackage`
+- [ ] 4.3 When `installedInTarget` is true or package not installed, use existing `fleet.InstallPackage` path
+- [ ] 4.4 Update wait loop to call `fleetPackageInstalled(pkg, spaceID, spaceAware)` so it respects strict space checking on 8.15+
+- [ ] 4.5 Ensure `force` parameter from plan is passed to `InstallKibanaAssets` body when calling the kibana_assets endpoint
+
+## 5. Resource Logic — Delete (`internal/fleet/integration/delete.go`)
+
+- [ ] 5.1 Add `isInstalledInMultipleSpaces` helper: inspect `InstalledKibanaSpaceId` and `AdditionalSpacesInstalledKibana` to determine if package spans multiple spaces
+- [ ] 5.2 When `spaceAware` is true, pre-flight with `GetPackage` to determine install scope
+- [ ] 5.3 When multi-space and `spaceAware`, call `fleet.DeleteKibanaAssets` scoped to target space
+- [ ] 5.4 When single-space or `!spaceAware`, use existing `fleet.Uninstall` path
+- [ ] 5.5 Ensure `force` flag from state is passed to whichever API is called
+
+## 6. Acceptance Tests (`internal/fleet/integration/acc_test.go`)
+
+- [ ] 6.1 Add test helper to create a Kibana space for testing (reuse existing space creation if available in acctest)
+- [ ] 6.2 Add `TestAccResourceIntegration_MultiSpaceInstall`: create space A and B, install same package in both, verify both succeed
+- [ ] 6.3 Add `TestAccResourceIntegration_MultiSpaceDelete`: install in two spaces, destroy one resource, verify package remains installed with assets in the other space
+- [ ] 6.4 Add `TestAccResourceIntegration_SpaceAwareDrift`: install in space A, manually delete kibana assets from space A via API, verify Terraform plan detects drift and wants re-creation
+- [ ] 6.5 Gate multi-space tests on `minVersionSpaceAwareIntegration = 8.15.0` using existing `versionutils.CheckIfVersionIsUnsupported` pattern
+
+## 7. Build, Lint, and OpenSpec Validation
+
+- [ ] 7.1 Run `make build` and fix any compilation errors
+- [ ] 7.2 Run `make check-lint` and fix any lint issues
+- [ ] 7.3 Run `make check-openspec` and fix any spec validation errors
+- [ ] 7.4 Run `openspec validate` on the change to ensure all artifacts are structurally correct


### PR DESCRIPTION
Add OpenSpec change proposal for making `elasticstack_fleet_integration` space-aware on Kibana 8.15+.

- Proposal, design, specs, and tasks for the fleet-integration-space-aware change
- See #1700 for the underlying issue

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenSpec design and proposal for space-aware Fleet integration behavior
> - Adds an OpenSpec change descriptor, design doc, proposal, spec, and task list for space-aware handling in Fleet integration packages.
> - Introduces a version gate at Kibana >= 8.15.0: create/update operations use `kibana_assets` endpoints when available, and delete logic checks for multi-space presence before removing assets.
> - Defines changes to helper signatures and placement of client helpers to support space context.
> - Tasks cover implementation of read/create/delete logic, version gating, acceptance tests, and build/lint/openspec validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f655a2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->