### PR TITLE
docs(openspec): typed client migration plan

### DIFF
--- a/openspec/changes/typed-client-acceptance-tests/.openspec.yaml
+++ b/openspec/changes/typed-client-acceptance-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-acceptance-tests/design.md
+++ b/openspec/changes/typed-client-acceptance-tests/design.md
@@ -1,0 +1,96 @@
+## Context
+
+All provider helper and resource code has been migrated to `go-elasticsearch` Typed API. The remaining `GetESClient()` usage is confined to acceptance-test files, where tests call raw `esapi` methods for:
+
+1. **Preflight / setup** — creating indices, templates, policies, or roles before Terraform applies.
+2. **Cleanup / destroy checks** — verifying that resources were actually deleted after `CheckDestroy` runs.
+3. **State assertions** — querying Elasticsearch during `TestCheckFunc` to validate side effects.
+
+These patterns are scattered across 25 test files. Each shares the same raw-client anti-pattern: get `*elasticsearch.Client`, build requests with `.With…` option funcs, manually read `*http.Response.Body`, and `json.Unmarshal` into ad-hoc structs or `map[string]interface{}`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace every `GetESClient()` call in the listed test files with `GetESTypedClient()`.
+- Convert raw `esapi` calls to strongly-typed `TypedClient` equivalents.
+- Remove manual response-body reading and JSON decoding where typed structs can be used directly.
+- Ensure every migrated test still compiles and passes (`go test` / acceptance tests).
+
+**Non-Goals:**
+
+- Do not modify any resource or helper source files (those are already migrated).
+- Do not change test assertions, Terraform configs, or test step definitions.
+- Do not alter `GetESClient()` or `ElasticsearchScopedClient` (the bridge already exists).
+- Do not migrate `GetESClient()` calls outside the listed test files.
+
+## Decisions
+
+### 1. Keep test file scope focused — one file per reviewable unit
+
+**Chosen:** Organize the migration task list by logical domain (transform, enrich, index, cluster, security, etc.) and migrate one file per top-level task.
+
+**Rationale:** Acceptance tests are large and domain-specific. Reviewing them file-by-file keeps diffs readable and makes it easy to run targeted tests for verification.
+
+### 2. Direct substitution of raw calls with typed equivalents
+
+**Chosen:** For each raw call, find the equivalent `TypedClient` method and map parameters directly.
+
+Examples:
+- `esClient.Indices.Get(...)` → `typedClient.Indices.Get(ctx, indexName).Do(ctx)`
+- `esClient.TransformGetTransform(...)` → `typedClient.Transform.GetTransform(ctx, transformId).Do(ctx)`
+- `esClient.Security.GetRole(...)` → `typedClient.Security.GetRole(ctx, roleName).Do(ctx)`
+- `esClient.EnrichGetPolicy(...)` → `typedClient.Enrich.GetPolicy(ctx, policyName).Do(ctx)`
+
+**Rationale:** The typed API surface closely mirrors the raw API. Most migrations are mechanical substitutions.
+
+### 3. Handle response extraction idiomatically
+
+**Chosen:** Use the strongly-typed response structs returned by `TypedClient` methods. Where raw code did:
+
+```go
+res, err := esClient.Indices.Get(...)
+// defer res.Body.Close()
+// json.NewDecoder(res.Body).Decode(&body)
+```
+
+Replace with:
+
+```go
+resp, err := typedClient.Indices.Get(ctx, indexName).Do(ctx)
+// resp is already a typed *indices.GetResponse or equivalent
+```
+
+**Rationale:** Eliminates `io.ReadAll`, `json.Unmarshal`, and ad-hoc struct definitions, reducing test code volume and error surface.
+
+### 4. Preserve existing error-checking semantics
+
+**Chosen:** Where raw code checked `res.StatusCode != 404` for existence checks, use typed API error handling or inspect the typed response. For example, a `Get` that returns a typed error on 404 can be checked with `elastic.IsNotFound(err)` or by checking the typed result.
+
+**Rationale:** We must not change test behavior. The typed client may return errors differently (e.g., structured error types), so each migration must map the old status-code check to the equivalent typed check.
+
+### 5. Use `context.Background()` or `t.Context()` where the raw call lacked explicit context
+
+**Chosen:** Where raw calls passed `WithContext(ctx)`, preserve the same `ctx`. Where raw calls had no context, use `context.Background()` for the typed call.
+
+**Rationale:** Typed API requires a context as the first argument. Using the same context semantics avoids unexpected side effects.
+
+## Risks / Trade-offs
+
+- **[Risk]** Some raw APIs may not yet have a perfect typed equivalent in the pinned `go-elasticsearch/v8` version.
+  - **Mitigation:** For any missing typed endpoint, fall back to `GetESClient()` with an inline `TODO` comment and file a follow-up ticket. Review the generated `TypedClient` surface before starting implementation.
+- **[Risk]** `kibana/streams/acc_test.go` performs raw HTTP requests against the ES query API (`/_query/view`) that may not be covered by the typed client.
+  - **Mitigation:** If a raw HTTP call has no typed equivalent, leave it unchanged or migrate only the `GetESClient()` parts that do have equivalents.
+- **[Risk]** Compilation errors in one test file may cascade to shared test helpers.
+  - **Mitigation:** Run `make build` and `go test ./...` after every few files to catch type mismatches early.
+- **[Risk]** Acceptance tests are slow; full acceptance suite execution may be impractical for every file.
+  - **Mitigation:** Run targeted acceptance tests per package. The CI pipeline provides the definitive acceptance run.
+
+## Migration Plan
+
+1. Verify `GetESTypedClient()` is available on `ElasticsearchScopedClient` (from `typed-client-bootstrap`).
+2. For each domain group, replace `GetESClient()` → `GetESTypedClient()` in the listed test files.
+3. Replace raw API calls with typed equivalents and update response handling.
+4. Run `go test ./internal/...` to verify compilation.
+5. Run targeted acceptance tests for actively migrated packages where possible.
+6. Final CI acceptance test run to confirm no regressions.

--- a/openspec/changes/typed-client-acceptance-tests/proposal.md
+++ b/openspec/changes/typed-client-acceptance-tests/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The provider-wide typed-client migration is in its final phase. All Elasticsearch helper and resource files have already been moved from the raw `esapi` client to `go-elasticsearch` Typed API (`elasticsearch.TypedClient`). The only remaining `GetESClient()` callers are inside acceptance-test files, where raw API methods are used directly for preflight setup, post-test cleanup, and existence checks. Eliminating these last untyped callers completes the migration, removes hand-structured request/response boilerplate from the test suite, and ensures the entire Elasticsearch surface is consistent.
+
+## What Changes
+
+- Migrate every remaining acceptance-test file that calls `GetESClient()` to `GetESTypedClient()` with typed API equivalents.
+- Replace raw `esapi` request patterns (e.g. `esClient.Indices.Get`, `esClient.TransformGetTransform`, `esClient.EnrichGetPolicy`, `esClient.Security.GetRole`) with their `TypedClient` counterparts.
+- Remove manual `io.ReadAll` + `json.Unmarshal` boilerplate where typed responses provide strongly-typed structs.
+- Keep test behavior identical — no Terraform resource schemas, no provider configuration changes, and no test assertions are modified.
+
+Files migrated:
+- `internal/elasticsearch/transform/transform_test.go`
+- `internal/elasticsearch/enrich/acc_test.go`
+- `internal/elasticsearch/index/ilm/acc_test.go`
+- `internal/elasticsearch/index/index/acc_test.go`
+- `internal/elasticsearch/index/component_template_test.go`
+- `internal/elasticsearch/index/data_stream_test.go`
+- `internal/elasticsearch/index/template/acc_test.go`
+- `internal/elasticsearch/index/templateilmattachment/acc_test.go`
+- `internal/elasticsearch/index/datastreamlifecycle/acc_test.go`
+- `internal/elasticsearch/index/alias/acc_test.go`
+- `internal/elasticsearch/inference/inferenceendpoint/acc_test.go`
+- `internal/elasticsearch/logstash/pipeline_test.go`
+- `internal/elasticsearch/security/role/acc_test.go`
+- `internal/elasticsearch/security/rolemapping/acc_test.go`
+- `internal/elasticsearch/security/user/acc_test.go`
+- `internal/elasticsearch/cluster/script_test.go`
+- `internal/elasticsearch/cluster/script/acc_test.go`
+- `internal/elasticsearch/cluster/settings_test.go`
+- `internal/elasticsearch/cluster/slm_test.go`
+- `internal/elasticsearch/cluster/snapshot_repository_test.go`
+- `internal/elasticsearch/ingest/pipeline_test.go`
+- `internal/elasticsearch/watcher/watch/acc_test.go`
+- `internal/kibana/streams/acc_test.go`
+- `internal/clients/elasticsearch_scoped_client_test.go`
+- `internal/clients/provider_client_factory_test.go`
+
+## Capabilities
+
+### New Capabilities
+_(none — this is an internal test-suite refactoring with no new user-visible capabilities)_
+
+### Modified Capabilities
+_(none — no spec-level requirements change; all tests preserve their existing behavior and assertions)_
+
+## Impact
+
+- **Test code only**: No provider runtime behavior changes.
+- **APIs**: All acceptance tests continue to exercise the same Elasticsearch/Kibana APIs, only through the typed client surface.
+- **Dependencies**: Relies on existing `go-elasticsearch/v8` (`ToTyped()`) already exposed via `ElasticsearchScopedClient.GetESTypedClient()`.
+- **Build / CI**: `go test` compilation and acceptance-test execution paths are affected; no new dependencies introduced.

--- a/openspec/changes/typed-client-acceptance-tests/specs/test-suite-elasticsearch-typed-client/spec.md
+++ b/openspec/changes/typed-client-acceptance-tests/specs/test-suite-elasticsearch-typed-client/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Acceptance tests use typed Elasticsearch client
+The listed acceptance test files SHALL use `GetESTypedClient()` to obtain a typed Elasticsearch client for preflight setup, post-test cleanup, and state assertions. They SHALL NOT call `GetESClient()` for direct Elasticsearch API interactions, except where no typed equivalent exists and a deliberate fallback is documented with a TODO comment.
+
+#### Scenario: Test preflight uses typed client
+- **GIVEN** an acceptance test that creates indices, templates, policies, or roles before Terraform applies
+- **WHEN** the test performs preflight setup
+- **THEN** it SHALL use `GetESTypedClient()` and typed API methods instead of `GetESClient()` and raw `esapi` calls
+
+#### Scenario: Test cleanup uses typed client
+- **GIVEN** an acceptance test that verifies resources were deleted after test completion
+- **WHEN** the test performs cleanup or destroy checks
+- **THEN** it SHALL use `GetESTypedClient()` and typed API methods instead of `GetESClient()` and raw `esapi` calls
+
+#### Scenario: Test state assertion uses typed client
+- **GIVEN** an acceptance test that queries Elasticsearch during test execution to validate side effects
+- **WHEN** the test performs state assertions
+- **THEN** it SHALL use `GetESTypedClient()` and typed API methods instead of `GetESClient()` and raw `esapi` calls
+
+### Requirement: Typed responses replace manual JSON decoding
+Where the typed Elasticsearch API provides strongly-typed response structs, acceptance test code SHALL use those structs directly. Manual `io.ReadAll`, `json.NewDecoder`, and `json.Unmarshal` from response bodies SHALL be removed.
+
+#### Scenario: Get response uses typed struct
+- **GIVEN** an acceptance test that previously read a raw HTTP response body and unmarshaled it into an ad-hoc struct or map
+- **WHEN** the test is migrated to the typed client
+- **THEN** the test SHALL receive a typed response struct directly from the typed API call
+- **AND** manual body reading and JSON decoding code SHALL be removed
+
+### Requirement: Preserve existing test behavior
+The migration SHALL NOT modify test assertions, Terraform configurations, test step definitions, or expected test outcomes. Only the client access pattern and response handling SHALL change.
+
+#### Scenario: Test assertions remain unchanged
+- **GIVEN** an acceptance test with existing assertions
+- **WHEN** the migration replaces raw client calls with typed equivalents
+- **THEN** all test assertions SHALL remain identical to their pre-migration form
+
+#### Scenario: Terraform configurations remain unchanged
+- **GIVEN** an acceptance test with existing Terraform configuration blocks
+- **WHEN** the migration replaces raw client calls with typed equivalents
+- **THEN** all Terraform configurations in the test SHALL remain identical to their pre-migration form
+
+### Requirement: No residual raw client calls in migrated files
+After migration, none of the listed acceptance test files SHALL contain direct `GetESClient()` calls for Elasticsearch API interactions.
+
+#### Scenario: Verify no remaining raw client usage
+- **GIVEN** the listed acceptance test files have been migrated
+- **WHEN** a search for `GetESClient()` is performed across those files
+- **THEN** no occurrences SHALL be found except where no typed equivalent exists and a deliberate fallback is documented with a TODO comment
+
+### Requirement: Compilation and test execution
+All migrated acceptance tests SHALL compile successfully without errors, and the repository unit test suite SHALL continue to pass.
+
+#### Scenario: Compilation succeeds after migration
+- **GIVEN** the migration is complete
+- **WHEN** `go test ./internal/...` is run
+- **THEN** all packages SHALL compile without errors
+
+#### Scenario: Unit tests pass after migration
+- **GIVEN** the migration is complete
+- **WHEN** unit tests are executed
+- **THEN** all tests SHALL pass

