### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/internal/elasticsearch/cluster/slm_test.go
+++ b/internal/elasticsearch/cluster/slm_test.go
@@ -205,13 +205,13 @@ func checkSlmDestroy(name string) func(s *terraform.State) error {
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "elasticstack_elasticsearch_snapshot_lifecycle" {
-				compID, _ := clients.CompositeIDFromStr(rs.Primary.ID)
-				if compID.ResourceID != name {
-					continue
-				}
+				continue
 			}
 
 			compID, _ := clients.CompositeIDFromStr(rs.Primary.ID)
+			if compID.ResourceID != name {
+				continue
+			}
 			esClient, err := client.GetESClient()
 			if err != nil {
 				return err


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/elastic/terraform-provider-elasticstack/security/quality/ai-findings)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix resource type filtering in `checkSlmDestroy` to skip non-matching resources
> Adds early-continue guards in [slm_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2639/files#diff-ca3b22183889fa89dbf0f3310d0d0c7e22f8896a9d86311958cc969cc652888b) so the SLM existence check is only performed for resources of type `elasticstack_elasticsearch_snapshot_lifecycle` whose `CompositeID.ResourceID` matches the given name. Previously, the `CompositeID` was parsed before confirming the resource type matched, which was flagged as a code quality issue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67fcee3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->