### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/internal/clients/elasticsearch/watch.go
+++ b/internal/clients/elasticsearch/watch.go
@@ -92,7 +92,7 @@ func GetWatch(ctx context.Context, apiClient *clients.ElasticsearchScopedClient,
 		return nil, nil
 	}
 
-	if d := diagutil.CheckHTTPErrorFromFW(res, "Unable to find watch on cluster."); d.HasError() {
+	if d := diagutil.CheckHTTPErrorFromFW(res, "Unable to get watch from cluster."); d.HasError() {
 		return nil, d
 	}
 

--- a/internal/clients/elasticsearch/watch.go
+++ b/internal/clients/elasticsearch/watch.go
@@ -59,7 +59,7 @@ func PutWatchBodyJSON(ctx context.Context, apiClient *clients.ElasticsearchScope
 
 	_, err = typedClient.Watcher.PutWatch(watchID).Active(active).Raw(bytes.NewReader(watchBodyJSON)).Do(ctx)
 	if err != nil {
-		diags.AddError("Unable to create or update watch", err.Error())
+		diags.AddError("Unable to put watch '"+watchID+"'", err.Error())
 		return diags
 	}
 	return diags


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/elastic/terraform-provider-elasticstack/security/quality/ai-findings)._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve diagnostic error messages in watch client functions
> Updates two diagnostic messages in [watch.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2640/files#diff-badfd296d4c725ca83949ff9a4a63a3f020540663a158952fb4518ca7a20db0d) for clarity. `PutWatchBodyJSON` now includes the specific watch ID in the failure message, and `GetWatch` changes 'Unable to find watch on cluster.' to 'Unable to get watch from cluster.'
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fa9548.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->