--- a/openspec/changes/typed-client-acceptance-tests/tasks.md
+++ b/openspec/changes/typed-client-acceptance-tests/tasks.md
@@ -1,0 +1,68 @@
+## 1. Transform
+
+- [ ] 1.1 Migrate `internal/elasticsearch/transform/transform_test.go` from `GetESClient()` to `GetESTypedClient()` and typed transform APIs
+
+## 2. Enrich
+
+- [ ] 2.1 Migrate `internal/elasticsearch/enrich/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed enrich APIs
+
+## 3. Index Lifecycle Management (ILM)
+
+- [ ] 3.1 Migrate `internal/elasticsearch/index/ilm/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed ILM APIs
+
+## 4. Index
+
+- [ ] 4.1 Migrate `internal/elasticsearch/index/index/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed index APIs
+- [ ] 4.2 Migrate `internal/elasticsearch/index/component_template_test.go` from `GetESClient()` to `GetESTypedClient()` and typed component-template APIs
+- [ ] 4.3 Migrate `internal/elasticsearch/index/data_stream_test.go` from `GetESClient()` to `GetESTypedClient()` and typed data-stream APIs
+- [ ] 4.4 Migrate `internal/elasticsearch/index/template/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed index-template APIs
+- [ ] 4.5 Migrate `internal/elasticsearch/index/templateilmattachment/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed APIs
+- [ ] 4.6 Migrate `internal/elasticsearch/index/datastreamlifecycle/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed data-stream-lifecycle APIs
+- [ ] 4.7 Migrate `internal/elasticsearch/index/alias/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed alias APIs
+
+## 5. Inference
+
+- [ ] 5.1 Migrate `internal/elasticsearch/inference/inferenceendpoint/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed inference APIs
+
+## 6. Logstash
+
+- [ ] 6.1 Migrate `internal/elasticsearch/logstash/pipeline_test.go` from `GetESClient()` to `GetESTypedClient()` and typed logstash-pipeline APIs
+
+## 7. Security
+
+- [ ] 7.1 Migrate `internal/elasticsearch/security/role/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed security-role APIs
+- [ ] 7.2 Migrate `internal/elasticsearch/security/rolemapping/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed security-role-mapping APIs
+- [ ] 7.3 Migrate `internal/elasticsearch/security/user/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed security-user APIs
+
+## 8. Cluster
+
+- [ ] 8.1 Migrate `internal/elasticsearch/cluster/script_test.go` from `GetESClient()` to `GetESTypedClient()` and typed script APIs
+- [ ] 8.2 Migrate `internal/elasticsearch/cluster/script/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed script APIs
+- [ ] 8.3 Migrate `internal/elasticsearch/cluster/settings_test.go` from `GetESClient()` to `GetESTypedClient()` and typed cluster-settings APIs
+- [ ] 8.4 Migrate `internal/elasticsearch/cluster/slm_test.go` from `GetESClient()` to `GetESTypedClient()` and typed SLM APIs
+- [ ] 8.5 Migrate `internal/elasticsearch/cluster/snapshot_repository_test.go` from `GetESClient()` to `GetESTypedClient()` and typed snapshot-repository APIs
+
+## 9. Ingest
+
+- [ ] 9.1 Migrate `internal/elasticsearch/ingest/pipeline_test.go` from `GetESClient()` to `GetESTypedClient()` and typed ingest-pipeline APIs
+
+## 10. Watcher
+
+- [ ] 10.1 Migrate `internal/elasticsearch/watcher/watch/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed watcher APIs
+
+## 11. Kibana Streams
+
+- [ ] 11.1 Migrate `internal/kibana/streams/acc_test.go` from `GetESClient()` to `GetESTypedClient()` and typed APIs where equivalents exist
+
+## 12. Client Tests
+
+- [ ] 12.1 Migrate `internal/clients/elasticsearch_scoped_client_test.go` from `GetESClient()` to `GetESTypedClient()` where applicable
+- [ ] 12.2 Migrate `internal/clients/provider_client_factory_test.go` from `GetESClient()` to `GetESTypedClient()` where applicable
+
+## 13. Verification
+
+- [ ] 13.1 Run `make build` and confirm zero compile errors across the entire codebase
+- [ ] 13.2 Run `make check-lint` and resolve any new lint warnings introduced by typed API usage
+- [ ] 13.3 Run `go test ./internal/...` to verify all unit tests pass
+- [ ] 13.4 Confirm no remaining `GetESClient()` calls exist in any of the listed test files
+- [ ] 13.5 Run CI acceptance tests to confirm full test-suite passes with the typed client

--- a/openspec/changes/typed-client-bootstrap/.openspec.yaml
+++ b/openspec/changes/typed-client-bootstrap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-bootstrap/design.md
+++ b/openspec/changes/typed-client-bootstrap/design.md
@@ -1,0 +1,46 @@
+## Context
+
+`ElasticsearchScopedClient` (in `internal/clients/elasticsearch_scoped_client.go`) is the canonical typed surface for Elasticsearch operations. It currently exposes `GetESClient()` which returns `*elasticsearch.Client` — the raw, untyped `esapi` client. All provider resources and helpers build requests manually using this client.
+
+The `go-elasticsearch/v8` library now provides `client.ToTyped()` which returns `*elasticsearch.TypedClient`. This client uses strongly-typed structs for every request/response, eliminating `map[string]interface{}` boilerplate and runtime shape mismatches. However, switching the entire provider at once would be high-risk and hard to review. We need an incremental migration path.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a bridge method `GetESTypedClient()` on `ElasticsearchScopedClient` that returns `*elasticsearch.TypedClient`.
+- Ensure the typed client is lazily initialized and cached (thread-safe).
+- Keep `GetESClient()` untouched so existing code continues to work without modification.
+- Enable subsequent changes (e.g., `typed-client-index`, `typed-client-cluster`) to migrate individual files incrementally.
+
+**Non-Goals:**
+- Migrating any existing resource or helper to the typed client (future changes).
+- Removing or deprecating `GetESClient()`.
+- Changing provider configuration, client construction, or authentication flows.
+- Adding new Terraform resources or data sources.
+
+## Decisions
+
+**1. Lazy initialization with `sync.Once`**
+- **Rationale**: `ToTyped()` is cheap but not free. `sync.Once` guarantees exactly-once initialization without holding a mutex for every call. The typed client is stateless and safe for concurrent use once created.
+- **Alternative considered**: `sync.Mutex` + nil check. Rejected because `sync.Once` is simpler and idiomatic for this pattern.
+
+**2. Cache the typed client as a struct field**
+- **Rationale**: Once created, the typed client is bound to the same underlying `*elasticsearch.Client` (same transport, same endpoints). Caching avoids repeated `ToTyped()` calls and keeps the API ergonomic.
+- **Alternative considered**: Computing `ToTyped()` on every `GetESTypedClient()` call. Rejected because it creates unnecessary garbage for no benefit.
+
+**3. Add the field directly to `ElasticsearchScopedClient` rather than a wrapper**
+- **Rationale**: The scoped client is already the abstraction layer. Adding a field keeps the surface simple and avoids proliferating types.
+- **Alternative considered**: A separate `TypedElasticsearchScopedClient` wrapper. Rejected because it would require updating every call site that constructs or accepts the scoped client.
+
+**4. `GetESTypedClient()` returns `*elasticsearch.TypedClient` (no error)**
+- **Rationale**: `client.ToTyped()` returns `*TypedClient` with no error — it is a pure wrapper around the existing client. Adding an error return to `GetESTypedClient()` would be misleading (there is no failure mode distinct from `GetESClient()`). Callers that need error handling can validate the underlying client first via `GetESClient()`.
+- **Alternative considered**: Returning `(*elasticsearch.TypedClient, error)` for API symmetry with `GetESClient()`. Rejected because it forces all callers to handle an error that can never occur.
+
+## Risks / Trade-offs
+
+- **[Risk]** `ToTyped()` re-runs the product check on the typed client's first request, which adds marginal latency on first use.
+  - **Mitigation**: The product check is fast and only runs once per cached typed client. Document this behavior in the method comment.
+- **[Risk]** Future `go-elasticsearch` versions could change `ToTyped()` behavior or signature.
+  - **Mitigation**: The provider pins `go-elasticsearch/v8`. Any upgrade would be a dedicated change with regression testing.
+- **[Risk]** Developers might inconsistently mix typed and untyped APIs in the same resource.
+  - **Mitigation**: This is expected during the transition. Each migration change should convert a resource fully. Code review enforces consistency.

--- a/openspec/changes/typed-client-bootstrap/proposal.md
+++ b/openspec/changes/typed-client-bootstrap/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The provider currently uses the raw `esapi` (untyped) client for all Elasticsearch API calls. The `go-elasticsearch` library now provides a fully typed API via `elasticsearch.TypedClient` (`ToTyped()`), which eliminates hand-structured request bodies, reduces runtime errors, and enables IDE-driven refactoring. We need a non-breaking bridge so that file-by-file migrations can opt-in to the typed client without disrupting existing code.
+
+## What Changes
+
+- Add a `typedClient *elasticsearch.TypedClient` field to `ElasticsearchScopedClient` (in `internal/clients/elasticsearch_scoped_client.go`).
+- Add `GetESTypedClient()` method that lazily converts the existing `*elasticsearch.Client` to `*elasticsearch.TypedClient` via `client.ToTyped()` and caches the result (thread-safe via `sync.Once`).
+- `GetESClient()` remains completely untouched — no existing consumer is affected.
+- No resources or helpers are migrated yet; this is pure infrastructure/bridge code only.
+
+## Capabilities
+
+### New Capabilities
+- `typed-client-bootstrap`: Bridge infrastructure that exposes `GetESTypedClient()` on `ElasticsearchScopedClient`, allowing subsequent migrations to use the typed client.
+
+### Modified Capabilities
+- (none — no spec-level behavior changes, purely additive infrastructure)
+
+## Impact
+
+- **Code**: `internal/clients/elasticsearch_scoped_client.go` only.
+- **APIs**: No Terraform resource or data source behavior changes.
+- **Dependencies**: Relies on existing `go-elasticsearch/v8` `ToTyped()` method.
+- **Systems**: None — this is a foundational, backward-compatible change.

--- a/openspec/changes/typed-client-bootstrap/specs/typed-client-bootstrap/spec.md
+++ b/openspec/changes/typed-client-bootstrap/specs/typed-client-bootstrap/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: ElasticsearchScopedClient exposes a typed client accessor
+`ElasticsearchScopedClient` SHALL provide a method `GetESTypedClient()` that returns `*elasticsearch.TypedClient`.
+
+#### Scenario: Typed client is accessible after initialization
+- **WHEN** an `ElasticsearchScopedClient` has been constructed with a valid `*elasticsearch.Client`
+- **THEN** calling `GetESTypedClient()` returns a non-nil `*elasticsearch.TypedClient`
+
+### Requirement: Typed client is lazily initialized
+`GetESTypedClient()` SHALL convert the underlying `*elasticsearch.Client` to `*elasticsearch.TypedClient` using `ToTyped()` only on the first invocation.
+
+#### Scenario: First call creates the typed client
+- **WHEN** `GetESTypedClient()` is called for the first time on an `ElasticsearchScopedClient` instance
+- **THEN** `ToTyped()` is invoked exactly once on the underlying client
+
+#### Scenario: Subsequent calls reuse the cached typed client
+- **GIVEN** `GetESTypedClient()` has already been called once
+- **WHEN** `GetESTypedClient()` is called again on the same instance
+- **THEN** `ToTyped()` is NOT invoked again and the same `*elasticsearch.TypedClient` pointer is returned
+
+### Requirement: Typed client initialization is thread-safe
+The lazy initialization of the typed client SHALL be safe for concurrent use by multiple goroutines.
+
+#### Scenario: Concurrent access during first call
+- **WHEN** multiple goroutines call `GetESTypedClient()` concurrently before any prior invocation
+- **THEN** `ToTyped()` is invoked exactly once and all goroutines receive the same `*elasticsearch.TypedClient` pointer
+
+### Requirement: Existing untyped client accessor remains unchanged
+`GetESClient()` on `ElasticsearchScopedClient` SHALL continue to behave exactly as before this change.
+
+#### Scenario: Untyped accessor is unaffected
+- **WHEN** code calls `GetESClient()` on an `ElasticsearchScopedClient`
+- **THEN** it returns the same `*elasticsearch.Client` and exhibits the same error behavior as prior to this change

--- a/openspec/changes/typed-client-bootstrap/tasks.md
+++ b/openspec/changes/typed-client-bootstrap/tasks.md
@@ -1,0 +1,13 @@
+## 1. Core Implementation
+
+- [ ] 1.1 Add `typedClient *elasticsearch.TypedClient` field to `ElasticsearchScopedClient` struct in `internal/clients/elasticsearch_scoped_client.go`
+- [ ] 1.2 Add `typedClientOnce sync.Once` field to `ElasticsearchScopedClient` struct for thread-safe lazy initialization
+- [ ] 1.3 Implement `GetESTypedClient() *elasticsearch.TypedClient` method with lazy `ToTyped()` initialization and caching
+- [ ] 1.4 Add Go doc comments to `GetESTypedClient()` explaining behavior, thread-safety, and that it shares the underlying transport
+
+## 2. Verification
+
+- [ ] 2.1 Run `make build` to ensure the project compiles without errors
+- [ ] 2.2 Run `make check-lint` to ensure code passes lint checks
+- [ ] 2.3 Verify `GetESClient()` remains unchanged and unaffected by the new code
+- [ ] 2.4 Confirm `go mod tidy` does not introduce new dependencies (change uses existing `go-elasticsearch/v8`)

--- a/openspec/changes/typed-client-cluster/.openspec.yaml
+++ b/openspec/changes/typed-client-cluster/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-cluster/design.md
+++ b/openspec/changes/typed-client-cluster/design.md
@@ -1,0 +1,112 @@
+## Context
+
+The provider is incrementally migrating Elasticsearch API calls from the raw `esapi` (untyped) client to the `go-elasticsearch` Typed API (`elasticsearch.TypedClient` via `ToTyped()`). Previous phases migrated lower-level helpers; this change targets the cluster surface in `internal/clients/elasticsearch/cluster.go`.
+
+Current state:
+- `GetClusterInfo` uses `esClient.Info()` and decodes into `models.ClusterInfo`.
+- Snapshot repository, SLM, settings, and script helpers manually marshal/unmarshal JSON via `esapi` and use custom models (`models.SnapshotRepository`, `models.SnapshotPolicy`, `models.Script`).
+- `internal/clients/elasticsearch/helpers.go` provides `doSDKWrite`/`doFWWrite` wrappers for raw API calls.
+- Callers in `internal/elasticsearch/cluster/` (resource and test files) consume the helper return types directly.
+- `ElasticsearchScopedClient` caches `*models.ClusterInfo` in `serverInfo()` and exposes `ClusterID()`, `ServerVersion()`, `ServerFlavor()`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Migrate all helpers in `internal/clients/elasticsearch/cluster.go` to typed API calls.
+- Remove custom models that duplicate upstream typed API structs (`ClusterInfo`, `SnapshotRepository`, `SnapshotPolicy`, `Script`).
+- Update all callers to use typed API response types.
+- Add a typed client accessor on `ElasticsearchScopedClient` so helpers can consistently obtain `*elasticsearch.TypedClient`.
+- Ensure the `serverInfo()` cache continues to work with typed responses.
+- Keep zero Terraform-level behavioral changes.
+
+**Non-Goals:**
+- Migrating other files in `internal/clients/elasticsearch/`.
+- Changing resource schemas, documentation, or Terraform user-facing behavior.
+- Adding new resources or data sources.
+
+## Decisions
+
+### 1. Typed client access via `ElasticsearchScopedClient.GetESTypedClient()`
+
+**Decision:** Add `GetESTypedClient() (*elasticsearch.TypedClient, error)` to `ElasticsearchScopedClient`.
+
+**Rationale:** Helpers currently call `GetESClient()` and then use the raw `*elasticsearch.Client`. To use the typed API they need `*elasticsearch.TypedClient`, obtained via `client.ToTyped()`. Centralizing this in the scoped client ensures endpoint validation (already present in `GetESClient()`) and avoids repeated `ToTyped()` calls scattered through helpers.
+
+**Alternative considered:** Call `ToTyped()` inline inside each helper. Rejected because it duplicates endpoint-not-configured checks and makes it harder to inject typed client mocks later.
+
+### 2. Return typed API response types instead of custom models
+
+**Decision:** Change return types:
+- `GetClusterInfo` → `*core.InfoResponse`
+- `GetSnapshotRepository` → `getrepository.Response` (map of `types.Repository`)
+- `GetSlm` → `*types.SLMPolicy` (extracted from `getlifecycle.Response`)
+- `GetScript` → `*types.StoredScript`
+- `GetSettings` → `*getsettings.Response`
+
+**Rationale:** Eliminates custom models that duplicate upstream structs and require manual JSON decoding. The typed API handles marshaling internally.
+
+**Impact on callers:** Callers need minor adaptation:
+- `cluster_info_data_source.go` reads `info.Version.Int` instead of `info.Version.Number` (the typed API uses `Int` for the version number field).
+- `snapshot_repository.go` and `snapshot_repository_data_source.go` iterate over `types.Repository` union values; each branch must be type-asserted to the concrete repository type (e.g., `types.SharedFileSystemRepository`, `types.S3Repository`, etc.) to access `Type` and `Settings`.
+- `slm.go` directly uses `types.SLMPolicy` and `types.Retention`.
+- `script` resource uses `types.StoredScript` (fields: `Lang`, `Source` — note `Params` is not part of `StoredScript`; callers must handle params separately).
+- `settings.go` handles `json.RawMessage` values in `getsettings.Response`.
+
+### 3. Keep helper signatures in `cluster.go` but change internals
+
+**Decision:** Retain the same function names and parameter lists; only migrate bodies and return types.
+
+**Rationale:** Minimizes diff size and avoids renaming churn across dozen+ call sites in resources and tests.
+
+### 4. Remove obsolete custom models from `models.go`
+
+**Decision:** Delete `ClusterInfo`, `SnapshotRepository`, `SnapshotPolicy`/`SnapshortRetention`/`SnapshotPolicyConfig`, and `Script` from `internal/models/models.go` after migrating all consumers.
+
+**Rationale:** Prevents drift between custom and upstream types. These models exist solely to bridge the raw API; the typed API makes them unnecessary.
+
+### 5. Adapt `ElasticsearchScopedClient.serverInfo()` to typed API
+
+**Decision:** Rewrite `serverInfo()` to use `typedClient.Core.Info().Do(ctx)`, returning `*core.InfoResponse`, and update the cached field type.
+
+**Rationale:** The cache uses `*models.ClusterInfo` today; it must switch to `*core.InfoResponse` so downstream methods (`ClusterID`, `ServerVersion`, `ServerFlavor`) compile without conversion layers.
+
+**Trade-off:** `core.InfoResponse` stores `BuildDate` as `types.DateTime` (not a custom `time.Time` wrapper). `DateTime` has its own `String()` implementation, so the data source `build_date` output may change format if the upstream stringer differs from the old custom `UnmarshalJSON` + `time.Time.String()`. Both produce RFC3339-like output; this is acceptable for a pure refactor.
+
+### 6. Snapshot repository typed API union handling
+
+**Decision:** In `GetSnapshotRepository`, after obtaining `getrepository.Response`, type-switch on `types.Repository` to extract the concrete repository struct and read its `Type` and `Settings` fields.
+
+**Rationale:** `types.Repository` is a Go `any` alias covering `AzureRepository`, `GcsRepository`, `S3Repository`, `SharedFileSystemRepository`, `ReadOnlyUrlRepository`, and `SourceOnlyRepository`. The existing resource only needs `Type` (discriminator) and the raw `Settings` map. Each concrete type exposes `Type` (string) and `Settings` (map[string]json.RawMessage or similar); a small adapter can flatten the settings into the `map[string]any` shape the resource already expects.
+
+## Risks / Trade-offs
+
+- **[Risk]** `types.Repository` union type-assertion logic is new code; missed branches could panic at runtime.
+  → **Mitigation:** Use a type switch with an explicit default returning a diagnostic error. Cover all known repository types (`fs`, `url`, `gcs`, `azure`, `s3`, `hdfs`, `source`); add a catch-all error for unknown types.
+
+- **[Risk]** `getsettings.Response` fields are `map[string]json.RawMessage`, requiring `json.Unmarshal` per value where the old code decoded into `map[string]any` in one step.
+  → **Mitigation:** Add a small flattening helper in `cluster.go` that unmarshals each `RawMessage` into `any` and returns the aggregated `map[string]any`. This preserves the existing caller contract.
+
+- **[Risk]** Script `params` field is not present on `types.StoredScript`; only `Lang`, `Source`, and `Options` exist.
+  → **Mitigation:** Keep the script resource's internal `params` logic (marshal/unmarshal from Terraform state) unchanged. `PutScript` will continue building the request body that includes params via a wrapper struct, but instead of using `models.Script`, it uses `types.StoredScript` plus params. Alternatively, build the request via the typed API `PutScript` request builder which accepts `*types.StoredScript` directly and handle params as an additional state-only field.
+
+- **[Risk]** Build date formatting change in `cluster_info_data_source.go`.
+  → **Mitigation:** Verify in acceptance tests that `build_date` remains a valid timestamp string; adapt if the exact string format changes.
+
+## Migration Plan
+
+1. Add `GetESTypedClient()` to `ElasticsearchScopedClient`.
+2. Update `serverInfo()` and cache to use `*core.InfoResponse`.
+3. Rewrite cluster helpers (`GetClusterInfo`, Snapshot repository, SLM, Settings, Script) to typed API.
+4. Update callers:
+   - `cluster_info_data_source.go`
+   - `snapshot_repository.go` + `snapshot_repository_data_source.go`
+   - `slm.go`
+   - `settings.go`
+   - `script/` resource files (`create.go`, `read.go`, `delete.go`, `update.go`)
+5. Remove dead models from `models.go`.
+6. Run `make build` and targeted acceptance tests.
+7. Archive change or sync delta specs if necessity is discovered.
+
+## Open Questions
+
+(none)

--- a/openspec/changes/typed-client-cluster/proposal.md
+++ b/openspec/changes/typed-client-cluster/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The provider is incrementally migrating Elasticsearch API calls from the raw `esapi` (untyped) client to the `go-elasticsearch` Typed API (`elasticsearch.TypedClient` via `ToTyped()`). The cluster helpers in `internal/clients/elasticsearch/cluster.go` are the next surface to migrate. Using the typed client eliminates hand-structured JSON request bodies, removes custom model types that duplicate upstream structs, and enables compile-time API shape checking.
+
+## What Changes
+
+- Migrate `internal/clients/elasticsearch/cluster.go` helper functions to use the typed client:
+  - `GetClusterInfo` → `typedapi.Core.Info().Do(ctx)` — return `*info.Response` instead of `*models.ClusterInfo`
+  - `PutSnapshotRepository` / `GetSnapshotRepository` / `DeleteSnapshotRepository` → snapshot repository typed APIs
+  - `PutSlm` / `GetSlm` / `DeleteSlm` → SLM typed APIs
+  - `PutSettings` / `GetSettings` → cluster settings typed APIs
+  - `GetScript` / `PutScript` / `DeleteScript` → script typed APIs (uses `types.StoredScript`)
+- Remove or deprecate custom models: `ClusterInfo`, `SnapshotRepository`, `SnapshotPolicy`, `Script`
+- Update all callers in `internal/elasticsearch/cluster/` resources and tests that consume the migrated helpers:
+  - `script` resource + tests
+  - `script` acceptance tests
+  - `settings` tests
+  - `slm` tests
+  - `snapshot_repository` tests
+- Ensure zero behavioral changes from the Terraform user perspective; this is a pure implementation refactor.
+
+## Capabilities
+
+### New Capabilities
+- `typed-client-cluster`: Internal contract for cluster helper functions migrated to the typed client. Defines typed API usage, return types, and not-found/error handling behavior for `GetClusterInfo`, snapshot repository, SLM, cluster settings, and script helpers.
+
+### Modified Capabilities
+<!-- No spec-level behavior changes for existing Terraform resources; this is an internal implementation refactor -->
+(none)
+
+## Impact
+
+- **Code**: `internal/clients/elasticsearch/cluster.go`, `internal/models/models.go`, and resource/test files under `internal/elasticsearch/cluster/`
+- **APIs**: No Terraform resource or data source behavior changes
+- **Dependencies**: Relies on existing `go-elasticsearch/v8` Typed API support
+- **Systems**: None — purely internal refactor

--- a/openspec/changes/typed-client-cluster/specs/elasticsearch-cluster-settings/spec.md
+++ b/openspec/changes/typed-client-cluster/specs/elasticsearch-cluster-settings/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for cluster settings
+The resource SHALL use the go-elasticsearch Typed API for cluster settings operations. `GetSettings` SHALL use `Cluster.GetSettings().Do(ctx)` with flat settings enabled. `PutSettings` SHALL use `Cluster.PutSettings().Do(ctx)`. Manual JSON decoding into `map[string]any` from raw response bodies SHALL be replaced with typed API response handling.
+
+#### Scenario: Typed API read with flat settings
+- GIVEN a successful Cluster Get Settings API call
+- WHEN the provider processes the response
+- THEN the typed API `getsettings.Response` SHALL provide `Persistent`, `Transient`, and `Defaults` as `map[string]json.RawMessage`
+- AND the provider SHALL unmarshal each `RawMessage` value to `any` to maintain the existing `map[string]any` contract with callers
+
+#### Scenario: Typed API write sends settings
+- GIVEN cluster settings to update
+- WHEN the provider calls the Cluster Put Settings API
+- THEN the request SHALL be built using typed API request builders
+- AND manual `json.Marshal` of a `map[string]any` into a raw request body SHALL NOT occur

--- a/openspec/changes/typed-client-cluster/specs/elasticsearch-info/spec.md
+++ b/openspec/changes/typed-client-cluster/specs/elasticsearch-info/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for cluster info
+The data source SHALL retrieve cluster metadata using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Core.Info().Do(ctx)`) instead of the raw `esapi` client. The typed API response SHALL be returned directly without manual JSON decoding into an intermediate model type.
+
+#### Scenario: Typed API success
+- GIVEN a valid Elasticsearch connection
+- WHEN the data source reads cluster info
+- THEN the provider SHALL call `Core.Info().Do(ctx)` on the typed client
+- AND the response SHALL be returned as `*core.InfoResponse`
+
+#### Scenario: Build date formatting
+- GIVEN a successful typed API response
+- WHEN the data source maps the `version.build_date` field
+- THEN the value SHALL be formatted using the typed API's `DateTime.String()` method
+- AND the resulting string SHALL remain a valid timestamp representation

--- a/openspec/changes/typed-client-cluster/specs/elasticsearch-script/spec.md
+++ b/openspec/changes/typed-client-cluster/specs/elasticsearch-script/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for stored script CRUD
+The resource SHALL use the go-elasticsearch Typed API for stored script operations. `GetScript` SHALL use `Core.GetScript().Do(ctx)`, `PutScript` SHALL use `Core.PutScript().Do(ctx)`, and `DeleteScript` SHALL use `Core.DeleteScript().Do(ctx)`. The typed API response type `types.StoredScript` SHALL replace the custom `models.Script` type for API fields `lang` and `source`.
+
+#### Scenario: Typed API read maps stored script
+- GIVEN a successful Get Stored Script API response
+- WHEN the provider processes the response
+- THEN `types.StoredScript` SHALL provide `Lang` and `Source` directly
+- AND the provider SHALL preserve `params` from prior state when the typed API response does not include params
+
+#### Scenario: Typed API write sends stored script
+- GIVEN a stored script to create or update
+- WHEN the provider calls the Put Stored Script API
+- THEN the request SHALL be built using typed API request builders
+- AND `types.StoredScript` SHALL be used for the script body fields (`Lang`, `Source`)
+- AND manual JSON marshaling into `models.Script` SHALL NOT occur
+
+#### Scenario: Context parameter preserved
+- GIVEN a script resource with `context` configured
+- WHEN create or update runs via the typed API
+- THEN the `context` value SHALL be passed as a query parameter to the Put Script API
+- AND `context` SHALL continue to be preserved from state on read because it is not returned by the Get Script API

--- a/openspec/changes/typed-client-cluster/specs/elasticsearch-snapshot-lifecycle/spec.md
+++ b/openspec/changes/typed-client-cluster/specs/elasticsearch-snapshot-lifecycle/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for SLM policy CRUD
+The resource SHALL use the go-elasticsearch Typed API for all SLM operations. `GetSlm` SHALL use `Slm.GetLifecycle().Do(ctx)`, `PutSlm` SHALL use `Slm.PutLifecycle().Do(ctx)`, and `DeleteSlm` SHALL use `Slm.DeleteLifecycle().Do(ctx)`. The typed API response type `types.SLMPolicy` SHALL replace the custom `models.SnapshotPolicy` type.
+
+#### Scenario: Typed API read maps SLM policy
+- GIVEN a successful Get Lifecycle API response
+- WHEN the provider extracts the policy
+- THEN the typed API `types.SLMPolicy` SHALL be used directly
+- AND fields (`name`, `repository`, `schedule`, `config`, `retention`) SHALL map to the resource state without intermediate model conversion
+
+#### Scenario: Typed API write sends SLM policy
+- GIVEN an SLM policy to create or update
+- WHEN the provider calls the Put Lifecycle API
+- THEN the request SHALL be built using typed API request builders accepting `*types.SLMPolicy`
+- AND manual JSON marshaling into `models.SnapshotPolicy` SHALL NOT occur

--- a/openspec/changes/typed-client-cluster/specs/elasticsearch-snapshot-repository/spec.md
+++ b/openspec/changes/typed-client-cluster/specs/elasticsearch-snapshot-repository/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for snapshot repository CRUD
+The resource and data source SHALL use the go-elasticsearch Typed API for all snapshot repository operations. `GetSnapshotRepository` SHALL use `Snapshot.GetRepository().Do(ctx)`, `PutSnapshotRepository` SHALL use `Snapshot.CreateRepository().Do(ctx)`, and `DeleteSnapshotRepository` SHALL use `Snapshot.DeleteRepository().Do(ctx)`. Manual JSON marshaling and unmarshaling SHALL be eliminated.
+
+#### Scenario: Typed API read with union type handling
+- GIVEN a successful Get Snapshot Repository API response
+- WHEN the provider processes the response
+- THEN the typed API response (`getrepository.Response`) SHALL be type-switched over `types.Repository` union variants
+- AND each known repository type (`fs`, `url`, `gcs`, `azure`, `s3`, `hdfs`, `source`) SHALL be mapped to its corresponding schema block
+
+#### Scenario: Unknown repository type error
+- GIVEN the API returns a repository type not covered by the `types.Repository` union handling
+- WHEN read runs
+- THEN the provider SHALL return an error diagnostic and SHALL NOT panic
+
+#### Scenario: Typed API write without manual marshal
+- GIVEN a snapshot repository to create or update
+- WHEN the provider calls the Put API
+- THEN the request body SHALL be constructed using typed API request builders
+- AND manual `json.Marshal` into an intermediate `models.SnapshotRepository` SHALL NOT occur

--- a/openspec/changes/typed-client-cluster/specs/typed-client-cluster/spec.md
+++ b/openspec/changes/typed-client-cluster/specs/typed-client-cluster/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Cluster info helper uses typed client
+`GetClusterInfo` SHALL use the typed client (`typedapi.Core.Info().Do(ctx)`) to retrieve cluster metadata. It SHALL return `*info.Response` from the typed client. When the API returns an error, the helper SHALL surface the error in Terraform diagnostics.
+
+#### Scenario: Successful cluster info retrieval
+- **WHEN** `GetClusterInfo` is called with a valid `*clients.ElasticsearchScopedClient`
+- **THEN** it returns a non-nil `*info.Response` and no error diagnostics
+
+#### Scenario: API failure on cluster info
+- **GIVEN** the Elasticsearch cluster info API returns an error
+- **WHEN** `GetClusterInfo` processes the response
+- **THEN** it returns nil and Terraform diagnostics include the API error
+
+### Requirement: Snapshot repository helpers use typed client
+`PutSnapshotRepository`, `GetSnapshotRepository`, and `DeleteSnapshotRepository` SHALL use the typed snapshot repository APIs (`Snapshot.CreateRepository`, `Snapshot.GetRepository`, `Snapshot.DeleteRepository`). `GetSnapshotRepository` SHALL return the repository's typed response and SHALL return `nil` with no error when the repository is not found.
+
+#### Scenario: Create or update snapshot repository
+- **WHEN** `PutSnapshotRepository` is called with a valid repository configuration
+- **THEN** it calls the typed `Snapshot.CreateRepository` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read existing snapshot repository
+- **WHEN** `GetSnapshotRepository` is called for an existing repository
+- **THEN** it returns the repository data and no error diagnostics
+
+#### Scenario: Read missing snapshot repository
+- **GIVEN** the requested snapshot repository does not exist
+- **WHEN** `GetSnapshotRepository` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete snapshot repository
+- **WHEN** `DeleteSnapshotRepository` is called with a valid repository name
+- **THEN** it calls the typed `Snapshot.DeleteRepository` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: SLM helpers use typed client
+`PutSlm`, `GetSlm`, and `DeleteSlm` SHALL use the typed SLM APIs (`Slm.PutLifecycle`, `Slm.GetLifecycle`, `Slm.DeleteLifecycle`). `GetSlm` SHALL return the policy's typed response and SHALL return `nil` with no error when the policy is not found.
+
+#### Scenario: Create or update SLM policy
+- **WHEN** `PutSlm` is called with a valid SLM policy
+- **THEN** it calls the typed `Slm.PutLifecycle` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read existing SLM policy
+- **WHEN** `GetSlm` is called for an existing policy
+- **THEN** it returns the policy data and no error diagnostics
+
+#### Scenario: Read missing SLM policy
+- **GIVEN** the requested SLM policy does not exist
+- **WHEN** `GetSlm` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete SLM policy
+- **WHEN** `DeleteSlm` is called with a valid policy name
+- **THEN** it calls the typed `Slm.DeleteLifecycle` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Cluster settings helpers use typed client
+`PutSettings` and `GetSettings` SHALL use the typed cluster settings APIs (`Cluster.PutSettings`, `Cluster.GetSettings`). `GetSettings` SHALL request flat settings (`flat_settings=true`) and return them as a `map[string]any`.
+
+#### Scenario: Update cluster settings
+- **WHEN** `PutSettings` is called with a settings map
+- **THEN** it calls the typed `Cluster.PutSettings` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read cluster settings with flat settings
+- **WHEN** `GetSettings` is called
+- **THEN** it calls the typed `Cluster.GetSettings` API with `flat_settings=true`
+- **AND** returns the settings as `map[string]any`
+
+### Requirement: Script helpers use typed client
+`GetScript`, `PutScript`, and `DeleteScript` SHALL use the typed script APIs (`Core.GetScript`, `Core.PutScript`, `Core.DeleteScript`). `GetScript` SHALL return `*types.StoredScript` and SHALL return `nil` with no error when the script is not found. `PutScript` SHALL build the request body from `*types.StoredScript`.
+
+#### Scenario: Create or update stored script
+- **WHEN** `PutScript` is called with a valid `*types.StoredScript`
+- **THEN** it calls the typed `Core.PutScript` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read existing stored script
+- **WHEN** `GetScript` is called for an existing script
+- **THEN** it returns `*types.StoredScript` and no error diagnostics
+
+#### Scenario: Read missing stored script
+- **GIVEN** the requested stored script does not exist
+- **WHEN** `GetScript` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete stored script
+- **WHEN** `DeleteScript` is called with a valid script ID
+- **THEN** it calls the typed `Core.DeleteScript` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Custom cluster model types are removed
+The custom model types `ClusterInfo`, `SnapshotRepository`, `SnapshotPolicy`, and `Script` in `internal/models/models.go` SHALL be removed once all callers have been migrated to typed client equivalents. No remaining code SHALL reference these types after the migration.
+
+#### Scenario: Build succeeds after model removal
+- **GIVEN** all callers have been updated to use typed client types
+- **WHEN** the custom models are removed from `internal/models/models.go`
+- **THEN** `make build` completes successfully

