### PR TITLE
Tidy up ingest processors

### DIFF
--- a/internal/elasticsearch/ingest/processor_append_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_append_pf_data_source.go
@@ -30,28 +30,22 @@ import (
 
 type processorAppendModel struct {
 	CommonProcessorModel
-	ID              types.String `tfsdk:"id"`
-	JSON            types.String `tfsdk:"json"`
 	Field           types.String `tfsdk:"field"`
 	Value           types.List   `tfsdk:"value"`
 	AllowDuplicates types.Bool   `tfsdk:"allow_duplicates"`
 	MediaType       types.String `tfsdk:"media_type"`
 }
 
-func (m *processorAppendModel) TypeName() string    { return "append" }
-func (m *processorAppendModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorAppendModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorAppendModel) TypeName() string { return "append" }
 
 func (m *processorAppendModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorAppendBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -83,11 +77,6 @@ func (m *processorAppendModel) MarshalBody() (any, diag.Diagnostics) {
 
 	if IsKnown(m.MediaType) {
 		body.MediaType = m.MediaType.ValueString()
-	}
-
-	// Ensure ignore_failure default is reflected in state.
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_bytes_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_bytes_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorBytesModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorBytesModel) TypeName() string    { return "bytes" }
-func (m *processorBytesModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorBytesModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorBytesModel) TypeName() string { return "bytes" }
 
 func (m *processorBytesModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorBytesBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_circle_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_circle_pf_data_source.go
@@ -30,51 +30,28 @@ import (
 
 type processorCircleModel struct {
 	CommonProcessorModel
-	ID            types.String  `tfsdk:"id"`
-	JSON          types.String  `tfsdk:"json"`
-	Field         types.String  `tfsdk:"field"`
-	TargetField   types.String  `tfsdk:"target_field"`
-	IgnoreMissing types.Bool    `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 	ErrorDistance types.Float64 `tfsdk:"error_distance"`
 	ShapeType     types.String  `tfsdk:"shape_type"`
 }
 
-func (m *processorCircleModel) TypeName() string    { return "circle" }
-func (m *processorCircleModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorCircleModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorCircleModel) TypeName() string { return "circle" }
 
 func (m *processorCircleModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorCircleBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
 	if IsKnown(m.ErrorDistance) {
 		body.ErrorDistance = m.ErrorDistance.ValueFloat64()
 	}
 	if IsKnown(m.ShapeType) {
 		body.ShapeType = m.ShapeType.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_common.go
+++ b/internal/elasticsearch/ingest/processor_common.go
@@ -25,14 +25,62 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// CommonProcessorModel holds the fields shared by every ingest processor data
-// source. Embed this struct in concrete processor models.
+// CommonProcessorModel holds the PF schema state shared by every ingest
+// processor data source. Embed this struct in concrete processor models.
 type CommonProcessorModel struct {
+	ID            types.String `tfsdk:"id"`
+	JSON          types.String `tfsdk:"json"`
 	Description   types.String `tfsdk:"description"`
 	If            types.String `tfsdk:"if"`
 	IgnoreFailure types.Bool   `tfsdk:"ignore_failure"`
 	OnFailure     types.List   `tfsdk:"on_failure"`
 	Tag           types.String `tfsdk:"tag"`
+}
+
+func (m *CommonProcessorModel) SetID(id string)     { m.ID = types.StringValue(id) }
+func (m *CommonProcessorModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+
+// WithTargetField holds the field attributes shared by processors that write to
+// a target field.
+type WithTargetField struct {
+	Field       types.String `tfsdk:"field"`
+	TargetField types.String `tfsdk:"target_field"`
+}
+
+func (m WithTargetField) toTargetFieldBody() WithTargetFieldBody {
+	var body WithTargetFieldBody
+
+	if IsKnown(m.Field) {
+		body.Field = m.Field.ValueString()
+	}
+	if IsKnown(m.TargetField) {
+		body.TargetField = m.TargetField.ValueString()
+	}
+
+	return body
+}
+
+// WithIgnorableTargetField holds the target field attributes shared by
+// processors that can ignore missing input fields.
+type WithIgnorableTargetField struct {
+	WithTargetField
+	IgnoreMissing types.Bool `tfsdk:"ignore_missing"`
+}
+
+func (m *WithIgnorableTargetField) toIgnorableTargetFieldBody(defaultIgnoreMissing bool) WithIgnorableTargetFieldBody {
+	body := WithIgnorableTargetFieldBody{
+		WithTargetFieldBody: m.toTargetFieldBody(),
+	}
+
+	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
+		// Normalize computed defaults while building the body so state matches the JSON.
+		m.IgnoreMissing = types.BoolValue(defaultIgnoreMissing)
+		body.IgnoreMissing = defaultIgnoreMissing
+	} else {
+		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
+	}
+
+	return body
 }
 
 // CommonProcessorSchemaAttributes returns the schema attributes that are common

--- a/internal/elasticsearch/ingest/processor_community_id_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_community_id_pf_data_source.go
@@ -30,8 +30,6 @@ import (
 
 type processorCommunityIDModel struct {
 	CommonProcessorModel
-	ID              types.String `tfsdk:"id"`
-	JSON            types.String `tfsdk:"json"`
 	SourceIP        types.String `tfsdk:"source_ip"`
 	SourcePort      types.Int64  `tfsdk:"source_port"`
 	DestinationIP   types.String `tfsdk:"destination_ip"`
@@ -45,9 +43,7 @@ type processorCommunityIDModel struct {
 	IgnoreMissing   types.Bool   `tfsdk:"ignore_missing"`
 }
 
-func (m *processorCommunityIDModel) TypeName() string    { return "community_id" }
-func (m *processorCommunityIDModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorCommunityIDModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorCommunityIDModel) TypeName() string { return "community_id" }
 
 func intPtr(v int64) *int {
 	i := int(v)
@@ -58,12 +54,10 @@ func (m *processorCommunityIDModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorCommunityIDBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.SourceIP) {
 		body.SourceIP = m.SourceIP.ValueString()

--- a/internal/elasticsearch/ingest/processor_convert_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_convert_pf_data_source.go
@@ -30,47 +30,24 @@ import (
 
 type processorConvertModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
-	Type          types.String `tfsdk:"type"`
+	WithIgnorableTargetField
+	Type types.String `tfsdk:"type"`
 }
 
-func (m *processorConvertModel) TypeName() string    { return "convert" }
-func (m *processorConvertModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorConvertModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorConvertModel) TypeName() string { return "convert" }
 
 func (m *processorConvertModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorConvertBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
 	if IsKnown(m.Type) {
 		body.Type = m.Type.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_csv_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_csv_pf_data_source.go
@@ -30,8 +30,6 @@ import (
 
 type processorCSVModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
 	Field         types.String `tfsdk:"field"`
 	TargetFields  types.List   `tfsdk:"target_fields"`
 	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
@@ -41,20 +39,16 @@ type processorCSVModel struct {
 	EmptyValue    types.String `tfsdk:"empty_value"`
 }
 
-func (m *processorCSVModel) TypeName() string    { return "csv" }
-func (m *processorCSVModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorCSVModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorCSVModel) TypeName() string { return "csv" }
 
 func (m *processorCSVModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorCSVBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()

--- a/internal/elasticsearch/ingest/processor_date_index_name_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_date_index_name_pf_data_source.go
@@ -30,8 +30,6 @@ import (
 
 type processorDateIndexNameModel struct {
 	CommonProcessorModel
-	ID              types.String `tfsdk:"id"`
-	JSON            types.String `tfsdk:"json"`
 	Field           types.String `tfsdk:"field"`
 	IndexNamePrefix types.String `tfsdk:"index_name_prefix"`
 	DateRounding    types.String `tfsdk:"date_rounding"`
@@ -41,20 +39,16 @@ type processorDateIndexNameModel struct {
 	IndexNameFormat types.String `tfsdk:"index_name_format"`
 }
 
-func (m *processorDateIndexNameModel) TypeName() string    { return "date_index_name" }
-func (m *processorDateIndexNameModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorDateIndexNameModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorDateIndexNameModel) TypeName() string { return "date_index_name" }
 
 func (m *processorDateIndexNameModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorDateIndexNameBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()

--- a/internal/elasticsearch/ingest/processor_date_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_date_pf_data_source.go
@@ -30,8 +30,6 @@ import (
 
 type processorDateModel struct {
 	CommonProcessorModel
-	ID           types.String `tfsdk:"id"`
-	JSON         types.String `tfsdk:"json"`
 	Field        types.String `tfsdk:"field"`
 	TargetField  types.String `tfsdk:"target_field"`
 	Formats      types.List   `tfsdk:"formats"`
@@ -40,20 +38,16 @@ type processorDateModel struct {
 	OutputFormat types.String `tfsdk:"output_format"`
 }
 
-func (m *processorDateModel) TypeName() string    { return "date" }
-func (m *processorDateModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorDateModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorDateModel) TypeName() string { return "date" }
 
 func (m *processorDateModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorDateBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()

--- a/internal/elasticsearch/ingest/processor_dissect_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_dissect_pf_data_source.go
@@ -28,28 +28,22 @@ import (
 
 type processorDissectModel struct {
 	CommonProcessorModel
-	ID              types.String `tfsdk:"id"`
-	JSON            types.String `tfsdk:"json"`
 	Field           types.String `tfsdk:"field"`
 	Pattern         types.String `tfsdk:"pattern"`
 	AppendSeparator types.String `tfsdk:"append_separator"`
 	IgnoreMissing   types.Bool   `tfsdk:"ignore_missing"`
 }
 
-func (m *processorDissectModel) TypeName() string    { return "dissect" }
-func (m *processorDissectModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorDissectModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorDissectModel) TypeName() string { return "dissect" }
 
 func (m *processorDissectModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorDissectBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -65,10 +59,6 @@ func (m *processorDissectModel) MarshalBody() (any, diag.Diagnostics) {
 		body.IgnoreMissing = false
 	} else {
 		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_dot_expander_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_dot_expander_pf_data_source.go
@@ -28,27 +28,21 @@ import (
 
 type processorDotExpanderModel struct {
 	CommonProcessorModel
-	ID       types.String `tfsdk:"id"`
-	JSON     types.String `tfsdk:"json"`
 	Field    types.String `tfsdk:"field"`
 	Path     types.String `tfsdk:"path"`
 	Override types.Bool   `tfsdk:"override"`
 }
 
-func (m *processorDotExpanderModel) TypeName() string    { return "dot_expander" }
-func (m *processorDotExpanderModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorDotExpanderModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorDotExpanderModel) TypeName() string { return "dot_expander" }
 
 func (m *processorDotExpanderModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorDotExpanderBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -61,10 +55,6 @@ func (m *processorDotExpanderModel) MarshalBody() (any, diag.Diagnostics) {
 		body.Override = false
 	} else {
 		body.Override = m.Override.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_drop_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_drop_pf_data_source.go
@@ -23,33 +23,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorDropModel struct {
 	CommonProcessorModel
-	ID   types.String `tfsdk:"id"`
-	JSON types.String `tfsdk:"json"`
 }
 
-func (m *processorDropModel) TypeName() string    { return "drop" }
-func (m *processorDropModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorDropModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorDropModel) TypeName() string { return "drop" }
 
 func (m *processorDropModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorDropBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
-	}
-	body.CommonProcessorBody = commonBody
-
-	// Ensure ignore_failure default is reflected in state.
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_enrich_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_enrich_pf_data_source.go
@@ -28,44 +28,25 @@ import (
 
 type processorEnrichModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 	PolicyName    types.String `tfsdk:"policy_name"`
 	Override      types.Bool   `tfsdk:"override"`
 	MaxMatches    types.Int64  `tfsdk:"max_matches"`
 	ShapeRelation types.String `tfsdk:"shape_relation"`
 }
 
-func (m *processorEnrichModel) TypeName() string    { return "enrich" }
-func (m *processorEnrichModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorEnrichModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorEnrichModel) TypeName() string { return "enrich" }
 
 func (m *processorEnrichModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorEnrichBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
 	if IsKnown(m.PolicyName) {
 		body.PolicyName = m.PolicyName.ValueString()
 	}
@@ -83,10 +64,6 @@ func (m *processorEnrichModel) MarshalBody() (any, diag.Diagnostics) {
 	}
 	if IsKnown(m.ShapeRelation) {
 		body.ShapeRelation = m.ShapeRelation.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_fail_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_fail_pf_data_source.go
@@ -28,25 +28,19 @@ import (
 
 type processorFailModel struct {
 	CommonProcessorModel
-	ID      types.String `tfsdk:"id"`
-	JSON    types.String `tfsdk:"json"`
 	Message types.String `tfsdk:"message"`
 }
 
-func (m *processorFailModel) TypeName() string    { return "fail" }
-func (m *processorFailModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorFailModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorFailModel) TypeName() string { return "fail" }
 
 func (m *processorFailModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorFailBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Message) {
 		body.Message = m.Message.ValueString()

--- a/internal/elasticsearch/ingest/processor_fingerprint_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_fingerprint_pf_data_source.go
@@ -31,8 +31,6 @@ import (
 
 type processorFingerprintModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
 	Fields        types.List   `tfsdk:"fields"`
 	TargetField   types.String `tfsdk:"target_field"`
 	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
@@ -40,20 +38,16 @@ type processorFingerprintModel struct {
 	Method        types.String `tfsdk:"method"`
 }
 
-func (m *processorFingerprintModel) TypeName() string    { return "fingerprint" }
-func (m *processorFingerprintModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorFingerprintModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorFingerprintModel) TypeName() string { return "fingerprint" }
 
 func (m *processorFingerprintModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorFingerprintBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Fields) {
 		elems := make([]string, 0, len(m.Fields.Elements()))

--- a/internal/elasticsearch/ingest/processor_foreach_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_foreach_pf_data_source.go
@@ -30,27 +30,21 @@ import (
 
 type processorForeachModel struct {
 	CommonProcessorModel
-	ID            types.String         `tfsdk:"id"`
-	JSON          types.String         `tfsdk:"json"`
 	Field         types.String         `tfsdk:"field"`
 	Processor     jsontypes.Normalized `tfsdk:"processor"`
 	IgnoreMissing types.Bool           `tfsdk:"ignore_missing"`
 }
 
-func (m *processorForeachModel) TypeName() string    { return "foreach" }
-func (m *processorForeachModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorForeachModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorForeachModel) TypeName() string { return "foreach" }
 
 func (m *processorForeachModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorForeachBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -70,11 +64,6 @@ func (m *processorForeachModel) MarshalBody() (any, diag.Diagnostics) {
 		body.IgnoreMissing = false
 	} else {
 		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	// Ensure ignore_failure default is reflected in state.
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_geoip_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_geoip_pf_data_source.go
@@ -28,45 +28,29 @@ import (
 
 type processorGeoIPModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
-	DatabaseFile  types.String `tfsdk:"database_file"`
-	Properties    types.Set    `tfsdk:"properties"`
-	FirstOnly     types.Bool   `tfsdk:"first_only"`
+	WithIgnorableTargetField
+	DatabaseFile types.String `tfsdk:"database_file"`
+	Properties   types.Set    `tfsdk:"properties"`
+	FirstOnly    types.Bool   `tfsdk:"first_only"`
 }
 
-func (m *processorGeoIPModel) TypeName() string    { return "geoip" }
-func (m *processorGeoIPModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorGeoIPModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorGeoIPModel) TypeName() string { return "geoip" }
 
 func (m *processorGeoIPModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorGeoIPBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
 	if m.TargetField.IsNull() || m.TargetField.IsUnknown() {
 		m.TargetField = types.StringValue("geoip")
-		body.TargetField = "geoip"
+		body.WithIgnorableTargetFieldBody.TargetField = "geoip"
 	} else {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
+		body.WithIgnorableTargetFieldBody.TargetField = m.TargetField.ValueString()
 	}
 	if IsKnown(m.DatabaseFile) {
 		body.DatabaseFile = m.DatabaseFile.ValueString()
@@ -92,10 +76,6 @@ func (m *processorGeoIPModel) MarshalBody() (any, diag.Diagnostics) {
 		body.FirstOnly = true
 	} else {
 		body.FirstOnly = m.FirstOnly.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_geoip_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_geoip_pf_data_source.go
@@ -48,9 +48,9 @@ func (m *processorGeoIPModel) MarshalBody() (any, diag.Diagnostics) {
 
 	if m.TargetField.IsNull() || m.TargetField.IsUnknown() {
 		m.TargetField = types.StringValue("geoip")
-		body.WithIgnorableTargetFieldBody.TargetField = "geoip"
+		body.TargetField = "geoip"
 	} else {
-		body.WithIgnorableTargetFieldBody.TargetField = m.TargetField.ValueString()
+		body.TargetField = m.TargetField.ValueString()
 	}
 	if IsKnown(m.DatabaseFile) {
 		body.DatabaseFile = m.DatabaseFile.ValueString()

--- a/internal/elasticsearch/ingest/processor_grok_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_grok_pf_data_source.go
@@ -31,8 +31,6 @@ import (
 
 type processorGrokModel struct {
 	CommonProcessorModel
-	ID                 types.String `tfsdk:"id"`
-	JSON               types.String `tfsdk:"json"`
 	Field              types.String `tfsdk:"field"`
 	Patterns           types.List   `tfsdk:"patterns"`
 	PatternDefinitions types.Map    `tfsdk:"pattern_definitions"`
@@ -41,20 +39,16 @@ type processorGrokModel struct {
 	IgnoreMissing      types.Bool   `tfsdk:"ignore_missing"`
 }
 
-func (m *processorGrokModel) TypeName() string    { return "grok" }
-func (m *processorGrokModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorGrokModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorGrokModel) TypeName() string { return "grok" }
 
 func (m *processorGrokModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorGrokBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()

--- a/internal/elasticsearch/ingest/processor_gsub_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_gsub_pf_data_source.go
@@ -28,51 +28,28 @@ import (
 
 type processorGsubModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	Pattern       types.String `tfsdk:"pattern"`
-	Replacement   types.String `tfsdk:"replacement"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
+	Pattern     types.String `tfsdk:"pattern"`
+	Replacement types.String `tfsdk:"replacement"`
 }
 
-func (m *processorGsubModel) TypeName() string    { return "gsub" }
-func (m *processorGsubModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorGsubModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorGsubModel) TypeName() string { return "gsub" }
 
 func (m *processorGsubModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorGsubBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
 	if IsKnown(m.Pattern) {
 		body.Pattern = m.Pattern.ValueString()
 	}
 	if IsKnown(m.Replacement) {
 		body.Replacement = m.Replacement.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_html_strip_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_html_strip_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorHTMLStripModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorHTMLStripModel) TypeName() string    { return "html_strip" }
-func (m *processorHTMLStripModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorHTMLStripModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorHTMLStripModel) TypeName() string { return "html_strip" }
 
 func (m *processorHTMLStripModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorHTMLStripBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_inference_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_inference_pf_data_source.go
@@ -28,28 +28,22 @@ import (
 
 type processorInferenceModel struct {
 	CommonProcessorModel
-	ID          types.String `tfsdk:"id"`
-	JSON        types.String `tfsdk:"json"`
 	ModelID     types.String `tfsdk:"model_id"`
 	InputOutput types.Object `tfsdk:"input_output"`
 	FieldMap    types.Map    `tfsdk:"field_map"`
 	TargetField types.String `tfsdk:"target_field"`
 }
 
-func (m *processorInferenceModel) TypeName() string    { return "inference" }
-func (m *processorInferenceModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorInferenceModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorInferenceModel) TypeName() string { return "inference" }
 
 func (m *processorInferenceModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorInferenceBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.ModelID) {
 		body.ModelID = m.ModelID.ValueString()

--- a/internal/elasticsearch/ingest/processor_join_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_join_pf_data_source.go
@@ -28,27 +28,21 @@ import (
 
 type processorJoinModel struct {
 	CommonProcessorModel
-	ID          types.String `tfsdk:"id"`
-	JSON        types.String `tfsdk:"json"`
 	Field       types.String `tfsdk:"field"`
 	Separator   types.String `tfsdk:"separator"`
 	TargetField types.String `tfsdk:"target_field"`
 }
 
-func (m *processorJoinModel) TypeName() string    { return "join" }
-func (m *processorJoinModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorJoinModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorJoinModel) TypeName() string { return "join" }
 
 func (m *processorJoinModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorJoinBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -58,10 +52,6 @@ func (m *processorJoinModel) MarshalBody() (any, diag.Diagnostics) {
 	}
 	if IsKnown(m.TargetField) {
 		body.TargetField = m.TargetField.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_json_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_json_pf_data_source.go
@@ -30,8 +30,6 @@ import (
 
 type processorJSONModel struct {
 	CommonProcessorModel
-	ID                        types.String `tfsdk:"id"`
-	JSON                      types.String `tfsdk:"json"`
 	Field                     types.String `tfsdk:"field"`
 	TargetField               types.String `tfsdk:"target_field"`
 	AddToRoot                 types.Bool   `tfsdk:"add_to_root"`
@@ -39,20 +37,16 @@ type processorJSONModel struct {
 	AllowDuplicateKeys        types.Bool   `tfsdk:"allow_duplicate_keys"`
 }
 
-func (m *processorJSONModel) TypeName() string    { return "json" }
-func (m *processorJSONModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorJSONModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorJSONModel) TypeName() string { return "json" }
 
 func (m *processorJSONModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorJSONBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -70,10 +64,6 @@ func (m *processorJSONModel) MarshalBody() (any, diag.Diagnostics) {
 	if IsKnown(m.AllowDuplicateKeys) {
 		v := m.AllowDuplicateKeys.ValueBool()
 		body.AllowDuplicateKeys = &v
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_kv_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_kv_pf_data_source.go
@@ -28,11 +28,7 @@ import (
 
 type processorKVModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 	FieldSplit    types.String `tfsdk:"field_split"`
 	ValueSplit    types.String `tfsdk:"value_split"`
 	IncludeKeys   types.Set    `tfsdk:"include_keys"`
@@ -43,9 +39,7 @@ type processorKVModel struct {
 	StripBrackets types.Bool   `tfsdk:"strip_brackets"`
 }
 
-func (m *processorKVModel) TypeName() string    { return "kv" }
-func (m *processorKVModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorKVModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorKVModel) TypeName() string { return "kv" }
 
 func stringSetValue(set types.Set, diags *diag.Diagnostics) []string {
 	if !IsKnown(set) {
@@ -56,9 +50,9 @@ func stringSetValue(set types.Set, diags *diag.Diagnostics) []string {
 		str, ok := elem.(types.String)
 		if !ok || !IsKnown(str) {
 			if !ok {
-				diags.AddError("Invalid list element type", "expected types.String")
+				diags.AddError("Invalid set element type", "expected types.String")
 			} else {
-				diags.AddError("Unknown list element", "list elements cannot be unknown")
+				diags.AddError("Unknown set element", "set elements cannot be unknown")
 			}
 			continue
 		}
@@ -71,25 +65,12 @@ func (m *processorKVModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorKVBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
 	if IsKnown(m.FieldSplit) {
 		body.FieldSplit = m.FieldSplit.ValueString()
 	}
@@ -112,10 +93,6 @@ func (m *processorKVModel) MarshalBody() (any, diag.Diagnostics) {
 		body.StripBrackets = false
 	} else {
 		body.StripBrackets = m.StripBrackets.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_lowercase_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_lowercase_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorLowercaseModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorLowercaseModel) TypeName() string    { return "lowercase" }
-func (m *processorLowercaseModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorLowercaseModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorLowercaseModel) TypeName() string { return "lowercase" }
 
 func (m *processorLowercaseModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorLowercaseBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_models.go
+++ b/internal/elasticsearch/ingest/processor_models.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // CommonProcessorBody holds the JSON-tagged fields shared by every ingest
@@ -34,24 +35,39 @@ type CommonProcessorBody struct {
 	Tag           string           `json:"tag,omitempty"`
 }
 
+type WithTargetFieldBody struct {
+	Field       string `json:"field"`
+	TargetField string `json:"target_field,omitempty"`
+}
+
+type WithIgnorableTargetFieldBody struct {
+	WithTargetFieldBody
+	IgnoreMissing bool `json:"ignore_missing"`
+}
+
 // toCommonProcessorBody translates a CommonProcessorModel into a
 // CommonProcessorBody. It returns any diagnostics collected while parsing
 // on_failure JSON values.
-func toCommonProcessorBody(model CommonProcessorModel) (CommonProcessorBody, diag.Diagnostics) {
+func (m *CommonProcessorModel) toCommonProcessorBody() (CommonProcessorBody, diag.Diagnostics) {
 	var body CommonProcessorBody
 	var diags diag.Diagnostics
 
-	if IsKnown(model.Description) {
-		body.Description = model.Description.ValueString()
+	if IsKnown(m.Description) {
+		body.Description = m.Description.ValueString()
 	}
-	if IsKnown(model.If) {
-		body.If = model.If.ValueString()
+	if IsKnown(m.If) {
+		body.If = m.If.ValueString()
 	}
-	if IsKnown(model.IgnoreFailure) {
-		body.IgnoreFailure = model.IgnoreFailure.ValueBool()
+	if IsKnown(m.IgnoreFailure) {
+		body.IgnoreFailure = m.IgnoreFailure.ValueBool()
+	} else {
+		// Normalize computed defaults while building the body so state matches the JSON.
+		m.IgnoreFailure = types.BoolValue(false)
 	}
-	if IsKnown(model.OnFailure) {
-		for _, elem := range model.OnFailure.Elements() {
+	if IsKnown(m.OnFailure) {
+		elements := m.OnFailure.Elements()
+		body.OnFailure = make([]map[string]any, 0, len(elements))
+		for _, elem := range elements {
 			norm, ok := elem.(jsontypes.Normalized)
 			if !ok {
 				diags.AddError("Invalid on_failure element type", "expected jsontypes.Normalized")
@@ -69,8 +85,8 @@ func toCommonProcessorBody(model CommonProcessorModel) (CommonProcessorBody, dia
 			body.OnFailure = append(body.OnFailure, item)
 		}
 	}
-	if IsKnown(model.Tag) {
-		body.Tag = model.Tag.ValueString()
+	if IsKnown(m.Tag) {
+		body.Tag = m.Tag.ValueString()
 	}
 
 	return body, diags
@@ -110,17 +126,13 @@ type processorForeachBody struct {
 // processorBytesBody is the JSON body for the bytes processor.
 type processorBytesBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorCircleBody is the JSON body for the circle processor.
 type processorCircleBody struct {
 	CommonProcessorBody
-	Field         string  `json:"field"`
-	TargetField   string  `json:"target_field,omitempty"`
-	IgnoreMissing bool    `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 	ErrorDistance float64 `json:"error_distance"`
 	ShapeType     string  `json:"shape_type"`
 }
@@ -144,10 +156,8 @@ type processorCommunityIDBody struct {
 // processorConvertBody is the JSON body for the convert processor.
 type processorConvertBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
-	Type          string `json:"type"`
+	WithIgnorableTargetFieldBody
+	Type string `json:"type"`
 }
 
 // processorCSVBody is the JSON body for the csv processor.
@@ -165,8 +175,7 @@ type processorCSVBody struct {
 // processorDateBody is the JSON body for the date processor.
 type processorDateBody struct {
 	CommonProcessorBody
-	Field        string   `json:"field"`
-	TargetField  string   `json:"target_field,omitempty"`
+	WithTargetFieldBody
 	Formats      []string `json:"formats"`
 	Timezone     string   `json:"timezone,omitempty"`
 	Locale       string   `json:"locale,omitempty"`
@@ -205,9 +214,7 @@ type processorDotExpanderBody struct {
 // processorEnrichBody is the JSON body for the enrich processor.
 type processorEnrichBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 	PolicyName    string `json:"policy_name"`
 	Override      bool   `json:"override"`
 	MaxMatches    int    `json:"max_matches"`
@@ -233,12 +240,10 @@ type processorFingerprintBody struct {
 // processorGeoIPBody is the JSON body for the geoip processor.
 type processorGeoIPBody struct {
 	CommonProcessorBody
-	Field         string   `json:"field"`
-	TargetField   string   `json:"target_field,omitempty"`
-	IgnoreMissing bool     `json:"ignore_missing"`
-	DatabaseFile  string   `json:"database_file,omitempty"`
-	Properties    []string `json:"properties,omitempty"`
-	FirstOnly     bool     `json:"first_only"`
+	WithIgnorableTargetFieldBody
+	DatabaseFile string   `json:"database_file,omitempty"`
+	Properties   []string `json:"properties,omitempty"`
+	FirstOnly    bool     `json:"first_only"`
 }
 
 // processorGrokBody is the JSON body for the grok processor.
@@ -255,19 +260,15 @@ type processorGrokBody struct {
 // processorGsubBody is the JSON body for the gsub processor.
 type processorGsubBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
-	Pattern       string `json:"pattern"`
-	Replacement   string `json:"replacement"`
+	WithIgnorableTargetFieldBody
+	Pattern     string `json:"pattern"`
+	Replacement string `json:"replacement"`
 }
 
 // processorHTMLStripBody is the JSON body for the html_strip processor.
 type processorHTMLStripBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorInferenceInputOutputBody is the JSON body for the inference input_output.
@@ -288,16 +289,14 @@ type processorInferenceBody struct {
 // processorJoinBody is the JSON body for the join processor.
 type processorJoinBody struct {
 	CommonProcessorBody
-	Field       string `json:"field"`
-	Separator   string `json:"separator"`
-	TargetField string `json:"target_field,omitempty"`
+	WithTargetFieldBody
+	Separator string `json:"separator"`
 }
 
 // processorJSONBody is the JSON body for the json processor.
 type processorJSONBody struct {
 	CommonProcessorBody
-	Field                     string `json:"field"`
-	TargetField               string `json:"target_field,omitempty"`
+	WithTargetFieldBody
 	AddToRoot                 *bool  `json:"add_to_root,omitempty"`
 	AddToRootConflictStrategy string `json:"add_to_root_conflict_strategy,omitempty"`
 	AllowDuplicateKeys        *bool  `json:"allow_duplicate_keys,omitempty"`
@@ -306,9 +305,7 @@ type processorJSONBody struct {
 // processorKVBody is the JSON body for the kv processor.
 type processorKVBody struct {
 	CommonProcessorBody
-	Field         string   `json:"field"`
-	TargetField   string   `json:"target_field,omitempty"`
-	IgnoreMissing bool     `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 	FieldSplit    string   `json:"field_split"`
 	ValueSplit    string   `json:"value_split"`
 	IncludeKeys   []string `json:"include_keys,omitempty"`
@@ -322,9 +319,7 @@ type processorKVBody struct {
 // processorLowercaseBody is the JSON body for the lowercase processor.
 type processorLowercaseBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorNetworkDirectionBody is the JSON body for the network_direction processor.
@@ -347,9 +342,7 @@ type processorPipelineBody struct {
 // processorRegisteredDomainBody is the JSON body for the registered_domain processor.
 type processorRegisteredDomainBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorRemoveBody is the JSON body for the remove processor.
@@ -362,9 +355,7 @@ type processorRemoveBody struct {
 // processorRenameBody is the JSON body for the rename processor.
 type processorRenameBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorRerouteBody is the JSON body for the reroute processor.
@@ -396,17 +387,14 @@ type processorSetSecurityUserBody struct {
 // processorSortBody is the JSON body for the sort processor.
 type processorSortBody struct {
 	CommonProcessorBody
-	Field       string `json:"field"`
-	Order       string `json:"order,omitempty"`
-	TargetField string `json:"target_field,omitempty"`
+	WithTargetFieldBody
+	Order string `json:"order,omitempty"`
 }
 
 // processorSplitBody is the JSON body for the split processor.
 type processorSplitBody struct {
 	CommonProcessorBody
-	Field            string `json:"field"`
-	TargetField      string `json:"target_field,omitempty"`
-	IgnoreMissing    bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 	Separator        string `json:"separator"`
 	PreserveTrailing bool   `json:"preserve_trailing"`
 }
@@ -414,42 +402,33 @@ type processorSplitBody struct {
 // processorTrimBody is the JSON body for the trim processor.
 type processorTrimBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorUppercaseBody is the JSON body for the uppercase processor.
 type processorUppercaseBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorURIPartsBody is the JSON body for the uri_parts processor.
 type processorURIPartsBody struct {
 	CommonProcessorBody
-	Field              string `json:"field"`
-	TargetField        string `json:"target_field,omitempty"`
-	KeepOriginal       bool   `json:"keep_original"`
-	RemoveIfSuccessful bool   `json:"remove_if_successful"`
+	WithTargetFieldBody
+	KeepOriginal       bool `json:"keep_original"`
+	RemoveIfSuccessful bool `json:"remove_if_successful"`
 }
 
 // processorURLDecodeBody is the JSON body for the urldecode processor.
 type processorURLDecodeBody struct {
 	CommonProcessorBody
-	Field         string `json:"field"`
-	TargetField   string `json:"target_field,omitempty"`
-	IgnoreMissing bool   `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 }
 
 // processorUserAgentBody is the JSON body for the user_agent processor.
 type processorUserAgentBody struct {
 	CommonProcessorBody
-	Field             string   `json:"field"`
-	TargetField       string   `json:"target_field,omitempty"`
-	IgnoreMissing     bool     `json:"ignore_missing"`
+	WithIgnorableTargetFieldBody
 	RegexFile         string   `json:"regex_file,omitempty"`
 	Properties        []string `json:"properties,omitempty"`
 	ExtractDeviceType *bool    `json:"extract_device_type,omitempty"`

--- a/internal/elasticsearch/ingest/processor_network_direction_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_network_direction_pf_data_source.go
@@ -28,8 +28,6 @@ import (
 
 type processorNetworkDirectionModel struct {
 	CommonProcessorModel
-	ID                    types.String `tfsdk:"id"`
-	JSON                  types.String `tfsdk:"json"`
 	SourceIP              types.String `tfsdk:"source_ip"`
 	DestinationIP         types.String `tfsdk:"destination_ip"`
 	TargetField           types.String `tfsdk:"target_field"`
@@ -38,20 +36,16 @@ type processorNetworkDirectionModel struct {
 	IgnoreMissing         types.Bool   `tfsdk:"ignore_missing"`
 }
 
-func (m *processorNetworkDirectionModel) TypeName() string    { return "network_direction" }
-func (m *processorNetworkDirectionModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorNetworkDirectionModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorNetworkDirectionModel) TypeName() string { return "network_direction" }
 
 func (m *processorNetworkDirectionModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorNetworkDirectionBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.SourceIP) {
 		body.SourceIP = m.SourceIP.ValueString()

--- a/internal/elasticsearch/ingest/processor_pipeline_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_pipeline_pf_data_source.go
@@ -28,32 +28,22 @@ import (
 
 type processorPipelineModel struct {
 	CommonProcessorModel
-	ID   types.String `tfsdk:"id"`
-	JSON types.String `tfsdk:"json"`
 	Name types.String `tfsdk:"name"`
 }
 
-func (m *processorPipelineModel) TypeName() string    { return "pipeline" }
-func (m *processorPipelineModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorPipelineModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorPipelineModel) TypeName() string { return "pipeline" }
 
 func (m *processorPipelineModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorPipelineBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Name) {
 		body.Name = m.Name.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_registered_domain_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_registered_domain_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorRegisteredDomainModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorRegisteredDomainModel) TypeName() string    { return "registered_domain" }
-func (m *processorRegisteredDomainModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorRegisteredDomainModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorRegisteredDomainModel) TypeName() string { return "registered_domain" }
 
 func (m *processorRegisteredDomainModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorRegisteredDomainBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_remove_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_remove_pf_data_source.go
@@ -28,26 +28,20 @@ import (
 
 type processorRemoveModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.Set    `tfsdk:"field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	Field         types.Set  `tfsdk:"field"`
+	IgnoreMissing types.Bool `tfsdk:"ignore_missing"`
 }
 
-func (m *processorRemoveModel) TypeName() string    { return "remove" }
-func (m *processorRemoveModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorRemoveModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorRemoveModel) TypeName() string { return "remove" }
 
 func (m *processorRemoveModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorRemoveBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		elems := make([]string, 0, len(m.Field.Elements()))

--- a/internal/elasticsearch/ingest/processor_rename_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_rename_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorRenameModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorRenameModel) TypeName() string    { return "rename" }
-func (m *processorRenameModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorRenameModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorRenameModel) TypeName() string { return "rename" }
 
 func (m *processorRenameModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorRenameBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_reroute_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_reroute_pf_data_source.go
@@ -28,27 +28,21 @@ import (
 
 type processorRerouteModel struct {
 	CommonProcessorModel
-	ID          types.String `tfsdk:"id"`
-	JSON        types.String `tfsdk:"json"`
 	Destination types.String `tfsdk:"destination"`
 	Dataset     types.String `tfsdk:"dataset"`
 	Namespace   types.String `tfsdk:"namespace"`
 }
 
-func (m *processorRerouteModel) TypeName() string    { return "reroute" }
-func (m *processorRerouteModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorRerouteModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorRerouteModel) TypeName() string { return "reroute" }
 
 func (m *processorRerouteModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorRerouteBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Destination) {
 		body.Destination = m.Destination.ValueString()
@@ -58,10 +52,6 @@ func (m *processorRerouteModel) MarshalBody() (any, diag.Diagnostics) {
 	}
 	if IsKnown(m.Namespace) {
 		body.Namespace = m.Namespace.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_script_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_script_pf_data_source.go
@@ -33,28 +33,22 @@ import (
 
 type processorScriptModel struct {
 	CommonProcessorModel
-	ID       types.String         `tfsdk:"id"`
-	JSON     types.String         `tfsdk:"json"`
 	Lang     types.String         `tfsdk:"lang"`
 	ScriptID types.String         `tfsdk:"script_id"`
 	Source   types.String         `tfsdk:"source"`
 	Params   jsontypes.Normalized `tfsdk:"params"`
 }
 
-func (m *processorScriptModel) TypeName() string    { return "script" }
-func (m *processorScriptModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorScriptModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorScriptModel) TypeName() string { return "script" }
 
 func (m *processorScriptModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorScriptBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Lang) {
 		body.Lang = m.Lang.ValueString()
@@ -72,11 +66,6 @@ func (m *processorScriptModel) MarshalBody() (any, diag.Diagnostics) {
 			return nil, diags
 		}
 		body.Params = params
-	}
-
-	// Ensure ignore_failure default is reflected in state.
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_set_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_set_pf_data_source.go
@@ -31,8 +31,6 @@ import (
 
 type processorSetModel struct {
 	CommonProcessorModel
-	ID               types.String `tfsdk:"id"`
-	JSON             types.String `tfsdk:"json"`
 	Field            types.String `tfsdk:"field"`
 	Value            types.String `tfsdk:"value"`
 	CopyFrom         types.String `tfsdk:"copy_from"`
@@ -41,20 +39,16 @@ type processorSetModel struct {
 	MediaType        types.String `tfsdk:"media_type"`
 }
 
-func (m *processorSetModel) TypeName() string    { return "set" }
-func (m *processorSetModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorSetModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorSetModel) TypeName() string { return "set" }
 
 func (m *processorSetModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorSetBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()

--- a/internal/elasticsearch/ingest/processor_set_security_user_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_set_security_user_pf_data_source.go
@@ -28,26 +28,20 @@ import (
 
 type processorSetSecurityUserModel struct {
 	CommonProcessorModel
-	ID         types.String `tfsdk:"id"`
-	JSON       types.String `tfsdk:"json"`
 	Field      types.String `tfsdk:"field"`
 	Properties types.Set    `tfsdk:"properties"`
 }
 
-func (m *processorSetSecurityUserModel) TypeName() string    { return "set_security_user" }
-func (m *processorSetSecurityUserModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorSetSecurityUserModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorSetSecurityUserModel) TypeName() string { return "set_security_user" }
 
 func (m *processorSetSecurityUserModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorSetSecurityUserBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -67,10 +61,6 @@ func (m *processorSetSecurityUserModel) MarshalBody() (any, diag.Diagnostics) {
 			elems = append(elems, str.ValueString())
 		}
 		body.Properties = elems
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_sort_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_sort_pf_data_source.go
@@ -30,27 +30,21 @@ import (
 
 type processorSortModel struct {
 	CommonProcessorModel
-	ID          types.String `tfsdk:"id"`
-	JSON        types.String `tfsdk:"json"`
 	Field       types.String `tfsdk:"field"`
 	Order       types.String `tfsdk:"order"`
 	TargetField types.String `tfsdk:"target_field"`
 }
 
-func (m *processorSortModel) TypeName() string    { return "sort" }
-func (m *processorSortModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorSortModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorSortModel) TypeName() string { return "sort" }
 
 func (m *processorSortModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorSortBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -63,10 +57,6 @@ func (m *processorSortModel) MarshalBody() (any, diag.Diagnostics) {
 	}
 	if IsKnown(m.TargetField) {
 		body.TargetField = m.TargetField.ValueString()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_split_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_split_pf_data_source.go
@@ -28,42 +28,23 @@ import (
 
 type processorSplitModel struct {
 	CommonProcessorModel
-	ID               types.String `tfsdk:"id"`
-	JSON             types.String `tfsdk:"json"`
-	Field            types.String `tfsdk:"field"`
-	TargetField      types.String `tfsdk:"target_field"`
-	IgnoreMissing    types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 	Separator        types.String `tfsdk:"separator"`
 	PreserveTrailing types.Bool   `tfsdk:"preserve_trailing"`
 }
 
-func (m *processorSplitModel) TypeName() string    { return "split" }
-func (m *processorSplitModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorSplitModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorSplitModel) TypeName() string { return "split" }
 
 func (m *processorSplitModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorSplitBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
 	if IsKnown(m.Separator) {
 		body.Separator = m.Separator.ValueString()
 	}
@@ -72,10 +53,6 @@ func (m *processorSplitModel) MarshalBody() (any, diag.Diagnostics) {
 		body.PreserveTrailing = false
 	} else {
 		body.PreserveTrailing = m.PreserveTrailing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_trim_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_trim_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorTrimModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorTrimModel) TypeName() string    { return "trim" }
-func (m *processorTrimModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorTrimModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorTrimModel) TypeName() string { return "trim" }
 
 func (m *processorTrimModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorTrimBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_uppercase_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_uppercase_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorUppercaseModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorUppercaseModel) TypeName() string    { return "uppercase" }
-func (m *processorUppercaseModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorUppercaseModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorUppercaseModel) TypeName() string { return "uppercase" }
 
 func (m *processorUppercaseModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorUppercaseBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_uri_parts_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_uri_parts_pf_data_source.go
@@ -28,28 +28,22 @@ import (
 
 type processorURIPartsModel struct {
 	CommonProcessorModel
-	ID                 types.String `tfsdk:"id"`
-	JSON               types.String `tfsdk:"json"`
 	Field              types.String `tfsdk:"field"`
 	TargetField        types.String `tfsdk:"target_field"`
 	KeepOriginal       types.Bool   `tfsdk:"keep_original"`
 	RemoveIfSuccessful types.Bool   `tfsdk:"remove_if_successful"`
 }
 
-func (m *processorURIPartsModel) TypeName() string    { return "uri_parts" }
-func (m *processorURIPartsModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorURIPartsModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorURIPartsModel) TypeName() string { return "uri_parts" }
 
 func (m *processorURIPartsModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorURIPartsBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
 
 	if IsKnown(m.Field) {
 		body.Field = m.Field.ValueString()
@@ -68,10 +62,6 @@ func (m *processorURIPartsModel) MarshalBody() (any, diag.Diagnostics) {
 		body.RemoveIfSuccessful = false
 	} else {
 		body.RemoveIfSuccessful = m.RemoveIfSuccessful.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags

--- a/internal/elasticsearch/ingest/processor_urldecode_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_urldecode_pf_data_source.go
@@ -23,49 +23,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type processorURLDecodeModel struct {
 	CommonProcessorModel
-	ID            types.String `tfsdk:"id"`
-	JSON          types.String `tfsdk:"json"`
-	Field         types.String `tfsdk:"field"`
-	TargetField   types.String `tfsdk:"target_field"`
-	IgnoreMissing types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 }
 
-func (m *processorURLDecodeModel) TypeName() string    { return "urldecode" }
-func (m *processorURLDecodeModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorURLDecodeModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorURLDecodeModel) TypeName() string { return "urldecode" }
 
 func (m *processorURLDecodeModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorURLDecodeBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
-
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
-	}
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
 	return body, diags
 }

--- a/internal/elasticsearch/ingest/processor_user_agent_pf_data_source.go
+++ b/internal/elasticsearch/ingest/processor_user_agent_pf_data_source.go
@@ -28,43 +28,24 @@ import (
 
 type processorUserAgentModel struct {
 	CommonProcessorModel
-	ID                types.String `tfsdk:"id"`
-	JSON              types.String `tfsdk:"json"`
-	Field             types.String `tfsdk:"field"`
-	TargetField       types.String `tfsdk:"target_field"`
-	IgnoreMissing     types.Bool   `tfsdk:"ignore_missing"`
+	WithIgnorableTargetField
 	RegexFile         types.String `tfsdk:"regex_file"`
 	Properties        types.Set    `tfsdk:"properties"`
 	ExtractDeviceType types.Bool   `tfsdk:"extract_device_type"`
 }
 
-func (m *processorUserAgentModel) TypeName() string    { return "user_agent" }
-func (m *processorUserAgentModel) SetID(id string)     { m.ID = types.StringValue(id) }
-func (m *processorUserAgentModel) SetJSON(json string) { m.JSON = types.StringValue(json) }
+func (m *processorUserAgentModel) TypeName() string { return "user_agent" }
 
 func (m *processorUserAgentModel) MarshalBody() (any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	body := processorUserAgentBody{}
 
-	commonBody, d := toCommonProcessorBody(m.CommonProcessorModel)
-	diags.Append(d...)
+	body.CommonProcessorBody, diags = m.toCommonProcessorBody()
 	if diags.HasError() {
 		return nil, diags
 	}
-	body.CommonProcessorBody = commonBody
+	body.WithIgnorableTargetFieldBody = m.toIgnorableTargetFieldBody(false)
 
-	if IsKnown(m.Field) {
-		body.Field = m.Field.ValueString()
-	}
-	if IsKnown(m.TargetField) {
-		body.TargetField = m.TargetField.ValueString()
-	}
-	if m.IgnoreMissing.IsNull() || m.IgnoreMissing.IsUnknown() {
-		m.IgnoreMissing = types.BoolValue(false)
-		body.IgnoreMissing = false
-	} else {
-		body.IgnoreMissing = m.IgnoreMissing.ValueBool()
-	}
 	if IsKnown(m.RegexFile) {
 		body.RegexFile = m.RegexFile.ValueString()
 	}
@@ -87,10 +68,6 @@ func (m *processorUserAgentModel) MarshalBody() (any, diag.Diagnostics) {
 	if IsKnown(m.ExtractDeviceType) {
 		v := m.ExtractDeviceType.ValueBool()
 		body.ExtractDeviceType = &v
-	}
-
-	if m.IgnoreFailure.IsNull() || m.IgnoreFailure.IsUnknown() {
-		m.IgnoreFailure = types.BoolValue(false)
 	}
 
 	return body, diags


### PR DESCRIPTION
Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/2658

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate common fields and body helpers across all ingest processor models
> - Moves `ID` and `JSON` fields from individual processor model structs into `CommonProcessorModel` in [processor_common.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2662/files#diff-ebbb7e7e98bd495270d7d834a9e99a9d8fdf3c562fa428ae3b4ad75176adb546), eliminating per-processor duplication.
> - Introduces `WithTargetField` and `WithIgnorableTargetField` helper structs with corresponding `toTargetFieldBody`/`toIgnorableTargetFieldBody` methods, replacing repeated `Field`/`TargetField`/`IgnoreMissing` field declarations across ~20 processor structs.
> - Converts the `toCommonProcessorBody` free function into a receiver method on `CommonProcessorModel`, with each processor now calling `m.toCommonProcessorBody()` instead.
> - `IgnoreFailure` normalization (defaulting to `false` when null/unknown) is now handled centrally in `toCommonProcessorBody` rather than repeated in each `MarshalBody` method.
> - Behavioral Change: `IgnoreFailure` is now always normalized to `false` in the common path; processors that previously handled this locally and those that did not may now behave consistently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffc4b47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->