### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/internal/elasticsearch/cluster/snapshot_repository_test.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_test.go
@@ -179,13 +179,17 @@ func checkRepoDestroy(name string) func(s *terraform.State) error {
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "elasticstack_elasticsearch_snapshot_repository" {
-				compID, _ := clients.CompositeIDFromStr(rs.Primary.ID)
-				if compID.ResourceID != name {
-					continue
-				}
+				continue
 			}
 
-			compID, _ := clients.CompositeIDFromStr(rs.Primary.ID)
+			compID, err := clients.CompositeIDFromStr(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+			if compID.ResourceID != name {
+				continue
+			}
+
 			esClient, err := client.GetESClient()
 			if err != nil {
 				return err

--- a/internal/elasticsearch/cluster/snapshot_repository_test.go
+++ b/internal/elasticsearch/cluster/snapshot_repository_test.go
@@ -182,9 +182,9 @@ func checkRepoDestroy(name string) func(s *terraform.State) error {
 				continue
 			}
 
-			compID, err := clients.CompositeIDFromStr(rs.Primary.ID)
-			if err != nil {
-				return err
+			compID, diags := clients.CompositeIDFromStr(rs.Primary.ID)
+			if diags.HasError() {
+				return fmt.Errorf("failed to parse snapshot repository composite ID %q: %v", rs.Primary.ID, diags)
 			}
 			if compID.ResourceID != name {
 				continue


### PR DESCRIPTION
_This PR applies 1/3 suggestions from code quality [AI findings](https://github.com/elastic/terraform-provider-elasticstack/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `checkRepoDestroy` to skip non-matching resource types and handle parse errors
> Fixes a code quality issue in [snapshot_repository_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2638/files#diff-9bcef2fa28184276e2d82e4a76250049ac47ba828137402233f6ef58a400bbd7). The function now skips resources that are not of type `elasticstack_elasticsearch_snapshot_repository` before parsing the composite ID, and returns an error if parsing fails. Previously, it could attempt to parse and act on non-matching resource types and silently ignored parse errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65c8e47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->