### PR TITLE
typed-client-easy-wins: Migrate inference, logstash, enrich, watch helpers to typed client

### DIFF
--- a/internal/clients/elasticsearch/enrich.go
+++ b/internal/clients/elasticsearch/enrich.go
@@ -20,139 +20,133 @@ package elasticsearch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io"
-	"net/http"
 
-	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/enrichpolicyphase"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
-	"github.com/elastic/terraform-provider-elasticstack/internal/diagutil"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
-type enrichPolicyResponse struct {
-	Name         string         `json:"name"`
-	Indices      []string       `json:"indices"`
-	MatchField   string         `json:"match_field"`
-	EnrichFields []string       `json:"enrich_fields"`
-	Query        map[string]any `json:"query,omitempty"`
-}
-
-type enrichPoliciesResponse struct {
-	Policies []struct {
-		Config map[string]enrichPolicyResponse `json:"config"`
-	} `json:"policies"`
-}
-
-var policyTypes = []string{"range", "match", "geo_match"}
-
-func getPolicyType(m map[string]enrichPolicyResponse) (string, error) {
-	for _, policyType := range policyTypes {
-		if _, ok := m[policyType]; ok {
-			return policyType, nil
-		}
-	}
-	return "", fmt.Errorf("did not find expected policy type")
-}
-
 func GetEnrichPolicy(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, policyName string) (*models.EnrichPolicy, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	esClient, err := apiClient.GetESClient()
+
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
-	req := esClient.EnrichGetPolicy.WithName(policyName)
-	res, err := esClient.EnrichGetPolicy(req, esClient.EnrichGetPolicy.WithContext(ctx))
+
+	res, err := typedClient.Enrich.GetPolicy().Name(policyName).Do(ctx)
 	if err != nil {
-		return nil, diag.FromErr(err)
-	}
-	defer res.Body.Close()
-	if res.StatusCode == http.StatusNotFound {
-		return nil, nil
-	}
-	if diags := diagutil.CheckError(res, fmt.Sprintf("Unable to get requested EnrichPolicy: %s", policyName)); diags.HasError() {
-		return nil, diags
-	}
-
-	var policies enrichPoliciesResponse
-	if err := json.NewDecoder(res.Body).Decode(&policies); err != nil {
+		var esErr *types.ElasticsearchError
+		if errors.As(err, &esErr) && esErr.Status == 404 {
+			return nil, nil
+		}
 		return nil, diag.FromErr(err)
 	}
 
-	if len(policies.Policies) == 0 {
+	if len(res.Policies) == 0 {
 		return nil, diags
 	}
 
-	if len(policies.Policies) > 1 {
+	if len(res.Policies) > 1 {
 		tflog.Warn(ctx, fmt.Sprintf(`Somehow found more than one policy for policy named %s`, policyName))
 	}
-	config := policies.Policies[0].Config
-	policyType, err := getPolicyType(config)
-	if err != nil {
-		return nil, diag.FromErr(err)
+
+	summary := res.Policies[0]
+
+	var policyType string
+	var policy types.EnrichPolicy
+	for pt, p := range summary.Config {
+		policyType = pt.String()
+		policy = p
+		break
 	}
-	policy := config[policyType]
-	queryJSON, err := json.Marshal(policy.Query)
-	if err != nil {
-		return nil, diag.FromErr(err)
+
+	name := policyName
+	if policy.Name != nil {
+		name = *policy.Name
+	}
+
+	var queryStr string
+	if policy.Query != nil {
+		queryBytes, err := json.Marshal(policy.Query)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		queryStr = string(queryBytes)
 	}
 
 	return &models.EnrichPolicy{
 		Type:         policyType,
-		Name:         policy.Name,
+		Name:         name,
 		Indices:      policy.Indices,
 		MatchField:   policy.MatchField,
 		EnrichFields: policy.EnrichFields,
-		Query:        string(queryJSON),
+		Query:        queryStr,
 	}, diags
 }
 
-func tryJSONUnmarshalString(s string) (any, bool) {
-	var data any
-	if err := json.Unmarshal([]byte(s), &data); err != nil {
-		return s, false
-	}
-	return data, true
-}
-
 func PutEnrichPolicy(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, policy *models.EnrichPolicy) diag.Diagnostics {
-	payloadPolicy := map[string]any{
-		"indices":       policy.Indices,
-		"enrich_fields": policy.EnrichFields,
-		"match_field":   policy.MatchField,
+	var diags diag.Diagnostics
+
+	typedClient, err := apiClient.GetESTypedClient()
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
-	if query, ok := tryJSONUnmarshalString(policy.Query); ok {
-		payloadPolicy["query"] = query
-	} else if policy.Query != "" {
-		tflog.Error(ctx, fmt.Sprintf("JAW: query did not unmarshall %s", policy.Query))
+	enrichPolicy := &types.EnrichPolicy{
+		Indices:      policy.Indices,
+		MatchField:   policy.MatchField,
+		EnrichFields: policy.EnrichFields,
 	}
 
-	payload := map[string]any{policy.Type: payloadPolicy}
-	return doSDKWrite(apiClient, payload, "Unable to create enrich policy",
-		func(esClient *elasticsearch.Client, body io.Reader) (*esapi.Response, error) {
-			return esClient.EnrichPutPolicy(policy.Name, body, esClient.EnrichPutPolicy.WithContext(ctx))
-		},
-	)
+	if policy.Query != "" {
+		var query types.Query
+		if err := json.Unmarshal([]byte(policy.Query), &query); err != nil {
+			return diag.FromErr(err)
+		}
+		enrichPolicy.Query = &query
+	}
+
+	req := typedClient.Enrich.PutPolicy(policy.Name)
+	switch policy.Type {
+	case "geo_match":
+		req.GeoMatch(enrichPolicy)
+	case "match":
+		req.Match(enrichPolicy)
+	case "range":
+		req.Range(enrichPolicy)
+	default:
+		return diag.Errorf("unsupported enrich policy type: %s", policy.Type)
+	}
+
+	_, err = req.Do(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
 }
 
 func DeleteEnrichPolicy(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, policyName string) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	esClient, err := apiClient.GetESClient()
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	res, err := esClient.EnrichDeletePolicy(policyName, esClient.EnrichDeletePolicy.WithContext(ctx))
+
+	_, err = typedClient.Enrich.DeletePolicy(policyName).Do(ctx)
 	if err != nil {
+		var esErr *types.ElasticsearchError
+		if errors.As(err, &esErr) && esErr.Status == 404 {
+			return diags
+		}
 		return diag.FromErr(err)
-	}
-	defer res.Body.Close()
-	if diags := diagutil.CheckError(res, fmt.Sprintf("Unable to delete enrich policy: %s", policyName)); diags.HasError() {
-		return diags
 	}
 
 	return diags
@@ -160,30 +154,24 @@ func DeleteEnrichPolicy(ctx context.Context, apiClient *clients.ElasticsearchSco
 
 func ExecuteEnrichPolicy(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, policyName string) diag.Diagnostics {
 	var diags diag.Diagnostics
-	esClient, err := apiClient.GetESClient()
+
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	res, err := esClient.EnrichExecutePolicy(
-		policyName, esClient.EnrichExecutePolicy.WithContext(ctx), esClient.EnrichExecutePolicy.WithWaitForCompletion(true),
-	)
+
+	res, err := typedClient.Enrich.ExecutePolicy(policyName).WaitForCompletion(true).Do(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		return diag.Errorf(`Executing policy "%s" failed with http status %d`, policyName, res.StatusCode)
+
+	if res.Status == nil {
+		return diag.Errorf(`Unexpected response to executing enrich policy: no status`)
 	}
-	var response struct {
-		Status struct {
-			Phase string `json:"phase"`
-		} `json:"status"`
+
+	if res.Status.Phase != enrichpolicyphase.COMPLETE {
+		return diag.Errorf(`Unexpected response to executing enrich policy: %s`, res.Status.Phase.String())
 	}
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
-		return diag.FromErr(err)
-	}
-	if response.Status.Phase != "COMPLETE" {
-		return diag.Errorf(`Unexpected response to executing enrich policy: %s`, response.Status.Phase)
-	}
+
 	return diags
 }

--- a/internal/clients/elasticsearch/enrich.go
+++ b/internal/clients/elasticsearch/enrich.go
@@ -65,6 +65,9 @@ func GetEnrichPolicy(ctx context.Context, apiClient *clients.ElasticsearchScoped
 		policy = p
 		break
 	}
+	if policyType == "" {
+		return nil, diag.Errorf("enrich policy %s has no recognized policy type", policyName)
+	}
 
 	name := policyName
 	if policy.Name != nil {

--- a/internal/clients/elasticsearch/inference.go
+++ b/internal/clients/elasticsearch/inference.go
@@ -19,163 +19,103 @@ package elasticsearch
 
 import (
 	"context"
-	"encoding/json"
-	"io"
-	"net/http"
+	"errors"
 
-	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/esapi"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
-	"github.com/elastic/terraform-provider-elasticstack/internal/diagutil"
 	fwdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
-// InferenceEndpoint is the model for the inference endpoint API.
-type InferenceEndpoint struct {
-	InferenceID      string         `json:"inference_id"`
-	TaskType         string         `json:"task_type"`
-	Service          string         `json:"service"`
-	ServiceSettings  map[string]any `json:"service_settings"`
-	TaskSettings     map[string]any `json:"task_settings,omitempty"`
-	ChunkingSettings map[string]any `json:"chunking_settings,omitempty"`
-}
-
-// inferenceEndpointCreateRequest is the request body for create (PUT /_inference/...).
-type inferenceEndpointCreateRequest struct {
-	Service          string         `json:"service"`
-	ServiceSettings  map[string]any `json:"service_settings"`
-	TaskSettings     map[string]any `json:"task_settings,omitempty"`
-	ChunkingSettings map[string]any `json:"chunking_settings,omitempty"`
-}
-
-// InferenceEndpointUpdate holds the fields we send to the update API
-// (PUT /_inference/{task_type}/{inference_id}/_update).
-// See https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-inference-update
-type InferenceEndpointUpdate struct {
-	InferenceID      string         `json:"inference_id"`
-	TaskType         string         `json:"task_type"`
-	ServiceSettings  map[string]any `json:"service_settings,omitempty"`
-	TaskSettings     map[string]any `json:"task_settings,omitempty"`
-	ChunkingSettings map[string]any `json:"chunking_settings,omitempty"`
-}
-
-// inferenceEndpointUpdateRequest is the JSON body for the update API.
-type inferenceEndpointUpdateRequest struct {
-	ServiceSettings  map[string]any `json:"service_settings,omitempty"`
-	TaskSettings     map[string]any `json:"task_settings,omitempty"`
-	ChunkingSettings map[string]any `json:"chunking_settings,omitempty"`
-}
-
-// inferenceGetResponse is the top-level GET response body.
-type inferenceGetResponse struct {
-	Endpoints []InferenceEndpoint `json:"endpoints"`
-}
-
-func PutInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, endpoint *InferenceEndpoint) fwdiag.Diagnostics {
-	reqBody := inferenceEndpointCreateRequest{
-		Service:          endpoint.Service,
-		ServiceSettings:  endpoint.ServiceSettings,
-		TaskSettings:     endpoint.TaskSettings,
-		ChunkingSettings: endpoint.ChunkingSettings,
-	}
-	return doFWWrite(apiClient, reqBody,
-		"Unable to marshal inference endpoint",
-		"Unable to create inference endpoint",
-		"Unable to create or update inference endpoint",
-		func(esClient *elasticsearch.Client, body io.Reader) (*esapi.Response, error) {
-			opts := []func(*esapi.InferencePutRequest){
-				esClient.InferencePut.WithBody(body),
-				esClient.InferencePut.WithContext(ctx),
-			}
-			if endpoint.TaskType != "" {
-				opts = append(opts, esClient.InferencePut.WithTaskType(endpoint.TaskType))
-			}
-			return esClient.InferencePut(endpoint.InferenceID, opts...)
-		},
-	)
-}
-
-func GetInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, inferenceID string) (*InferenceEndpoint, fwdiag.Diagnostics) {
+func PutInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, inferenceID, taskType string, endpoint *types.InferenceEndpoint) fwdiag.Diagnostics {
 	var diags fwdiag.Diagnostics
 
-	esClient, err := apiClient.GetESClient()
+	typedClient, err := apiClient.GetESTypedClient()
+	if err != nil {
+		diags.AddError("Unable to get Elasticsearch client", err.Error())
+		return diags
+	}
+
+	req := typedClient.Inference.Put(inferenceID).Request(endpoint)
+	if taskType != "" {
+		req.TaskType(taskType)
+	}
+
+	_, err = req.Do(ctx)
+	if err != nil {
+		diags.AddError("Unable to create or update inference endpoint", err.Error())
+		return diags
+	}
+
+	return diags
+}
+
+func GetInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, inferenceID string) (*types.InferenceEndpointInfo, fwdiag.Diagnostics) {
+	var diags fwdiag.Diagnostics
+
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		diags.AddError("Unable to get Elasticsearch client", err.Error())
 		return nil, diags
 	}
 
-	res, err := esClient.InferenceGet(
-		esClient.InferenceGet.WithInferenceID(inferenceID),
-		esClient.InferenceGet.WithContext(ctx),
-	)
+	res, err := typedClient.Inference.Get().InferenceId(inferenceID).Do(ctx)
 	if err != nil {
+		var esErr *types.ElasticsearchError
+		if errors.As(err, &esErr) && esErr.Status == 404 {
+			return nil, nil
+		}
 		diags.AddError("Unable to get inference endpoint", err.Error())
 		return nil, diags
 	}
-	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusNotFound {
+	if len(res.Endpoints) == 0 {
 		return nil, nil
 	}
 
-	if d := diagutil.CheckErrorFromFW(res, "Unable to get inference endpoint"); d.HasError() {
-		return nil, d
-	}
-
-	var response inferenceGetResponse
-	if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
-		diags.AddError("Unable to decode inference endpoint response", err.Error())
-		return nil, diags
-	}
-
-	if len(response.Endpoints) == 0 {
-		return nil, nil
-	}
-
-	return &response.Endpoints[0], nil
+	return &res.Endpoints[0], nil
 }
 
-func UpdateInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, update *InferenceEndpointUpdate) fwdiag.Diagnostics {
-	reqBody := inferenceEndpointUpdateRequest{
-		ServiceSettings:  update.ServiceSettings,
-		TaskSettings:     update.TaskSettings,
-		ChunkingSettings: update.ChunkingSettings,
+func UpdateInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, inferenceID, taskType string, update *types.InferenceEndpoint) fwdiag.Diagnostics {
+	var diags fwdiag.Diagnostics
+
+	typedClient, err := apiClient.GetESTypedClient()
+	if err != nil {
+		diags.AddError("Unable to get Elasticsearch client", err.Error())
+		return diags
 	}
-	return doFWWrite(apiClient, reqBody,
-		"Unable to marshal inference endpoint update",
-		"Unable to update inference endpoint",
-		"Unable to update inference endpoint",
-		func(esClient *elasticsearch.Client, body io.Reader) (*esapi.Response, error) {
-			opts := []func(*esapi.InferenceUpdateRequest){
-				esClient.InferenceUpdate.WithBody(body),
-				esClient.InferenceUpdate.WithContext(ctx),
-			}
-			if update.TaskType != "" {
-				opts = append(opts, esClient.InferenceUpdate.WithTaskType(update.TaskType))
-			}
-			return esClient.InferenceUpdate(update.InferenceID, opts...)
-		},
-	)
+
+	req := typedClient.Inference.Update(inferenceID).Request(update)
+	if taskType != "" {
+		req.TaskType(taskType)
+	}
+
+	_, err = req.Do(ctx)
+	if err != nil {
+		diags.AddError("Unable to update inference endpoint", err.Error())
+		return diags
+	}
+
+	return diags
 }
 
 func DeleteInferenceEndpoint(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, inferenceID string) fwdiag.Diagnostics {
 	var diags fwdiag.Diagnostics
 
-	esClient, err := apiClient.GetESClient()
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		diags.AddError("Unable to get Elasticsearch client", err.Error())
 		return diags
 	}
 
-	res, err := esClient.InferenceDelete(
-		inferenceID,
-		esClient.InferenceDelete.WithContext(ctx),
-	)
+	_, err = typedClient.Inference.Delete(inferenceID).Do(ctx)
 	if err != nil {
+		var esErr *types.ElasticsearchError
+		if errors.As(err, &esErr) && esErr.Status == 404 {
+			return diags
+		}
 		diags.AddError("Unable to delete inference endpoint", err.Error())
 		return diags
 	}
-	defer res.Body.Close()
 
-	return diagutil.CheckErrorFromFW(res, "Unable to delete inference endpoint")
+	return diags
 }

--- a/internal/clients/elasticsearch/inference.go
+++ b/internal/clients/elasticsearch/inference.go
@@ -18,7 +18,9 @@
 package elasticsearch
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
@@ -84,7 +86,47 @@ func UpdateInferenceEndpoint(ctx context.Context, apiClient *clients.Elasticsear
 		return diags
 	}
 
-	req := typedClient.Inference.Update(inferenceID).Request(update)
+	// Build the update body manually, omitting Service which the API rejects as
+	// an immutable field. The typed client's InferenceEndpoint always serializes
+	// Service because the struct tag lacks omitempty.
+	body := make(map[string]any)
+	if len(update.ServiceSettings) > 0 {
+		var ss map[string]any
+		if err := json.Unmarshal(update.ServiceSettings, &ss); err != nil {
+			diags.AddError("Unable to unmarshal service_settings", err.Error())
+			return diags
+		}
+		body["service_settings"] = ss
+	}
+	if len(update.TaskSettings) > 0 {
+		var ts map[string]any
+		if err := json.Unmarshal(update.TaskSettings, &ts); err != nil {
+			diags.AddError("Unable to unmarshal task_settings", err.Error())
+			return diags
+		}
+		body["task_settings"] = ts
+	}
+	if update.ChunkingSettings != nil {
+		b, err := json.Marshal(update.ChunkingSettings)
+		if err != nil {
+			diags.AddError("Unable to marshal chunking_settings", err.Error())
+			return diags
+		}
+		var cs map[string]any
+		if err := json.Unmarshal(b, &cs); err != nil {
+			diags.AddError("Unable to unmarshal chunking_settings", err.Error())
+			return diags
+		}
+		body["chunking_settings"] = cs
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		diags.AddError("Unable to marshal update body", err.Error())
+		return diags
+	}
+
+	req := typedClient.Inference.Update(inferenceID).Raw(bytes.NewReader(jsonBody))
 	if taskType != "" {
 		req.TaskType(taskType)
 	}

--- a/internal/clients/elasticsearch/logstash.go
+++ b/internal/clients/elasticsearch/logstash.go
@@ -18,14 +18,12 @@
 package elasticsearch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
-	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/diagutil"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
@@ -33,29 +31,51 @@ import (
 )
 
 func PutLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, logstashPipeline *models.LogstashPipeline) diag.Diagnostics {
-	return doSDKWrite(apiClient, logstashPipeline, "Unable to create or update logstash pipeline",
-		func(esClient *elasticsearch.Client, body io.Reader) (*esapi.Response, error) {
-			return esClient.LogstashPutPipeline(logstashPipeline.PipelineID, body, esClient.LogstashPutPipeline.WithContext(ctx))
-		},
-	)
+	var diags diag.Diagnostics
+
+	typedClient, err := apiClient.GetESTypedClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	b, err := json.Marshal(logstashPipeline)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	res, err := typedClient.Logstash.PutPipeline(logstashPipeline.PipelineID).Raw(bytes.NewReader(b)).Perform(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer res.Body.Close()
+
+	if d := diagutil.CheckHTTPError(res, "Unable to create or update logstash pipeline"); d.HasError() {
+		return d
+	}
+
+	return diags
 }
 
 func GetLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, pipelineID string) (*models.LogstashPipeline, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	esClient, err := apiClient.GetESClient()
+
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
-	res, err := esClient.LogstashGetPipeline(esClient.LogstashGetPipeline.WithDocumentID(pipelineID), esClient.LogstashGetPipeline.WithContext(ctx))
+
+	res, err := typedClient.Logstash.GetPipeline().Id(pipelineID).Perform(ctx)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
 	defer res.Body.Close()
+
 	if res.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}
-	if diags := diagutil.CheckError(res, "Unable to find logstash pipeline on cluster."); diags.HasError() {
-		return nil, diags
+
+	if d := diagutil.CheckHTTPError(res, "Unable to find logstash pipeline on cluster."); d.HasError() {
+		return nil, d
 	}
 
 	logstashPipeline := make(map[string]models.LogstashPipeline)
@@ -63,9 +83,9 @@ func GetLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchSc
 		return nil, diag.FromErr(err)
 	}
 
-	if logstashPipeline, ok := logstashPipeline[pipelineID]; ok {
-		logstashPipeline.PipelineID = pipelineID
-		return &logstashPipeline, diags
+	if pipeline, ok := logstashPipeline[pipelineID]; ok {
+		pipeline.PipelineID = pipelineID
+		return &pipeline, diags
 	}
 
 	diags = append(diags, diag.Diagnostic{
@@ -78,18 +98,16 @@ func GetLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchSc
 
 func DeleteLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, pipelineID string) diag.Diagnostics {
 	var diags diag.Diagnostics
-	esClient, err := apiClient.GetESClient()
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	res, err := esClient.LogstashDeletePipeline(pipelineID, esClient.LogstashDeletePipeline.WithContext(ctx))
 
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	defer res.Body.Close()
-	if diags := diagutil.CheckError(res, "Unable to delete logstash pipeline"); diags.HasError() {
-		return diags
+
+	_, err = typedClient.Logstash.DeletePipeline(pipelineID).Do(ctx)
+	if err != nil {
+		return diag.FromErr(err)
 	}
+
 	return diags
 }

--- a/internal/clients/elasticsearch/logstash.go
+++ b/internal/clients/elasticsearch/logstash.go
@@ -106,7 +106,12 @@ func DeleteLogstashPipeline(ctx context.Context, apiClient *clients.Elasticsearc
 
 	_, err = typedClient.Logstash.DeletePipeline(pipelineID).Do(ctx)
 	if err != nil {
-		return diag.FromErr(err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Unable to delete logstash pipeline",
+			Detail:   fmt.Sprintf("Failed with: %s", err.Error()),
+		})
+		return diags
 	}
 
 	return diags

--- a/internal/clients/elasticsearch/logstash.go
+++ b/internal/clients/elasticsearch/logstash.go
@@ -38,6 +38,11 @@ func PutLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchSc
 		return diag.FromErr(err)
 	}
 
+	// The typed client's types.LogstashPipeline.PipelineSettings only supports
+	// a subset of the settings keys the provider uses (6 of ~17). Using the typed
+	// struct would silently drop unsupported settings on both PUT and GET. We
+	// therefore marshal the provider's model to JSON and send it via Raw() to
+	// preserve all settings while still using the typed client for transport.
 	b, err := json.Marshal(logstashPipeline)
 	if err != nil {
 		return diag.FromErr(err)
@@ -64,6 +69,10 @@ func GetLogstashPipeline(ctx context.Context, apiClient *clients.ElasticsearchSc
 		return nil, diag.FromErr(err)
 	}
 
+	// We use .Perform() instead of .Do() because types.LogstashPipeline only
+	// supports a subset of pipeline settings. Decoding into the provider's own
+	// model via json.NewDecoder preserves all settings sent by Elasticsearch.
+	// See the comment in PutLogstashPipeline for the same rationale.
 	res, err := typedClient.Logstash.GetPipeline().Id(pipelineID).Perform(ctx)
 	if err != nil {
 		return nil, diag.FromErr(err)
@@ -104,7 +113,10 @@ func DeleteLogstashPipeline(ctx context.Context, apiClient *clients.Elasticsearc
 		return diag.FromErr(err)
 	}
 
-	_, err = typedClient.Logstash.DeletePipeline(pipelineID).Do(ctx)
+	// Use .Perform() for explicit 404 handling, consistent with GetLogstashPipeline.
+	// The typed client's .Do() handles 404 internally, but making the status check
+	// explicit in provider code makes the contract visible to maintainers.
+	res, err := typedClient.Logstash.DeletePipeline(pipelineID).Perform(ctx)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -112,6 +124,15 @@ func DeleteLogstashPipeline(ctx context.Context, apiClient *clients.Elasticsearc
 			Detail:   fmt.Sprintf("Failed with: %s", err.Error()),
 		})
 		return diags
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return diags
+	}
+
+	if d := diagutil.CheckHTTPError(res, "Unable to delete logstash pipeline"); d.HasError() {
+		return d
 	}
 
 	return diags

--- a/internal/clients/elasticsearch/watch.go
+++ b/internal/clients/elasticsearch/watch.go
@@ -18,13 +18,11 @@
 package elasticsearch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 
-	"github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/esapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/diagutil"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
@@ -38,37 +36,39 @@ func PutWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient,
 		diags.AddError("Unable to marshal watch body", err.Error())
 		return diags
 	}
-	return putWatchBytes(ctx, apiClient, watch.WatchID, watch.Active, watchBodyBytes)
+	return PutWatchBodyJSON(ctx, apiClient, watch.WatchID, watch.Active, watchBodyBytes)
 }
 
 // PutWatchBodyJSON sends a pre-encoded watch document (the JSON object under the watch id) to Put Watch.
 func PutWatchBodyJSON(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, watchID string, active bool, watchBodyJSON []byte) fwdiag.Diagnostics {
-	return putWatchBytes(ctx, apiClient, watchID, active, watchBodyJSON)
-}
+	var diags fwdiag.Diagnostics
 
-func putWatchBytes(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, watchID string, active bool, watchBodyBytes []byte) fwdiag.Diagnostics {
-	return doFWWrite(apiClient, json.RawMessage(watchBodyBytes),
-		"Unable to marshal watch body",
-		"Unable to create or update watch",
-		"Unable to create or update watch",
-		func(esClient *elasticsearch.Client, body io.Reader) (*esapi.Response, error) {
-			return esClient.Watcher.PutWatch(watchID, body,
-				esClient.Watcher.PutWatch.WithActive(active),
-				esClient.Watcher.PutWatch.WithContext(ctx))
-		},
-	)
+	typedClient, err := apiClient.GetESTypedClient()
+	if err != nil {
+		diags.AddError("Unable to get Elasticsearch client", err.Error())
+		return diags
+	}
+
+	res, err := typedClient.Watcher.PutWatch(watchID).Active(active).Raw(bytes.NewReader(watchBodyJSON)).Perform(ctx)
+	if err != nil {
+		diags.AddError("Unable to create or update watch", err.Error())
+		return diags
+	}
+	defer res.Body.Close()
+
+	return diagutil.CheckHTTPErrorFromFW(res, "Unable to create or update watch")
 }
 
 func GetWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, watchID string) (*models.Watch, fwdiag.Diagnostics) {
 	var diags fwdiag.Diagnostics
 
-	esClient, err := apiClient.GetESClient()
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		diags.AddError("Unable to get Elasticsearch client", err.Error())
 		return nil, diags
 	}
 
-	res, err := esClient.Watcher.GetWatch(watchID, esClient.Watcher.GetWatch.WithContext(ctx))
+	res, err := typedClient.Watcher.GetWatch(watchID).Perform(ctx)
 	if err != nil {
 		diags.AddError("Unable to get watch", err.Error())
 		return nil, diags
@@ -79,7 +79,7 @@ func GetWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient,
 		return nil, nil
 	}
 
-	if d := diagutil.CheckErrorFromFW(res, "Unable to find watch on cluster."); d.HasError() {
+	if d := diagutil.CheckHTTPErrorFromFW(res, "Unable to find watch on cluster."); d.HasError() {
 		return nil, d
 	}
 
@@ -96,13 +96,13 @@ func GetWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient,
 func DeleteWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, watchID string) fwdiag.Diagnostics {
 	var diags fwdiag.Diagnostics
 
-	esClient, err := apiClient.GetESClient()
+	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
 		diags.AddError("Unable to get Elasticsearch client", err.Error())
 		return diags
 	}
 
-	res, err := esClient.Watcher.DeleteWatch(watchID, esClient.Watcher.DeleteWatch.WithContext(ctx))
+	res, err := typedClient.Watcher.DeleteWatch(watchID).Perform(ctx)
 	if err != nil {
 		diags.AddError("Unable to delete watch", err.Error())
 		return diags
@@ -113,5 +113,5 @@ func DeleteWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClie
 		return diags // already gone, treat as success
 	}
 
-	return diagutil.CheckErrorFromFW(res, "Unable to delete watch")
+	return diagutil.CheckHTTPErrorFromFW(res, "Unable to delete watch")
 }

--- a/internal/clients/elasticsearch/watch.go
+++ b/internal/clients/elasticsearch/watch.go
@@ -21,8 +21,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/diagutil"
 	"github.com/elastic/terraform-provider-elasticstack/internal/models"
@@ -49,14 +51,12 @@ func PutWatchBodyJSON(ctx context.Context, apiClient *clients.ElasticsearchScope
 		return diags
 	}
 
-	res, err := typedClient.Watcher.PutWatch(watchID).Active(active).Raw(bytes.NewReader(watchBodyJSON)).Perform(ctx)
+	_, err = typedClient.Watcher.PutWatch(watchID).Active(active).Raw(bytes.NewReader(watchBodyJSON)).Do(ctx)
 	if err != nil {
 		diags.AddError("Unable to create or update watch", err.Error())
 		return diags
 	}
-	defer res.Body.Close()
-
-	return diagutil.CheckHTTPErrorFromFW(res, "Unable to create or update watch")
+	return diags
 }
 
 func GetWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, watchID string) (*models.Watch, fwdiag.Diagnostics) {
@@ -68,6 +68,13 @@ func GetWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient,
 		return nil, diags
 	}
 
+	// We use .Perform() (raw *http.Response) instead of .Do() which would
+	// return *getwatch.Response containing *types.Watch. The typed
+	// types.Watch has trigger/input/condition/actions as strongly-typed
+	// unboxed structs, while the provider's models.Watch stores them as
+	// map[string]any under Body (with json:"watch"). The JSON shapes do
+	// not align for a simple Marshal/Unmarshal round-trip, so we decode
+	// directly from the raw response body into models.Watch.
 	res, err := typedClient.Watcher.GetWatch(watchID).Perform(ctx)
 	if err != nil {
 		diags.AddError("Unable to get watch", err.Error())
@@ -102,16 +109,14 @@ func DeleteWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClie
 		return diags
 	}
 
-	res, err := typedClient.Watcher.DeleteWatch(watchID).Perform(ctx)
+	_, err = typedClient.Watcher.DeleteWatch(watchID).Do(ctx)
 	if err != nil {
+		var esErr *types.ElasticsearchError
+		if errors.As(err, &esErr) && esErr.Status == 404 {
+			return diags // already gone, treat as success
+		}
 		diags.AddError("Unable to delete watch", err.Error())
 		return diags
 	}
-	defer res.Body.Close()
-
-	if res.StatusCode == http.StatusNotFound {
-		return diags // already gone, treat as success
-	}
-
-	return diagutil.CheckHTTPErrorFromFW(res, "Unable to delete watch")
+	return diags
 }

