### PR TITLE
Wait for close on ML delete

### DIFF
--- a/openspec/changes/fix-ml-job-delete-close-race/.openspec.yaml
+++ b/openspec/changes/fix-ml-job-delete-close-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/fix-ml-job-delete-close-race/design.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The `anomalydetectionjob` delete function calls `CloseJob` then immediately calls `DeleteJob`. The Elasticsearch ML API uses optimistic concurrency control on its internal `.ml-config` index: `DeleteJob` reads the document's `seqNo` then performs a conditional write. If `CloseJob`'s final state transition commits to the primary shard between the read and write of `DeleteJob`, Elasticsearch returns HTTP 409 `version_conflict_engine_exception` (`required seqNo [N], current seqNo [N+1]`). The CI log shows this +1 pattern consistently, confirming the exact race.
+
+The fix is to poll `GetMLJobStats` after `CloseJob` returns, waiting until the job's reported state is `closed` (or the job is gone), before calling `DeleteJob`. The codebase already has all the building blocks: `asyncutils.WaitForStateTransition` for bounded polling and `GetMLJobStats` for state inspection; `jobstate/state_utils.go` uses the same pattern to wait for open/close transitions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the `version_conflict_engine_exception` on `DeleteJob` when the job was open at destroy time.
+- Reuse existing polling infrastructure (`asyncutils`, `GetMLJobStats`) without introducing new abstractions.
+
+**Non-Goals:**
+- Retry logic on `DeleteJob` itself — the root cause is a missing wait, not a need to retry.
+- Changes to the job state resource or datafeed resources.
+- Timeout configuration for the new wait — the existing Terraform delete-operation context provides the bound.
+
+## Decisions
+
+**Polling location**: Add `WaitForMLJobClosed` to `internal/clients/elasticsearch/ml_job.go` (alongside `GetMLJobStats`, `OpenMLJob`, `CloseMLJob`) and call it from `anomalydetectionjob/delete.go`. This keeps the helper co-located with other ML job client functions and avoids duplicating the polling logic inline.
+
+**Alternative considered — retry DeleteJob on 409**: Could catch the 409 and retry `DeleteJob` with a short backoff. Rejected: it treats the symptom rather than the cause. If the polling wait is in place, the 409 cannot occur.
+
+**Alternative considered — inline poll in delete.go**: Could put the `asyncutils.WaitForStateTransition` call directly in `delete.go`. Rejected: the helper belongs in the client layer alongside `GetMLJobStats`. Keeping it there makes it reusable and keeps delete.go focused on orchestration.
+
+**Context/timeout**: The context passed to `Delete()` already carries Terraform's delete timeout (default 20 minutes). No additional timeout parameter is needed.
+
+**"Not found" as settled state**: If `GetMLJobStats` returns `nil` (job not found), the wait treats that as the job being gone and returns immediately. This handles edge cases where the close also deleted the job or it was externally removed.
+
+## Risks / Trade-offs
+
+[Slower delete for open jobs] → Poll adds latency (up to a few seconds, typically one 2s poll tick) when a job is open at destroy time. This is acceptable — it prevents a hard failure.
+
+[Poll loop runs indefinitely if job stays in `opening` or `closing` state forever] → Mitigated by the Terraform delete context timeout (default 20 min). In practice, close transitions complete in seconds.
+
+## Migration Plan
+
+No migration needed — this is a bug fix with no API or schema changes. Existing Terraform state is unaffected.

--- a/openspec/changes/fix-ml-job-delete-close-race/proposal.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `elasticstack_elasticsearch_ml_anomaly_detection_job` delete path calls `CloseJob` then immediately calls `DeleteJob` without waiting for the close transition to commit in Elasticsearch's internal `.ml-config` index. The ES `DeleteJob` API uses optimistic concurrency control: if the document's sequence number is incremented by the close operation between when `DeleteJob` reads and writes it, the call fails with HTTP 409 `version_conflict_engine_exception`. This happens deterministically whenever a job is deleted from `opened` state — which is exactly what occurs during the post-test teardown of `TestAccResourceMLJobStateExplicitConnection` (whose final step leaves the job open).
+
+## What Changes
+
+- Add a `WaitForMLJobClosed` polling helper to `internal/clients/elasticsearch/ml_job.go` that blocks until a job's stats report `closed` state (or the job is gone).
+- Call `WaitForMLJobClosed` in `internal/elasticsearch/ml/anomalydetectionjob/delete.go` between the `CloseJob` and `DeleteJob` API calls.
+- Update REQ-021 in the `elasticsearch-ml-anomaly-detection-job` spec to require polling for `closed` state after `CloseJob` returns and before `DeleteJob` is called.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `elasticsearch-ml-anomaly-detection-job`: REQ-021 (Delete — close before delete) must be strengthened to require that the provider polls the job's state until `closed` is confirmed before calling `DeleteJob`. This closes a gap where `CloseJob` returns before its internal `.ml-config` document write is durable, causing a version conflict on the subsequent delete.
+
+## Impact
+
+- `internal/clients/elasticsearch/ml_job.go`: new exported `WaitForMLJobClosed` function.
+- `internal/elasticsearch/ml/anomalydetectionjob/delete.go`: insert wait between close and delete.
+- `openspec/specs/elasticsearch-ml-anomaly-detection-job/spec.md`: update REQ-021.
+- No API or schema changes.
+- No new dependencies — reuses `asyncutils.WaitForStateTransition` and `GetMLJobStats` already in the codebase.

