### PR TITLE
feat(openspec): flaky-test-catcher change proposal

### DIFF
--- a/openspec/changes/flaky-test-catcher/.openspec.yaml
+++ b/openspec/changes/flaky-test-catcher/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/flaky-test-catcher/design.md
+++ b/openspec/changes/flaky-test-catcher/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The repo uses a compiled agentic workflow system where source templates live in `.github/workflows-src/<name>/workflow.md.tmpl` and are compiled to `.github/workflows/<name>.md` by `scripts/compile-workflow-sources/main.go`. The `manifest.json` in `.github/workflows-src/` registers each template/output pair.
+
+Agentic workflows (`*.md` output) follow a two-job pattern: a deterministic **pre-activation** job (pure `actions/github-script` steps) produces gating outputs, and the **agent** job runs conditionally on those outputs. The `schema-coverage-rotation` workflow is the established reference for this pattern.
+
+The repo has a large acceptance test matrix: ~22 Elastic Stack versions × 2 shards, run for every push to `main`. Tests are written in Go (`--- FAIL: TestName`) and named after the Terraform resource they cover (`TestAccElasticsearchIndexResource_*`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect broken tests (failing in 100% of recent CI runs on `main`) and flaky tests (failing in ≥ 20% of runs).
+- Open one GitHub issue per affected resource, labelled `flaky-test` + `code-factory`.
+- Perform commit-based fix detection to surface whether a fix has already been merged.
+- No-op cleanly when there are no failures or the issue cap is reached.
+- Keep implementation complexity significantly lower than `schema-coverage-rotation` (no Go rotation scripts, no repo-memory).
+
+**Non-Goals:**
+- Analysing SNAPSHOT stack versions (CI jobs for SNAPSHOT use `continue-on-error: true` on the test step, which makes them invisible as failures at the job-level API — excluded automatically).
+- Fixing flaky tests (delegated to the `code-factory` workflow via label).
+- Tracking historical flakiness across runs older than 3 days.
+- Per-shard granularity in issue reporting (issues are per resource, not per shard).
+
+## Decisions
+
+### Pre-activation in JS, not in the agent job
+
+**Decision**: Use a deterministic `actions/github-script` pre-activation step to detect CI failures and count issue slots. The agent receives structured outputs rather than discovering this itself.
+
+**Rationale**: Keeps the no-op path cheap and deterministic — if there are no failures, the agent job never starts, burning no agent tokens. Matches the `schema-coverage-rotation` pattern.
+
+**Alternative considered**: Let the agent check for failures itself. Rejected: wastes agent quota on a pure data-fetch operation with no judgement required.
+
+### No Go scripts, no repo-memory
+
+**Decision**: No Go helper programs or repo-memory orphan branch.
+
+**Rationale**: Unlike `schema-coverage-rotation`, there is no rotation state to maintain. Deduplication is handled by checking for existing open `flaky-test` issues via the GitHub API. Fresh CI data is fetched each run. This makes the workflow substantially simpler.
+
+### Fail-rate denominator = total run count from pre-activation
+
+**Decision**: Classify a test as flaky if `fail_count / total_run_count >= 0.20`, where `total_run_count` is the number of workflow runs on `main` in the last 3 days (output from pre-activation).
+
+**Rationale**: The denominator includes all runs (not just those where the test was in scope). Because tests are sharded deterministically, a test that runs in every shard-0 run is compared against the total run count — slightly under-counting the true fail rate. The 20% threshold is a heuristic, so this approximation is acceptable and avoids the complexity of parsing success logs to count per-test attempts.
+
+**Alternative considered**: Parse successful run logs to count actual test attempts per test. Rejected: too expensive (downloading logs from every run, including successful ones).
+
+### Group issues by resource, not by test function
+
+**Decision**: One issue per Terraform resource (e.g., `elasticstack_elasticsearch_index`), listing all failing test functions within it.
+
+**Rationale**: Issues are actioned by `code-factory` which works at the resource level. One issue per test would create noise and hit the issue cap quickly for resources with multiple flaky tests.
+
+**Extraction rule**: Strip the `TestAcc` prefix and the `_<scenario>` suffix. `TestAccElasticsearchIndexResource_basic` → `elasticstack_elasticsearch_index`.
+
+### Commit-based fix detection: messages + changed file paths
+
+**Decision**: For each affected resource, inspect commits to `main` since the oldest failing run. Check both commit messages and the set of changed file paths for references to the resource or test names.
+
+**Rationale**: Changed file paths (e.g., `internal/elasticsearch/index/resource_test.go`) are a strong signal that a fix was attempted, even when commit messages are terse. Both together cover the common cases without requiring full diff analysis.
+
+**Alternative considered**: Full diff analysis of test files. Rejected: expensive and rarely needed — message + file path is sufficient to flag "this may already be addressed".
+
+### Issue labels: `flaky-test` + `code-factory`
+
+**Decision**: Created issues receive both labels.
+
+**Rationale**: `flaky-test` enables the issue-slot cap query in pre-activation. `code-factory` triggers the existing code-factory workflow to attempt automated remediation.
+
+## Risks / Trade-offs
+
+- **Log size**: CI job logs can be large. The agent must stream or truncate logs rather than loading them entirely into context. Risk: agent hits context limits. Mitigation: agent skill instructs fetching only the relevant test step log section.
+- **Fail-rate approximation**: Using total run count (not per-test attempt count) as denominator slightly under-reports true fail rate for sharded tests. Risk: borderline flaky tests (close to 20%) may be mis-classified. Mitigation: the 20% threshold has enough margin; the approximation is consistently in one direction.
+- **Issue dedup relies on open issues only**: If a flaky-test issue is closed (e.g., marked as fixed) but the test remains flaky, a new issue will be opened. This is intentional — closed issues represent resolved or dismissed findings.
+- **No toolchain setup steps**: The workflow skips Go/Node setup (unlike schema-coverage-rotation). The agent uses only `gh` CLI and `bash`, which are available on standard GitHub Actions runners.

--- a/openspec/changes/flaky-test-catcher/design.md
+++ b/openspec/changes/flaky-test-catcher/design.md
@@ -4,7 +4,7 @@ The repo uses a compiled agentic workflow system where source templates live in 
 
 Agentic workflows (`*.md` output) follow a two-job pattern: a deterministic **pre-activation** job (pure `actions/github-script` steps) produces gating outputs, and the **agent** job runs conditionally on those outputs. The `schema-coverage-rotation` workflow is the established reference for this pattern.
 
-The repo has a large acceptance test matrix: ~22 Elastic Stack versions × 2 shards, run for every push to `main`. Tests are written in Go (`--- FAIL: TestName`) and named after the Terraform resource they cover (`TestAccElasticsearchIndexResource_*`).
+The repo has a large acceptance test matrix: ~22 Elastic Stack versions × 2 shards, run for every push to `main`. Tests are written in Go (`--- FAIL: TestName`) and named after the Terraform resource they cover (e.g., `TestAccResourceAgentConfiguration`, `TestAccResourceAgentConfiguration_minimal`).
 
 ## Goals / Non-Goals
 
@@ -45,13 +45,15 @@ The repo has a large acceptance test matrix: ~22 Elastic Stack versions × 2 sha
 
 **Alternative considered**: Parse successful run logs to count actual test attempts per test. Rejected: too expensive (downloading logs from every run, including successful ones).
 
-### Group issues by resource, not by test function
+### Group issues by base test name (`TestAcc[^_]+`)
 
-**Decision**: One issue per Terraform resource (e.g., `elasticstack_elasticsearch_index`), listing all failing test functions within it.
+**Decision**: One issue per base test name (the portion of the test function name before the first `_`), listing all scenario variants within it.
 
-**Rationale**: Issues are actioned by `code-factory` which works at the resource level. One issue per test would create noise and hit the issue cap quickly for resources with multiple flaky tests.
+**Rationale**: Issues are actioned by `code-factory` which works at a coherent unit of test logic. One issue per scenario variant would create noise and hit the issue cap quickly. The base test name is derivable purely from the test name string already present in the failure log — no file lookup or package mapping needed.
 
-**Extraction rule**: Strip the `TestAcc` prefix and the `_<scenario>` suffix. `TestAccElasticsearchIndexResource_basic` → `elasticstack_elasticsearch_index`.
+**Extraction rule**: Apply the regex `TestAcc[^_]+` to the failing test name. `TestAccResourceAgentConfiguration_alternateEnvironment` → `TestAccResourceAgentConfiguration`. Issue title: `[flaky-test] TestAccResourceAgentConfiguration`.
+
+**Alternative considered**: Group by Go package (extractable from the `FAIL <pkg>` line in test output). Rejected for the initial implementation: requires parsing a second line type from the log and the package path is less directly human-readable as an issue title. Can be revisited if the base-name grouping proves too fine-grained.
 
 ### Commit-based fix detection: messages + changed file paths
 

--- a/openspec/changes/flaky-test-catcher/proposal.md
+++ b/openspec/changes/flaky-test-catcher/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+There is no automated mechanism to detect broken or flaky acceptance tests accumulating on `main`. Failures surface only when developers notice CI noise or a test blocks a PR, leading to slow detection and manual triage.
+
+## What Changes
+
+- New GitHub Actions Agentic Workflow (`flaky-test-catcher`) that runs daily, inspects CI results for `main` over the last 3 days, classifies test failures as **broken** (100% fail rate) or **flaky** (≥ 20% fail rate), and opens one GitHub issue per affected resource.
+- New workflow source template at `.github/workflows-src/flaky-test-catcher/workflow.md.tmpl`, compiled to `.github/workflows/flaky-test-catcher.md`.
+- New pre-activation JS script at `.github/workflows-src/flaky-test-catcher/scripts/check_ci_failures.inline.js`.
+- New agent skill document at `.agents/skills/flaky-test-catcher/SKILL.md`.
+- Updated `.github/workflows-src/manifest.json` to register the new workflow.
+- Issues are labelled `flaky-test` + `code-factory`, which triggers the existing code-factory workflow to attempt automated fixes.
+
+## Capabilities
+
+### New Capabilities
+
+- `flaky-test-catcher`: Daily workflow that identifies broken and flaky acceptance tests on `main`, performs commit-based fix detection, and opens structured GitHub issues per affected resource.
+
+### Modified Capabilities
+
+## Impact
+
+- New files in `.github/workflows-src/flaky-test-catcher/` and `.github/workflows/`.
+- `.github/workflows-src/manifest.json` gains one entry.
+- No changes to provider Go code, existing resources, or acceptance tests.
+- Downstream: `code-factory` workflow is triggered by the `code-factory` label on created issues.

--- a/openspec/changes/flaky-test-catcher/specs/flaky-test-catcher/spec.md
+++ b/openspec/changes/flaky-test-catcher/specs/flaky-test-catcher/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Workflow triggers
+The flaky-test-catcher workflow SHALL run on a daily schedule and SHALL support manual `workflow_dispatch` triggering.
+
+#### Scenario: Daily scheduled run
+- **WHEN** the daily cron schedule fires
+- **THEN** the workflow starts and executes the pre-activation job
+
+#### Scenario: Manual dispatch
+- **WHEN** a user triggers the workflow via `workflow_dispatch`
+- **THEN** the workflow starts and executes the pre-activation job
+
+---
+
+### Requirement: Pre-activation CI failure scan
+The pre-activation job SHALL query the GitHub Actions API for all workflow runs of the Build/Lint/Test workflow on `main` within the last 3 days and identify those with `conclusion == 'failure'`.
+
+#### Scenario: Failures present
+- **WHEN** one or more workflow runs on `main` in the last 3 days have `conclusion == 'failure'`
+- **THEN** pre-activation outputs `has_ci_failures = 'true'`, a JSON array of failed run IDs as `failed_run_ids`, and the total run count as `total_run_count`
+
+#### Scenario: No failures present
+- **WHEN** all workflow runs on `main` in the last 3 days have `conclusion != 'failure'` (or there are no runs)
+- **THEN** pre-activation outputs `has_ci_failures = 'false'` and the agent job is skipped
+
+#### Scenario: SNAPSHOT failures excluded
+- **WHEN** a SNAPSHOT matrix cell's acceptance test step fails but the job concludes as `success` due to `continue-on-error: true` on the step
+- **THEN** that run is NOT counted as a failure and is excluded from analysis
+
+---
+
+### Requirement: Pre-activation issue slot check
+The pre-activation job SHALL count open GitHub issues labelled `flaky-test` (excluding pull requests) and compute available issue slots against a cap of 3.
+
+#### Scenario: Slots available
+- **WHEN** fewer than 3 open `flaky-test` issues exist
+- **THEN** pre-activation outputs `issue_slots_available` as the remaining capacity and `open_issues` as the current count
+
+#### Scenario: Cap reached
+- **WHEN** 3 or more open `flaky-test` issues already exist
+- **THEN** pre-activation outputs `issue_slots_available = '0'` and the agent job is skipped via the `if` gate
+
+---
+
+### Requirement: Agent activation gate
+The agent job SHALL only run when both `has_ci_failures == 'true'` AND `issue_slots_available != '0'`.
+
+#### Scenario: Both gates pass
+- **WHEN** pre-activation reports CI failures and available issue slots
+- **THEN** the agent job starts
+
+#### Scenario: Either gate fails
+- **WHEN** pre-activation reports no CI failures OR no available issue slots
+- **THEN** the agent job is skipped without error
+
+---
+
+### Requirement: Test failure extraction
+The agent SHALL fetch job logs for each failed run ID from pre-activation, identify jobs with `conclusion == 'failure'` in the `Matrix Acceptance Test` job group, and extract failing test names matching the Go test output pattern `--- FAIL: <TestName>`.
+
+#### Scenario: Failures found in logs
+- **WHEN** a failed run's job logs contain `--- FAIL: TestAccXxx`
+- **THEN** the agent records `TestAccXxx` as a failing test for that run
+
+#### Scenario: No recognisable test failures in log
+- **WHEN** a failed run's job logs do not contain `--- FAIL:` patterns (e.g., infrastructure failure before tests ran)
+- **THEN** the agent skips that run and continues with remaining failed runs
+
+---
+
+### Requirement: Failure rate classification
+The agent SHALL compute a fail rate for each test as `fail_count / total_run_count` and classify it as **broken** (rate = 1.0) or **flaky** (rate ≥ 0.20 and < 1.0). Tests with a fail rate below 0.20 SHALL be ignored.
+
+#### Scenario: Broken test
+- **WHEN** a test appears in the failure logs of every workflow run in the analysis window
+- **THEN** the test is classified as **broken**
+
+#### Scenario: Flaky test
+- **WHEN** a test appears in the failure logs of ≥ 20% but < 100% of workflow runs in the analysis window
+- **THEN** the test is classified as **flaky** with the computed fail rate recorded
+
+#### Scenario: Noise (below threshold)
+- **WHEN** a test appears in the failure logs of fewer than 20% of workflow runs in the analysis window
+- **THEN** the test is ignored and no issue is created for it
+
+---
+
+### Requirement: Resource grouping
+The agent SHALL group failing tests by Terraform resource name. The resource name SHALL be derived by stripping the `TestAcc` prefix and the trailing `_<scenario>` suffix from the test function name, then converting to snake_case Terraform naming.
+
+#### Scenario: Multiple tests map to one resource
+- **WHEN** `TestAccElasticsearchIndexResource_basic` and `TestAccElasticsearchIndexResource_update` both appear as failing
+- **THEN** they are grouped under a single issue for `elasticstack_elasticsearch_index`
+
+---
+
+### Requirement: Commit-based fix detection
+For each affected resource, the agent SHALL inspect commits to `main` since the timestamp of the oldest failing run. It SHALL check both commit messages and changed file paths for references to the resource name, test names, or related keywords (e.g., "fix", "flaky"). If a relevant commit is found, the issue body SHALL note "may already be addressed in `<sha>`" rather than suppressing issue creation.
+
+#### Scenario: Fix commit detected
+- **WHEN** a commit after the oldest failing run modifies a file matching the resource's test file path or references the resource/test name in its message
+- **THEN** the issue body includes a "may already be addressed" note with the commit SHA
+
+#### Scenario: No fix commit found
+- **WHEN** no commits after the oldest failing run reference the resource or its tests
+- **THEN** the issue body contains no fix-detection note
+
+---
+
+### Requirement: Issue deduplication
+The agent SHALL check for existing open GitHub issues labelled `flaky-test` whose title matches `[flaky-test] <resource_name>` before creating a new issue. If a matching open issue exists, no new issue SHALL be created for that resource.
+
+#### Scenario: Existing open issue
+- **WHEN** an open issue titled `[flaky-test] elasticstack_elasticsearch_index` already exists
+- **THEN** the agent skips issue creation for that resource
+
+#### Scenario: No existing issue
+- **WHEN** no open issue matches the resource title
+- **THEN** the agent proceeds with issue creation (subject to issue slot cap)
+
+---
+
+### Requirement: Issue creation
+The agent SHALL create one GitHub issue per affected resource (up to `issue_slots_available`). Each issue SHALL be labelled `flaky-test` and `code-factory`, and SHALL include: broken test list, flaky test list with fail rates, commit analysis result, a sample failure excerpt, and the affected stack versions.
+
+#### Scenario: Issue created for resource with broken and flaky tests
+- **WHEN** `elasticstack_elasticsearch_index` has both broken and flaky tests
+- **THEN** an issue titled `[flaky-test] elasticstack_elasticsearch_index` is created with sections for Broken Tests, Flaky Tests, Commit Analysis, Sample Failure Output, and Affected Stack Versions, labelled `flaky-test` and `code-factory`
+
+#### Scenario: Issue cap enforced
+- **WHEN** the agent has already created `issue_slots_available` issues in this run
+- **THEN** no further issues are created regardless of remaining affected resources
+
+---
+
+### Requirement: No-op when nothing actionable
+The agent SHALL call `noop` with a descriptive reason when the analysis completes without creating any issues (e.g., all affected resources already have open issues, or all failures are below the 20% threshold).
+
+#### Scenario: All resources already tracked
+- **WHEN** every resource with qualifying failures already has an open `flaky-test` issue
+- **THEN** the agent calls `noop` with the reason "all affected resources already have open issues"

--- a/openspec/changes/flaky-test-catcher/specs/flaky-test-catcher/spec.md
+++ b/openspec/changes/flaky-test-catcher/specs/flaky-test-catcher/spec.md
@@ -86,12 +86,16 @@ The agent SHALL compute a fail rate for each test as `fail_count / total_run_cou
 
 ---
 
-### Requirement: Resource grouping
-The agent SHALL group failing tests by Terraform resource name. The resource name SHALL be derived by stripping the `TestAcc` prefix and the trailing `_<scenario>` suffix from the test function name, then converting to snake_case Terraform naming.
+### Requirement: Test grouping by base test name
+The agent SHALL group failing tests by their base test name, defined as the portion of the test function name matching `TestAcc[^_]+` (i.e., everything up to but not including the first `_`). Scenario variants of the same test SHALL be grouped into one issue.
 
-#### Scenario: Multiple tests map to one resource
-- **WHEN** `TestAccElasticsearchIndexResource_basic` and `TestAccElasticsearchIndexResource_update` both appear as failing
-- **THEN** they are grouped under a single issue for `elasticstack_elasticsearch_index`
+#### Scenario: Multiple scenario variants map to one group
+- **WHEN** `TestAccResourceAgentConfiguration_alternateEnvironment` and `TestAccResourceAgentConfiguration_minimal` both appear as failing
+- **THEN** they are grouped under a single issue titled `[flaky-test] TestAccResourceAgentConfiguration`
+
+#### Scenario: Test with no underscore suffix
+- **WHEN** `TestAccResourceAgentConfiguration` appears as failing (no `_scenario` suffix)
+- **THEN** it maps to the issue title `[flaky-test] TestAccResourceAgentConfiguration` unchanged
 
 ---
 

--- a/openspec/changes/flaky-test-catcher/specs/flaky-test-catcher/spec.md
+++ b/openspec/changes/flaky-test-catcher/specs/flaky-test-catcher/spec.md
@@ -1,3 +1,11 @@
+# `ci-flaky-test-catcher` — broken and flaky test detection workflow
+
+Workflow implementation: repository-authored source under `.github/workflows-src/flaky-test-catcher/`, compiled to `.github/workflows/flaky-test-catcher.md`.
+
+## Purpose
+
+Define requirements for a GitHub Agentic Workflow that scans recent `main` CI failures, classifies acceptance test failures as broken (100% fail rate) or flaky (≥ 20% fail rate), and opens bounded, actionable GitHub issues per affected test group for automated remediation.
+
 ## ADDED Requirements
 
 ### Requirement: Workflow triggers
@@ -14,7 +22,7 @@ The flaky-test-catcher workflow SHALL run on a daily schedule and SHALL support 
 ---
 
 ### Requirement: Pre-activation CI failure scan
-The pre-activation job SHALL query the GitHub Actions API for all workflow runs of the Build/Lint/Test workflow on `main` within the last 3 days and identify those with `conclusion == 'failure'`.
+The pre-activation job SHALL query the GitHub Actions API for all workflow runs of the `.github/workflows/test.yml` workflow on `main` within the last 3 days and identify those with `conclusion == 'failure'`.
 
 #### Scenario: Failures present
 - **WHEN** one or more workflow runs on `main` in the last 3 days have `conclusion == 'failure'`

--- a/openspec/changes/flaky-test-catcher/tasks.md
+++ b/openspec/changes/flaky-test-catcher/tasks.md
@@ -1,0 +1,26 @@
+## 1. Pre-activation JS Script
+
+- [ ] 1.1 Create `.github/workflows-src/flaky-test-catcher/scripts/check_ci_failures.inline.js` — queries workflow runs on `main` in the last 3 days, filters `conclusion == 'failure'`, outputs `has_ci_failures`, `failed_run_ids` (JSON), `total_run_count`, `open_issues`, `issue_slots_available`, `gate_reason`
+- [ ] 1.2 Add shared JS logic to `.github/workflows-src/lib/` if any reusable issue-slot or CI-run query logic is extracted (otherwise inline in the script)
+- [ ] 1.3 Write unit tests for the pre-activation script logic in `.github/workflows-src/lib/flaky-test-catcher.test.mjs`
+
+## 2. Workflow Template
+
+- [ ] 2.1 Create `.github/workflows-src/flaky-test-catcher/workflow.md.tmpl` with YAML frontmatter: trigger (`workflow_dispatch` + daily schedule), `engine`, `permissions` (`contents: read`, `issues: write`, `actions: read`), `safe-outputs` (`create-issue` with labels `flaky-test` + `code-factory`, cap 3; `noop`), `network` (`defaults`), pre-activation job wiring, agent `if` gate
+- [ ] 2.2 Write the agent prompt (markdown body after `---`) covering: skill reference, pre-activation context usage, log fetching via `gh api`, `--- FAIL:` extraction, fail-rate classification (broken ≥ 100%, flaky ≥ 20%), resource grouping, commit analysis (messages + changed file paths), dedup against existing `flaky-test` issues, issue creation rules and body format, `noop` conditions
+
+## 3. Agent Skill Document
+
+- [ ] 3.1 Create `.agents/skills/flaky-test-catcher/SKILL.md` defining the analysis protocol: how to fetch logs (`gh api .../jobs/{id}/logs`), the `--- FAIL:` extraction pattern, the fail-rate formula and thresholds, the resource-name extraction rule (`TestAcc<Resource>Resource_*` → `elasticstack_<resource>`), the commit analysis steps, and the required issue body sections
+
+## 4. Compiled Output and Manifest
+
+- [ ] 4.1 Run `make compile-workflows` (or `go run ./scripts/compile-workflow-sources`) to generate `.github/workflows/flaky-test-catcher.md` from the template
+- [ ] 4.2 Add the new entry to `.github/workflows-src/manifest.json`: `{ "template": ".github/workflows-src/flaky-test-catcher/workflow.md.tmpl", "output": ".github/workflows/flaky-test-catcher.md" }`
+- [ ] 4.3 Verify the compiled `.github/workflows/flaky-test-catcher.md` matches the template (no inline JS discrepancies, correct `x-script-include` references resolved)
+
+## 5. Validation
+
+- [ ] 5.1 Run `make workflow-test` and confirm pre-activation JS unit tests pass
+- [ ] 5.2 Run `make check-lint` to confirm the new workflow and manifests pass all lint checks
+- [ ] 5.3 Trigger the workflow manually via `workflow_dispatch` on a branch and confirm pre-activation outputs are correct in the Actions log

--- a/openspec/changes/flaky-test-catcher/tasks.md
+++ b/openspec/changes/flaky-test-catcher/tasks.md
@@ -7,11 +7,11 @@
 ## 2. Workflow Template
 
 - [ ] 2.1 Create `.github/workflows-src/flaky-test-catcher/workflow.md.tmpl` with YAML frontmatter: trigger (`workflow_dispatch` + daily schedule), `engine`, `permissions` (`contents: read`, `issues: write`, `actions: read`), `safe-outputs` (`create-issue` with labels `flaky-test` + `code-factory`, cap 3; `noop`), `network` (`defaults`), pre-activation job wiring, agent `if` gate
-- [ ] 2.2 Write the agent prompt (markdown body after `---`) covering: skill reference, pre-activation context usage, log fetching via `gh api`, `--- FAIL:` extraction, fail-rate classification (broken ≥ 100%, flaky ≥ 20%), resource grouping, commit analysis (messages + changed file paths), dedup against existing `flaky-test` issues, issue creation rules and body format, `noop` conditions
+- [ ] 2.2 Write the agent prompt (markdown body after `---`) covering: skill reference, pre-activation context usage, log fetching via `gh api`, `--- FAIL:` extraction, fail-rate classification (broken = 100%, flaky ≥ 20%), base-test-name grouping via `TestAcc[^_]+`, commit analysis (messages + changed file paths), dedup against existing `flaky-test` issues, issue creation rules and body format, `noop` conditions
 
 ## 3. Agent Skill Document
 
-- [ ] 3.1 Create `.agents/skills/flaky-test-catcher/SKILL.md` defining the analysis protocol: how to fetch logs (`gh api .../jobs/{id}/logs`), the `--- FAIL:` extraction pattern, the fail-rate formula and thresholds, the resource-name extraction rule (`TestAcc<Resource>Resource_*` → `elasticstack_<resource>`), the commit analysis steps, and the required issue body sections
+- [ ] 3.1 Create `.agents/skills/flaky-test-catcher/SKILL.md` defining the analysis protocol: how to query `.github/workflows/test.yml` runs via `gh api`, how to fetch job logs (`gh api .../jobs/{id}/logs`), the `--- FAIL:` extraction pattern, the fail-rate formula and thresholds (broken = 100%, flaky ≥ 20%), the base-test-name grouping rule (`TestAcc[^_]+`), the commit analysis steps, and the required issue body sections
 
 ## 4. Compiled Output and Manifest
 


### PR DESCRIPTION
## Summary

- Proposes a new `flaky-test-catcher` GH AW workflow that runs daily on `main` CI results
- Classifies test failures as **broken** (100% fail rate) or **flaky** (≥ 20%) and opens one GitHub issue per affected resource
- Issues are labelled `flaky-test` + `code-factory` to trigger automated fix attempts
- Full OpenSpec proposal, design, specs, and task breakdown included — ready for `/opsx:apply`

## Key design decisions (from `design.md`)

- **Pre-activation in JS**: deterministic CI failure scan + issue slot check before the agent runs; no-op is free
- **No Go scripts / no repo-memory**: deduplication via existing open issues; fresh analysis each run
- **Fail-rate thresholds**: broken = 100%, flaky = ≥ 20% (denominator = total run count from pre-activation)
- **SNAPSHOT excluded automatically**: `continue-on-error` on the test step makes SNAPSHOT job conclusions `success` at the API level
- **Commit fix detection**: checks messages + changed file paths since oldest failing run

## Test plan

- [ ] Review `proposal.md`, `design.md`, `specs/flaky-test-catcher/spec.md`, and `tasks.md` for accuracy and completeness
- [ ] Confirm design decisions match the exploration discussion
- [ ] Approve and merge to unblock `/opsx:apply` implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OpenSpec proposal and specification for the `ci-flaky-test-catcher` workflow
> - Adds an [OpenSpec change-set](https://github.com/elastic/terraform-provider-elasticstack/pull/2667/files#diff-f378849f008597bd4d91f2adf656392db1fb5bcd974fd91545bb9699b5e723de) with a [proposal](https://github.com/elastic/terraform-provider-elasticstack/pull/2667/files#diff-51e7c5f6e3668b58d1b74b4a2122a2e6546c95ab861718ad4ee62786e2069771), [design doc](https://github.com/elastic/terraform-provider-elasticstack/pull/2667/files#diff-baf97cc9abe1614119bec2dceb1324c9a70efb4d0099a572b86dfbc89834c592), [spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2667/files#diff-95cda5fc0c15f0c50b399ef6322c64181f9f8b30e399c6015e45a78c0db970cf), and [task list](https://github.com/elastic/terraform-provider-elasticstack/pull/2667/files#diff-e29235358033bccf9a52d2f80ac7f51c7224e81fc19b44a61f350f032590f4f3) for a new agentic CI workflow.
> - The `ci-flaky-test-catcher` workflow scans CI failures, classifies tests by failure rate, groups them by base test name, and creates or deduplicates issues with appropriate labels.
> - Design decisions include pre-activation scripting in JS (no Go scripts or repo-memory), commit-based fix detection, and issue-slot gating before agent activation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0962cd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->