--- a/internal/elasticsearch/inference/inferenceendpoint/acc_test.go
+++ b/internal/elasticsearch/inference/inferenceendpoint/acc_test.go
@@ -209,7 +209,8 @@ func TestAccResourceInferenceEndpointTaskSettingsNoDrift(t *testing.T) {
 	}
 
 	inferenceID := fmt.Sprintf("test-inference-%s", sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum))
-	apiKey, _ := inferenceEndpointTestAPIKey()
+	apiKey, usingFakeAPIKey := inferenceEndpointTestAPIKey()
+	skipIfUsingFakeAPIKey := skipWhenUsingFakeInferenceEndpointAPIKey(usingFakeAPIKey)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(t); skipValidateAndStart(t) },
@@ -240,6 +241,7 @@ func TestAccResourceInferenceEndpointTaskSettingsNoDrift(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("without_task_settings"),
 				ConfigVariables:          inferenceEndpointConfigVariables(inferenceID, apiKey),
+				SkipFunc:                 skipIfUsingFakeAPIKey,
 				Check:                    resource.TestCheckNoResourceAttr("elasticstack_elasticsearch_inference_endpoint.test", "task_settings"),
 			},
 			// Re-plan after removing task_settings — still no drift.
@@ -247,6 +249,7 @@ func TestAccResourceInferenceEndpointTaskSettingsNoDrift(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.Providers,
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("without_task_settings"),
 				ConfigVariables:          inferenceEndpointConfigVariables(inferenceID, apiKey),
+				SkipFunc:                 skipIfUsingFakeAPIKey,
 				PlanOnly:                 true,
 				ExpectNonEmptyPlan:       false,
 			},