--- a/openspec/changes/fix-ml-job-delete-close-race/specs/elasticsearch-ml-anomaly-detection-job/spec.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/specs/elasticsearch-ml-anomaly-detection-job/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Delete — close before delete (REQ-021–REQ-022)
+
+On delete, the resource SHALL first attempt to close the job by calling the Close Anomaly Detection Job API with `force=true` and `allow_no_match=true`. If the close call fails, the resource SHALL log a warning and continue. After the Close Job API call returns (whether it succeeded or failed), the resource SHALL poll the job's state via the Get Job Stats API until the job reports `closed` state or is no longer found, before calling the Delete Job API. This polling SHALL be bounded by the Terraform operation context (i.e. the delete timeout). The resource SHALL then call the Delete Anomaly Detection Job API. A non-success response from the Delete API SHALL be surfaced as an error diagnostic.
+
+#### Scenario: Close succeeds before delete
+
+- **WHEN** delete is called on an open anomaly detection job
+- **THEN** the resource SHALL call Close Job, then poll until the job is `closed`, then call Delete Job
+
+#### Scenario: Close returns error; polling confirms job is already closed
+
+- **WHEN** the Close Job API call returns an error
+- **THEN** the resource SHALL log a warning, poll until the job reports `closed` state, and then call Delete Job
+
+#### Scenario: Polling confirms job not found before delete
+
+- **WHEN** polling the job stats returns no result (job not found)
+- **THEN** the resource SHALL treat the job as closed and proceed to Delete Job
+
+#### Scenario: Delete succeeds after polling confirms closed state
+
+- **WHEN** the job reaches `closed` state and Delete Job is called
+- **THEN** the Delete Job API SHALL succeed (no version conflict)

--- a/openspec/changes/fix-ml-job-delete-close-race/specs/elasticsearch-ml-anomaly-detection-job/spec.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/specs/elasticsearch-ml-anomaly-detection-job/spec.md
@@ -19,7 +19,7 @@ On delete, the resource SHALL first attempt to close the job by calling the Clos
 - **WHEN** polling the job stats returns no result (job not found)
 - **THEN** the resource SHALL treat the job as closed and proceed to Delete Job
 
-#### Scenario: Delete succeeds after polling confirms closed state
+#### Scenario: Delete is called after polling confirms closed state
 
 - **WHEN** the job reaches `closed` state and Delete Job is called
-- **THEN** the Delete Job API SHALL succeed (no version conflict)
+- **THEN** the resource SHALL call Delete Job only after observing `closed` state, and SHALL not fail with a version conflict caused by the close/delete race

--- a/openspec/changes/fix-ml-job-delete-close-race/specs/elasticsearch-ml-anomaly-detection-job/spec.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/specs/elasticsearch-ml-anomaly-detection-job/spec.md
@@ -2,24 +2,26 @@
 
 ### Requirement: Delete — close before delete (REQ-021–REQ-022)
 
-On delete, the resource SHALL first attempt to close the job by calling the Close Anomaly Detection Job API with `force=true` and `allow_no_match=true`. If the close call fails, the resource SHALL log a warning and continue. After the Close Job API call returns (whether it succeeded or failed), the resource SHALL poll the job's state via the Get Job Stats API until the job reports `closed` state or is no longer found, before calling the Delete Job API. This polling SHALL be bounded by the Terraform operation context (i.e. the delete timeout). The resource SHALL then call the Delete Anomaly Detection Job API. A non-success response from the Delete API SHALL be surfaced as an error diagnostic.
+On delete, the resource SHALL first attempt to close the job by calling the Close Anomaly Detection Job API with `force=true` and `allow_no_match=true`. If the close call fails, the resource SHALL log a warning and continue. After the Close Job API call returns (whether it succeeded or failed), the resource SHALL poll the job's state via the Get Job Stats API until the job reports `closed` state or is no longer found, before calling the Delete Job API. This polling SHALL be bounded by the Terraform operation context (i.e. the delete timeout). If polling fails, the resource SHALL log a warning and continue to deletion.
 
-#### Scenario: Close succeeds before delete
+The resource SHALL then call the Delete Anomaly Detection Job API. If the first delete attempt fails, the resource SHALL retry once with `force=true`. If the retry also fails, the error SHALL be surfaced as a Terraform diagnostic.
 
-- **WHEN** delete is called on an open anomaly detection job
-- **THEN** the resource SHALL call Close Job, then poll until the job is `closed`, then call Delete Job
+#### Scenario: Normal delete succeeds
 
-#### Scenario: Close returns error; polling confirms job is already closed
+- **WHEN** the job is `closed` (or not found) before delete is called
+- **THEN** the resource SHALL call Delete Job and it SHALL succeed without `force`
 