--- a/openspec/changes/typed-client-cluster/tasks.md
+++ b/openspec/changes/typed-client-cluster/tasks.md
@@ -1,0 +1,72 @@
+## 1. Typed Client Infrastructure
+
+- [ ] 1.1 Add `GetESTypedClient() (*elasticsearch.TypedClient, error)` to `ElasticsearchScopedClient` in `internal/clients/elasticsearch_scoped_client.go`
+- [ ] 1.2 Update `serverInfo()` and cached field to use `*core.InfoResponse` instead of `*models.ClusterInfo`
+- [ ] 1.3 Update `ClusterID()`, `ServerVersion()`, and `ServerFlavor()` to read from `*core.InfoResponse`
+- [ ] 1.4 Verify `make build` passes after scoped client changes
+
+## 2. Cluster Helper Migration
+
+- [ ] 2.1 Rewrite `GetClusterInfo` in `internal/clients/elasticsearch/cluster.go` to use `typedClient.Core.Info().Do(ctx)`
+- [ ] 2.2 Rewrite `PutSnapshotRepository` to use typed API `Snapshot.CreateRepository().Do(ctx)`
+- [ ] 2.3 Rewrite `GetSnapshotRepository` to use typed API `Snapshot.GetRepository().Do(ctx)` with union type handling
+- [ ] 2.4 Rewrite `DeleteSnapshotRepository` to use typed API `Snapshot.DeleteRepository().Do(ctx)`
+- [ ] 2.5 Rewrite `PutSlm` to use typed API `Slm.PutLifecycle().Do(ctx)`
+- [ ] 2.6 Rewrite `GetSlm` to use typed API `Slm.GetLifecycle().Do(ctx)` and return `*types.SLMPolicy`
+- [ ] 2.7 Rewrite `DeleteSlm` to use typed API `Slm.DeleteLifecycle().Do(ctx)`
+- [ ] 2.8 Rewrite `PutSettings` to use typed API `Cluster.PutSettings().Do(ctx)`
+- [ ] 2.9 Rewrite `GetSettings` to use typed API `Cluster.GetSettings().Do(ctx)` and flatten `json.RawMessage` values
+- [ ] 2.10 Rewrite `GetScript` to use typed API `Core.GetScript().Do(ctx)` and return `*types.StoredScript`
+- [ ] 2.11 Rewrite `PutScript` to use typed API `Core.PutScript().Do(ctx)`
+- [ ] 2.12 Rewrite `DeleteScript` to use typed API `Core.DeleteScript().Do(ctx)`
+- [ ] 2.13 Remove unused imports (`bytes`, `encoding/json`, `io`, `net/http`, `esapi`) from `cluster.go` after migration
+- [ ] 2.14 Verify `make build` passes after helper migration
+
+## 3. Caller Updates — Cluster Info
+
+- [ ] 3.1 Update `internal/elasticsearch/cluster/cluster_info_data_source.go` to use `*core.InfoResponse`
+- [ ] 3.2 Adapt `build_date` extraction to use typed API `DateTime.String()`
+- [ ] 3.3 Update `internal/elasticsearch/cluster/cluster_info_data_source_test.go` if needed
+
+## 4. Caller Updates — Snapshot Repository
+
+- [ ] 4.1 Update `internal/elasticsearch/cluster/snapshot_repository.go` to adapt to typed API response type
+- [ ] 4.2 Add repository union type-switch logic (`types.Repository` → concrete type → `Type` + `Settings`)
+- [ ] 4.3 Update `internal/elasticsearch/cluster/snapshot_repository_data_source.go` for typed API response
+- [ ] 4.4 Update `internal/elasticsearch/cluster/snapshot_repository_test.go` and `snapshot_repository_data_source_test.go` if needed
+
+## 5. Caller Updates — SLM
+
+- [ ] 5.1 Update `internal/elasticsearch/cluster/slm.go` to use `*types.SLMPolicy` and `*types.Retention`
+- [ ] 5.2 Adapt `config` field mapping to typed API `types.Configuration`
+- [ ] 5.3 Update `internal/elasticsearch/cluster/slm_test.go` if needed
+
+## 6. Caller Updates — Cluster Settings
+
+- [ ] 6.1 Update `internal/elasticsearch/cluster/settings.go` to handle `getsettings.Response` with `json.RawMessage` values
+- [ ] 6.2 Add flattening helper to convert `map[string]json.RawMessage` to `map[string]any`
+- [ ] 6.3 Update `internal/elasticsearch/cluster/settings_test.go` if needed
+
+## 7. Caller Updates — Script Resource
+
+- [ ] 7.1 Update `internal/elasticsearch/cluster/script/read.go` to use `*types.StoredScript`
+- [ ] 7.2 Update `internal/elasticsearch/cluster/script/update.go` to build request via typed API and preserve `params` behavior
+- [ ] 7.3 Update `internal/elasticsearch/cluster/script/delete.go` to call typed `DeleteScript`
+- [ ] 7.4 Update `internal/elasticsearch/cluster/script/acc_test.go` if needed
+
+## 8. Model Cleanup
+
+- [ ] 8.1 Remove `ClusterInfo` struct from `internal/models/models.go`
+- [ ] 8.2 Remove `SnapshotRepository` struct from `internal/models/models.go`
+- [ ] 8.3 Remove `SnapshotPolicy`, `SnapshortRetention`, and `SnapshotPolicyConfig` from `internal/models/models.go`
+- [ ] 8.4 Remove `Script` struct from `internal/models/models.go`
+- [ ] 8.5 Remove any unused imports from `internal/models/models.go`
+- [ ] 8.6 Verify `make build` passes after model removal
+
+## 9. Regression Testing
+
+- [ ] 9.1 Run `make build` and ensure clean compilation
+- [ ] 9.2 Run `make test` for unit tests
+- [ ] 9.3 Verify `make check-openspec` passes
+- [ ] 9.4 Run acceptance tests for affected resources: `script`, `snapshot_repository`, `slm`, `settings`
+- [ ] 9.5 Run acceptance test for `cluster_info` data source