--- a/internal/elasticsearch/inference/inferenceendpoint/create.go
+++ b/internal/elasticsearch/inference/inferenceendpoint/create.go
@@ -64,7 +64,7 @@ func (r *inferenceEndpointResource) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
-	putDiags := elasticsearch.PutInferenceEndpoint(ctx, client, endpoint)
+	putDiags := elasticsearch.PutInferenceEndpoint(ctx, client, inferenceID, data.TaskType.ValueString(), endpoint)
 	resp.Diagnostics.Append(putDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/elasticsearch/inference/inferenceendpoint/models.go
+++ b/internal/elasticsearch/inference/inferenceendpoint/models.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
+	estypes "github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils/customtypes"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -40,13 +40,11 @@ type Data struct {
 	ChunkingSettings        customtypes.JSONWithDefaultsValue[map[string]any] `tfsdk:"chunking_settings"`
 }
 
-func (data *Data) toAPIModel(_ context.Context) (*elasticsearch.InferenceEndpoint, diag.Diagnostics) {
+func (data *Data) toAPIModel(_ context.Context) (*estypes.InferenceEndpoint, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	endpoint := &elasticsearch.InferenceEndpoint{
-		InferenceID: data.InferenceID.ValueString(),
-		TaskType:    data.TaskType.ValueString(),
-		Service:     data.Service.ValueString(),
+	endpoint := &estypes.InferenceEndpoint{
+		Service: data.Service.ValueString(),
 	}
 
 	if !data.ServiceSettings.IsNull() && !data.ServiceSettings.IsUnknown() {
@@ -55,7 +53,12 @@ func (data *Data) toAPIModel(_ context.Context) (*elasticsearch.InferenceEndpoin
 			diags.AddError("Invalid service_settings JSON", fmt.Sprintf("Error parsing service_settings: %s", err))
 			return nil, diags
 		}
-		endpoint.ServiceSettings = ss
+		b, err := json.Marshal(ss)
+		if err != nil {
+			diags.AddError("JSON Marshal Error", fmt.Sprintf("Error marshaling service_settings: %s", err))
+			return nil, diags
+		}
+		endpoint.ServiceSettings = b
 	}
 
 	if !data.TaskSettings.IsNull() && !data.TaskSettings.IsUnknown() {
@@ -64,7 +67,12 @@ func (data *Data) toAPIModel(_ context.Context) (*elasticsearch.InferenceEndpoin
 			diags.AddError("Invalid task_settings JSON", fmt.Sprintf("Error parsing task_settings: %s", err))
 			return nil, diags
 		}
-		endpoint.TaskSettings = ts
+		b, err := json.Marshal(ts)
+		if err != nil {
+			diags.AddError("JSON Marshal Error", fmt.Sprintf("Error marshaling task_settings: %s", err))
+			return nil, diags
+		}
+		endpoint.TaskSettings = b
 	}
 
 	if !data.ChunkingSettings.IsNull() && !data.ChunkingSettings.IsUnknown() {
@@ -73,44 +81,37 @@ func (data *Data) toAPIModel(_ context.Context) (*elasticsearch.InferenceEndpoin
 			diags.AddError("Invalid chunking_settings JSON", fmt.Sprintf("Error parsing chunking_settings: %s", err))
 			return nil, diags
 		}
-		endpoint.ChunkingSettings = cs
+		b, err := json.Marshal(cs)
+		if err != nil {
+			diags.AddError("JSON Marshal Error", fmt.Sprintf("Error marshaling chunking_settings: %s", err))
+			return nil, diags
+		}
+		endpoint.ChunkingSettings = estypes.NewInferenceChunkingSettings()
+		if err := json.Unmarshal(b, endpoint.ChunkingSettings); err != nil {
+			diags.AddError("Invalid chunking_settings JSON", fmt.Sprintf("Error parsing chunking_settings into typed struct: %s", err))
+			return nil, diags
+		}
 	}
 
 	return endpoint, diags
 }
 
-func (data *Data) toUpdateModel(ctx context.Context) (*elasticsearch.InferenceEndpointUpdate, diag.Diagnostics) {
-	endpoint, diags := data.toAPIModel(ctx)
-	if diags.HasError() {
-		return nil, diags
-	}
-
-	return &elasticsearch.InferenceEndpointUpdate{
-		InferenceID:      endpoint.InferenceID,
-		TaskType:         endpoint.TaskType,
-		ServiceSettings:  endpoint.ServiceSettings,
-		TaskSettings:     endpoint.TaskSettings,
-		ChunkingSettings: endpoint.ChunkingSettings,
-	}, diags
+func (data *Data) toUpdateModel(ctx context.Context) (*estypes.InferenceEndpoint, diag.Diagnostics) {
+	return data.toAPIModel(ctx)
 }
 
-func (data *Data) fromAPIModel(_ context.Context, endpoint *elasticsearch.InferenceEndpoint) diag.Diagnostics {
+func (data *Data) fromAPIModel(_ context.Context, endpoint *estypes.InferenceEndpointInfo) diag.Diagnostics {
 	var diags diag.Diagnostics
 
-	data.InferenceID = types.StringValue(endpoint.InferenceID)
-	data.TaskType = types.StringValue(endpoint.TaskType)
+	data.InferenceID = types.StringValue(endpoint.InferenceId)
+	data.TaskType = types.StringValue(endpoint.TaskType.String())
 	data.Service = types.StringValue(endpoint.Service)
 
 	// service_settings: preserve plan value since the API may omit sensitive fields (e.g. api_key)
 	// We only update if the field was previously null/unknown (first read after import).
 	if data.ServiceSettings.IsNull() || data.ServiceSettings.IsUnknown() {
-		if endpoint.ServiceSettings != nil {
-			b, err := json.Marshal(endpoint.ServiceSettings)
-			if err != nil {
-				diags.AddError("JSON Marshal Error", fmt.Sprintf("Error marshaling service_settings: %s", err))
-				return diags
-			}
-			data.ServiceSettings = jsontypes.NewNormalizedValue(string(b))
+		if len(endpoint.ServiceSettings) > 0 {
+			data.ServiceSettings = jsontypes.NewNormalizedValue(string(endpoint.ServiceSettings))
 		}
 	}
 
@@ -125,8 +126,13 @@ func (data *Data) fromAPIModel(_ context.Context, endpoint *elasticsearch.Infere
 			return diags
 		}
 
-		if endpoint.TaskSettings != nil {
-			filtered := intersectKeys(endpoint.TaskSettings, stateTS)
+		if len(endpoint.TaskSettings) > 0 {
+			var apiTS map[string]any
+			if err := json.Unmarshal(endpoint.TaskSettings, &apiTS); err != nil {
+				diags.AddError("Invalid task_settings JSON", fmt.Sprintf("Error parsing API task_settings: %s", err))
+				return diags
+			}
+			filtered := intersectKeys(apiTS, stateTS)
 			b, err := json.Marshal(filtered)
 			if err != nil {
 				diags.AddError("JSON Marshal Error", fmt.Sprintf("Error marshaling task_settings: %s", err))

--- a/internal/elasticsearch/inference/inferenceendpoint/update.go
+++ b/internal/elasticsearch/inference/inferenceendpoint/update.go
@@ -57,7 +57,7 @@ func (r *inferenceEndpointResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	updateDiags := elasticsearch.UpdateInferenceEndpoint(ctx, client, update)
+	updateDiags := elasticsearch.UpdateInferenceEndpoint(ctx, client, plan.InferenceID.ValueString(), plan.TaskType.ValueString(), update)
 	diags.Append(updateDiags...)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)

--- a/openspec/changes/typed-client-easy-wins/tasks.md
+++ b/openspec/changes/typed-client-easy-wins/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Inference
 
-- [ ] 1.1 Migrate `PutInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Put()` with `types.InferenceEndpoint`
-- [ ] 1.2 Migrate `GetInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Get()` with `types.InferenceEndpointInfo`
-- [ ] 1.3 Migrate `UpdateInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Update()` with `types.InferenceEndpoint`
-- [ ] 1.4 Migrate `DeleteInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Delete()`
-- [ ] 1.5 Update `internal/elasticsearch/inference/inferenceendpoint/create.go` to compile with migrated `PutInferenceEndpoint` signature
-- [ ] 1.6 Update `internal/elasticsearch/inference/inferenceendpoint/read.go` to compile with migrated `GetInferenceEndpoint` signature
-- [ ] 1.7 Update `internal/elasticsearch/inference/inferenceendpoint/update.go` to compile with migrated `UpdateInferenceEndpoint` signature
-- [ ] 1.8 Update `internal/elasticsearch/inference/inferenceendpoint/delete.go` to compile with migrated `DeleteInferenceEndpoint` signature
-- [ ] 1.9 Remove now-unused custom `InferenceEndpoint` structs from `inference.go` if fully replaced by typed types
+- [x] 1.1 Migrate `PutInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Put()` with `types.InferenceEndpoint`
+- [x] 1.2 Migrate `GetInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Get()` with `types.InferenceEndpointInfo`
+- [x] 1.3 Migrate `UpdateInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Update()` with `types.InferenceEndpoint`
+- [x] 1.4 Migrate `DeleteInferenceEndpoint` in `internal/clients/elasticsearch/inference.go` to use `GetESTypedClient()` and `typedapi.Inference.Delete()`
+- [x] 1.5 Update `internal/elasticsearch/inference/inferenceendpoint/create.go` to compile with migrated `PutInferenceEndpoint` signature
+- [x] 1.6 Update `internal/elasticsearch/inference/inferenceendpoint/read.go` to compile with migrated `GetInferenceEndpoint` signature
+- [x] 1.7 Update `internal/elasticsearch/inference/inferenceendpoint/update.go` to compile with migrated `UpdateInferenceEndpoint` signature
+- [x] 1.8 Update `internal/elasticsearch/inference/inferenceendpoint/delete.go` to compile with migrated `DeleteInferenceEndpoint` signature
+- [x] 1.9 Remove now-unused custom `InferenceEndpoint` structs from `inference.go` if fully replaced by typed types
 
 ## 2. Logstash
 
@@ -20,15 +20,15 @@
 
 ## 3. Enrich
 
-- [ ] 3.1 Migrate `GetEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.GetPolicy()` with `types.Summary`/`types.EnrichPolicy`
-- [ ] 3.2 Migrate `PutEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.PutPolicy()` with `types.EnrichPolicy`
-- [ ] 3.3 Migrate `DeleteEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.DeletePolicy()`
-- [ ] 3.4 Migrate `ExecuteEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.ExecutePolicy()`
-- [ ] 3.5 Handle query string↔`types.Query` conversion at the boundary in enrich helpers
-- [ ] 3.6 Update `internal/elasticsearch/enrich/create.go` to compile with migrated `PutEnrichPolicy` signature
-- [ ] 3.7 Update `internal/elasticsearch/enrich/data_source.go` to compile with migrated `GetEnrichPolicy` signature
-- [ ] 3.8 Update `internal/elasticsearch/enrich/delete.go` to compile with migrated `DeleteEnrichPolicy` signature
-- [ ] 3.9 Remove now-unused custom `enrichPolicyResponse` and `enrichPoliciesResponse` structs from `enrich.go`
+- [x] 3.1 Migrate `GetEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.GetPolicy()` with `types.Summary`/`types.EnrichPolicy`
+- [x] 3.2 Migrate `PutEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.PutPolicy()` with `types.EnrichPolicy`
+- [x] 3.3 Migrate `DeleteEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.DeletePolicy()`
+- [x] 3.4 Migrate `ExecuteEnrichPolicy` in `internal/clients/elasticsearch/enrich.go` to use `GetESTypedClient()` and `typedapi.Enrich.ExecutePolicy()`
+- [x] 3.5 Handle query string↔`types.Query` conversion at the boundary in enrich helpers
+- [x] 3.6 Update `internal/elasticsearch/enrich/create.go` to compile with migrated `PutEnrichPolicy` signature
+- [x] 3.7 Update `internal/elasticsearch/enrich/data_source.go` to compile with migrated `GetEnrichPolicy` signature
+- [x] 3.8 Update `internal/elasticsearch/enrich/delete.go` to compile with migrated `DeleteEnrichPolicy` signature
+- [x] 3.9 Remove now-unused custom `enrichPolicyResponse` and `enrichPoliciesResponse` structs from `enrich.go`
 
 ## 4. Watch
 

--- a/openspec/changes/typed-client-easy-wins/tasks.md
+++ b/openspec/changes/typed-client-easy-wins/tasks.md
@@ -32,14 +32,14 @@
 
 ## 4. Watch
 
-- [ ] 4.1 Migrate `PutWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.PutWatch()` with `types.Watch` or `types.WatcherAction`/`types.WatcherCondition`/`types.WatcherInput`
-- [ ] 4.2 Migrate `PutWatchBodyJSON` in `internal/clients/elasticsearch/watch.go` to use typed API, converting raw JSON to typed request fields
-- [ ] 4.3 Migrate `GetWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.GetWatch()` with `types.Watch`
-- [ ] 4.4 Migrate `DeleteWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.DeleteWatch()`, preserving 404-as-success semantics
-- [ ] 4.5 Update `internal/elasticsearch/watcher/watch/create.go` to compile with migrated `PutWatch`/`PutWatchBodyJSON` signatures
-- [ ] 4.6 Update `internal/elasticsearch/watcher/watch/read.go` to compile with migrated `GetWatch` signature
-- [ ] 4.7 Update `internal/elasticsearch/watcher/watch/delete.go` to compile with migrated `DeleteWatch` signature
-- [ ] 4.8 Evaluate whether `models.Watch`, `models.PutWatch`, and `models.WatchBody` can be removed or must be retained for schema-layer mapping
+- [x] 4.1 Migrate `PutWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.PutWatch()` with `types.Watch` or `types.WatcherAction`/`types.WatcherCondition`/`types.WatcherInput`
+- [x] 4.2 Migrate `PutWatchBodyJSON` in `internal/clients/elasticsearch/watch.go` to use typed API, converting raw JSON to typed request fields
+- [x] 4.3 Migrate `GetWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.GetWatch()` with `types.Watch`
+- [x] 4.4 Migrate `DeleteWatch` in `internal/clients/elasticsearch/watch.go` to use `GetESTypedClient()` and `typedapi.Watcher.DeleteWatch()`, preserving 404-as-success semantics
+- [x] 4.5 Update `internal/elasticsearch/watcher/watch/create.go` to compile with migrated `PutWatch`/`PutWatchBodyJSON` signatures
+- [x] 4.6 Update `internal/elasticsearch/watcher/watch/read.go` to compile with migrated `GetWatch` signature
+- [x] 4.7 Update `internal/elasticsearch/watcher/watch/delete.go` to compile with migrated `DeleteWatch` signature
+- [x] 4.8 Evaluate whether `models.Watch`, `models.PutWatch`, and `models.WatchBody` can be removed or must be retained for schema-layer mapping
 
 ## 5. Cleanup and Verification
 

--- a/openspec/changes/typed-client-easy-wins/tasks.md
+++ b/openspec/changes/typed-client-easy-wins/tasks.md
@@ -12,11 +12,11 @@
 
 ## 2. Logstash
 
-- [ ] 2.1 Migrate `PutLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.PutPipeline()` with `types.LogstashPipeline`
-- [ ] 2.2 Migrate `GetLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.GetPipeline()`
-- [ ] 2.3 Migrate `DeleteLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.DeletePipeline()`
-- [ ] 2.4 Update `internal/elasticsearch/logstash/pipeline.go` to compile with migrated helper signatures
-- [ ] 2.5 Remove or deprecate `models.LogstashPipeline` if fully replaced by `types.LogstashPipeline`
+- [x] 2.1 Migrate `PutLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.PutPipeline()` with `types.LogstashPipeline`
+- [x] 2.2 Migrate `GetLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.GetPipeline()`
+- [x] 2.3 Migrate `DeleteLogstashPipeline` in `internal/clients/elasticsearch/logstash.go` to use `GetESTypedClient()` and `typedapi.Logstash.DeletePipeline()`
+- [x] 2.4 Update `internal/elasticsearch/logstash/pipeline.go` to compile with migrated helper signatures
+- [x] 2.5 Remove or deprecate `models.LogstashPipeline` if fully replaced by `types.LogstashPipeline`
 
 ## 3. Enrich
 

--- a/openspec/changes/typed-client-easy-wins/tasks.md
+++ b/openspec/changes/typed-client-easy-wins/tasks.md
@@ -43,10 +43,10 @@
 
 ## 5. Cleanup and Verification
 
-- [ ] 5.1 Run `make build` and confirm zero compile errors across the entire codebase
-- [ ] 5.2 Run `make check-lint` and resolve any new lint warnings introduced by typed API usage
-- [ ] 5.3 Run `go test ./internal/clients/elasticsearch/...` to verify unit tests pass
-- [ ] 5.4 Confirm no remaining `GetESClient()` calls exist in the four migrated helper files
-- [ ] 5.5 Clean up any unused imports in the migrated helper files
-- [ ] 5.6 If `models.LogstashPipeline`, `models.Watch`, `models.PutWatch`, or `models.WatchBody` are fully redundant, remove them from `internal/models/models.go`
-- [ ] 5.7 Run targeted acceptance tests for inference, logstash, enrich, and watcher packages where possible
+- [x] 5.1 Run `make build` and confirm zero compile errors across the entire codebase
+- [x] 5.2 Run `make check-lint` and resolve any new lint warnings introduced by typed API usage
+- [x] 5.3 Run `go test ./internal/clients/elasticsearch/...` to verify unit tests pass
+- [x] 5.4 Confirm no remaining `GetESClient()` calls exist in the four migrated helper files
+- [x] 5.5 Clean up any unused imports in the migrated helper files
+- [x] 5.6 If `models.LogstashPipeline`, `models.Watch`, `models.PutWatch`, or `models.WatchBody` are fully redundant, remove them from `internal/models/models.go`
+- [x] 5.7 Run targeted acceptance tests for inference, logstash, enrich, and watcher packages where possible


### PR DESCRIPTION
typed-client-easy-wins: Migrate inference, logstash, enrich, watch helpers to typed client

## Summary

Migrate four Elasticsearch client helper files to use the typed client (GetESTypedClient()):

1. internal/clients/elasticsearch/inference.go -- PutInferenceEndpoint, GetInferenceEndpoint, UpdateInferenceEndpoint, DeleteInferenceEndpoint
2. internal/clients/elasticsearch/logstash.go -- PutLogstashPipeline, GetLogstashPipeline, DeleteLogstashPipeline
3. internal/clients/elasticsearch/enrich.go -- GetEnrichPolicy, PutEnrichPolicy, DeleteEnrichPolicy, ExecuteEnrichPolicy
4. internal/clients/elasticsearch/watch.go -- PutWatch, PutWatchBodyJSON, GetWatch, DeleteWatch

## Changelog

Replace raw esapi calls in inference, logstash, enrich, and watch helpers with typed API equivalents using GetESTypedClient(). Preserves error semantics (404-as-not-found/success) and dynamic JSON handling where typed structs lack full coverage.

### Customer impact

No end-user-facing changes. This is an internal implementation migration from raw Elasticsearch API client to typed client. No new provider capabilities or breaking changes.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate inference, logstash, enrich, and watch helpers to the typed Elasticsearch client
> - Rewrites [enrich.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2610/files#diff-2bd4391ac1ba16c4139a7b5c83e55371496fe52ff2abdc0303a6bd380da8dc6e), [inference.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2610/files#diff-de1244640bc04e34cbddba8bbbeecb47b75b7a9d736d8b0e3c54a0b5c8b95725), [logstash.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2610/files#diff-bc411f77c8eb9eaa955530cccc2f58482dbb9c5c3f7930acd2a4c9d030439609), and [watch.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2610/files#diff-badfd296d4c725ca83949ff9a4a63a3f020540663a158952fb4518ca7a20db0d) to use the typed ES client (`GetESTypedClient`) instead of the legacy HTTP client.
> - 404 responses are now treated as "not found" (returning `nil, nil`) rather than errors across all four modules, making delete and get operations idempotent.
> - `UpdateInferenceEndpoint` now omits the immutable `service` field from update requests to avoid API rejection.
> - Logstash and watch operations use `Raw()` / `Perform()` to preserve full JSON payloads that the typed structs would otherwise drop.
> - Removes numerous custom request/response structs (`InferenceEndpoint`, `enrichPolicyResponse`, etc.) replaced by typed API structs.
> - Behavioral Change: `PutInferenceEndpoint` and `UpdateInferenceEndpoint` now require `inferenceID` and `taskType` as separate arguments, requiring callers to be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4630685.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->