-- **WHEN** the Close Job API call returns an error
-- **THEN** the resource SHALL log a warning, poll until the job reports `closed` state, and then call Delete Job
+#### Scenario: First delete fails — retry with force succeeds
 
-#### Scenario: Polling confirms job not found before delete
+- **WHEN** the initial Delete Job call fails (e.g. job is still open due to polling timeout)
+- **THEN** the resource SHALL retry Delete Job with `force=true` and treat a success response as the job being deleted
 
-- **WHEN** polling the job stats returns no result (job not found)
-- **THEN** the resource SHALL treat the job as closed and proceed to Delete Job
+#### Scenario: Both delete attempts fail
 
-#### Scenario: Delete is called after polling confirms closed state
+- **WHEN** both the initial Delete Job and the `force=true` retry fail
+- **THEN** the resource SHALL surface the retry error as a Terraform diagnostic
 
-- **WHEN** the job reaches `closed` state and Delete Job is called
-- **THEN** the resource SHALL call Delete Job only after observing `closed` state, and SHALL not fail with a version conflict caused by the close/delete race
+#### Scenario: Delete called regardless of polling outcome
+
+- **WHEN** the polling wait fails for any reason
+- **THEN** the resource SHALL still call the Delete Job API (not skip it)

--- a/openspec/changes/fix-ml-job-delete-close-race/tasks.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/tasks.md
@@ -8,7 +8,7 @@
 
 ## 3. Spec update
 
-- [ ] 3.1 Apply the delta spec: update REQ-021 in `openspec/specs/elasticsearch-ml-anomaly-detection-job/spec.md` to require polling for `closed` state after `CloseJob` returns and before `DeleteJob` is called
+- [ ] 3.1 Apply the delta spec: update REQ-021–REQ-022 in `openspec/specs/elasticsearch-ml-anomaly-detection-job/spec.md` to require polling for `closed` state after `CloseJob` returns and before `DeleteJob` is called
 
 ## 4. Verification
 

--- a/openspec/changes/fix-ml-job-delete-close-race/tasks.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/tasks.md
@@ -4,7 +4,7 @@
 
 ## 2. Delete fix
 
-- [ ] 2.1 Update `internal/elasticsearch/ml/anomalydetectionjob/delete.go` to call `WaitForMLJobClosed` after `CloseJob` and before `DeleteJob`; surface diagnostics errors if the wait fails
+- [ ] 2.1 Update `internal/elasticsearch/ml/anomalydetectionjob/delete.go` to call `WaitForMLJobClosed` after `CloseJob` (log warning and continue if wait fails), then call `DeleteJob`; if `DeleteJob` fails, retry once with `force=true` and surface the retry error as a diagnostic if that also fails
 
 ## 3. Spec update
 

--- a/openspec/changes/fix-ml-job-delete-close-race/tasks.md
+++ b/openspec/changes/fix-ml-job-delete-close-race/tasks.md
@@ -1,0 +1,16 @@
+## 1. Client helper
+
+- [ ] 1.1 Add `WaitForMLJobClosed(ctx, apiClient, jobID)` to `internal/clients/elasticsearch/ml_job.go` using `asyncutils.WaitForStateTransition` and `GetMLJobStats`; treat a nil stats result (job not found) as settled
+
+## 2. Delete fix
+
+- [ ] 2.1 Update `internal/elasticsearch/ml/anomalydetectionjob/delete.go` to call `WaitForMLJobClosed` after `CloseJob` and before `DeleteJob`; surface diagnostics errors if the wait fails
+
+## 3. Spec update
+
+- [ ] 3.1 Apply the delta spec: update REQ-021 in `openspec/specs/elasticsearch-ml-anomaly-detection-job/spec.md` to require polling for `closed` state after `CloseJob` returns and before `DeleteJob` is called
+
+## 4. Verification
+
+- [ ] 4.1 Run `make build` to confirm the project compiles
+- [ ] 4.2 Run the `TestAccResourceMLJobStateExplicitConnection` acceptance test locally (or confirm it passes in CI) to verify the fix


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix race condition between CloseJob and DeleteJob in ML anomaly detection
- Adds a `WaitForMLJobClosed` helper in [`internal/clients/elasticsearch/ml_job.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2665/files#diff-265434616cdae1d50bccb2729c4f6d6d7c8c3142c0171b65e6fff5d3ea406c65) that polls `GetMLJobStats` until the job state is `closed` or the job is not found.
- Updates [`anomalydetectionjob/delete.go`](https://github.com/elastic/terraform-provider-elasticstack/pull/2665/files#diff-d9abc6c4ddcda5a3326ebd4eb1ed34eabc7273c26c6c57aeb3dc050eeb921439) to call this helper between `CloseJob` and `DeleteJob`, preventing deletion before the job has fully closed.
- If polling fails or times out, deletion still proceeds to avoid blocking Terraform operations.
- On initial delete failure, the delete is retried once with `force=true`; if the retry also fails, the error is surfaced.
- Behavioral Change: delete operations now wait for job closure before proceeding, which may increase the time taken for ML job deletion.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized c85afce.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->