### PR TITLE
Fix SLM tests

### DIFF
--- a/internal/clients/elasticsearch/cluster.go
+++ b/internal/clients/elasticsearch/cluster.go
@@ -54,26 +54,27 @@ type SnapshotRepositoryInfo struct {
 }
 
 type SlmPolicy struct {
-	Name       string
-	Schedule   string
-	Repository string
-	Config     *SlmConfig
-	Retention  *SlmRetention
+	Name       string        `json:"name"`
+	Schedule   string        `json:"schedule"`
+	Repository string        `json:"repository"`
+	Config     *SlmConfig    `json:"config"`
+	Retention  *SlmRetention `json:"retention"`
 }
 
 type SlmConfig struct {
-	FeatureStates      []string
-	IgnoreUnavailable  *bool
-	IncludeGlobalState *bool
-	Indices            []string
-	Metadata           types.Metadata
-	Partial            *bool
+	FeatureStates      []string       `json:"feature_states"`
+	ExpandWildcards    string         `json:"expand_wildcards"`
+	IgnoreUnavailable  *bool          `json:"ignore_unavailable"`
+	IncludeGlobalState *bool          `json:"include_global_state"`
+	Indices            []string       `json:"indices"`
+	Metadata           types.Metadata `json:"metadata"`
+	Partial            *bool          `json:"partial"`
 }
 
 type SlmRetention struct {
-	ExpireAfter *string
-	MaxCount    *int
-	MinCount    *int
+	ExpireAfter *string `json:"expire_after"`
+	MaxCount    *int    `json:"max_count"`
+	MinCount    *int    `json:"min_count"`
 }
 
 func PutSnapshotRepository(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, name string, repoType string, settings map[string]any, verify bool) sdkdiag.Diagnostics {
@@ -303,7 +304,7 @@ func DeleteSnapshotRepository(ctx context.Context, apiClient *clients.Elasticsea
 	return diags
 }
 
-func PutSlm(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, policyID string, slm *types.SLMPolicy, expandWildcards string, maxCountSet bool, minCountSet bool) sdkdiag.Diagnostics {
+func PutSlm(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, policyID string, slm *SlmPolicy) sdkdiag.Diagnostics {
 	var diags sdkdiag.Diagnostics
 	typedClient, err := apiClient.GetESTypedClient()
 	if err != nil {
@@ -347,25 +348,23 @@ func PutSlm(ctx context.Context, apiClient *clients.ElasticsearchScopedClient, p
 		if slm.Config.Partial != nil {
 			config["partial"] = *slm.Config.Partial
 		}
-		if expandWildcards != "" {
-			config["expand_wildcards"] = expandWildcards
+		if slm.Config.ExpandWildcards != "" {
+			config["expand_wildcards"] = slm.Config.ExpandWildcards
 		}
 		if len(config) > 0 {
 			body["config"] = config
 		}
-	} else if expandWildcards != "" {
-		body["config"] = map[string]any{"expand_wildcards": expandWildcards}
 	}
 	if slm.Retention != nil {
 		retention := map[string]any{}
 		if slm.Retention.ExpireAfter != nil {
-			retention["expire_after"] = slm.Retention.ExpireAfter
+			retention["expire_after"] = *slm.Retention.ExpireAfter
 		}
-		if maxCountSet {
-			retention["max_count"] = slm.Retention.MaxCount
+		if slm.Retention.MaxCount != nil {
+			retention["max_count"] = *slm.Retention.MaxCount
 		}
-		if minCountSet {
-			retention["min_count"] = slm.Retention.MinCount
+		if slm.Retention.MinCount != nil {
+			retention["min_count"] = *slm.Retention.MinCount
 		}
 		if len(retention) > 0 {
 			body["retention"] = retention

--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -182,9 +182,9 @@ func resourceSlmPut(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		return diags
 	}
 
-	var slm types.SLMPolicy
-	var slmConfig types.Configuration
-	var slmRetention types.Retention
+	var slm elasticsearch.SlmPolicy
+	var slmConfig elasticsearch.SlmConfig
+	var slmRetention elasticsearch.SlmRetention
 
 	slm.Name = slmID
 	slm.Repository = d.Get("repository").(string)
@@ -192,26 +192,23 @@ func resourceSlmPut(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if v, ok := d.GetOk("snapshot_name"); ok {
 		slm.Name = v.(string)
 	}
-	var maxCountSet, minCountSet bool
 	if v, ok := d.GetOk("expire_after"); ok {
-		slmRetention.ExpireAfter = v.(string)
+		expireAfter := v.(string)
+		slmRetention.ExpireAfter = &expireAfter
 	}
 	if v, ok := d.GetOk("max_count"); ok {
-		slmRetention.MaxCount = v.(int)
-		maxCountSet = true
+		maxCount := v.(int)
+		slmRetention.MaxCount = &maxCount
 	}
 	if v, ok := d.GetOk("min_count"); ok {
-		slmRetention.MinCount = v.(int)
-		minCountSet = true
+		minCount := v.(int)
+		slmRetention.MinCount = &minCount
 	}
-	if slmRetention.ExpireAfter != nil || maxCountSet || minCountSet {
+	if slmRetention.ExpireAfter != nil || slmRetention.MaxCount != nil || slmRetention.MinCount != nil {
 		slm.Retention = &slmRetention
 	}
 
-	expandWildcards := "open,hidden" // default
-	if v, ok := d.GetOk("expand_wildcards"); ok {
-		expandWildcards = v.(string)
-	}
+	slmConfig.ExpandWildcards = d.Get("expand_wildcards").(string)
 	vvIgnore := d.Get("ignore_unavailable").(bool)
 	slmConfig.IgnoreUnavailable = &vvIgnore
 	vvInclude := d.Get("include_global_state").(bool)
@@ -252,7 +249,7 @@ func resourceSlmPut(ctx context.Context, d *schema.ResourceData, meta any) diag.
 
 	slm.Config = &slmConfig
 
-	if diags := elasticsearch.PutSlm(ctx, client, slmID, &slm, expandWildcards, maxCountSet, minCountSet); diags.HasError() {
+	if diags := elasticsearch.PutSlm(ctx, client, slmID, &slm); diags.HasError() {
 		return diags
 	}
 	d.SetId(id.String())
@@ -314,9 +311,10 @@ func resourceSlmRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 	}
 
 	if c := slm.Config; c != nil {
-		// expand_wildcards is not returned by the typed API; preserve from state
-		if err := d.Set("expand_wildcards", d.Get("expand_wildcards")); err != nil {
-			return diag.FromErr(err)
+		if c.ExpandWildcards != "" {
+			if err := d.Set("expand_wildcards", c.ExpandWildcards); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 		if c.IncludeGlobalState != nil {
 			if err := d.Set("include_global_state", *c.IncludeGlobalState); err != nil {

--- a/internal/elasticsearch/cluster/slm.go
+++ b/internal/elasticsearch/cluster/slm.go
@@ -28,13 +28,15 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/tfsdkutils"
-	"github.com/elastic/terraform-provider-elasticstack/internal/utils"
+	schemautil "github.com/elastic/terraform-provider-elasticstack/internal/utils"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+const slmDefaultExpandWildcards = "open,hidden"
 
 func ResourceSlm() *schema.Resource {
 	slmSchema := map[string]*schema.Schema{
@@ -53,7 +55,7 @@ func ResourceSlm() *schema.Resource {
 			Description: "Determines how wildcard patterns in the `indices` parameter match data streams and indices. Supports comma-separated values, such as `closed,hidden`.",
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "open,hidden",
+			Default:     slmDefaultExpandWildcards,
 			ValidateDiagFunc: func(value any, _ cty.Path) diag.Diagnostics {
 				validValues := []string{"all", "open", "closed", "hidden", "none"}
 
@@ -292,44 +294,51 @@ func resourceSlmRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 	if err := d.Set("schedule", slm.Schedule); err != nil {
 		return diag.FromErr(err)
 	}
+
+	var expireAfter string
+	var maxCount int
+	var minCount int
 	if slm.Retention != nil {
 		if slm.Retention.ExpireAfter != nil {
-			if err := d.Set("expire_after", *slm.Retention.ExpireAfter); err != nil {
-				return diag.FromErr(err)
-			}
+			expireAfter = *slm.Retention.ExpireAfter
 		}
 		if slm.Retention.MaxCount != nil {
-			if err := d.Set("max_count", *slm.Retention.MaxCount); err != nil {
-				return diag.FromErr(err)
-			}
+			maxCount = *slm.Retention.MaxCount
 		}
 		if slm.Retention.MinCount != nil {
-			if err := d.Set("min_count", *slm.Retention.MinCount); err != nil {
-				return diag.FromErr(err)
-			}
+			minCount = *slm.Retention.MinCount
 		}
 	}
+	if err := d.Set("expire_after", expireAfter); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("max_count", maxCount); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("min_count", minCount); err != nil {
+		return diag.FromErr(err)
+	}
+
+	expandWildcards := slmDefaultExpandWildcards
+	includeGlobalState := true
+	ignoreUnavailable := false
+	partial := false
+	var metadata string
+	var indices []string
+	var featureStates []string
 
 	if c := slm.Config; c != nil {
 		if c.ExpandWildcards != "" {
-			if err := d.Set("expand_wildcards", c.ExpandWildcards); err != nil {
-				return diag.FromErr(err)
-			}
+			expandWildcards = c.ExpandWildcards
 		}
 		if c.IncludeGlobalState != nil {
-			if err := d.Set("include_global_state", *c.IncludeGlobalState); err != nil {
-				return diag.FromErr(err)
-			}
+			includeGlobalState = *c.IncludeGlobalState
 		}
 		if c.IgnoreUnavailable != nil {
-			if err := d.Set("ignore_unavailable", *c.IgnoreUnavailable); err != nil {
-				return diag.FromErr(err)
-			}
+			ignoreUnavailable = *c.IgnoreUnavailable
 		}
 		if c.Partial != nil {
-			if err := d.Set("partial", *c.Partial); err != nil {
-				return diag.FromErr(err)
-			}
+			partial = *c.Partial
 		}
 		if c.Metadata != nil {
 			meta := make(map[string]any)
@@ -344,16 +353,31 @@ func resourceSlmRead(ctx context.Context, d *schema.ResourceData, meta any) diag
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			if err := d.Set("metadata", string(metaBytes)); err != nil {
-				return diag.FromErr(err)
-			}
+			metadata = string(metaBytes)
 		}
-		if err := d.Set("indices", c.Indices); err != nil {
-			return diag.FromErr(err)
-		}
-		if err := d.Set("feature_states", c.FeatureStates); err != nil {
-			return diag.FromErr(err)
-		}
+		indices = c.Indices
+		featureStates = c.FeatureStates
+	}
+	if err := d.Set("expand_wildcards", expandWildcards); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("include_global_state", includeGlobalState); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("ignore_unavailable", ignoreUnavailable); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("partial", partial); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("metadata", metadata); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("indices", indices); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("feature_states", featureStates); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return diags

--- a/internal/elasticsearch/cluster/slm_test.go
+++ b/internal/elasticsearch/cluster/slm_test.go
@@ -19,6 +19,7 @@ package cluster_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
@@ -130,6 +131,31 @@ func TestAccResourceSLMExtended(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_snapshot_lifecycle.test_slm", "max_count", "50"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_snapshot_lifecycle.test_slm", "metadata", `{"created_by":"terraform","purpose":"daily backup"}`),
 				),
+			},
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				ConfigVariables:          config.Variables{"name": config.StringVariable(name)},
+				ResourceName:             "elasticstack_elasticsearch_snapshot_lifecycle.test_slm",
+				ImportState:              true,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					attrs := is[0].Attributes
+					if got := attrs["expand_wildcards"]; got != "closed,hidden" {
+						return fmt.Errorf("expected imported expand_wildcards [closed,hidden], got [%s]", got)
+					}
+					if got := attrs["min_count"]; got != "5" {
+						return fmt.Errorf("expected imported min_count [5], got [%s]", got)
+					}
+					if got := attrs["feature_states.#"]; got != "1" {
+						return fmt.Errorf("expected imported feature_states count [1], got [%s]", got)
+					}
+					for attr, value := range attrs {
+						if strings.HasPrefix(attr, "feature_states.") && attr != "feature_states.#" && value == "kibana" {
+							return nil
+						}
+					}
+					return fmt.Errorf("expected imported feature_states to contain [kibana]")
+				},
 			},
 			{
 				// Step 2: update schedule, retention, indices, feature_states, and boolean flags


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix SLM resource state reads and request serialization for `expand_wildcards` and retention fields
- Adds JSON struct tags to `SlmPolicy`, `SlmConfig`, and `SlmRetention` in [cluster.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2635/files#diff-0b7aa1af41c769f4c6b1fc385a4943536a50ddbbf55400737a01206251ebc6f9) so fields serialize correctly; moves `expand_wildcards` onto `SlmConfig.ExpandWildcards` instead of a separate parameter.
- `PutSlm` now omits retention fields when unset and sends concrete values instead of pointers; the `expandWildcards`, `maxCountSet`, and `minCountSet` parameters are removed from the signature.
- `resourceSlmRead` in [slm.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2635/files#diff-1b28461f29de33d5e8302c446212d56633a4f092a392bcf63c4fde31cf3dc374) now sources `expand_wildcards` from the API response (defaulting to `"open,hidden"`) rather than preserving prior state; `include_global_state`, `ignore_unavailable`, and `partial` are set to explicit defaults when absent.
- Adds an import-state test step in [slm_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2635/files#diff-ca3b22183889fa89dbf0f3310d0d0c7e22f8896a9d86311958cc969cc652888b) verifying `expand_wildcards`, `min_count`, and `feature_states` are correctly populated after import.
- Behavioral Change: `expand_wildcards` in Terraform state will now reflect the API value (or default) on every read rather than retaining the previously stored value.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70f5b07.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->