--- a/openspec/changes/typed-client-easy-wins/.openspec.yaml
+++ b/openspec/changes/typed-client-easy-wins/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-easy-wins/design.md
+++ b/openspec/changes/typed-client-easy-wins/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The `typed-client-bootstrap` change already added `GetESTypedClient()` to `ElasticsearchScopedClient`, returning a cached `*elasticsearch.TypedClient`. All Elasticsearch API calls in the provider currently go through the raw `esapi` client returned by `GetESClient()`, which requires manual request construction, JSON marshaling, and response body parsing.
+
+This change targets four helper files in `internal/clients/elasticsearch/` that are small, self-contained, and have direct typed API equivalents in `go-elasticsearch/v8`. Migrating these first establishes patterns for larger, more complex migrations in subsequent phases.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Convert `inference.go`, `logstash.go`, `enrich.go`, and `watch.go` to use `GetESTypedClient()` instead of `GetESClient()`.
+- Eliminate manual `json.Marshal`/`json.Unmarshal` in these helpers by using typed request/response structs.
+- Reduce or eliminate custom model structs where typed API types (`typedapi/types.*`) provide equivalent or better coverage.
+- Update all downstream resource callers so they compile and behave identically.
+- Ensure every migrated helper preserves existing error semantics (404 = not found, etc.).
+
+**Non-Goals:**
+- Do not migrate resource files themselves beyond the minimal changes needed to compile with updated helper signatures.
+- Do not remove `GetESClient()` or change `ElasticsearchScopedClient` construction.
+- Do not introduce new Terraform resources, data sources, or schema changes.
+- Do not modify acceptance test behavior (tests may be updated in `typed-client-acceptance-tests`).
+
+## Decisions
+
+### 1. Migrate helper signatures to accept `*elasticsearch.TypedClient` directly
+
+**Chosen:** Each helper function will obtain the typed client from `apiClient.GetESTypedClient()` at the top of the function, then use it for all API calls.
+
+**Rationale:** Keeps the change localized to each helper. Callers in resource files don't need to change how they pass `apiClient`.
+
+**Alternative considered:** Changing resource files to call `GetESTypedClient()` themselves and pass the typed client down. Rejected because it would proliferate changes across many files instead of keeping them in the four targeted helpers.
+
+### 2. Use typed API request/response types where they match provider needs
+
+**Chosen:**
+- For **inference**: `types.InferenceEndpoint` (PUT/update request) and `types.InferenceEndpointInfo` (GET response).
+- For **logstash**: `types.LogstashPipeline` (GET/PUT response/request body is `map[string]types.LogstashPipeline`).
+- For **enrich**: `types.EnrichPolicy` (GET/PUT) and `types.Summary` (GET response wrapper).
+- For **watch**: `types.Watch` (GET response) and `types.WatcherAction`/`types.WatcherCondition`/`types.WatcherInput` (PUT request fields).
+
+**Rationale:** Eliminates custom structs and manual JSON handling. The typed types are generated from the Elasticsearch specification and stay in sync with the server.
+
+**Alternative considered:** Keeping custom structs and only using the typed client for transport. Rejected because it defeats the purpose of the migration — we want type safety end-to-end.
+
+### 3. Preserve `map[string]any` fields where typed API is too rigid
+
+**Chosen:** For deeply nested or highly dynamic fields (e.g., watch `metadata`, inference `service_settings`), continue using `map[string]any` or JSON strings at the Terraform schema layer, and convert to/from typed types at the API boundary.
+
+**Rationale:** The Terraform provider's schema uses `types.String` with JSON normalization for these fields. Converting the entire provider to strongly-typed nested structs would require schema changes, which are out of scope for this migration.
+
+**Alternative considered:** Fully typed nested structs throughout. Rejected because it would require breaking schema changes and massive resource file rework.
+
+### 4. Map 404 semantics identically
+
+**Chosen:** Where raw code checked `res.StatusCode == http.StatusNotFound`, use the typed API's error handling pattern. Most typed `Get`/`Delete` calls return an error on 404; helpers should detect this and return `nil` (for Get) or empty diagnostics (for Delete), preserving existing behavior.
+
+**Rationale:** Terraform resources rely on "not found" being a non-error during read and delete operations. Changing this would break state refresh and destroy.
+
+**Alternative considered:** Letting typed API errors propagate unchanged. Rejected because typed client 404s may surface as structured errors that resources don't expect.
+
+### 5. Keep `InferenceEndpoint` custom type if typed API lacks task-type support
+
+**Chosen:** The current `InferenceEndpoint` struct includes `TaskType` and `InferenceID` as top-level fields, but `types.InferenceEndpoint` does not have a `TaskType` field (it's a path parameter in the typed API). The helper functions will continue to accept task type and inference ID as function parameters, and construct the typed request with the appropriate path parameter.
+
+**Rationale:** The typed API separates path parameters from the request body. The provider's model currently conflates them for convenience.
+
+**Alternative considered:** Changing resource schemas to match typed API structure. Rejected because it would be a breaking schema change.
+
+## Risks / Trade-offs
+
+- **[Risk]** Typed API `types.EnrichPolicy.Query` is `*types.Query` (strongly typed), but the provider stores query as a JSON string.
+  - **Mitigation:** Use `json.Marshal`/`json.Unmarshal` at the boundary to convert between `*types.Query` and `string`. This is a small, localized conversion in the enrich helper.
+
+- **[Risk]** Typed API `types.Watch` has different field shapes than the provider's `models.Watch` (e.g., `WatchID` is not part of the typed struct).
+  - **Mitigation:** Extract `WatchID` from the function parameter or response wrapper (`GetWatchResponse.Id_`), and map fields individually rather than whole-struct replacement.
+
+- **[Risk]** `DeleteWatch` raw code returns success on 404; typed API may return an error.
+  - **Mitigation:** Check the typed API error for 404 semantics (e.g., `elastic.IsNotFound(err)` or status-code extraction) and return empty diagnostics, matching existing behavior.
+
+- **[Risk]** Logstash pipeline typed response is `map[string]types.LogstashPipeline`, which doesn't include `PipelineID` as a struct field.
+  - **Mitigation:** Map the map key to `PipelineID` after decoding, just as the current code does.
+
+- **[Risk]** Compilation errors in downstream resource files due to changed helper return types or model structs.
+  - **Mitigation:** After migrating each helper, immediately update and compile its callers. Run `make build` after each file group.
+
+## Migration Plan
+
+1. Migrate `inference.go` helpers and compile `internal/elasticsearch/inference/inferenceendpoint/*.go`.
+2. Migrate `logstash.go` helpers and compile `internal/elasticsearch/logstash/pipeline.go`.
+3. Migrate `enrich.go` helpers and compile `internal/elasticsearch/enrich/*.go`.
+4. Migrate `watch.go` helpers and compile `internal/elasticsearch/watcher/watch/*.go`.
+5. Run `make build` and `make check-lint` for the full project.
+6. Remove any now-unused custom model structs from `internal/models/models.go`.
+7. Verify no remaining references to the old helper signatures.

--- a/openspec/changes/typed-client-easy-wins/proposal.md
+++ b/openspec/changes/typed-client-easy-wins/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The provider-wide typed-client migration is underway. The `go-elasticsearch/v8` Typed API (`elasticsearch.TypedClient` via `ToTyped()`) provides strongly-typed request/response structs that eliminate hand-written JSON marshaling, reduce runtime errors, and enable IDE-driven refactoring. Phase 2 targets four small, self-contained client helper files that have straightforward typed API equivalents, making them ideal early migration candidates.
+
+## What Changes
+
+Migrate the following four client helper files in `internal/clients/elasticsearch/` from raw `esapi` to the typed client (`GetESTypedClient()`):
+
+1. **`inference.go`** — `PutInferenceEndpoint`, `GetInferenceEndpoint`, `UpdateInferenceEndpoint`, `DeleteInferenceEndpoint`
+   - Replace custom `InferenceEndpoint` types with `types.InferenceEndpointInfo`/`types.InferenceEndpoint` where possible.
+   - Replace `doFWWrite` and manual JSON handling with typed API calls.
+
+2. **`logstash.go`** — `PutLogstashPipeline`, `GetLogstashPipeline`, `DeleteLogstashPipeline`
+   - Replace custom `models.LogstashPipeline` usage with `types.LogstashPipeline` where possible.
+   - Replace manual JSON decode with typed `Logstash.GetPipeline`/`PutPipeline`/`DeletePipeline`.
+
+3. **`enrich.go`** — `GetEnrichPolicy`, `PutEnrichPolicy`, `DeleteEnrichPolicy`, `ExecuteEnrichPolicy`
+   - Replace custom `enrichPolicyResponse` unmarshal with typed `EnrichPolicy` from `types.EnrichPolicy`.
+   - Handle query string↔object mapping via `types.Query` or raw JSON as needed.
+   - Replace raw `esapi` calls with `typedapi.Enrich.*` equivalents.
+
+4. **`watch.go`** — `PutWatch`, `PutWatchBodyJSON`, `GetWatch`, `DeleteWatch`
+   - Replace custom `models.Watch`/`models.PutWatch`/`models.WatchBody` with typed `types.Watch` and `types.WatcherAction` equivalents where possible.
+   - Replace manual JSON marshal/unmarshal with typed `Watcher.PutWatch`/`GetWatch`/`DeleteWatch`.
+
+## Capabilities
+
+### New Capabilities
+- _(none — no new provider capabilities introduced)_
+
+### Modified Capabilities
+- _(none — no spec-level requirement changes; this is a pure implementation migration)_
+
+## Impact
+
+- **Code**: `internal/clients/elasticsearch/inference.go`, `internal/clients/elasticsearch/logstash.go`, `internal/clients/elasticsearch/enrich.go`, `internal/clients/elasticsearch/watch.go`.
+- **Callers**: `internal/elasticsearch/inference/inferenceendpoint/*.go`, `internal/elasticsearch/logstash/pipeline.go`, `internal/elasticsearch/enrich/*.go`, `internal/elasticsearch/watcher/watch/*.go`.
+- **Models**: `internal/models/models.go` — custom `LogstashPipeline`, `Watch`, `PutWatch`, `WatchBody` may become redundant if fully replaced by typed types.
+- **APIs**: No Terraform resource or data source behavior changes; all existing acceptance tests should continue to pass.
+- **Dependencies**: Relies on the existing `typed-client-bootstrap` bridge (`GetESTypedClient()`).

--- a/openspec/changes/typed-client-easy-wins/specs/typed-client-easy-wins/spec.md
+++ b/openspec/changes/typed-client-easy-wins/specs/typed-client-easy-wins/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: Inference helpers use typed client
+The `inference.go` helper functions SHALL use the typed Elasticsearch client (`GetESTypedClient()`) for all inference endpoint API operations.
+
+#### Scenario: PutInferenceEndpoint uses typed API
+- **WHEN** `PutInferenceEndpoint` creates or updates an inference endpoint
+- **THEN** it SHALL call `typedapi.Inference.Put()` with `types.InferenceEndpoint`
+- **AND** it SHALL NOT use `esapi.InferencePut` or manual JSON marshaling
+
+#### Scenario: GetInferenceEndpoint uses typed API
+- **WHEN** `GetInferenceEndpoint` reads an inference endpoint
+- **THEN** it SHALL call `typedapi.Inference.Get()` and use `types.InferenceEndpointInfo` for the response
+- **AND** it SHALL NOT decode JSON from an `*esapi.Response`
+
+#### Scenario: UpdateInferenceEndpoint uses typed API
+- **WHEN** `UpdateInferenceEndpoint` updates an inference endpoint
+- **THEN** it SHALL call `typedapi.Inference.Update()`
+- **AND** it SHALL NOT use `esapi.InferenceUpdate` or manual JSON marshaling
+
+#### Scenario: DeleteInferenceEndpoint uses typed API
+- **WHEN** `DeleteInferenceEndpoint` deletes an inference endpoint
+- **THEN** it SHALL call `typedapi.Inference.Delete()`
+- **AND** it SHALL NOT use `esapi.InferenceDelete`
+
+### Requirement: Logstash helpers use typed client
+The `logstash.go` helper functions SHALL use the typed Elasticsearch client for all logstash pipeline API operations.
+
+#### Scenario: PutLogstashPipeline uses typed API
+- **WHEN** `PutLogstashPipeline` creates or updates a logstash pipeline
+- **THEN** it SHALL call `typedapi.Logstash.PutPipeline()` with `types.LogstashPipeline`
+- **AND** it SHALL NOT use `esapi.LogstashPutPipeline` or manual JSON marshaling
+
+#### Scenario: GetLogstashPipeline uses typed API
+- **WHEN** `GetLogstashPipeline` reads a logstash pipeline
+- **THEN** it SHALL call `typedapi.Logstash.GetPipeline()` and extract `types.LogstashPipeline` from the response map
+- **AND** it SHALL NOT decode JSON from an `*esapi.Response`
+
+#### Scenario: DeleteLogstashPipeline uses typed API
+- **WHEN** `DeleteLogstashPipeline` deletes a logstash pipeline
+- **THEN** it SHALL call `typedapi.Logstash.DeletePipeline()`
+- **AND** it SHALL NOT use `esapi.LogstashDeletePipeline`
+
+### Requirement: Enrich helpers use typed client
+The `enrich.go` helper functions SHALL use the typed Elasticsearch client for all enrich policy API operations.
+
+#### Scenario: GetEnrichPolicy uses typed API
+- **WHEN** `GetEnrichPolicy` reads an enrich policy
+- **THEN** it SHALL call `typedapi.Enrich.GetPolicy()` and use `types.EnrichPolicy` for the response
+- **AND** it SHALL NOT decode JSON from an `*esapi.Response`
+
+#### Scenario: PutEnrichPolicy uses typed API
+- **WHEN** `PutEnrichPolicy` creates an enrich policy
+- **THEN** it SHALL call `typedapi.Enrich.PutPolicy()` with `types.EnrichPolicy`
+- **AND** it SHALL NOT use `esapi.EnrichPutPolicy` or manual JSON marshaling
+
+#### Scenario: DeleteEnrichPolicy uses typed API
+- **WHEN** `DeleteEnrichPolicy` deletes an enrich policy
+- **THEN** it SHALL call `typedapi.Enrich.DeletePolicy()`
+- **AND** it SHALL NOT use `esapi.EnrichDeletePolicy`
+
+#### Scenario: ExecuteEnrichPolicy uses typed API
+- **WHEN** `ExecuteEnrichPolicy` executes an enrich policy
+- **THEN** it SHALL call `typedapi.Enrich.ExecutePolicy()` with `wait_for_completion=true`
+- **AND** it SHALL NOT use `esapi.EnrichExecutePolicy`
+
+### Requirement: Watch helpers use typed client
+The `watch.go` helper functions SHALL use the typed Elasticsearch client for all watcher API operations.
+
+#### Scenario: PutWatch uses typed API
+- **WHEN** `PutWatch` creates or updates a watch
+- **THEN** it SHALL call `typedapi.Watcher.PutWatch()` with `types.Watch` or equivalent typed request fields
+- **AND** it SHALL NOT use `esapi.Watcher.PutWatch` or manual JSON marshaling
+
+#### Scenario: GetWatch uses typed API
+- **WHEN** `GetWatch` reads a watch
+- **THEN** it SHALL call `typedapi.Watcher.GetWatch()` and use `types.Watch` for the response
+- **AND** it SHALL NOT decode JSON from an `*esapi.Response`
+
+#### Scenario: DeleteWatch uses typed API
+- **WHEN** `DeleteWatch` deletes a watch
+- **THEN** it SHALL call `typedapi.Watcher.DeleteWatch()`
+- **AND** it SHALL NOT use `esapi.Watcher.DeleteWatch`
+- **AND** a 404 response SHALL be treated as success (no error diagnostic)
+
+### Requirement: Preserved error semantics
+All migrated helpers SHALL preserve the existing error handling and not-found semantics observed by downstream Terraform resources.
+
+#### Scenario: Get helpers return nil on not found
+- **WHEN** a Get helper queries a resource that does not exist
+- **THEN** it SHALL return `nil` for the resource and no error diagnostic
+
+#### Scenario: Delete helpers succeed on not found
+- **WHEN** a Delete helper targets a resource that does not exist
+- **THEN** it SHALL return empty diagnostics without error
+
+### Requirement: No raw esapi usage in migrated files
+After migration, the four migrated helper files SHALL contain no calls to `GetESClient()` and no usage of `esapi` types for the APIs they cover.
+
+#### Scenario: inference.go contains no raw esapi calls
+- **GIVEN** `internal/clients/elasticsearch/inference.go` has been migrated
+- **WHEN** inspecting the file for `GetESClient` and `esapi.Inference` usage
+- **THEN** no such usage SHALL remain
+
+#### Scenario: logstash.go contains no raw esapi calls
+- **GIVEN** `internal/clients/elasticsearch/logstash.go` has been migrated
+- **WHEN** inspecting the file for `GetESClient` and `esapi.Logstash` usage
+- **THEN** no such usage SHALL remain
+
+#### Scenario: enrich.go contains no raw esapi calls
+- **GIVEN** `internal/clients/elasticsearch/enrich.go` has been migrated
+- **WHEN** inspecting the file for `GetESClient` and `esapi.Enrich` usage
+- **THEN** no such usage SHALL remain
+
+#### Scenario: watch.go contains no raw esapi calls
+- **GIVEN** `internal/clients/elasticsearch/watch.go` has been migrated
+- **WHEN** inspecting the file for `GetESClient` and `esapi.Watcher` usage
+- **THEN** no such usage SHALL remain

--- a/openspec/changes/typed-client-easy-wins/tasks.md
+++ b/openspec/changes/typed-client-easy-wins/tasks.md
@@ -1,0 +1,52 @@
+## 1. Inference
+
+- [ ] 1.1 Migrate `PutInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Put()` with `types.InferenceEndpoint`
+- [ ] 1.2 Migrate `GetInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Get()` with `types.InferenceEndpointInfo`
+- [ ] 1.3 Migrate `UpdateInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Update()` with `types.InferenceEndpoint`
+- [ ] 1.4 Migrate `DeleteInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Delete()`
+- [ ] 1.5 Update `internal/elasticsearch/inference/inferenceendpoint/create.go` to compile with migrated `PutInferenceEndpoint` signature
+- [ ] 1.6 Update `internal/elasticsearch/inference/inferenceendpoint/read.go` to compile with migrated `GetInferenceEndpoint` signature
+- [ ] 1.7 Update `internal/elasticsearch/inference/inferenceendpoint/update.go` to compile with migrated `UpdateInferenceEndpoint` signature
+- [ ] 1.8 Update `internal/elasticsearch/inference/inferenceendpoint/delete.go` to compile with migrated `DeleteInferenceEndpoint` signature
+- [ ] 1.9 Remove now-unused custom `InferenceEndpoint` structs from `inference.go` if fully replaced by typed types
+
+## 2. Logstash
+
+- [ ] 2.1 Migrate `PutLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.PutPipeline()` with `types.LogstashPipeline`
+- [ ] 2.2 Migrate `GetLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.GetPipeline()`
+- [ ] 2.3 Migrate `DeleteLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.DeletePipeline()`
+- [ ] 2.4 Update `internal/elasticsearch/logstash/pipeline.go` to compile with migrated helper signatures
+- [ ] 2.5 Remove or deprecate `models.LogstashPipeline` if fully replaced by `types.LogstashPipeline`
+
+## 3. Enrich
+
+- [ ] 3.1 Migrate `GetEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.GetPolicy()` with `types.Summary`/`types.EnrichPolicy`
+- [ ] 3.2 Migrate `PutEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.PutPolicy()` with `types.EnrichPolicy`
+- [ ] 3.3 Migrate `DeleteEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.DeletePolicy()`
+- [ ] 3.4 Migrate `ExecuteEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.ExecutePolicy()`
+- [ ] 3.5 Handle query string↔`types.Query` conversion at the boundary in enrich helpers
+- [ ] 3.6 Update `internal/elasticsearch/enrich/create.go` to compile with migrated `PutEnrichPolicy` signature
+- [ ] 3.7 Update `internal/elasticsearch/enrich/data_source.go` to compile with migrated `GetEnrichPolicy` signature
+- [ ] 3.8 Update `internal/elasticsearch/enrich/delete.go` to compile with migrated `DeleteEnrichPolicy` signature
+- [ ] 3.9 Remove now-unused custom `enrichPolicyResponse` and `enrichPoliciesResponse` structs from `enrich.go`
+
+## 4. Watch
+
+- [ ] 4.1 Migrate `PutWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.PutWatch()` with `types.Watch` or `types.WatcherAction`/`types.WatcherCondition`/`types.WatcherInput`
+- [ ] 4.2 Migrate `PutWatchBodyJSON` in `internal/clients/elasticsearch/watch.go` to use typed API, converting raw JSON to typed request fields
+- [ ] 4.3 Migrate `GetWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.GetWatch()` with `types.Watch`
+- [ ] 4.4 Migrate `DeleteWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.DeleteWatch()`, preserving 404-as-success semantics
+- [ ] 4.5 Update `internal/elasticsearch/watcher/watch/create.go` to compile with migrated `PutWatch`/`PutWatchBodyJSON` signatures
+- [ ] 4.6 Update `internal/elasticsearch/watcher/watch/read.go` to compile with migrated `GetWatch` signature
+- [ ] 4.7 Update `internal/elasticsearch/watcher/watch/delete.go` to compile with migrated `DeleteWatch` signature
+- [ ] 4.8 Evaluate whether `models.Watch`, `models.PutWatch`, and `models.WatchBody` can be removed or must be retained for schema-layer mapping
+
+## 5. Cleanup and Verification
+
+- [ ] 5.1 Run `make build` and confirm zero compile errors across the entire codebase
+- [ ] 5.2 Run `make check-lint` and resolve any new lint warnings introduced by typed API usage
+- [ ] 5.3 Run `go test ./internal/clients/elasticsearch/...` to verify unit tests pass
+- [ ] 5.4 Confirm no remaining `GetESClient()` calls exist in the four migrated helper files
+- [ ] 5.5 Clean up any unused imports in the migrated helper files
+- [ ] 5.6 If `models.LogstashPipeline`, `models.Watch`, `models.PutWatch`, or `models.WatchBody` are fully redundant, remove them from `internal/models/models.go`
+- [ ] 5.7 Run targeted acceptance tests for inference, logstash, enrich, and watcher packages where possible

--- a/openspec/changes/typed-client-final-cleanup/.openspec.yaml
+++ b/openspec/changes/typed-client-final-cleanup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-final-cleanup/design.md
+++ b/openspec/changes/typed-client-final-cleanup/design.md
@@ -1,0 +1,62 @@
+## Context
+
+All prior typed-client migration phases have converted every Elasticsearch resource and helper to the `go-elasticsearch` Typed API. The `ElasticsearchScopedClient` currently carries both a raw `*elasticsearch.Client` field and a `typedClient` field (added in `typed-client-bootstrap`), exposing `GetESClient()` (raw) and `GetESTypedClient()` (typed). Because every consumer now uses the typed path, the raw client accessor and its supporting infrastructure are dead code.
+
+In parallel, `internal/models/` contains large hand-rolled structs (`ClusterInfo`, `User`, `Role`, `Datafeed`, `Transform`, etc.) that were created to unmarshal raw `esapi` responses. Since the typed client generates equivalent structs under `go-elasticsearch/v8/typedapi/types`, these provider-local models are also unused.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the raw `elasticsearch` field from `ElasticsearchScopedClient` and make `GetESClient()` return `*elasticsearch.TypedClient` directly.
+- Delete `internal/clients/elasticsearch/helpers.go` (`doFWWrite`, `doSDKWrite`).
+- Delete redundant model files (`models.go` leftovers, `ml.go`, `transform.go`, `enrich.go`) from `internal/models/`.
+- Update imports site-wide to remove unused raw-client paths and add `typedapi/types` where needed.
+- Keep the build green and all tests passing.
+
+**Non-Goals:**
+- Migrating any resource or helper that is not already on the typed client (handled in earlier phases).
+- Changing Terraform resource schemas or behavior.
+- Modifying Kibana/Fleet/Observability models — those are out of scope for this change.
+- Removing `internal/models/ingest.go` — ingest processor structs are custom and have no typedapi equivalent.
+
+## Decisions
+
+**1. Change `GetESClient()` return type to `*elasticsearch.TypedClient` rather than introducing a new method name**
+- **Rationale**: By this phase every caller already expects a typed client. Renaming the method would create a larger diff across the entire codebase. Changing the return type keeps the call sites identical; only the method body and the callers' local variable types need adjustment.
+- **Alternative considered**: Keep `GetESClient()` returning the raw client and rename `GetESTypedClient()` to `GetESClient()` with a phased deprecation. Rejected because there are zero remaining raw consumers — no deprecation period is needed.
+
+**2. Delete `helpers.go` entirely**
+- **Rationale**: `doFWWrite` and `doSDKWrite` exist solely to bridge the raw client (marshal body → call fn → check response). Typed API methods accept structs directly and return typed errors, making both functions obsolete.
+- **Alternative considered**: Keep the file but empty it. Rejected because an empty file with a package declaration is noise; Go does not allow completely empty files.
+
+**3. Retain `BuildDate` and a minimal `ClusterInfo` equivalent if needed for `serverInfo()`**
+- **Rationale**: `ElasticsearchScopedClient.serverInfo()` currently unmarshals `esapi` `Info()` JSON into `models.ClusterInfo` to extract the cluster UUID and version. After removing the raw client, this method must switch to the typed client's `Info().Do(ctx)`, which returns `*types.InfoResponse`. The `ClusterInfo` model can therefore be removed and the method can use `types.InfoResponse` directly.
+- **Alternative considered**: Keeping a slimmed-down `ClusterInfo` struct. Rejected because `types.InfoResponse` from the typed API already has the same fields (`ClusterName`, `ClusterUUID`, `Version.Number`, etc.).
+
+**4. Remove model files in bulk rather than one per capability**
+- **Rationale**: The model deletions are tightly coupled — they are all driven by the same "typedapi now provides these types" reason. Splitting them into separate changes would create unnecessary coordination overhead.
+- **Alternative considered**: Deleting `ml.go` in `typed-client-ml`, `transform.go` in `typed-client-transform`, etc. Rejected because those earlier phases focused on migrating the API calls; leaving model cleanup until the end is cleaner and prevents compilation breaks if a model is still referenced by another helper.
+
+## Risks / Trade-offs
+
+- **[Risk]** A helper or test file outside the obvious directories may still import a model being deleted.
+  - **Mitigation**: Run `make build` and `go test ./...` locally after deletions. The compiler will surface any remaining references immediately.
+- **[Risk]** `serverInfo()` uses raw `esapi.Info` to populate `models.ClusterInfo`; removing the raw client requires rewriting this method.
+  - **Mitigation**: This is a small, well-scoped change: replace `esClient.Info(...)` with `typedClient.Info().Do(ctx)` and decode into `*types.InfoResponse`. Add unit-test coverage for the new path if not already present.
+- **[Risk]** `doFWWrite` / `doSDKWrite` might still be imported by a helper that was supposed to migrate but slipped through.
+  - **Mitigation**: Deleting the file is itself the verification — any remaining import will fail compilation.
+
+## Migration Plan
+
+1. Update `ElasticsearchScopedClient` — remove raw field, retarget `GetESClient()` to typed client, rewrite `serverInfo()` to use typed API.
+2. Update unit tests in `elasticsearch_scoped_client_test.go` to assert on typed client returns.
+3. Delete `internal/clients/elasticsearch/helpers.go`.
+4. Delete redundant model files (`internal/models/ml.go`, `internal/models/transform.go`, `internal/models/enrich.go`, strip unused types from `internal/models/models.go`).
+5. Run `make build` to identify any remaining broken references.
+6. Fix any import or reference issues surfaced by the compiler.
+7. Run `make check-lint`.
+8. Run targeted acceptance tests for affected resources (cluster settings, security, index, ML, transform, enrich, etc.) to confirm no behavioral regressions.
+
+## Open Questions
+
+- (none — design is straightforward given the prior migration phases)

--- a/openspec/changes/typed-client-final-cleanup/proposal.md
+++ b/openspec/changes/typed-client-final-cleanup/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The typed-client migration has progressed through all prior phases and every Elasticsearch API consumer has been moved to the `go-elasticsearch` Typed API. The raw `esapi` client, bridging helpers, and hand-rolled model types are now entirely unused and represent dead code. Removing them reduces maintenance surface, eliminates confusion for future contributors, and completes the migration.
+
+## What Changes
+
+- **Update `ElasticsearchScopedClient` to return `*elasticsearch.TypedClient` directly**
+  - Remove the raw `elasticsearch` field from `ElasticsearchScopedClient`
+  - Rename `GetESTypedClient()` (added in prior phases) to `GetESClient()` and change its return type to `*elasticsearch.TypedClient`
+  - Update the endpoint-validation logic to work with the typed-client accessor
+  - **BREAKING** for any internal code still referencing the raw client (none expected — all consumers already migrated)
+
+- **Delete `internal/clients/elasticsearch/helpers.go`**
+  - `doFWWrite` and `doSDKWrite` are obsolete because typed API methods handle JSON marshaling and response parsing internally
+
+- **Delete redundant model files from `internal/models/`**
+  - `models.go` — remove types that have typedapi equivalents: `ClusterInfo`, `User`, `Role`, `APIKey*`, `RoleMapping`, `IndexTemplate*`, `ComponentTemplate*`, `Policy*`, `SnapshotRepository`, `SnapshotPolicy*`, `DataStream*`, `LogstashPipeline`, `Script`, `Watch*`, `Index*` (retain `BuildDate` if still used by remaining code)
+  - `ml.go` — delete all ML types (`Datafeed*`, `MLJob*`)
+  - `transform.go` — delete all transform types
+  - `enrich.go` — delete `EnrichPolicy`
+  - Retain Kibana/Observability types (`action_connector.go`, `agent_builder.go`, `alert_rule.go`, `slo.go`) and truly custom types such as ingest processor structs in `ingest.go`
+
+- **Update imports throughout**
+  - Replace direct `github.com/elastic/go-elasticsearch/v8` imports with `github.com/elastic/go-elasticsearch/v8/typedapi/types` where appropriate
+  - Remove unused `esapi` imports
+
+## Capabilities
+
+### New Capabilities
+- `typed-client-final-cleanup`: Final infrastructure cleanup for the typed-client migration — removing the raw client accessor, obsolete helper functions, and redundant model types.
+
+### Modified Capabilities
+- (none — no Terraform resource or data source behavior changes; purely internal refactoring)
+
+## Impact
+
+- **Code**: `internal/clients/elasticsearch_scoped_client.go`, `internal/clients/elasticsearch/helpers.go`, `internal/models/*.go`, and all helper packages under `internal/clients/elasticsearch/`
+- **APIs**: No Terraform resource or data source behavior changes
+- **Dependencies**: Removes dependency on `esapi` response types from the raw client path
+- **Tests**: Unit tests for `GetESClient` will need updating to expect a `*elasticsearch.TypedClient`; acceptance tests should be unaffected

--- a/openspec/changes/typed-client-final-cleanup/specs/typed-client-final-cleanup/spec.md
+++ b/openspec/changes/typed-client-final-cleanup/specs/typed-client-final-cleanup/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: GetESClient returns the typed client
+`ElasticsearchScopedClient.GetESClient()` SHALL return `*elasticsearch.TypedClient` instead of `*elasticsearch.Client`.
+
+#### Scenario: Typed client is returned
+- **WHEN** `GetESClient()` is called on a configured `ElasticsearchScopedClient`
+- **THEN** it returns a non-nil `*elasticsearch.TypedClient`
+
+### Requirement: Raw client field removed from ElasticsearchScopedClient
+`ElasticsearchScopedClient` SHALL no longer contain a raw `*elasticsearch.Client` field.
+
+#### Scenario: Struct definition contains only typed client
+- **WHEN** inspecting the `ElasticsearchScopedClient` struct definition
+- **THEN** it does NOT contain a field of type `*elasticsearch.Client` from `github.com/elastic/go-elasticsearch/v8`
+
+### Requirement: Obsolete helper functions deleted
+`internal/clients/elasticsearch/helpers.go` SHALL be removed entirely, and no equivalent `doFWWrite` or `doSDKWrite` functions SHALL exist elsewhere in the codebase.
+
+#### Scenario: Helpers file is absent
+- **WHEN** checking for `internal/clients/elasticsearch/helpers.go`
+- **THEN** the file does not exist
+
+#### Scenario: Helper functions are not recreated
+- **WHEN** searching the codebase for `doFWWrite` or `doSDKWrite`
+- **THEN** no references exist outside of version control history
+
+### Requirement: Redundant model types removed
+The following model files SHALL be deleted, and their types SHALL not be referenced by any compiling code:
+- `internal/models/ml.go`
+- `internal/models/transform.go`
+- `internal/models/enrich.go`
+
+#### Scenario: ML model file is absent
+- **WHEN** checking for `internal/models/ml.go`
+- **THEN** the file does not exist
+
+#### Scenario: Transform model file is absent
+- **WHEN** checking for `internal/models/transform.go`
+- **THEN** the file does not exist
+
+#### Scenario: Enrich model file is absent
+- **WHEN** checking for `internal/models/enrich.go`
+- **THEN** the file does not exist
+
+### Requirement: Unused types removed from models.go
+`internal/models/models.go` SHALL retain only types that lack a `go-elasticsearch/v8/typedapi/types` equivalent or are documented as custom provider abstractions.
+
+#### Scenario: Removed types have no remaining references
+- **WHEN** searching the codebase for `models.ClusterInfo`, `models.User`, `models.Role`, `models.RoleMapping`, `models.APIKey`, `models.IndexTemplate`, `models.ComponentTemplate`, `models.Policy`, `models.SnapshotRepository`, `models.SnapshotPolicy`, `models.DataStream`, `models.LogstashPipeline`, `models.Script`, `models.Watch`
+- **THEN** no references exist in compiling source files
+
+#### Scenario: Custom types remain
+- **WHEN** inspecting `internal/models/models.go`
+- **THEN** it still contains types such as `BuildDate` if they are still used by remaining code
+
+### Requirement: serverInfo uses typed API
+`ElasticsearchScopedClient.serverInfo()` SHALL use the typed client's `Info().Do(ctx)` method and unmarshal into `*types.InfoResponse` from `go-elasticsearch/v8/typedapi/types`.
+
+#### Scenario: serverInfo does not use raw esapi
+- **WHEN** inspecting `serverInfo()` implementation
+- **THEN** it does NOT call `esClient.Info()` or import `github.com/elastic/go-elasticsearch/v8/esapi`
+
+### Requirement: Imports updated site-wide
+All source files SHALL import `github.com/elastic/go-elasticsearch/v8/typedapi/types` where typed API types are used, and SHALL NOT import `github.com/elastic/go-elasticsearch/v8/esapi` unless required by Kibana or Fleet code paths outside Elasticsearch scope.
+
+#### Scenario: No stale esapi imports in Elasticsearch helpers
+- **WHEN** inspecting all `.go` files under `internal/clients/elasticsearch/`
+- **THEN** none import `github.com/elastic/go-elasticsearch/v8/esapi`
+
+### Requirement: Project builds successfully
+`make build` SHALL complete without errors after all deletions and modifications.
+
+#### Scenario: Clean build
+- **WHEN** running `make build`
+- **THEN** the command exits with status 0 and produces no compilation errors
+
+### Requirement: Lint checks pass
+`make check-lint` SHALL complete without new lint failures introduced by this change.
+
+#### Scenario: Lint passes
+- **WHEN** running `make check-lint`
+- **THEN** the command exits with status 0

--- a/openspec/changes/typed-client-final-cleanup/tasks.md
+++ b/openspec/changes/typed-client-final-cleanup/tasks.md
@@ -1,0 +1,33 @@
+## 1. Update ElasticsearchScopedClient
+
+- [ ] 1.1 Remove the raw `*elasticsearch.Client` field from `ElasticsearchScopedClient`
+- [ ] 1.2 Rename the existing `GetESTypedClient()` method to `GetESClient()` and set its return type to `*elasticsearch.TypedClient`
+- [ ] 1.3 Remove the old `GetESClient()` method that returned the raw client
+- [ ] 1.4 Rewrite `serverInfo()` to use `typedClient.Info().Do(ctx)` and unmarshal into `*types.InfoResponse`
+- [ ] 1.5 Update `internal/clients/elasticsearch_scoped_client_test.go` to assert on `*elasticsearch.TypedClient` returns
+
+## 2. Delete obsolete helpers
+
+- [ ] 2.1 Delete `internal/clients/elasticsearch/helpers.go`
+- [ ] 2.2 Verify no remaining references to `doFWWrite` or `doSDKWrite` across the codebase
+
+## 3. Delete redundant model files
+
+- [ ] 3.1 Delete `internal/models/ml.go`
+- [ ] 3.2 Delete `internal/models/transform.go`
+- [ ] 3.3 Delete `internal/models/enrich.go`
+- [ ] 3.4 Remove unused types from `internal/models/models.go` (`ClusterInfo`, `User`, `Role`, `RoleMapping`, `APIKey`, `IndexTemplate`, `ComponentTemplate`, `Policy`, `SnapshotRepository`, `SnapshotPolicy`, `DataStream`, `LogstashPipeline`, `Script`, `Watch`, and any other types with typedapi equivalents)
+- [ ] 3.5 Retain custom types such as `BuildDate` and any Kibana/Observability-related models that are out of scope
+- [ ] 3.6 Retain `internal/models/ingest.go` — ingest processor structs are custom and have no typedapi equivalent
+
+## 4. Fix imports and references
+
+- [ ] 4.1 Replace any remaining direct `github.com/elastic/go-elasticsearch/v8` (raw client) imports with `github.com/elastic/go-elasticsearch/v8/typedapi/types` where typed API types are used
+- [ ] 4.2 Remove unused `github.com/elastic/go-elasticsearch/v8/esapi` imports from all files under `internal/clients/elasticsearch/` and any other Elasticsearch-scoped packages
+- [ ] 4.3 Resolve any compilation errors uncovered by the build step
+
+## 5. Verify build and quality
+
+- [ ] 5.1 Run `make build` and confirm it exits with status 0
+- [ ] 5.2 Run `make check-lint` and confirm no new lint failures
+- [ ] 5.3 Run targeted acceptance tests for affected resources (cluster settings, security, index, ML, transform, enrich, etc.) to confirm no behavioral regressions

--- a/openspec/changes/typed-client-index/.openspec.yaml
+++ b/openspec/changes/typed-client-index/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-index/design.md
+++ b/openspec/changes/typed-client-index/design.md
@@ -1,0 +1,58 @@
+## Context
+
+`internal/clients/elasticsearch/index.go` is the provider’s largest Elasticsearch helper file (~29KB). It contains hand-written request construction (`json.Marshal` into `bytes.NewReader`), raw `esapi.Response` decoding, and an extensive set of custom models (`models.Policy`, `models.IndexTemplate`, `models.ComponentTemplate`, `models.Index`, `models.DataStream`, `models.IngestPipeline`, etc.) that shadow types already present in the `go-elasticsearch/v8` typed API.
+
+The typed client bridge (`GetESTypedClient()`) was added in the `typed-client-bootstrap` change, making it possible to incrementally migrate individual helper files. All other typed-client phases have been completed; the Index APIs are the remaining major surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Migrate every function in `index.go` to use `elasticsearch.TypedClient`.
+- Replace custom models with typed API equivalents (`types.IndexTemplateItem`, `types.IndexState`, `types.IngestPipeline`, `types.Alias`, `types.IndexSettings`, `types.TypeMapping`, `types.DataStream`, `types.DataStreamLifecycle`, etc.) where feasible.
+- Keep thin conversion helpers only where Terraform-specific semantics (e.g., `map[string]any` for raw settings, alias action builder) are required.
+- Preserve all existing behavior: `flat_settings` reads, date-math name encoding, atomic alias updates, 404 → nil/empty state handling, and diagnostic formatting.
+
+**Non-Goals:**
+- Changing any Terraform resource schema, attribute, or validation.
+- Adding new resources or data sources.
+- Removing `GetESClient()` or breaking untyped consumers in other files.
+- Changing provider-level client construction, authentication, or connection logic.
+
+## Decisions
+
+**1. Keep `flat_settings=true` for read paths**
+- **Rationale**: The existing resource mapping logic (especially in `elasticstack_elasticsearch_index`) expects flat keys such as `"index.number_of_shards"`. The typed API supports `FlatSettings(true)` on `Indices.Get` and `Cluster.GetComponentTemplate`. The generated `types.IndexSettings` struct has a `default` fallback in its custom `UnmarshalJSON` that stores unknown flat keys in `IndexSettings map[string]json.RawMessage`, so no data is lost. Relying on this avoids rewriting the resource-side settings flattening/unflattening logic.
+- **Alternative considered**: Switching to nested settings and re-mapping inside each resource. Rejected because it would touch far more resource code and risk introducing behavioral drift.
+
+**2. Use typed request builders for write paths**
+- **Rationale**: Instead of `json.Marshal` on custom models, construct typed structs (e.g., `types.IndexTemplate`, `types.IngestPipeline`) and pass them directly to the typed client’s `.Do()` methods. This gives compile-time safety and removes the need for parallel model maintenance.
+- **Alternative considered**: Keeping custom models and only swapping the transport layer. Rejected because it defeats the purpose of the typed API—we would still be maintaining duplicate shapes.
+
+**3. Migrate `index.go` function-by-function in logical groups**
+- **Rationale**: The file covers ILM, component templates, index templates, index CRUD, aliases, settings/mappings, data streams, data stream lifecycle, and ingest pipelines. Migrating group-by-group keeps diffs reviewable and makes bisection easier if a regression occurs.
+- **Order**: ILM → component templates → index templates → index CRUD → aliases → settings/mappings → data streams → data stream lifecycle → ingest pipelines.
+
+**4. Return typed API errors directly**
+- **Rationale**: The typed API returns `*types.ElasticsearchError` for non-2xx responses. We can map `Status == 404` to the existing “not found → nil” semantics and wrap all other errors into diagnostics using the existing `diagutil` helpers.
+- **Alternative considered**: Converting every error back to raw `*esapi.Response` to reuse legacy error paths. Rejected because it adds unnecessary wrapping; the typed error already carries status, header, and body information.
+
+**5. Retain `AliasAction` struct for atomic alias updates**
+- **Rationale**: The typed API does not expose a high-level alias-action builder. The existing `[]AliasAction` → `map[string]any` builder is small, well-understood, and Terraform-specific (e.g., handling `IsWriteIndex`, `Filter`). We will keep it but switch the execution from `esClient.Indices.UpdateAliases` to the typed equivalent.
+- **Alternative considered**: Deleting `AliasAction` and inlining the builder into each resource. Rejected because two resources (`index` and `alias`) share the same atomic-update logic.
+
+## Risks / Trade-offs
+
+- **[Risk]** Typed API request structs may omit empty fields differently than our custom `json.Marshal` calls, causing Elasticsearch to apply defaults we previously avoided.
+  - **Mitigation**: Run the full acceptance test suite for affected resources and inspect the JSON diff (via transport logging or unit tests) for each migrated write path before moving to the next group.
+- **[Risk]** `flat_settings` fallback into `map[string]json.RawMessage` may miss keys that the resource mapping expects to be present as strongly-typed struct fields.
+  - **Mitigation**: Validate with existing data source tests that read settings (`TestAccIndicesDataSource_ReadsIndexSettings_BroadCoverage`, `TestAccIndicesDataSource_ReadsSlowlogSettings`, etc.). Add a helper that preferentially reads from typed fields and falls back to the raw map.
+- **[Risk]** Partial migration could leave a resource calling both typed and untyped helpers.
+  - **Mitigation**: Migrate all functions in `index.go` in a single commit/PR so that every consumer in the listed resource packages switches together.
+
+## Migration Plan
+
+This is an internal code migration with no deployment or rollout steps. The change is merged as a normal PR. Rollback is a standard git revert. Acceptance tests on the affected resources serve as the regression gate.
+
+## Open Questions
+
+- None at design time.

--- a/openspec/changes/typed-client-index/proposal.md
+++ b/openspec/changes/typed-client-index/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The provider-wide typed-client migration is moving through its phases. The helpers in `internal/clients/elasticsearch/index.go` are the largest single client file (~811 lines) and the last major Elasticsearch surface still using the raw `esapi` client. Migrating this file to the `go-elasticsearch` Typed API (`elasticsearch.TypedClient` via `GetESTypedClient()`) eliminates hand-structured JSON request bodies, manual response decoding, and custom model types that duplicate upstream structs.
+
+## What Changes
+
+Migrate `internal/clients/elasticsearch/index.go` and all callers from raw `esapi` to typed client APIs:
+
+- **ILM** — `PutIlm`, `GetIlm`, `DeleteIlm` → `TypedClient.ILM.PutLifecycle` / `GetLifecycle` / `DeleteLifecycle`
+- **Component templates** — `PutComponentTemplate`, `GetComponentTemplate`, `DeleteComponentTemplate` → `TypedClient.Cluster.PutComponentTemplate` / `GetComponentTemplate` / `DeleteComponentTemplate`
+- **Index templates** — `PutIndexTemplate`, `GetIndexTemplate`, `DeleteIndexTemplate` → `TypedClient.Indices.PutIndexTemplate` / `GetIndexTemplate` / `DeleteIndexTemplate`
+- **Index CRUD** — `PutIndex`, `GetIndex`, `GetIndices`, `DeleteIndex` → `TypedClient.Indices.Create` / `Get` / `Delete`
+- **Aliases** — `UpdateIndexAlias`, `DeleteIndexAlias`, `GetAlias`, `UpdateAliasesAtomic` → `TypedClient.Indices.PutAlias` / `DeleteAlias` / `GetAlias` / `UpdateAliases`
+- **Settings & mappings** — `UpdateIndexSettings`, `UpdateIndexMappings` → `TypedClient.Indices.PutSettings` / `PutMapping`
+- **Data streams** — `PutDataStream`, `GetDataStream`, `DeleteDataStream` → `TypedClient.Indices.CreateDataStream` / `GetDataStream` / `DeleteDataStream`
+- **Data stream lifecycle** — `PutDataStreamLifecycle`, `GetDataStreamLifecycle`, `DeleteDataStreamLifecycle` → `TypedClient.Indices.PutDataLifecycle` / `GetDataLifecycle` / `DeleteDataLifecycle`
+- **Ingest pipelines** — `PutIngestPipeline`, `GetIngestPipeline`, `DeleteIngestPipeline` → `TypedClient.Ingest.PutPipeline` / `GetPipeline` / `DeletePipeline`
+
+Update all downstream resources, data sources, and tests under:
+- `internal/elasticsearch/index/*`
+- `internal/elasticsearch/ingest/*`
+- `internal/acctest/*` (any index/ingest helpers)
+
+Remove or deprecate custom model types that become redundant when typed API equivalents are available (e.g. `ComponentTemplateResponse`, `IndexTemplateResponse`, `DataStream`, `DataStreamLifecycle`, `IngestPipeline`, `PolicyDefinition`, `AliasAction`, etc.).
+
+No Terraform resource schemas, provider configuration, or user-visible behavior changes.
+
+## Capabilities
+
+### New Capabilities
+_(none — this is an internal refactoring with no new user-visible capabilities)_
+
+### Modified Capabilities
+_(none — no spec-level requirement changes; all resource schemas, validation, and behavior remain identical)_
+
+## Impact
+
+- **Code**: `internal/clients/elasticsearch/index.go` (~29KB), downstream resource files under `internal/elasticsearch/index/` and `internal/elasticsearch/ingest/`, and acceptance-test helpers.
+- **APIs**: No Terraform resource or data source behavior changes.
+- **Dependencies**: Relies on existing `go-elasticsearch/v8` `GetESTypedClient()` already exposed via `ElasticsearchScopedClient`.
+- **Build / CI**: Compilation and acceptance tests are affected; no new dependencies introduced.

--- a/openspec/changes/typed-client-index/specs/typed-client-index/spec.md
+++ b/openspec/changes/typed-client-index/specs/typed-client-index/spec.md
@@ -1,0 +1,243 @@
+## ADDED Requirements
+
+### Requirement: ILM helpers use typed client
+`PutIlm`, `GetIlm`, and `DeleteIlm` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `ILM.PutLifecycle`, `ILM.GetLifecycle`, and `ILM.DeleteLifecycle` APIs. `GetIlm` SHALL return the policy definition and SHALL return `nil` with no error when the policy is not found.
+
+#### Scenario: Create or update ILM policy with typed client
+- **WHEN** `PutIlm` is called with a valid policy configuration
+- **THEN** it calls the typed `ILM.PutLifecycle` API and returns no error diagnostics on success
+
+#### Scenario: Read existing ILM policy with typed client
+- **WHEN** `GetIlm` is called for an existing policy
+- **THEN** it returns the policy data and no error diagnostics
+
+#### Scenario: Read missing ILM policy with typed client
+- **GIVEN** the requested ILM policy does not exist
+- **WHEN** `GetIlm` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete ILM policy with typed client
+- **WHEN** `DeleteIlm` is called with a valid policy name
+- **THEN** it calls the typed `ILM.DeleteLifecycle` API and returns no error diagnostics on success
+
+### Requirement: Component template helpers use typed client
+`PutComponentTemplate`, `GetComponentTemplate`, and `DeleteComponentTemplate` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Cluster.PutComponentTemplate`, `Cluster.GetComponentTemplate`, and `Cluster.DeleteComponentTemplate` APIs. `GetComponentTemplate` SHALL request `flat_settings=true` and SHALL return `nil` with no error when the template is not found.
+
+#### Scenario: Create or update component template with typed client
+- **WHEN** `PutComponentTemplate` is called with a valid template configuration
+- **THEN** it calls the typed `Cluster.PutComponentTemplate` API and returns no error diagnostics on success
+
+#### Scenario: Read existing component template with typed client
+- **WHEN** `GetComponentTemplate` is called for an existing template
+- **THEN** it returns the template data and no error diagnostics
+
+#### Scenario: Read missing component template with typed client
+- **GIVEN** the requested component template does not exist
+- **WHEN** `GetComponentTemplate` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete component template with typed client
+- **WHEN** `DeleteComponentTemplate` is called with a valid template name
+- **THEN** it calls the typed `Cluster.DeleteComponentTemplate` API and returns no error diagnostics on success
+
+### Requirement: Index template helpers use typed client
+`PutIndexTemplate`, `GetIndexTemplate`, and `DeleteIndexTemplate` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Indices.PutIndexTemplate`, `Indices.GetIndexTemplate`, and `Indices.DeleteIndexTemplate` APIs. `GetIndexTemplate` SHALL return `nil` with no error when the template is not found.
+
+#### Scenario: Create or update index template with typed client
+- **WHEN** `PutIndexTemplate` is called with a valid template configuration
+- **THEN** it calls the typed `Indices.PutIndexTemplate` API and returns no error diagnostics on success
+
+#### Scenario: Read existing index template with typed client
+- **WHEN** `GetIndexTemplate` is called for an existing template
+- **THEN** it returns the template data and no error diagnostics
+
+#### Scenario: Read missing index template with typed client
+- **GIVEN** the requested index template does not exist
+- **WHEN** `GetIndexTemplate` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete index template with typed client
+- **WHEN** `DeleteIndexTemplate` is called with a valid template name
+- **THEN** it calls the typed `Indices.DeleteIndexTemplate` API and returns no error diagnostics on success
+
+### Requirement: Index CRUD helpers use typed client
+`PutIndex`, `GetIndex`, `GetIndices`, and `DeleteIndex` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Indices.Create`, `Indices.Get`, and `Indices.Delete` APIs. `GetIndex` and `GetIndices` SHALL request `flat_settings=true` and SHALL return `nil` with no error when the index is not found. `PutIndex` SHALL preserve date-math name URI encoding and timeout options.
+
+#### Scenario: Create index with typed client
+- **WHEN** `PutIndex` is called with a valid index configuration
+- **THEN** it calls the typed `Indices.Create` API and returns the concrete index name and no error diagnostics on success
+
+#### Scenario: Create index with date math name
+- **GIVEN** the configured index name is a validated date math expression
+- **WHEN** `PutIndex` is called
+- **THEN** the name SHALL be URI-encoded before sending in the typed API request path
+
+#### Scenario: Read existing index with typed client
+- **WHEN** `GetIndex` is called for an existing index
+- **THEN** it returns the index data and no error diagnostics
+
+#### Scenario: Read missing index with typed client
+- **GIVEN** the requested index does not exist
+- **WHEN** `GetIndex` or `GetIndices` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete index with typed client
+- **WHEN** `DeleteIndex` is called with a valid index name
+- **THEN** it calls the typed `Indices.Delete` API and returns no error diagnostics on success
+
+### Requirement: Alias helpers use typed client
+`UpdateIndexAlias`, `DeleteIndexAlias`, `GetAlias`, and `UpdateAliasesAtomic` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Indices.PutAlias`, `Indices.DeleteAlias`, `Indices.GetAlias`, and `Indices.UpdateAliases` APIs. `GetAlias` SHALL return `nil` with no error when the alias is not found. `UpdateAliasesAtomic` SHALL keep the existing `AliasAction` builder and pass the resulting actions body to the typed API.
+
+#### Scenario: Upsert alias with typed client
+- **WHEN** `UpdateIndexAlias` is called with a valid alias configuration
+- **THEN** it calls the typed `Indices.PutAlias` API and returns no error diagnostics on success
+
+#### Scenario: Delete alias with typed client
+- **WHEN** `DeleteIndexAlias` is called with valid index and alias names
+- **THEN** it calls the typed `Indices.DeleteAlias` API and returns no error diagnostics on success
+
+#### Scenario: Read alias with typed client
+- **WHEN** `GetAlias` is called for an existing alias
+- **THEN** it returns the alias data and no error diagnostics
+
+#### Scenario: Read missing alias with typed client
+- **GIVEN** the requested alias does not exist
+- **WHEN** `GetAlias` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Atomic alias update with typed client
+- **WHEN** `UpdateAliasesAtomic` is called with a list of `AliasAction` values
+- **THEN** it builds the actions JSON body and calls the typed `Indices.UpdateAliases` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Settings and mappings helpers use typed client
+`UpdateIndexSettings` and `UpdateIndexMappings` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Indices.PutSettings` and `Indices.PutMapping` APIs.
+
+#### Scenario: Update index settings with typed client
+- **WHEN** `UpdateIndexSettings` is called with a settings map
+- **THEN** it calls the typed `Indices.PutSettings` API and returns no error diagnostics on success
+
+#### Scenario: Update index mappings with typed client
+- **WHEN** `UpdateIndexMappings` is called with a mappings JSON string
+- **THEN** it calls the typed `Indices.PutMapping` API and returns no error diagnostics on success
+
+### Requirement: Data stream helpers use typed client
+`PutDataStream`, `GetDataStream`, and `DeleteDataStream` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Indices.CreateDataStream`, `Indices.GetDataStream`, and `Indices.DeleteDataStream` APIs. `GetDataStream` SHALL return `nil` with no error when the data stream is not found.
+
+#### Scenario: Create data stream with typed client
+- **WHEN** `PutDataStream` is called with a valid data stream name
+- **THEN** it calls the typed `Indices.CreateDataStream` API and returns no error diagnostics on success
+
+#### Scenario: Read existing data stream with typed client
+- **WHEN** `GetDataStream` is called for an existing data stream
+- **THEN** it returns the data stream data and no error diagnostics
+
+#### Scenario: Read missing data stream with typed client
+- **GIVEN** the requested data stream does not exist
+- **WHEN** `GetDataStream` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete data stream with typed client
+- **WHEN** `DeleteDataStream` is called with a valid data stream name
+- **THEN** it calls the typed `Indices.DeleteDataStream` API and returns no error diagnostics on success
+
+### Requirement: Data stream lifecycle helpers use typed client
+`PutDataStreamLifecycle`, `GetDataStreamLifecycle`, and `DeleteDataStreamLifecycle` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Indices.PutDataLifecycle`, `Indices.GetDataLifecycle`, and `Indices.DeleteDataLifecycle` APIs. `GetDataStreamLifecycle` SHALL return `nil` with no error when the lifecycle is not found.
+
+#### Scenario: Create or update data stream lifecycle with typed client
+- **WHEN** `PutDataStreamLifecycle` is called with valid lifecycle settings
+- **THEN** it calls the typed `Indices.PutDataLifecycle` API and returns no error diagnostics on success
+
+#### Scenario: Read existing data stream lifecycle with typed client
+- **WHEN** `GetDataStreamLifecycle` is called for an existing lifecycle
+- **THEN** it returns the lifecycle data and no error diagnostics
+
+#### Scenario: Read missing data stream lifecycle with typed client
+- **GIVEN** the requested data stream lifecycle does not exist
+- **WHEN** `GetDataStreamLifecycle` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete data stream lifecycle with typed client
+- **WHEN** `DeleteDataStreamLifecycle` is called with a valid data stream name
+- **THEN** it calls the typed `Indices.DeleteDataLifecycle` API and returns no error diagnostics on success
+
+### Requirement: Ingest pipeline helpers use typed client
+`PutIngestPipeline`, `GetIngestPipeline`, and `DeleteIngestPipeline` in `internal/clients/elasticsearch/index.go` SHALL use `GetESTypedClient()` and SHALL call the typed `Ingest.PutPipeline`, `Ingest.GetPipeline`, and `Ingest.DeletePipeline` APIs. `GetIngestPipeline` SHALL return `nil` with no error when the pipeline is not found.
+
+#### Scenario: Create or update ingest pipeline with typed client
+- **WHEN** `PutIngestPipeline` is called with a valid pipeline configuration
+- **THEN** it calls the typed `Ingest.PutPipeline` API and returns no error diagnostics on success
+
+#### Scenario: Read existing ingest pipeline with typed client
+- **WHEN** `GetIngestPipeline` is called for an existing pipeline
+- **THEN** it returns the pipeline data and no error diagnostics
+
+#### Scenario: Read missing ingest pipeline with typed client
+- **GIVEN** the requested ingest pipeline does not exist
+- **WHEN** `GetIngestPipeline` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete ingest pipeline with typed client
+- **WHEN** `DeleteIngestPipeline` is called with a valid pipeline name
+- **THEN** it calls the typed `Ingest.DeletePipeline` API and returns no error diagnostics on success
+
+### Requirement: Index resources consume typed helpers
+All index-related resource packages under `internal/elasticsearch/index/` and `internal/elasticsearch/ingest/` SHALL compile successfully after `index.go` helper signatures and internals are updated to use the typed client.
+
+#### Scenario: ILM resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/ilm`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Component template resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/component_template`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Index template resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/template`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Index resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/index`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Alias resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/alias`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Data stream resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/data_stream`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Data stream lifecycle resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/datastreamlifecycle`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Index template ILM attachment resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/index/templateilmattachment`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Ingest pipeline resource compiles after migration
+- **WHEN** compiling `internal/elasticsearch/ingest/pipeline`
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+### Requirement: Redundant custom index model structs removed
+The custom model types in `internal/models/models.go` that are fully replaced by typed API equivalents SHALL be removed once all callers have been migrated. This includes at minimum `ComponentTemplateResponse`, `ComponentTemplatesResponse`, `IndexTemplateResponse`, `IndexTemplatesResponse`, `DataStream`, `DataStreamLifecycle`, `IngestPipeline`, `PolicyDefinition`, `Policy`, `IndexAlias`, and related wrapper structs.
+
+#### Scenario: Custom index types have no remaining references
+- **GIVEN** all callers have been updated to use typed client types
+- **WHEN** searching the codebase for the removed custom model types
+- **THEN** no references exist in compiling source files
+
+### Requirement: Project builds successfully after index migration
+`make build` SHALL complete without errors after all index files are migrated and redundant models are removed.
+
+#### Scenario: Clean build after index migration
+- **WHEN** running `make build`
+- **THEN** the command exits with status 0 and produces no compilation errors
+
+### Requirement: Lint checks pass after index migration
+`make check-lint` SHALL complete without new lint failures introduced by the typed-client migration.
+
+#### Scenario: Lint passes after index migration
+- **WHEN** running `make check-lint`
+- **THEN** the command exits with status 0

--- a/openspec/changes/typed-client-index/tasks.md
+++ b/openspec/changes/typed-client-index/tasks.md
@@ -1,0 +1,81 @@
+## 1. Typed client migration — ILM
+
+- [ ] 1.1 Replace `PutIlm` raw `esapi` call with typed `ILM.PutLifecycle` using `types.IlmPolicy` or equivalent.
+- [ ] 1.2 Replace `GetIlm` raw call with typed `ILM.GetLifecycle`; map 404 → nil.
+- [ ] 1.3 Replace `DeleteIlm` raw call with typed `ILM.DeleteLifecycle`.
+- [ ] 1.4 Remove `models.Policy` and `models.PolicyDefinition` if no longer used; keep conversion helpers if resources need them.
+
+## 2. Typed client migration — Component templates
+
+- [ ] 2.1 Replace `PutComponentTemplate` raw call with typed `Cluster.PutComponentTemplate`.
+- [ ] 2.2 Replace `GetComponentTemplate` raw call with typed `Cluster.GetComponentTemplate` using `FlatSettings(true)`.
+- [ ] 2.3 Replace `DeleteComponentTemplate` raw call with typed `Cluster.DeleteComponentTemplate`.
+- [ ] 2.4 Remove or narrow `models.ComponentTemplate`, `models.ComponentTemplatesResponse`, `models.ComponentTemplateResponse`.
+
+## 3. Typed client migration — Index templates
+
+- [ ] 3.1 Replace `PutIndexTemplate` raw call with typed `Indices.PutIndexTemplate`.
+- [ ] 3.2 Replace `GetIndexTemplate` raw call with typed `Indices.GetIndexTemplate`.
+- [ ] 3.3 Replace `DeleteIndexTemplate` raw call with typed `Indices.DeleteIndexTemplate`.
+- [ ] 3.4 Remove or narrow `models.IndexTemplate`, `models.IndexTemplatesResponse`, `models.IndexTemplateResponse`.
+
+## 4. Typed client migration — Index CRUD
+
+- [ ] 4.1 Replace `PutIndex` raw call with typed `Indices.Create`; preserve date-math name URI encoding and timeout options.
+- [ ] 4.2 Replace `DeleteIndex` raw call with typed `Indices.Delete`.
+- [ ] 4.3 Replace `GetIndex` / `GetIndices` raw calls with typed `Indices.Get` using `FlatSettings(true)`; preserve 404 → nil semantics.
+- [ ] 4.4 Remove or narrow `models.Index`, `models.PutIndexParams`.
+
+## 5. Typed client migration — Aliases
+
+- [ ] 5.1 Replace `DeleteIndexAlias` raw call with typed `Indices.DeleteAlias`.
+- [ ] 5.2 Replace `UpdateIndexAlias` raw call with typed `Indices.PutAlias`.
+- [ ] 5.3 Replace `GetAlias` raw call with typed `Indices.GetAlias`.
+- [ ] 5.4 Replace `UpdateAliasesAtomic` raw call with typed `Indices.UpdateAliases`; keep the existing `AliasAction` builder.
+- [ ] 5.5 Remove or narrow `models.IndexAlias` if fully replaced by `types.Alias`.
+
+## 6. Typed client migration — Settings and mappings
+
+- [ ] 6.1 Replace `UpdateIndexSettings` raw call with typed `Indices.PutSettings`.
+- [ ] 6.2 Replace `UpdateIndexMappings` raw call with typed `Indices.PutMapping`.
+
+## 7. Typed client migration — Data streams
+
+- [ ] 7.1 Replace `PutDataStream` raw call with typed `Indices.CreateDataStream`.
+- [ ] 7.2 Replace `GetDataStream` raw call with typed `Indices.GetDataStream`.
+- [ ] 7.3 Replace `DeleteDataStream` raw call with typed `Indices.DeleteDataStream`.
+- [ ] 7.4 Remove or narrow `models.DataStream`.
+
+## 8. Typed client migration — Data stream lifecycle
+
+- [ ] 8.1 Replace `PutDataStreamLifecycle` raw call with typed `Indices.PutDataLifecycle`.
+- [ ] 8.2 Replace `GetDataStreamLifecycle` raw call with typed `Indices.GetDataLifecycle`.
+- [ ] 8.3 Replace `DeleteDataStreamLifecycle` raw call with typed `Indices.DeleteDataLifecycle`.
+- [ ] 8.4 Remove or narrow `models.DataStreamLifecycle`, `models.LifecycleSettings`, `models.Downsampling`.
+
+## 9. Typed client migration — Ingest pipelines
+
+- [ ] 9.1 Replace `PutIngestPipeline` raw call with typed `Ingest.PutPipeline`.
+- [ ] 9.2 Replace `GetIngestPipeline` raw call with typed `Ingest.GetPipeline`.
+- [ ] 9.3 Replace `DeleteIngestPipeline` raw call with typed `Ingest.DeletePipeline`.
+- [ ] 9.4 Remove or narrow `models.IngestPipeline`.
+
+## 10. Resource and test updates
+
+- [ ] 10.1 Update `internal/elasticsearch/index/ilm` resource and acceptance tests to use migrated helpers.
+- [ ] 10.2 Update `internal/elasticsearch/index/component_template` resource and tests.
+- [ ] 10.3 Update `internal/elasticsearch/index/template` resource and tests.
+- [ ] 10.4 Update `internal/elasticsearch/index/index` resource and tests.
+- [ ] 10.5 Update `internal/elasticsearch/index/alias` resource and tests.
+- [ ] 10.6 Update `internal/elasticsearch/index/data_stream` resource and tests.
+- [ ] 10.7 Update `internal/elasticsearch/index/datastreamlifecycle` resource and tests.
+- [ ] 10.8 Update `internal/elasticsearch/index/templateilmattachment` resource and tests.
+- [ ] 10.9 Update `internal/elasticsearch/ingest/pipeline` resource and tests.
+
+## 11. Verification and cleanup
+
+- [ ] 11.1 Run `make build` and fix all compilation errors.
+- [ ] 11.2 Run `make check-lint` and fix any issues.
+- [ ] 11.3 Run targeted acceptance tests for at least one resource per group (ILM, component template, index template, index, alias, data stream, data stream lifecycle, ingest pipeline).
+- [ ] 11.4 Run the full acceptance test suite for all affected resources if feasible.
+- [ ] 11.5 Prune any now-unused imports or models in `internal/models` and `internal/clients/elasticsearch/index.go`.

--- a/openspec/changes/typed-client-ml/.openspec.yaml
+++ b/openspec/changes/typed-client-ml/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-ml/design.md
+++ b/openspec/changes/typed-client-ml/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The provider's ML subsystem currently relies on the raw `esapi` client (`GetESClient()`) for every Elasticsearch ML API call. Request bodies are hand-marshaled to JSON, and responses are decoded into custom model structs defined in `internal/models/ml.go`. The typed client (`GetESTypedClient()`) was introduced by `typed-client-bootstrap` and provides strongly-typed `types.*` structs for every ML endpoint.
+
+Files involved:
+- **`internal/clients/elasticsearch/ml_job.go`** — 10 helper functions that call raw `esapi` ML endpoints.
+- **`internal/elasticsearch/ml/anomalydetectionjob/*.go`** — resource methods that call raw `esClient.ML.PutJob`, `GetJobs`, `UpdateJob`, `CloseJob`, `DeleteJob` directly.
+- **`internal/elasticsearch/ml/datafeed/*.go`** — resource methods that consume `PutDatafeed`, `GetDatafeed`, `UpdateDatafeed`, `DeleteDatafeed`, `StopDatafeed`, `StartDatafeed`, and `GetDatafeedStats` helpers.
+- **`internal/elasticsearch/ml/jobstate/*.go`** — resource methods that consume `OpenMLJob`, `CloseMLJob`, and `GetMLJobStats` helpers.
+- **`internal/elasticsearch/ml/datafeed_state/*.go`** — resource methods that consume `GetDatafeedStats`, `StartDatafeed`, and `StopDatafeed` helpers.
+- **`internal/models/ml.go`** — custom ML model structs that shadow typed API structs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Convert every raw `esapi` ML API call in `ml_job.go` to use the typed client (`elasticsearch.TypedClient`).
+- Convert every raw `esapi` ML API call in `anomalydetectionjob/*.go` to use the typed client.
+- Remove or replace custom model structs in `internal/models/ml.go` with typed API equivalents.
+- Ensure all downstream ML resources (`datafeed`, `jobstate`, `datafeed_state`) continue to compile and pass acceptance tests.
+- Preserve all existing error-handling behavior (not-found handling, force flags, timeouts, diagnostics).
+
+**Non-Goals:**
+- Changing ML resource schemas, Terraform behaviors, or force-new rules.
+- Adding new ML resources or data sources.
+- Migrating non-ML Elasticsearch helpers or resources.
+- Renaming or restructuring package boundaries beyond what the typed client requires.
+
+## Decisions
+
+**1. Replace `GetESClient()` with `GetESTypedClient()` in all ML helpers**
+- **Rationale**: The typed client provides the same transport and endpoints but with compile-time type safety. `GetESTypedClient()` is cached (via `sync.Once`) so there is no per-call overhead.
+- **Alternative considered**: Keeping `ml_job.go` on the raw client and only migrating resource files. Rejected because the helpers are the primary API surface and keeping them raw would leave the main migration unfinished.
+
+**2. Delete custom model structs and use `types.*` directly**
+- **Rationale**: `go-elasticsearch/v8` already defines `types.Datafeed`, `types.Job`, `types.DatafeedStats`, etc. Maintaining parallel structs in `internal/models/ml.go` is redundant and invites drift.
+- **Alternative considered**: Keeping custom structs as thin wrappers around typed structs. Rejected because it adds indirection with no benefit; the typed structs already have the correct `json` tags and optional field shapes.
+
+**3. Update `ml_job.go` function signatures to accept typed request structs**
+- **Rationale**: Typed API methods accept strongly-typed builders (e.g., `typedapi.ML.PutDatafeed().Request(&types.Datafeed{...})`). Passing raw `[]byte` bodies would defeat the purpose. Helpers will construct the typed request inline or accept typed structs from callers.
+- **Alternative considered**: Keeping `[]byte` signatures and doing an extra marshal/unmarshal step. Rejected because it would negate the type-safety benefits.
+
+**4. Keep the same diagnostics and error-handling patterns**
+- **Rationale**: The typed client's `.Do(ctx)` returns `(Response, error)`. The first `error` is transport-level (same as raw client). Response-level errors are checked via `.IsError()`. This maps cleanly to existing `diag.Diagnostics` patterns.
+- **Alternative considered**: Introducing a new shared wrapper for typed API error handling. Rejected because each helper has slightly different not-found semantics; explicit handling per function is clearer.
+
+**5. Migrate anomaly detection job resource inline with helpers**
+- **Rationale**: The anomaly detection job resource currently calls `esClient.ML.PutJob`, `GetJobs`, `UpdateJob`, `CloseJob`, and `DeleteJob` directly, bypassing `ml_job.go`. Migrating these simultaneously avoids a half-typed state in the ML subsystem and keeps the scope of the change coherent.
+- **Alternative considered**: Splitting into two changes (helpers first, anomaly detection job second). Rejected because the anomaly detection job resource is tightly coupled to the same APIs and would require a second, nearly identical review pass.
+
+## Risks / Trade-offs
+
+- **[Risk]** Typed API structs may have slightly different field types (pointers, slices, or custom types) compared to custom models, causing subtle serialization differences.
+  - **Mitigation**: Compare field-by-field with existing models before removal; run the full ML acceptance test suite to verify round-tripping.
+- **[Risk]** Typed API response nesting may differ (e.g., `GetDatafeedsResponse.Datafeeds` vs. custom `[]models.Datafeed`).
+  - **Mitigation**: Inspect the generated typed API response struct in `go-elasticsearch` and update index lookups accordingly.
+- **[Risk]** `go-elasticsearch` typed API builders may omit fields when set to zero values differently than manual JSON marshaling.
+  - **Mitigation**: Add explicit nil checks before setting builder fields; ensure optional+computed fields are omitted when unknown/null.
+- **[Risk]** Mixing typed and untyped clients in the same resource during review.
+  - **Mitigation**: Verify that every ML file compiles and that no raw `esapi` imports remain in the migrated packages.
+
+## Migration Plan
+
+1. Update `ml_job.go` helpers to use `GetESTypedClient()` and typed API types.
+2. Update `anomalydetectionjob/*.go` to use `GetESTypedClient()` and typed API types.
+3. Remove unused custom model structs from `internal/models/ml.go`.
+4. Ensure `datafeed`, `jobstate`, and `datafeed_state` packages compile against updated helper signatures.
+5. Run `make build` and `make check-lint`.
+6. Run ML acceptance tests (`go test ./internal/elasticsearch/ml/...`) against a live cluster.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/typed-client-ml/proposal.md
+++ b/openspec/changes/typed-client-ml/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The provider currently uses the raw `esapi` (untyped) client via `GetESClient()` for all ML API calls. The `go-elasticsearch/v8` Typed API (`elasticsearch.TypedClient`) provides strongly-typed request/response structs that eliminate hand-written JSON marshaling, reduce runtime errors, and enable IDE-driven refactoring. Phase 5 of the incremental typed-client migration targets the ML APIs.
+
+## What Changes
+
+- Migrate all functions in `internal/clients/elasticsearch/ml_job.go` from raw `esapi` to the typed client (`GetESTypedClient()`):
+  - `OpenMLJob` → `typedapi.ML.OpenJob(...).Do(ctx)`
+  - `PutDatafeed` → `typedapi.ML.PutDatafeed(...).Do(ctx)`
+  - `CloseMLJob` → `typedapi.ML.CloseJob(...).Do(ctx)`
+  - `GetMLJobStats` → `typedapi.ML.GetJobStats(...).Do(ctx)`
+  - `GetDatafeed` → `typedapi.ML.GetDatafeeds(...).Do(ctx)`
+  - `UpdateDatafeed` → `typedapi.ML.UpdateDatafeed(...).Do(ctx)`
+  - `DeleteDatafeed` → `typedapi.ML.DeleteDatafeed(...).Do(ctx)`
+  - `StopDatafeed` → `typedapi.ML.StopDatafeed(...).Do(ctx)`
+  - `StartDatafeed` → `typedapi.ML.StartDatafeed(...).Do(ctx)`
+  - `GetDatafeedStats` → `typedapi.ML.GetDatafeedStats(...).Do(ctx)`
+- Migrate `internal/elasticsearch/ml/anomalydetectionjob/create.go`, `read.go`, `update.go`, and `delete.go` from direct `esClient.ML.*` raw calls to the typed client.
+- Replace custom request/response model structs (`Datafeed`, `DatafeedCreateRequest`, `DatafeedUpdateRequest`, `DatafeedStats`, `DatafeedStatsResponse`, `MLJob`, `MLJobStats`) with typed API types (`types.Datafeed`, `types.Job`, etc.) where possible, or remove them entirely.
+- Update downstream ML resource files (`datafeed`, `jobstate`, `datafeed_state`) that consume the migrated helpers so they continue to compile and behave identically.
+- No Terraform user-facing schema or behavior changes.
+
+## Capabilities
+
+### New Capabilities
+- `typed-client-ml`: Migrate all ML API calls and the ML anomaly detection job resource from the raw `esapi` client to the `go-elasticsearch` Typed API, and remove redundant custom ML model structs.
+
+### Modified Capabilities
+- _(none — no spec-level requirement changes; this is a pure implementation migration)_
+
+## Impact
+
+- **Code**: `internal/clients/elasticsearch/ml_job.go`, `internal/elasticsearch/ml/anomalydetectionjob/*.go`, `internal/elasticsearch/ml/datafeed/*.go`, `internal/elasticsearch/ml/jobstate/*.go`, `internal/elasticsearch/ml/datafeed_state/*.go`.
+- **Models**: `internal/models/ml.go` — custom ML model structs become redundant and will be removed.
+- **APIs**: No Terraform resource or data source behavior changes; all existing acceptance tests should continue to pass.
+- **Dependencies**: Relies on the existing `typed-client-bootstrap` bridge (`GetESTypedClient()`).

--- a/openspec/changes/typed-client-ml/specs/typed-client-ml/spec.md
+++ b/openspec/changes/typed-client-ml/specs/typed-client-ml/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: ML helper functions use typed client
+All functions in `internal/clients/elasticsearch/ml_job.go` SHALL use `GetESTypedClient()` and SHALL call the corresponding typed API methods instead of raw `esapi` methods.
+
+#### Scenario: OpenMLJob uses typed client
+- **WHEN** `OpenMLJob` is invoked
+- **THEN** it calls `client.ML.OpenJob(...).Do(ctx)` instead of `esClient.ML.OpenJob(...)`
+
+#### Scenario: PutDatafeed uses typed client
+- **WHEN** `PutDatafeed` is invoked
+- **THEN** it calls `client.ML.PutDatafeed(...).Request(&types.DatafeedConfig{...}).Do(ctx)` instead of `esClient.ML.PutDatafeed(...)`
+
+#### Scenario: CloseMLJob uses typed client
+- **WHEN** `CloseMLJob` is invoked
+- **THEN** it calls `client.ML.CloseJob(...).Do(ctx)` instead of `esClient.ML.CloseJob(...)`
+
+#### Scenario: GetMLJobStats uses typed client
+- **WHEN** `GetMLJobStats` is invoked
+- **THEN** it calls `client.ML.GetJobStats(...).Do(ctx)` and returns a typed `*types.JobStats` instead of decoding into a custom model
+
+#### Scenario: GetDatafeed uses typed client
+- **WHEN** `GetDatafeed` is invoked
+- **THEN** it calls `client.ML.GetDatafeeds(...).Do(ctx)` and returns a typed `*types.Datafeed` instead of decoding into a custom model
+
+#### Scenario: UpdateDatafeed uses typed client
+- **WHEN** `UpdateDatafeed` is invoked
+- **THEN** it calls `client.ML.UpdateDatafeed(...).Request(&types.DatafeedConfig{...}).Do(ctx)` instead of `esClient.ML.UpdateDatafeed(...)`
+
+#### Scenario: DeleteDatafeed uses typed client
+- **WHEN** `DeleteDatafeed` is invoked
+- **THEN** it calls `client.ML.DeleteDatafeed(...).Do(ctx)` instead of `esClient.ML.DeleteDatafeed(...)`
+
+#### Scenario: StopDatafeed uses typed client
+- **WHEN** `StopDatafeed` is invoked
+- **THEN** it calls `client.ML.StopDatafeed(...).Do(ctx)` instead of `esClient.ML.StopDatafeed(...)`
+
+#### Scenario: StartDatafeed uses typed client
+- **WHEN** `StartDatafeed` is invoked
+- **THEN** it calls `client.ML.StartDatafeed(...).Do(ctx)` instead of `esClient.ML.StartDatafeed(...)`
+
+#### Scenario: GetDatafeedStats uses typed client
+- **WHEN** `GetDatafeedStats` is invoked
+- **THEN** it calls `client.ML.GetDatafeedStats(...).Do(ctx)` and returns a typed `*types.DatafeedStats` instead of decoding into a custom model
+
+### Requirement: Anomaly detection job resource uses typed client
+`internal/elasticsearch/ml/anomalydetectionjob/create.go`, `read.go`, `update.go`, and `delete.go` SHALL use `GetESTypedClient()` and SHALL NOT call raw `esapi` ML methods directly.
+
+#### Scenario: Create uses typed PutJob
+- **WHEN** the anomaly detection job resource creates a job
+- **THEN** it builds a `types.JobConfig` request and calls `client.ML.PutJob(...).Do(ctx)` instead of `esClient.ML.PutJob(...)`
+
+#### Scenario: Read uses typed GetJobs
+- **WHEN** the anomaly detection job resource reads a job
+- **THEN** it calls `client.ML.GetJobs(...).Do(ctx)` and uses typed `types.Job` responses instead of manual JSON decoding into custom structs
+
+#### Scenario: Update uses typed UpdateJob
+- **WHEN** the anomaly detection job resource updates a job
+- **THEN** it calls `client.ML.UpdateJob(...).Do(ctx)` instead of `esClient.ML.UpdateJob(...)`
+
+#### Scenario: Delete uses typed CloseJob and DeleteJob
+- **WHEN** the anomaly detection job resource deletes a job
+- **THEN** it calls `client.ML.CloseJob(...).Do(ctx)` and `client.ML.DeleteJob(...).Do(ctx)` instead of raw `esClient.ML.CloseJob(...)` and `esClient.ML.DeleteJob(...)`
+
+### Requirement: Redundant custom ML model structs removed
+`internal/models/ml.go` SHALL be deleted, and the provider SHALL NOT contain custom structs `Datafeed`, `DatafeedCreateRequest`, `DatafeedUpdateRequest`, `DatafeedStats`, `DatafeedStatsResponse`, `MLJob`, or `MLJobStats`.
+
+#### Scenario: ML model file is absent
+- **WHEN** checking for `internal/models/ml.go`
+- **THEN** the file does not exist
+
+#### Scenario: Custom ML types have no remaining references
+- **WHEN** searching the codebase for `models.Datafeed`, `models.DatafeedCreateRequest`, `models.DatafeedUpdateRequest`, `models.DatafeedStats`, `models.DatafeedStatsResponse`, `models.MLJob`, or `models.MLJobStats`
+- **THEN** no references exist in compiling source files
+
+### Requirement: Downstream ML resources compile against migrated helpers
+`internal/elasticsearch/ml/datafeed`, `internal/elasticsearch/ml/jobstate`, and `internal/elasticsearch/ml/datafeed_state` SHALL compile successfully after `ml_job.go` helper signatures are updated.
+
+#### Scenario: Datafeed resource compiles
+- **WHEN** compiling the datafeed resource package
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Job state resource compiles
+- **WHEN** compiling the jobstate resource package
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+#### Scenario: Datafeed state resource compiles
+- **WHEN** compiling the datafeed_state resource package
+- **THEN** it succeeds with no errors referencing the updated helper signatures
+
+### Requirement: Project builds successfully after ML migration
+`make build` SHALL complete without errors after all ML files are migrated and redundant models are removed.
+
+#### Scenario: Clean build after ML migration
+- **WHEN** running `make build`
+- **THEN** the command exits with status 0 and produces no compilation errors
+
+### Requirement: Lint checks pass after ML migration
+`make check-lint` SHALL complete without new lint failures introduced by the typed-client migration.
+
+#### Scenario: Lint passes after ML migration
+- **WHEN** running `make check-lint`
+- **THEN** the command exits with status 0

--- a/openspec/changes/typed-client-ml/tasks.md
+++ b/openspec/changes/typed-client-ml/tasks.md
@@ -1,0 +1,49 @@
+## 1. Migrate `internal/clients/elasticsearch/ml_job.go` helpers
+
+- [ ] 1.1 Replace `esClient.ML.OpenJob` with `typedapi.ML.OpenJob(...).Do(ctx)` in `OpenMLJob`
+- [ ] 1.2 Replace `esClient.ML.PutDatafeed` with `typedapi.ML.PutDatafeed(...).Do(ctx)` in `PutDatafeed`; accept typed `types.DatafeedConfig` instead of `models.DatafeedCreateRequest`
+- [ ] 1.3 Replace `esClient.ML.CloseJob` with `typedapi.ML.CloseJob(...).Do(ctx)` in `CloseMLJob`
+- [ ] 1.4 Replace `esClient.ML.GetJobStats` with `typedapi.ML.GetJobStats(...).Do(ctx)` in `GetMLJobStats`; return typed `types.JobStats` instead of `models.MLJob`
+- [ ] 1.5 Replace `esClient.ML.GetDatafeeds` with `typedapi.ML.GetDatafeeds(...).Do(ctx)` in `GetDatafeed`; return typed `types.Datafeed` instead of `models.Datafeed`
+- [ ] 1.6 Replace `esClient.ML.UpdateDatafeed` with `typedapi.ML.UpdateDatafeed(...).Do(ctx)` in `UpdateDatafeed`; accept typed `types.DatafeedConfig` instead of `models.DatafeedUpdateRequest`
+- [ ] 1.7 Replace `esClient.ML.DeleteDatafeed` with `typedapi.ML.DeleteDatafeed(...).Do(ctx)` in `DeleteDatafeed`
+- [ ] 1.8 Replace `esClient.ML.StopDatafeed` with `typedapi.ML.StopDatafeed(...).Do(ctx)` in `StopDatafeed`
+- [ ] 1.9 Replace `esClient.ML.StartDatafeed` with `typedapi.ML.StartDatafeed(...).Do(ctx)` in `StartDatafeed`
+- [ ] 1.10 Replace `esClient.ML.GetDatafeedStats` with `typedapi.ML.GetDatafeedStats(...).Do(ctx)` in `GetDatafeedStats`; return typed `types.DatafeedStats` instead of `models.DatafeedStats`
+- [ ] 1.11 Update all helper signatures to accept `*clients.ElasticsearchScopedClient` and call `GetESTypedClient()` instead of `GetESClient()`
+- [ ] 1.12 Remove unused `bytes`, `encoding/json`, `net/http`, and `esapi` imports from `ml_job.go` where possible
+
+## 2. Migrate `internal/elasticsearch/ml/anomalydetectionjob` resource files
+
+- [ ] 2.1 Replace raw `esClient.ML.PutJob` with typed client in `create.go`; build request with `types.JobConfig` directly
+- [ ] 2.2 Replace raw `esClient.ML.GetJobs` with typed client in `read.go`; decode into `types.Job` instead of custom `APIModel`
+- [ ] 2.3 Replace raw `esClient.ML.UpdateJob` with typed client in `update.go`; build update body with typed struct
+- [ ] 2.4 Replace raw `esClient.ML.CloseJob` and `esClient.ML.DeleteJob` with typed client in `delete.go`
+- [ ] 2.5 Remove raw `esapi` import and JSON marshal/unmarshal boilerplate from `anomalydetectionjob/*.go`
+- [ ] 2.6 Ensure `models_api.go` and `models_tf.go` (if any) are updated or removed in favor of typed API structs
+
+## 3. Update downstream ML resource files that consume helpers
+
+- [ ] 3.1 Update `internal/elasticsearch/ml/datafeed/create.go` to pass typed request to `elasticsearch.PutDatafeed`
+- [ ] 3.2 Update `internal/elasticsearch/ml/datafeed/read.go` to consume typed response from `elasticsearch.GetDatafeed`
+- [ ] 3.3 Update `internal/elasticsearch/ml/datafeed/update.go` to pass typed request to `elasticsearch.UpdateDatafeed` and `elasticsearch.StartDatafeed`
+- [ ] 3.4 Update `internal/elasticsearch/ml/datafeed/delete.go` to consume typed helpers for stop and delete
+- [ ] 3.5 Update `internal/elasticsearch/ml/datafeed/state_utils.go` to consume typed response from `elasticsearch.GetDatafeedStats`
+- [ ] 3.6 Update `internal/elasticsearch/ml/jobstate/update.go` to consume typed helpers for open and close
+- [ ] 3.7 Update `internal/elasticsearch/ml/jobstate/state_utils.go` to consume typed response from `elasticsearch.GetMLJobStats`
+- [ ] 3.8 Update `internal/elasticsearch/ml/datafeed_state/*.go` to consume typed helpers for stats, start, and stop
+
+## 4. Clean up redundant custom models
+
+- [ ] 4.1 Remove `Datafeed`, `DatafeedCreateRequest`, `DatafeedUpdateRequest`, `DatafeedStats`, `DatafeedStatsResponse`, `MLJob`, and `MLJobStats` from `internal/models/ml.go`
+- [ ] 4.2 Verify no other packages import the removed model structs
+- [ ] 4.3 Run `go mod tidy` and `make build` to confirm everything compiles
+
+## 5. Verify behavior and tests
+
+- [ ] 5.1 Run `make check-lint` and fix any issues
+- [ ] 5.2 Run `make build` to ensure no compilation errors
+- [ ] 5.3 Run ML unit tests: `go test ./internal/elasticsearch/ml/...`
+- [ ] 5.4 Run ML acceptance tests against a live Elasticsearch cluster
+- [ ] 5.5 Verify error handling for 404/not-found scenarios remains unchanged
+- [ ] 5.6 Verify force flags, timeouts, and optional parameters are still passed correctly

--- a/openspec/changes/typed-client-security/.openspec.yaml
+++ b/openspec/changes/typed-client-security/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-security/design.md
+++ b/openspec/changes/typed-client-security/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`internal/clients/elasticsearch/security.go` currently contains helper functions for all Elasticsearch Security API operations using the raw `esapi` client (`*elasticsearch.Client`). These helpers manually construct HTTP requests, marshal/unmarshal JSON into custom `models` types, and handle status-code-based error and not-found semantics. The `go-elasticsearch/v8` library provides strongly-typed equivalents via `elasticsearch.TypedClient`, available through `ElasticsearchScopedClient.GetESTypedClient()`.
+
+The security surface is the largest in the provider-wide typed-client migration. It covers:
+
+- **Users**: `PutUser`, `GetUser`, `DeleteUser`, `ChangeUserPassword`, `EnableUser`, `DisableUser`
+- **Roles**: `PutRole`, `GetRole`, `DeleteRole`
+- **Role mappings**: `PutRoleMapping`, `GetRoleMapping`, `DeleteRoleMapping`
+- **API keys**: `CreateAPIKey`, `GetAPIKey`, `UpdateAPIKey`, `DeleteAPIKey`
+- **Cross-cluster API keys**: `CreateCrossClusterAPIKey`, `UpdateCrossClusterAPIKey`
+- **Acceptance-test helper**: `CreateESAccessToken` in `internal/acctest/security_helpers.go`
+
+The custom models (`models.User`, `models.Role`, `models.RoleMapping`, `models.APIKey`, `models.APIKeyRoleDescriptor`, `models.CrossClusterAPIKey`, `models.UserPassword`) duplicate the shape of upstream typed-client types. The helpers also use shared `doSDKWrite`/`doFWWrite` wrappers that are tied to the raw `esapi` response type.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rewrite all functions in `internal/clients/elasticsearch/security.go` to use typed `TypedClient.Security.*` APIs.
+- Replace custom model types with typed-client equivalents (`types.User`, `types.Role`, `types.SecurityRoleMapping`, `types.ApiKey`, `types.RoleDescriptor`, `types.Access`, etc.) where possible.
+- Update every resource, data source, and test that calls these helpers so the codebase compiles and all tests pass.
+- Migrate `internal/acctest/security_helpers.go` (`CreateESAccessToken`) to the typed client.
+- Preserve exact Terraform-visible behavior: identical state mapping, identical error messages where possible, identical not-found handling.
+
+**Non-Goals:**
+- Adding new Terraform resources or data sources.
+- Changing schema definitions, validation, or plan modifiers.
+- Modifying provider-level client construction or the scoped-client type itself.
+- Removing `GetESClient()` or migrating other `internal/clients/elasticsearch/` files.
+
+## Decisions
+
+**1. Use `apiClient.GetESTypedClient()` inline in each helper rather than adding a cached typed-client accessor.**
+- **Rationale**: `GetESTypedClient()` is already available from `typed-client-bootstrap`. Calling it per operation is cheap (cached via `sync.Once`) and keeps this change self-contained.
+- **Alternative considered**: Cache the typed client locally in `security.go`. Rejected because the scoped client already caches it.
+
+**2. Map typed-client response types directly into resource state rather than maintaining parallel custom models.**
+- **Rationale**: The custom models duplicate upstream types. Once helpers return typed types, resources consume them directly, allowing model cleanup.
+- **Alternative considered**: Keep custom models and add adapter functions. Rejected because it preserves duplication and adds boilerplate with no benefit.
+
+**3. Preserve SDK-style `diag.Diagnostics` for SDK resources and `fwdiag.Diagnostics` for Plugin Framework resources.**
+- **Rationale**: The helper signatures are consumed by both SDK (`user_data_source.go`, `role_data_source.go`) and PF (`user/`, `role/`, `rolemapping/`, `api_key/`, `systemuser/`) resources. Keeping existing diagnostic types avoids a broader PF migration.
+
+**4. Keep not-found handling explicit and identical to today.**
+- **Rationale**: The typed client returns errors that may wrap a 404. We will inspect the underlying `*http.Response` for `StatusCode == http.StatusNotFound` so resources continue to see the same nil+no-error behavior on missing resources.
+
+**5. Retain `models.APIKeyRoleDescriptor` and related domain-specific types in resource models where they are embedded in JSON-with-defaults custom types.**
+- **Rationale**: `api_key` resources use `customtypes.JSONWithDefaultsValue[map[string]models.APIKeyRoleDescriptor]` for `role_descriptors`. Changing this to `types.RoleDescriptor` would require updating the JSON-with-defaults generic type and its default-population logic, expanding the change surface. The helper layer can accept/return typed `types.RoleDescriptor` and the resource can convert at the boundary.
+- **Alternative considered**: Replace `models.APIKeyRoleDescriptor` everywhere. Rejected because it would force changes to the `customtypes` package and the JSON defaults mechanism.
+
+**6. Update `CreateESAccessToken` to use `typedapi.Security.GetToken().Do(ctx)`.**
+- **Rationale**: The typed `gettoken.Request` and `gettoken.Response` types map cleanly to the current password-grant flow. This removes the last raw `esapi` call from `internal/acctest/security_helpers.go`.
+
+## Risks / Trade-offs
+
+- **[Risk]** Typed-client types may have slightly different JSON tags or omitempty behavior than our custom models, causing state-mapping mismatches. → **Mitigation**: Run the full acceptance test suite for affected security resources and compare TF state before/after.
+- **[Risk]** `types.Role` uses `clusterprivilege.ClusterPrivilege` enum slices instead of raw `[]string`, and `Global` has a deeply nested `map[string]map[string]map[string][]string` shape that differs from our `map[string]any`. → **Mitigation**: Verify the role resource's `toAPIModel`/`fromAPIModel` conversions produce identical JSON payloads. Acceptance tests cover all role fields.
+- **[Risk]** `types.SecurityRoleMapping.Rules` is `types.RoleMappingRule` (a typed union) rather than `map[string]any`. → **Mitigation**: The role mapping resource already serializes/rules via JSON strings. Converting `types.RoleMappingRule` back to JSON for state should yield the same normalized output.
+- **[Risk]** `types.ApiKey` does not include `EncodedKey` or the raw `api_key` credential; these only exist on create responses. → **Mitigation**: Create helpers already return separate response structs (`*createapikey.Response`, `*createcrossclusterapikey.Response`). Read helpers return `*types.ApiKey`, and the resource preserves `api_key`/`encoded` from prior state, matching today's behavior.
+- **[Risk]** Deleting custom models from `internal/models/models.go` may break imports elsewhere. → **Mitigation**: Verify all references are removed before deleting. Use `make build` to confirm.
+
+## Migration Plan
+
+1. Rewrite user helpers: `PutUser`, `GetUser`, `DeleteUser`, `EnableUser`, `DisableUser`, `ChangeUserPassword`.
+2. Rewrite role helpers: `PutRole`, `GetRole`, `DeleteRole`.
+3. Rewrite role mapping helpers: `PutRoleMapping`, `GetRoleMapping`, `DeleteRoleMapping`.
+4. Rewrite API key helpers: `CreateAPIKey`, `GetAPIKey`, `UpdateAPIKey`, `DeleteAPIKey`.
+5. Rewrite cross-cluster API key helpers: `CreateCrossClusterAPIKey`, `UpdateCrossClusterAPIKey`.
+6. Rewrite `CreateESAccessToken` in `internal/acctest/security_helpers.go`.
+7. Update all call sites in security resources and data sources to match new helper signatures and typed types.
+8. Remove now-unused custom model types from `internal/models/models.go` (or verify they are unused elsewhere).
+9. Run `make build` and targeted acceptance tests for affected resources.
+
+## Open Questions
+
+- None — the scoped client, typed client surface, and security resource patterns are already well understood.

--- a/openspec/changes/typed-client-security/proposal.md
+++ b/openspec/changes/typed-client-security/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The provider-wide typed-client migration is moving through its phases. Security is the largest API surface — covering users, roles, role mappings, API keys, and cross-cluster API keys. The `internal/clients/elasticsearch/security.go` helper file currently uses the raw `esapi` client with hand-structured request bodies, manual JSON marshaling, and ad-hoc response decoding. Migrating this to the `go-elasticsearch` Typed API (`elasticsearch.TypedClient` via `GetESTypedClient()`) eliminates runtime errors from untyped JSON, enables IDE-driven refactoring, and brings the security helpers in line with the rest of the migrated codebase.
+
+## What Changes
+
+- Migrate `internal/clients/elasticsearch/security.go` from raw `esapi` calls to typed `TypedClient.Security.*` equivalents.
+- Migrate security resources and data sources (user, role, role mapping, API key, system user) to call typed helpers instead of raw-client helpers.
+- Migrate `internal/acctest/security_helpers.go` (`CreateESAccessToken`) from raw `esapi` to typed client.
+- Remove manual `json.Marshal`/`json.Unmarshal` boilerplate where typed request/response structs are available.
+- No Terraform resource schemas, provider configuration, or user-visible behavior changes.
+
+Files affected:
+- `internal/clients/elasticsearch/security.go`
+- `internal/acctest/security_helpers.go`
+- `internal/elasticsearch/security/user/*`
+- `internal/elasticsearch/security/role/*`
+- `internal/elasticsearch/security/rolemapping/*`
+- `internal/elasticsearch/security/api_key/*`
+- `internal/elasticsearch/security/systemuser/*`
+- `internal/elasticsearch/security/user_data_source.go`
+- `internal/elasticsearch/security/role_data_source.go`
+
+## Capabilities
+
+### New Capabilities
+_(none — this is an internal refactoring with no new user-visible capabilities)_
+
+### Modified Capabilities
+_(none — no spec-level requirements change; all resource schemas, validation, and behavior remain identical)_
+
+## Impact
+
+- **Code**: Security helpers (`security.go`), security resources, data sources, and acceptance-test helpers.
+- **APIs**: No Terraform resource or data source behavior changes.
+- **Dependencies**: Relies on existing `go-elasticsearch/v8` `ToTyped()` already exposed via `ElasticsearchScopedClient.GetESTypedClient()`.
+- **Build / CI**: Compilation and acceptance tests are affected; no new dependencies introduced.

--- a/openspec/changes/typed-client-security/specs/elasticsearch-security-api-key/spec.md
+++ b/openspec/changes/typed-client-security/specs/elasticsearch-security-api-key/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for security API key
+The `elasticstack_elasticsearch_security_api_key` resource SHALL create, read, update, and invalidate API keys using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Security.CreateApiKey`, `Security.GetApiKey`, `Security.UpdateApiKey`, `Security.InvalidateApiKey`) instead of the raw `esapi` client. The typed API responses SHALL be used directly without manual JSON decoding into intermediate `models.APIKey*` types.
+
+#### Scenario: Typed API success for API key resource create
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the resource creates a regular API key
+- **THEN** the provider SHALL call `Security.CreateApiKey` on the typed client
+- **AND** the response SHALL be returned as `*createapikey.Response`
+
+#### Scenario: Typed API success for cross-cluster API key create
+- **GIVEN** a valid Elasticsearch connection and `type = "cross_cluster"`
+- **WHEN** the resource creates a cross-cluster API key
+- **THEN** the provider SHALL call `Security.CreateCrossClusterApiKey` on the typed client
+- **AND** the response SHALL be returned as `*createcrossclusterapikey.Response`
+
+#### Scenario: Typed API success for API key read
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the resource refreshes state
+- **THEN** the provider SHALL call `Security.GetApiKey` on the typed client
+- **AND** the response SHALL be used as `*types.ApiKey`

--- a/openspec/changes/typed-client-security/specs/elasticsearch-security-role-mapping/spec.md
+++ b/openspec/changes/typed-client-security/specs/elasticsearch-security-role-mapping/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for security role mapping
+The `elasticstack_elasticsearch_security_role_mapping` resource and data source SHALL retrieve and manage role mappings using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Security.PutRoleMapping`, `Security.GetRoleMapping`, `Security.DeleteRoleMapping`) instead of the raw `esapi` client. The typed API response SHALL be used directly without manual JSON decoding into an intermediate `models.RoleMapping` type.
+
+#### Scenario: Typed API success for role mapping resource
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the resource performs create, read, update, or delete
+- **THEN** the provider SHALL call the typed Security role mapping APIs
+- **AND** role mapping data SHALL be returned as `*types.SecurityRoleMapping`
+
+#### Scenario: Typed API success for role mapping data source
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the data source reads a role mapping
+- **THEN** the provider SHALL call `Security.GetRoleMapping` on the typed client
+- **AND** the response SHALL be used as `getrolemapping.Response`

--- a/openspec/changes/typed-client-security/specs/elasticsearch-security-role/spec.md
+++ b/openspec/changes/typed-client-security/specs/elasticsearch-security-role/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for security role
+The `elasticstack_elasticsearch_security_role` resource and data source SHALL retrieve and manage roles using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Security.PutRole`, `Security.GetRole`, `Security.DeleteRole`) instead of the raw `esapi` client. The typed API response SHALL be used directly without manual JSON decoding into an intermediate `models.Role` type.
+
+#### Scenario: Typed API success for role resource
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the resource performs create, read, update, or delete
+- **THEN** the provider SHALL call the typed Security role APIs
+- **AND** role data SHALL be returned as `*types.Role`
+
+#### Scenario: Typed API success for role data source
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the data source reads a role
+- **THEN** the provider SHALL call `Security.GetRole` on the typed client
+- **AND** the response SHALL be used as `getrole.Response`

--- a/openspec/changes/typed-client-security/specs/elasticsearch-security-system-user/spec.md
+++ b/openspec/changes/typed-client-security/specs/elasticsearch-security-system-user/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for security system user
+The `elasticstack_elasticsearch_security_system_user` resource SHALL read system users and toggle their enabled state using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Security.GetUser`, `Security.EnableUser`, `Security.DisableUser`, `Security.ChangePassword`) instead of the raw `esapi` client. The typed API response SHALL be used directly without manual JSON decoding into an intermediate `models.User` type.
+
+#### Scenario: Typed API success for system user resource
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the resource performs create, read, update, or delete
+- **THEN** the provider SHALL call the typed Security user APIs
+- **AND** user data SHALL be returned as `*types.User`

--- a/openspec/changes/typed-client-security/specs/elasticsearch-security-user/spec.md
+++ b/openspec/changes/typed-client-security/specs/elasticsearch-security-user/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Typed client implementation for security user
+The `elasticstack_elasticsearch_security_user` resource and data source SHALL retrieve and manage users using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Security.PutUser`, `Security.GetUser`, `Security.DeleteUser`) instead of the raw `esapi` client. The typed API response SHALL be used directly without manual JSON decoding into an intermediate `models.User` type.
+
+#### Scenario: Typed API success for user resource
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the resource performs create, read, update, or delete
+- **THEN** the provider SHALL call the typed Security user APIs
+- **AND** user data SHALL be returned as `*types.User`
+
+#### Scenario: Typed API success for user data source
+- **GIVEN** a valid Elasticsearch connection
+- **WHEN** the data source reads a user
+- **THEN** the provider SHALL call `Security.GetUser` on the typed client
+- **AND** the response SHALL be used as `getuser.Response`

--- a/openspec/changes/typed-client-security/specs/typed-client-security/spec.md
+++ b/openspec/changes/typed-client-security/specs/typed-client-security/spec.md
@@ -1,0 +1,138 @@
+## ADDED Requirements
+
+### Requirement: Security helpers use typed client
+`PutUser`, `GetUser`, `DeleteUser`, `EnableUser`, `DisableUser`, and `ChangeUserPassword` in `internal/clients/elasticsearch/security.go` SHALL use the typed `Security.PutUser`, `Security.GetUser`, `Security.DeleteUser`, `Security.EnableUser`, `Security.DisableUser`, and `Security.ChangePassword` APIs. `GetUser` SHALL return `*types.User` and SHALL return `nil` with no error when the user is not found.
+
+#### Scenario: Create or update user
+- **WHEN** `PutUser` is called with a valid user definition
+- **THEN** it calls the typed `Security.PutUser` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read existing user
+- **WHEN** `GetUser` is called for an existing user
+- **THEN** it returns `*types.User` and no error diagnostics
+
+#### Scenario: Read missing user
+- **GIVEN** the requested user does not exist
+- **WHEN** `GetUser` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete user
+- **WHEN** `DeleteUser` is called with a valid username
+- **THEN** it calls the typed `Security.DeleteUser` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Enable user
+- **WHEN** `EnableUser` is called with a valid username
+- **THEN** it calls the typed `Security.EnableUser` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Disable user
+- **WHEN** `DisableUser` is called with a valid username
+- **THEN** it calls the typed `Security.DisableUser` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Change user password
+- **WHEN** `ChangeUserPassword` is called with a valid username and password payload
+- **THEN** it calls the typed `Security.ChangePassword` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Role helpers use typed client
+`PutRole`, `GetRole`, and `DeleteRole` in `internal/clients/elasticsearch/security.go` SHALL use the typed `Security.PutRole`, `Security.GetRole`, and `Security.DeleteRole` APIs. `GetRole` SHALL return `*types.Role` and SHALL return `nil` with no error when the role is not found.
+
+#### Scenario: Create or update role
+- **WHEN** `PutRole` is called with a valid role definition
+- **THEN** it calls the typed `Security.PutRole` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read existing role
+- **WHEN** `GetRole` is called for an existing role
+- **THEN** it returns `*types.Role` and no error diagnostics
+
+#### Scenario: Read missing role
+- **GIVEN** the requested role does not exist
+- **WHEN** `GetRole` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete role
+- **WHEN** `DeleteRole` is called with a valid role name
+- **THEN** it calls the typed `Security.DeleteRole` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Role mapping helpers use typed client
+`PutRoleMapping`, `GetRoleMapping`, and `DeleteRoleMapping` in `internal/clients/elasticsearch/security.go` SHALL use the typed `Security.PutRoleMapping`, `Security.GetRoleMapping`, and `Security.DeleteRoleMapping` APIs. `GetRoleMapping` SHALL return `*types.SecurityRoleMapping` and SHALL return `nil` with no error when the role mapping is not found.
+
+#### Scenario: Create or update role mapping
+- **WHEN** `PutRoleMapping` is called with a valid role mapping definition
+- **THEN** it calls the typed `Security.PutRoleMapping` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Read existing role mapping
+- **WHEN** `GetRoleMapping` is called for an existing role mapping
+- **THEN** it returns `*types.SecurityRoleMapping` and no error diagnostics
+
+#### Scenario: Read missing role mapping
+- **GIVEN** the requested role mapping does not exist
+- **WHEN** `GetRoleMapping` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Delete role mapping
+- **WHEN** `DeleteRoleMapping` is called with a valid role mapping name
+- **THEN** it calls the typed `Security.DeleteRoleMapping` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: API key helpers use typed client
+`CreateAPIKey`, `GetAPIKey`, `UpdateAPIKey`, and `DeleteAPIKey` in `internal/clients/elasticsearch/security.go` SHALL use the typed `Security.CreateApiKey`, `Security.GetApiKey`, `Security.UpdateApiKey`, and `Security.InvalidateApiKey` APIs. `GetAPIKey` SHALL return `*types.ApiKey` and SHALL return `nil` with no error when the API key is not found.
+
+#### Scenario: Create API key
+- **WHEN** `CreateAPIKey` is called with a valid API key definition
+- **THEN** it calls the typed `Security.CreateApiKey` API
+- **AND** returns the create response and no error diagnostics on success
+
+#### Scenario: Read existing API key
+- **WHEN** `GetAPIKey` is called for an existing API key
+- **THEN** it returns `*types.ApiKey` and no error diagnostics
+
+#### Scenario: Read missing API key
+- **GIVEN** the requested API key does not exist
+- **WHEN** `GetAPIKey` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+#### Scenario: Update API key
+- **WHEN** `UpdateAPIKey` is called with a valid API key definition
+- **THEN** it calls the typed `Security.UpdateApiKey` API
+- **AND** returns no error diagnostics on success
+
+#### Scenario: Delete API key
+- **WHEN** `DeleteAPIKey` is called with a valid API key id
+- **THEN** it calls the typed `Security.InvalidateApiKey` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Cross-cluster API key helpers use typed client
+`CreateCrossClusterAPIKey` and `UpdateCrossClusterAPIKey` in `internal/clients/elasticsearch/security.go` SHALL use the typed `Security.CreateCrossClusterApiKey` and `Security.UpdateCrossClusterApiKey` APIs.
+
+#### Scenario: Create cross-cluster API key
+- **WHEN** `CreateCrossClusterAPIKey` is called with a valid definition
+- **THEN** it calls the typed `Security.CreateCrossClusterApiKey` API
+- **AND** returns the create response and no error diagnostics on success
+
+#### Scenario: Update cross-cluster API key
+- **WHEN** `UpdateCrossClusterAPIKey` is called with a valid definition
+- **THEN** it calls the typed `Security.UpdateCrossClusterApiKey` API
+- **AND** returns no error diagnostics on success
+
+### Requirement: Acceptance test helper uses typed client
+`CreateESAccessToken` in `internal/acctest/security_helpers.go` SHALL use the typed `Security.GetToken` API instead of the raw `esapi` client.
+
+#### Scenario: Create access token for tests
+- **WHEN** `CreateESAccessToken` is called
+- **THEN** it calls the typed `Security.GetToken` API with the password grant type
+- **AND** returns the access token string on success
+
+### Requirement: Custom security model types are removed
+The custom model types `User`, `UserPassword`, `Role`, `RoleMapping`, `APIKey`, `APIKeyCreateResponse`, `APIKeyResponse`, `CrossClusterAPIKey`, and `CrossClusterAPIKeyCreateResponse` in `internal/models/models.go` SHALL be removed once all callers have been migrated to typed client equivalents. No remaining code SHALL reference these types after the migration.
+
+#### Scenario: Build succeeds after model removal
+- **GIVEN** all callers have been updated to use typed client types
+- **WHEN** the custom models are removed from `internal/models/models.go`
+- **THEN** `make build` completes successfully

--- a/openspec/changes/typed-client-security/tasks.md
+++ b/openspec/changes/typed-client-security/tasks.md
@@ -1,0 +1,75 @@
+## 1. Typed client migration — user helpers
+
+- [ ] 1.1 Rewrite `PutUser` in `internal/clients/elasticsearch/security.go` to use typed `Security.PutUser` API
+- [ ] 1.2 Rewrite `GetUser` to use typed `Security.GetUser` API and return `*types.User`
+- [ ] 1.3 Rewrite `DeleteUser` to use typed `Security.DeleteUser` API
+- [ ] 1.4 Rewrite `EnableUser` to use typed `Security.EnableUser` API
+- [ ] 1.5 Rewrite `DisableUser` to use typed `Security.DisableUser` API
+- [ ] 1.6 Rewrite `ChangeUserPassword` to use typed `Security.ChangePassword` API
+- [ ] 1.7 Update `internal/elasticsearch/security/user/` resource files for new helper signatures and `*types.User`
+- [ ] 1.8 Update `internal/elasticsearch/security/user_data_source.go` for new `GetUser` signature and `*types.User`
+- [ ] 1.9 Update `internal/elasticsearch/security/systemuser/` resource files for new helper signatures and `*types.User`
+
+## 2. Typed client migration — role helpers
+
+- [ ] 2.1 Rewrite `PutRole` in `internal/clients/elasticsearch/security.go` to use typed `Security.PutRole` API
+- [ ] 2.2 Rewrite `GetRole` to use typed `Security.GetRole` API and return `*types.Role`
+- [ ] 2.3 Rewrite `DeleteRole` to use typed `Security.DeleteRole` API
+- [ ] 2.4 Update `internal/elasticsearch/security/role/` resource files for new helper signatures and `*types.Role`
+- [ ] 2.5 Update `internal/elasticsearch/security/role_data_source.go` for new `GetRole` signature and `*types.Role`
+
+## 3. Typed client migration — role mapping helpers
+
+- [ ] 3.1 Rewrite `PutRoleMapping` in `internal/clients/elasticsearch/security.go` to use typed `Security.PutRoleMapping` API
+- [ ] 3.2 Rewrite `GetRoleMapping` to use typed `Security.GetRoleMapping` API and return `*types.SecurityRoleMapping`
+- [ ] 3.3 Rewrite `DeleteRoleMapping` to use typed `Security.DeleteRoleMapping` API
+- [ ] 3.4 Update `internal/elasticsearch/security/rolemapping/` resource files for new helper signatures and `*types.SecurityRoleMapping`
+- [ ] 3.5 Update `internal/elasticsearch/security/rolemapping/data_source.go` for new `GetRoleMapping` signature
+
+## 4. Typed client migration — API key helpers
+
+- [ ] 4.1 Rewrite `CreateAPIKey` to use typed `Security.CreateApiKey` API and return `*createapikey.Response`
+- [ ] 4.2 Rewrite `GetAPIKey` to use typed `Security.GetApiKey` API and return `*types.ApiKey`
+- [ ] 4.3 Rewrite `UpdateAPIKey` to use typed `Security.UpdateApiKey` API
+- [ ] 4.4 Rewrite `DeleteAPIKey` to use typed `Security.InvalidateApiKey` API
+- [ ] 4.5 Update `internal/elasticsearch/security/api_key/` resource files for new helper signatures and typed responses
+
+## 5. Typed client migration — cross-cluster API key helpers
+
+- [ ] 5.1 Rewrite `CreateCrossClusterAPIKey` to use typed `Security.CreateCrossClusterApiKey` API and return `*createcrossclusterapikey.Response`
+- [ ] 5.2 Rewrite `UpdateCrossClusterAPIKey` to use typed `Security.UpdateCrossClusterApiKey` API
+- [ ] 5.3 Update `internal/elasticsearch/security/api_key/` resource files for new cross-cluster helper signatures
+
+## 6. Typed client migration — acceptance test helper
+
+- [ ] 6.1 Rewrite `CreateESAccessToken` in `internal/acctest/security_helpers.go` to use typed `Security.GetToken` API
+- [ ] 6.2 Remove raw `esapi` import and manual JSON marshaling from `security_helpers.go`
+
+## 7. Model cleanup and verification
+
+- [ ] 7.1 Verify `models.User` is no longer used outside `security.go`, then remove from `internal/models/models.go`
+- [ ] 7.2 Verify `models.UserPassword` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.3 Verify `models.Role` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.4 Verify `models.RoleMapping` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.5 Verify `models.APIKey` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.6 Verify `models.APIKeyCreateResponse` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.7 Verify `models.APIKeyResponse` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.8 Verify `models.CrossClusterAPIKey` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.9 Verify `models.CrossClusterAPIKeyCreateResponse` is no longer used, then remove from `internal/models/models.go`
+- [ ] 7.10 Run `go mod tidy` and `make build` to confirm compilation
+
+## 8. Testing
+
+- [ ] 8.1 Run unit tests for `internal/elasticsearch/security/user`
+- [ ] 8.2 Run unit tests for `internal/elasticsearch/security/role`
+- [ ] 8.3 Run unit tests for `internal/elasticsearch/security/rolemapping`
+- [ ] 8.4 Run unit tests for `internal/elasticsearch/security/api_key`
+- [ ] 8.5 Run unit tests for `internal/elasticsearch/security/systemuser`
+- [ ] 8.6 Run acceptance tests for `elasticstack_elasticsearch_security_user`
+- [ ] 8.7 Run acceptance tests for `elasticstack_elasticsearch_security_role`
+- [ ] 8.8 Run acceptance tests for `elasticstack_elasticsearch_security_role_mapping`
+- [ ] 8.9 Run acceptance tests for `elasticstack_elasticsearch_security_api_key`
+- [ ] 8.10 Run acceptance tests for `elasticstack_elasticsearch_security_system_user`
+- [ ] 8.11 Run acceptance tests for user data source
+- [ ] 8.12 Run acceptance tests for role data source
+- [ ] 8.13 Run `make check-lint` and `make check-openspec`

--- a/openspec/changes/typed-client-transform/.openspec.yaml
+++ b/openspec/changes/typed-client-transform/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/typed-client-transform/design.md
+++ b/openspec/changes/typed-client-transform/design.md
@@ -1,0 +1,75 @@
+## Context
+
+`internal/clients/elasticsearch/transform.go` currently contains seven helper functions that perform Elasticsearch Transform API operations using the raw `esapi` client (`*elasticsearch.Client`). Each helper manually constructs HTTP requests via the `esapi` namespace, marshals request bodies into custom `models` types, and unmarshals JSON responses into parallel custom structs. The `go-elasticsearch/v8` library provides strongly-typed equivalents for all of these APIs via `elasticsearch.TypedClient`.
+
+The typed client is already available through `ElasticsearchScopedClient.GetESTypedClient()` (introduced in `typed-client-bootstrap`). The scoped client caches the typed instance so callers do not pay the `ToTyped()` cost on every invocation.
+
+The transform resource (`internal/elasticsearch/transform/transform.go`) is a Terraform Plugin SDK resource that consumes these helpers and performs schema-level state mapping. The resource supports version-gated capabilities such as `destination.aliases` (ES >= 8.8.0) that may not be fully represented in the current typed-client generated types.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rewrite all functions in `internal/clients/elasticsearch/transform.go` to use the typed client APIs.
+- Update the transform resource and tests to call the migrated helpers.
+- Preserve exact Terraform-visible behavior: identical state mapping, identical error messages, identical not-found handling, identical start/stop semantics.
+- Replace custom model types with typed-client equivalents where the shapes match one-to-one.
+
+**Non-Goals:**
+- Adding new Terraform resources or data sources.
+- Changing schema definitions, validation, or plan modifiers.
+- Modifying provider-level client construction or the scoped-client type itself.
+- Removing support for version-gated fields that are not yet present in the typed-client specification.
+
+## Decisions
+
+**1. Use `client.GetESTypedClient()` to obtain the typed client.**
+- **Rationale**: The scoped client already caches the typed client. Using the accessor keeps the change consistent with the bootstrap pattern and avoids per-call `ToTyped()` overhead.
+- **Alternative considered**: Calling `client.GetESClient().ToTyped()` inline. Rejected because it would bypass the cached instance and add unnecessary allocations.
+
+**2. Migrate Delete, Start, Stop, and Stats helpers to fully-typed `.Do()` calls.**
+- **Rationale**: These APIs have simple request/response shapes and the typed client models them completely. `DeleteTransform`, `StartTransform`, `StopTransform`, and `GetTransformStats` can be expressed entirely through the typed API with no custom JSON handling.
+- **Alternative considered**: Keeping raw `esapi` for these. Rejected because the typed API is a direct replacement with no gaps.
+
+**3. Use `.Raw()` for Put and Update Transform request bodies.**
+- **Rationale**: The typed `puttransform.Request.Dest` is `types.TransformDestination`, which does not include the `aliases` field that the resource supports (ES >= 8.8.0). Rather than dropping aliases support or constructing hybrid JSON, we keep the existing `models.Transform` body-building logic, marshal it to JSON, and pass the payload via the typed API's `.Raw()` method. This still moves the call off the raw `esapi` namespace and onto the typed client's transport, error handling, and parameter helpers (`Timeout()`, `DeferValidation()`).
+- **Alternative considered**: Building `puttransform.Request` directly with typed structures. Rejected because it would silently drop `destination.aliases`, violating the zero-behavior-change requirement.
+
+**4. Keep manual response decoding for Get Transform.**
+- **Rationale**: The typed `gettransform.Response` uses `types.TransformSummary`, whose `Dest` field is `types.ReindexDestination` — again lacking `aliases`. To preserve read-back of aliases and all other fields, `GetTransform` will use the typed client's `.Perform()` to obtain the raw `*http.Response`, then decode into the existing `models.GetTransformResponse` structure exactly as today.
+- **Alternative considered**: Using `.Do()` and mapping from `types.TransformSummary`. Rejected because it would lose `aliases` on read.
+
+**5. Preserve `diag.Diagnostics` return type for SDK compatibility.**
+- **Rationale**: The transform resource is a Plugin SDK resource. Helper signatures already return `diag.Diagnostics`. Keeping this return type avoids expanding the change into SDK-to-PF migration territory.
+- **Alternative considered**: Migrating to `fwdiag.Diagnostics`. Rejected because that belongs to a separate PF migration effort.
+
+**6. Retain custom models for request body construction and Get response decoding; remove response-only wrappers where possible.**
+- **Rationale**: `models.Transform` and its nested types are still needed for JSON body construction (Put/Update) and response decoding (Get). `models.PutTransformParams`, `models.UpdateTransformParams`, and `models.TransformStats` can be removed because their shapes are superseded by typed-client parameters and `types.TransformStats`. `models.GetTransformResponse` is retained as the decode target for Get Transform.
+- **Alternative considered**: Removing all custom models unconditionally. Rejected because the gap in typed-client types for aliases makes them still necessary.
+
+## Risks / Trade-offs
+
+- **[Risk]** The typed-client `types.TransformDestination` and `types.ReindexDestination` do not model `aliases`. For Put/Update we work around this with `.Raw()`; for Get we work around it with manual decode. If a future `go-elasticsearch` version adds aliases to these types, the workaround can be replaced with native typed structures.
+  - **Mitigation**: Document the workaround in code comments and leave a TODO referencing the upstream gap.
+- **[Risk]** `types.Settings.DocsPerSecond` is `*float32` while our model uses `*float64`. Converting between them could introduce precision loss.
+  - **Mitigation**: Since we use `.Raw()` for Put/Update, we bypass `types.Settings` entirely for write paths. On read, `types.TransformSummary.Settings` is not consumed because we decode the raw response.
+- **[Risk]** Typed-client error responses are returned as `*types.ElasticsearchError`. The current `diagutil.CheckError` expects an `*http.Response`. When using `.Do()`, the error is already parsed.
+  - **Mitigation**: For helpers using `.Do()`, wrap the returned `error` directly into diagnostics. For helpers using `.Perform()`, continue using `diagutil.CheckError` on the raw response.
+- **[Risk]** Manual JSON decode for Get Transform means we do not benefit from typed-client response validation.
+  - **Mitigation**: The decode target (`models.GetTransformResponse`) has been stable for multiple provider releases. Acceptance tests will verify the mapping remains correct.
+
+## Migration Plan
+
+1. Update `PutTransform` to obtain the typed client, build the `models.Transform` body as today, marshal to JSON, and call `typedClient.Transform.PutTransform(name).Raw(body).Timeout(...).DeferValidation(...).Do(ctx)`.
+2. Update `GetTransform` to use `typedClient.Transform.GetTransform().TransformId(name).Perform(ctx)`, then decode the response into `models.GetTransformResponse` and search for the matching transform.
+3. Update `GetTransformStats` to use `typedClient.Transform.GetTransformStats(name).Do(ctx)`, then search the returned `[]types.TransformStats` for the matching ID.
+4. Update `UpdateTransform` to use the typed client with `.Raw()` for the body, mirroring the Put approach.
+5. Update `DeleteTransform` to use `typedClient.Transform.DeleteTransform(name).Force(true).Do(ctx)`.
+6. Update `startTransform` to use `typedClient.Transform.StartTransform(name).Timeout(...).Do(ctx)`.
+7. Update `stopTransform` to use `typedClient.Transform.StopTransform(name).Timeout(...).Do(ctx)`.
+8. Update `internal/elasticsearch/transform/transform.go` to call the new helpers (signatures remain the same, so call sites should need zero or minimal changes).
+9. Remove now-unused custom model types (`models.PutTransformParams`, `models.UpdateTransformParams`, `models.TransformStats`, `models.GetTransformStatsResponse`) from `internal/models/transform.go` if they are no longer referenced elsewhere.
+10. Run `make build` and targeted acceptance tests for `elasticstack_elasticsearch_transform`.
+
+## Open Questions
+
+- None — the scoped client and typed client surface are already well understood.

--- a/openspec/changes/typed-client-transform/proposal.md
+++ b/openspec/changes/typed-client-transform/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The provider is incrementally migrating Elasticsearch API calls from the raw `esapi` (untyped) client to the `go-elasticsearch` Typed API (`elasticsearch.TypedClient`). The transform helpers in `internal/clients/elasticsearch/transform.go` are the next surface to migrate. Using the typed client eliminates hand-structured JSON request bodies, removes manual JSON marshaling/unmarshaling boilerplate, and enables compile-time API shape checking.
+
+## What Changes
+
+- Migrate `internal/clients/elasticsearch/transform.go` helper functions to use the typed client:
+  - `PutTransform` → typed `Transform.PutTransform` API
+  - `GetTransform` → typed `Transform.GetTransform` API
+  - `GetTransformStats` → typed `Transform.GetTransformStats` API
+  - `UpdateTransform` → typed `Transform.UpdateTransform` API
+  - `DeleteTransform` → typed `Transform.DeleteTransform` API
+  - `startTransform` → typed `Transform.StartTransform` API
+  - `stopTransform` → typed `Transform.StopTransform` API
+- Replace custom model types (`models.Transform`, `models.TransformStats`, `models.PutTransformParams`, `models.UpdateTransformParams`, and related response wrappers) with their typed-client equivalents where possible.
+- Update the `internal/elasticsearch/transform/transform.go` resource and test files to consume the migrated helpers.
+- Ensure zero behavioral changes from the Terraform user perspective; this is a pure implementation refactor.
+
+Files affected:
+- `internal/clients/elasticsearch/transform.go`
+- `internal/models/transform.go`
+- `internal/elasticsearch/transform/transform.go`
+- `internal/elasticsearch/transform/transform_test.go`
+
+## Capabilities
+
+### New Capabilities
+_(none — this is an internal refactoring with no new user-visible capabilities)_
+
+### Modified Capabilities
+- `elasticsearch-transform`: Migrate internal Transform API client usage from raw `esapi` to the typed API. The Terraform resource schema and user-visible behavior remain identical, but the implementation contract (helper signatures, model structs, and response parsing paths) changes, warranting an updated spec.
+
+## Impact
+
+- **Code**: Transform helpers (`transform.go`), transform resource, and transform tests.
+- **APIs**: No Terraform resource or data source behavior changes.
+- **Dependencies**: Relies on existing `go-elasticsearch/v8` Typed API support via `ElasticsearchScopedClient.GetESTypedClient()`.
+- **Build / CI**: Compilation and acceptance tests are affected; no new dependencies introduced.

--- a/openspec/changes/typed-client-transform/specs/elasticsearch-transform/spec.md
+++ b/openspec/changes/typed-client-transform/specs/elasticsearch-transform/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Transform create uses typed client
+`PutTransform` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.PutTransform`). It SHALL pass the transform request body via the typed API's `.Raw()` method so that all fields — including `destination.aliases` — are preserved. Query parameters (`defer_validation`, `timeout`) SHALL be set via the typed API builder methods. The helper SHALL surface API errors as Terraform diagnostics.
+
+#### Scenario: Typed API create with aliases
+- **GIVEN** a transform configuration that includes `destination.aliases`
+- **WHEN** `PutTransform` is called
+- **THEN** it calls the typed `Transform.PutTransform` API
+- **AND** the request body includes the `aliases` field
+- **AND** it returns no error diagnostics on success
+
+#### Scenario: Typed API create error handling
+- **GIVEN** the Put Transform API returns an error
+- **WHEN** `PutTransform` processes the response
+- **THEN** it returns Terraform diagnostics containing the API error
+
+### Requirement: Transform read uses typed client
+`GetTransform` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.GetTransform`) via `.Perform()` to obtain the raw HTTP response. It SHALL decode the response body into the existing `models.GetTransformResponse` structure so that all fields — including `destination.aliases` — are read correctly. When the API returns HTTP 404, the helper SHALL return `nil` with no error diagnostics.
+
+#### Scenario: Typed API read existing transform
+- **GIVEN** an existing transform with `destination.aliases`
+- **WHEN** `GetTransform` is called
+- **THEN** it calls the typed `Transform.GetTransform` API
+- **AND** the returned transform includes the `aliases` field
+- **AND** it returns no error diagnostics
+
+#### Scenario: Typed API read missing transform
+- **GIVEN** the requested transform does not exist
+- **WHEN** `GetTransform` is called
+- **THEN** it returns `nil` and no error diagnostics
+
+### Requirement: Transform stats uses typed client
+`GetTransformStats` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.GetTransformStats`). It SHALL search the returned `[]types.TransformStats` for the matching transform ID and derive the `enabled` state from the `state` field ("started" or "indexing" means enabled).
+
+#### Scenario: Typed API stats for started transform
+- **GIVEN** a transform whose state is "started"
+- **WHEN** `GetTransformStats` is called
+- **THEN** it calls the typed `Transform.GetTransformStats` API
+- **AND** it returns stats with `IsStarted() == true`
+
+#### Scenario: Typed API stats for stopped transform
+- **GIVEN** a transform whose state is "stopped"
+- **WHEN** `GetTransformStats` is called
+- **THEN** it calls the typed `Transform.GetTransformStats` API
+- **AND** it returns stats with `IsStarted() == false`
+
+### Requirement: Transform update uses typed client
+`UpdateTransform` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.UpdateTransform`). It SHALL pass the transform request body via the typed API's `.Raw()` method so that all updatable fields are preserved. Query parameters (`defer_validation`, `timeout`) SHALL be set via the typed API builder methods. After a successful update, it SHALL optionally call `startTransform` or `stopTransform` based on the `enabled` change exactly as today.
+
+#### Scenario: Typed API update with enabled change
+- **GIVEN** an existing transform and `enabled` changed to `false`
+- **WHEN** `UpdateTransform` is called
+- **THEN** it calls the typed `Transform.UpdateTransform` API
+- **AND** it calls `stopTransform` after the update succeeds
+- **AND** it returns no error diagnostics on success
+
+#### Scenario: Typed API update without enabled change
+- **GIVEN** an existing transform and `enabled` is unchanged
+- **WHEN** `UpdateTransform` is called
+- **THEN** it calls the typed `Transform.UpdateTransform` API
+- **AND** it does NOT call `startTransform` or `stopTransform`
+
+### Requirement: Transform delete uses typed client
+`DeleteTransform` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.DeleteTransform`). It SHALL pass `force=true` via the typed API builder method. The helper SHALL surface API errors as Terraform diagnostics.
+
+#### Scenario: Typed API delete transform
+- **GIVEN** an existing transform
+- **WHEN** `DeleteTransform` is called
+- **THEN** it calls the typed `Transform.DeleteTransform` API with `force=true`
+- **AND** it returns no error diagnostics on success
+
+#### Scenario: Typed API delete error handling
+- **GIVEN** the Delete Transform API returns an error
+- **WHEN** `DeleteTransform` processes the response
+- **THEN** it returns Terraform diagnostics containing the API error
+
+### Requirement: Transform start uses typed client
+`startTransform` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.StartTransform`). It SHALL pass the `timeout` parameter via the typed API builder method. The helper SHALL surface API errors as Terraform diagnostics.
+
+#### Scenario: Typed API start transform
+- **GIVEN** a stopped transform
+- **WHEN** `startTransform` is called
+- **THEN** it calls the typed `Transform.StartTransform` API
+- **AND** it returns no error diagnostics on success
+
+### Requirement: Transform stop uses typed client
+`stopTransform` SHALL use the go-elasticsearch Typed API (`elasticsearch.TypedClient.Transform.StopTransform`). It SHALL pass the `timeout` parameter via the typed API builder method. The helper SHALL surface API errors as Terraform diagnostics.
+
+#### Scenario: Typed API stop transform
+- **GIVEN** a started transform
+- **WHEN** `stopTransform` is called
+- **THEN** it calls the typed `Transform.StopTransform` API
+- **AND** it returns no error diagnostics on success
+
+### Requirement: Unused transform model types are removed
+The custom model types `models.PutTransformParams`, `models.UpdateTransformParams`, `models.TransformStats`, and `models.GetTransformStatsResponse` SHALL be removed once all callers have been migrated to typed client equivalents or to inline parameters. `models.Transform` and `models.GetTransformResponse` MAY be retained for JSON body construction and response decoding where the typed API types do not fully cover provider-supported fields.
+
+#### Scenario: Build succeeds after model cleanup
+- **GIVEN** all callers have been updated to use typed client types or inline params
+- **WHEN** the unused custom models are removed from `internal/models/transform.go`
+- **THEN** `make build` completes successfully

--- a/openspec/changes/typed-client-transform/specs/typed-client-transform/spec.md
+++ b/openspec/changes/typed-client-transform/specs/typed-client-transform/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Transform helper functions use typed client
+All functions in `internal/clients/elasticsearch/transform.go` SHALL use `GetESTypedClient()` and SHALL call the corresponding typed API methods instead of raw `esapi` methods.
+
+#### Scenario: PutTransform uses typed client
+- **WHEN** `PutTransform` is invoked
+- **THEN** it calls `client.Transform.PutTransform(...).Do(ctx)` instead of `esClient.TransformPutTransform(...)`
+
+#### Scenario: GetTransform uses typed client
+- **WHEN** `GetTransform` is invoked
+- **THEN** it calls `client.Transform.GetTransform(...).Do(ctx)` and returns a typed `*types.Transform` instead of decoding into a custom model
+
+#### Scenario: GetTransformStats uses typed client
+- **WHEN** `GetTransformStats` is invoked
+- **THEN** it calls `client.Transform.GetTransformStats(...).Do(ctx)` and returns a typed `*types.TransformStats` instead of decoding into a custom model
+
+#### Scenario: UpdateTransform uses typed client
+- **WHEN** `UpdateTransform` is invoked
+- **THEN** it calls `client.Transform.UpdateTransform(...).Do(ctx)` instead of `esClient.TransformUpdateTransform(...)`
+
+#### Scenario: DeleteTransform uses typed client
+- **WHEN** `DeleteTransform` is invoked
+- **THEN** it calls `client.Transform.DeleteTransform(...).Force(true).Do(ctx)` instead of `esClient.TransformDeleteTransform(...)`
+
+#### Scenario: startTransform uses typed client
+- **WHEN** `startTransform` is invoked
+- **THEN** it calls `client.Transform.StartTransform(...).Do(ctx)` instead of `esClient.TransformStartTransform(...)`
+
+#### Scenario: stopTransform uses typed client
+- **WHEN** `stopTransform` is invoked
+- **THEN** it calls `client.Transform.StopTransform(...).Do(ctx)` instead of `esClient.TransformStopTransform(...)`
+
+### Requirement: Transform resource uses typed client
+`internal/elasticsearch/transform/transform.go` SHALL consume the migrated helpers and SHALL NOT call raw `esapi` transform methods directly.
+
+#### Scenario: Create uses typed PutTransform
+- **WHEN** the transform resource creates a transform
+- **THEN** it calls `elasticsearch.PutTransform(...)` which uses the typed client internally
+
+#### Scenario: Read uses typed GetTransform and GetTransformStats
+- **WHEN** the transform resource reads a transform
+- **THEN** it calls `elasticsearch.GetTransform(...)` and `elasticsearch.GetTransformStats(...)` which use the typed client internally
+
+#### Scenario: Update uses typed UpdateTransform
+- **WHEN** the transform resource updates a transform
+- **THEN** it calls `elasticsearch.UpdateTransform(...)` which uses the typed client internally
+
+#### Scenario: Delete uses typed DeleteTransform
+- **WHEN** the transform resource deletes a transform
+- **THEN** it calls `elasticsearch.DeleteTransform(...)` which uses the typed client internally
+
+### Requirement: Redundant custom transform model structs removed
+`internal/models/transform.go` SHALL be deleted, and the provider SHALL NOT contain custom structs `Transform`, `TransformSource`, `TransformDestination`, `TransformAlias`, `TransformRetentionPolicy`, `TransformRetentionPolicyTime`, `TransformSync`, `TransformSyncTime`, `TransformSettings`, `PutTransformParams`, `UpdateTransformParams`, `GetTransformResponse`, `TransformStats`, or `GetTransformStatsResponse`.
+
+#### Scenario: Transform model file is absent
+- **WHEN** checking for `internal/models/transform.go`
+- **THEN** the file does not exist
+
+#### Scenario: Custom transform types have no remaining references
+- **WHEN** searching the codebase for `models.Transform`, `models.TransformStats`, or other custom transform types
+- **THEN** no references exist in compiling source files
+
+### Requirement: Transform acceptance tests compile and pass
+`internal/elasticsearch/transform/transform_test.go` SHALL compile successfully after the migration, and the transform acceptance test suite SHALL pass.
+
+#### Scenario: CheckDestroy uses typed client
+- **WHEN** `checkResourceTransformDestroy` runs
+- **THEN** it uses the typed client to verify transform deletion
+
+#### Scenario: Acceptance tests pass after migration
+- **WHEN** running the transform acceptance tests
+- **THEN** all tests pass without errors
+
+### Requirement: Project builds successfully after transform migration
+`make build` SHALL complete without errors after all transform files are migrated and redundant models are removed.
+
+#### Scenario: Clean build after transform migration
+- **WHEN** running `make build`
+- **THEN** the command exits with status 0 and produces no compilation errors
+
+### Requirement: Lint checks pass after transform migration
+`make check-lint` SHALL complete without new lint failures introduced by the typed-client migration.
+
+#### Scenario: Lint passes after transform migration
+- **WHEN** running `make check-lint`
+- **THEN** the command exits with status 0

--- a/openspec/changes/typed-client-transform/tasks.md
+++ b/openspec/changes/typed-client-transform/tasks.md
@@ -1,0 +1,29 @@
+## 1. Typed client migration — transform helpers
+
+- [ ] 1.1 Rewrite `PutTransform` in `internal/clients/elasticsearch/transform.go` to use `typedClient.Transform.PutTransform(name).Raw(body).Timeout(...).DeferValidation(...).Do(ctx)`
+- [ ] 1.2 Rewrite `GetTransform` to use `typedClient.Transform.GetTransform().TransformId(name).Perform(ctx)` and manual decode into `models.GetTransformResponse`
+- [ ] 1.3 Rewrite `GetTransformStats` to use `typedClient.Transform.GetTransformStats(name).Do(ctx)` and search `[]types.TransformStats` for the matching ID
+- [ ] 1.4 Rewrite `UpdateTransform` to use `typedClient.Transform.UpdateTransform(name).Raw(body).Timeout(...).DeferValidation(...).Do(ctx)`
+- [ ] 1.5 Rewrite `DeleteTransform` to use `typedClient.Transform.DeleteTransform(name).Force(true).Do(ctx)`
+- [ ] 1.6 Rewrite `startTransform` to use `typedClient.Transform.StartTransform(name).Timeout(...).Do(ctx)`
+- [ ] 1.7 Rewrite `stopTransform` to use `typedClient.Transform.StopTransform(name).Timeout(...).Do(ctx)`
+
+## 2. Resource and test updates
+
+- [ ] 2.1 Update `internal/elasticsearch/transform/transform.go` to call the migrated helpers (verify signatures remain compatible)
+- [ ] 2.2 Update `internal/elasticsearch/transform/transform_test.go` for any signature or type changes
+- [ ] 2.3 Verify all transform testdata configurations still compile and run correctly
+
+## 3. Model cleanup
+
+- [ ] 3.1 Remove `models.PutTransformParams` from `internal/models/transform.go` once `PutTransform` no longer needs it
+- [ ] 3.2 Remove `models.UpdateTransformParams` from `internal/models/transform.go` once `UpdateTransform` no longer needs it
+- [ ] 3.3 Remove `models.TransformStats` and `models.GetTransformStatsResponse` from `internal/models/transform.go` once `GetTransformStats` returns `*types.TransformStats` directly
+- [ ] 3.4 Verify `models.Transform` and `models.GetTransformResponse` are not removed — they are still needed for `.Raw()` body construction and manual response decode
+
+## 4. Build and testing
+
+- [ ] 4.1 Run `make build` to confirm compilation
+- [ ] 4.2 Run unit tests for `internal/elasticsearch/transform`
+- [ ] 4.3 Run acceptance tests for `elasticstack_elasticsearch_transform`
+- [ ] 4.4 Run `make check-lint` and `make check-openspec`


### PR DESCRIPTION
## Summary

This PR adds OpenSpec change proposals for migrating the provider's Elasticsearch client from the raw untyped `esapi` interface to the strongly-typed `go-elasticsearch` Typed API (via `elasticsearch.Client.ToTyped()`).

## Phase Overview

| Phase | Change | Scope |
|-------|--------|-------|
| 1 | `typed-client-bootstrap` | Add `GetESTypedClient()` bridge method |
| 2 | `typed-client-easy-wins` | inference, logstash, enrich, watch helpers |
| 3 | `typed-client-cluster` | cluster info, snapshot repo, SLM, settings, scripts |
| 4 | `typed-client-transform` | transforms + resource |
| 5 | `typed-client-ml` | ML jobs/datafeeds + anomaly detection resource |
| 6 | `typed-client-security` | users, roles, role mappings, API keys |
| 7 | `typed-client-index` | ILM, templates, indices, aliases, pipelines |
| 8 | `typed-client-acceptance-tests` | All remaining test files |
| 9 | `typed-client-final-cleanup` | Remove raw client, delete helpers/models |

## What's Included

Each phase contains:
- **proposal.md** — What and why
- **design.md** — Key decisions, risks, migration plan
- **specs/** — Delta requirements with scenarios
- **tasks.md** — Implementation checklist

## References

- Fixes #2327

---


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration plan and specs for typed go-elasticsearch client across all provider helpers
> Adds OpenSpec planning documents (proposals, designs, tasks, and specs) for migrating all internal Elasticsearch helper functions from raw `esapi` to the go-elasticsearch `TypedClient`.
>
> - Covers security (users, roles, role mappings, API keys), cluster (info, settings, SLM, snapshot repositories, scripts), index (ILM, templates, indices, aliases, data streams, ingest), ML, transform, and inference/logstash/enrich/watch helpers
> - Defines a bootstrap step to add `GetESTypedClient()` with lazy, thread-safe initialization on `ElasticsearchScopedClient` before migrating each domain
> - Specifies replacing manual JSON marshal/unmarshal and custom model structs with typed request/response types from `typedapi/types`
> - Includes migration of acceptance test helpers to use `GetESTypedClient()` and typed assertions
> - Final cleanup step removes the raw `*elasticsearch.Client` entirely and deletes obsolete helper and model files
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d205a63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->