### PR TITLE
proposal: changelog breaking changes improvements

### DIFF
--- a/openspec/changes/changelog-breaking-changes/.openspec.yaml
+++ b/openspec/changes/changelog-breaking-changes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/changelog-breaking-changes/design.md
+++ b/openspec/changes/changelog-breaking-changes/design.md
@@ -27,9 +27,9 @@ The concrete problem: contributors adding content after their intended breaking 
 
 ### Decision 1: End marker as HTML comment `<!-- /breaking-changes -->`
 
-**Choice:** An HTML comment using a closing-tag convention (`/breaking-changes`), whitespace-flexible internally (`<!--\s*\/breaking-changes\s*-->`), matched by literal regex.
+**Choice:** An HTML comment using a closing-tag convention (`/breaking-changes`), recognised via the anchored regex `/^\s*<!--\s*\/breaking-changes\s*-->\s*$/` (case-sensitive). This allows optional leading/trailing whitespace on the line (indented markers) and optional internal whitespace around the tag name, while requiring the whole line to be nothing but the marker.
 
-**Rationale:** HTML comments are invisible in rendered GitHub Markdown, so the marker doesn't pollute the PR body's display. The `/<name>` convention mirrors common HTML/XML idioms and is visually clear about being a closing delimiter. Whitespace flexibility (`<!--   /breaking-changes   -->`) reduces friction for contributors who add spaces by habit.
+**Rationale:** HTML comments are invisible in rendered GitHub Markdown, so the marker doesn't pollute the PR body's display. The `/<name>` convention mirrors common HTML/XML idioms and is visually clear about being a closing delimiter. Full-line anchoring (`^...$`) prevents accidental matches on lines that merely contain the marker alongside other content. Internal whitespace flexibility (`\s*` around the tag name) is a practical allowance for contributors who add spaces by habit; case-sensitivity is preserved to match HTML comment semantics.
 
 **Alternatives considered:**
 - `<!-- end-breaking-changes -->` — slightly wordier, same properties. Rejected for brevity.

--- a/openspec/changes/changelog-breaking-changes/design.md
+++ b/openspec/changes/changelog-breaking-changes/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The PR changelog system has three layers:
+
+1. **`pr-changelog-parser.js`** — parses and validates the `## Changelog` section from a PR body. `extractBreakingChanges` reads the `### Breaking changes` block, stopping at the next `##`/`###` heading or the end of the changelog section. `validateChangelogSectionFull` enforces structural rules including that `### Breaking changes` must be present when `Customer impact: breaking` and must not be empty.
+
+2. **`pr-changelog-check.js`** — builds the comment body that the verifier workflow posts to the PR when the check fails. Contains the "Expected format" documentation block.
+
+3. **`.github/pull_request_template.md`** — provides the default PR body that contributors fill in. Currently pre-fills `Customer impact: none / Summary:` which passes the checker without any author action.
+
+The concrete problem: contributors adding content after their intended breaking change block (OpenSpec notes, Macroscope summaries, separators) have all of that content swept into the released changelog because the parser has no early-stop mechanism within the `### Breaking changes` block.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let authors explicitly terminate the `### Breaking changes` block with an HTML comment end marker
+- Reject `### Breaking changes` subsections on PRs where `Customer impact` is not `breaking`
+- Make the default PR template state fail the changelog check, forcing conscious authorship
+- Document the end marker in the PR template and in the verifier failure comment
+
+**Non-Goals:**
+- Changing the changelog renderer (`changelog-renderer.js`) — validation at PR time is sufficient; any pre-existing misuse can be cleaned up manually at release time
+- Supporting alternative marker syntaxes or case-insensitive matching — HTML comment semantics are case-sensitive; whitespace flexibility is sufficient
+- Retroactively fixing already-merged PRs in release history
+
+## Decisions
+
+### Decision 1: End marker as HTML comment `<!-- /breaking-changes -->`
+
+**Choice:** An HTML comment using a closing-tag convention (`/breaking-changes`), whitespace-flexible internally (`<!--\s*\/breaking-changes\s*-->`), matched by literal regex.
+
+**Rationale:** HTML comments are invisible in rendered GitHub Markdown, so the marker doesn't pollute the PR body's display. The `/<name>` convention mirrors common HTML/XML idioms and is visually clear about being a closing delimiter. Whitespace flexibility (`<!--   /breaking-changes   -->`) reduces friction for contributors who add spaces by habit.
+
+**Alternatives considered:**
+- `<!-- end-breaking-changes -->` — slightly wordier, same properties. Rejected for brevity.
+- A `###` heading as a delimiter — visible in rendered markdown, increases required boilerplate. Rejected.
+- Nothing (rely on authors to keep breaking change blocks short) — doesn't address the root cause. Rejected.
+
+### Decision 2: Marker only fires inside `### Breaking changes`, and only outside a code fence
+
+**Choice:** The marker check is placed in `extractBreakingChanges`, guarded by `inBreaking === true` and `fenceType === null`. A marker before `### Breaking changes`, or inside a fenced code block, is silently ignored.
+
+**Rationale:** Ignoring the marker outside the breaking changes block makes it safe to mention `<!-- /breaking-changes -->` in documentation (e.g., the PR template instructions) without accidentally triggering extraction boundaries. The fence guard preserves the existing invariant that content inside fenced blocks is never treated as structural.
+
+### Decision 3: New validation rule in `validateChangelogSectionFull` only, not in the renderer
+
+**Choice:** Add the rule "if `breakingChangesHeadingPresent` and `customerImpact` is a valid value other than `breaking`, emit an error" to `validateChangelogSectionFull`. The renderer (`changelog-renderer.js`) is left unchanged.
+
+**Rationale:** The verifier runs on every PR push and is the enforcement gate before merge. The renderer runs only at release time against already-merged PRs; adding the rule there adds complexity without meaningful protection (any violation would already have been caught at PR time). Any pre-existing merged PRs that violate the new rule can be cleaned up manually.
+
+**Guard against double-errors:** The rule is guarded with `VALID_CUSTOMER_IMPACTS.has(parsed.customerImpact)`. If `customerImpact` is already invalid (e.g., `patch`), the base validator emits an "invalid impact" error and rule C is suppressed — avoiding a confusing second error for the same root cause.
+
+### Decision 4: Error message includes end-marker hint
+
+**Choice:** Error message: `"### Breaking changes section requires Customer impact: breaking; use <!-- /breaking-changes --> as an end marker."`
+
+**Rationale:** The error is directly actionable — it tells the author both what's wrong and the escape hatch if they have extra context they want to preserve in their PR body without it leaking into the changelog.
+
+### Decision 5: PR template default is invalid placeholder text
+
+**Choice:** Replace `Customer impact: none\nSummary:` with `Customer impact: <none, fix, enhancement, breaking>\nSummary: <single line summary>`.
+
+**Rationale:** Angle-bracket placeholders are a widely understood "fill this in" convention. Crucially, `<none, fix, enhancement, breaking>` is not a valid `Customer impact` value, so the changelog check will fail if a contributor submits without replacing it. This creates a "pit of success" — the path of least resistance requires engagement with the format.
+
+### Decision 6: PR template gains a `breaking` example with end marker
+
+**Choice:** Add a second "Good example" block showing a complete `breaking` entry with a short `### Breaking changes` prose block and `<!-- /breaking-changes -->`.
+
+**Rationale:** The breaking + end-marker pattern is the most complex case contributors will author. Showing a concrete example is more effective than prose description alone.
+
+## Risks / Trade-offs
+
+**[Risk] Marker regex complexity** — `<!--\s*\/breaking-changes\s*-->` could theoretically match content inside a tilde-fenced block if the fence-tracking has a bug. → Mitigation: the fence guard (`fenceType === null`) is checked first; existing tests cover fence-tracking correctness.
+
+**[Risk] Contributors may not know about the end marker** — PRs authored before the template update won't have it. → Mitigation: the verifier failure comment's "Expected format" block documents it; the new breaking example in the template provides a model. Adoption will grow incrementally.
+
+**[Risk] Rule C fires late (release time) for pre-existing merged PRs** — The renderer doesn't enforce the new rule, so old PRs with `Customer impact: fix` + `### Breaking changes` will render their breaking block into the changelog until manually cleaned. → Accepted: scope is pre-merge enforcement only; cleanup is manual.
+
+## Migration Plan
+
+No deployment steps beyond merging the PR. The workflow tests (`npm test`) cover the parser and check logic. The PR template change takes effect immediately on merge. No rollback mechanism is needed — reverting the PR reverts all changes.
+
+## Open Questions
+
+None — all decisions made during exploration.

--- a/openspec/changes/changelog-breaking-changes/proposal.md
+++ b/openspec/changes/changelog-breaking-changes/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The `### Breaking changes` parser currently reads until the next `##`-level heading, so any content following the intended breaking-change prose (OpenSpec notes, Macroscope bot summaries, separators) is silently included in the generated changelog. Additionally, nothing prevents a contributor from adding a `### Breaking changes` block to a PR whose `Customer impact` is `fix` or `none`, producing a misleading or unintended changelog entry. The default pre-filled template also allows a PR to accidentally pass as `Customer impact: none` without the author realising they need to make a choice.
+
+## What Changes
+
+- **End marker support** — `extractBreakingChanges` stops at `<!-- /breaking-changes -->` when the marker appears inside the `### Breaking changes` block (outside a code fence), in addition to the existing heading-boundary stop. The marker is whitespace-flexible but case-sensitive (HTML comment semantics).
+- **Validation rule: breaking changes require breaking impact** — `validateChangelogSectionFull` rejects a `### Breaking changes` subsection when `Customer impact` is anything other than `breaking`. The error message directs authors to use the end marker if they want extra context in their PR body.
+- **PR template: invalid default state** — The pre-filled template body is changed from `Customer impact: none / Summary:` to angle-bracket placeholder text that fails the changelog check, forcing authors to consciously replace it.
+- **PR template: breaking example with end marker** — A second "Good example" block is added showing a complete `breaking` entry with a `### Breaking changes` block and the `<!-- /breaking-changes -->` end marker.
+- **Verifier comment: document end marker** — The `Expected format` block in the failure comment is updated to show `<!-- /breaking-changes -->` after the breaking-changes prose.
+
+## Capabilities
+
+### New Capabilities
+- (none)
+
+### Modified Capabilities
+- `ci-pr-changelog-authoring`: new end-marker extraction rule, new validation rule (breaking changes require breaking impact), updated PR template defaults and examples, updated failure comment format block.
+
+## Impact
+
+- `.github/workflows-src/lib/pr-changelog-parser.js` — parser and validator logic
+- `.github/workflows-src/lib/pr-changelog-parser.test.mjs` — new test cases
+- `.github/workflows-src/lib/pr-changelog-check.js` — failure comment body
+- `.github/pull_request_template.md` — default pre-fill and examples

--- a/openspec/changes/changelog-breaking-changes/specs/ci-pr-changelog-authoring/spec.md
+++ b/openspec/changes/changelog-breaking-changes/specs/ci-pr-changelog-authoring/spec.md
@@ -21,14 +21,14 @@ When validation fails, the workflow SHALL post or update a PR comment identifyin
 - **WHEN** the pull request body contains `### Breaking changes` content and `Customer impact` is `fix`, `enhancement`, or `none`
 - **THEN** the workflow SHALL fail and SHALL upsert a PR comment containing the error `### Breaking changes section requires Customer impact: breaking; use <!-- /breaking-changes --> as an end marker.`
 
-#### Scenario: Invalid impact value with breaking changes does not emit rule-C error
+#### Scenario: Invalid impact value with breaking changes does not emit the breaking-impact-mismatch error
 - **WHEN** the pull request body contains `### Breaking changes` content and `Customer impact` is an unsupported value (e.g., `patch`)
-- **THEN** the workflow SHALL fail with an "invalid Customer impact" error only; it SHALL NOT also emit the rule-C error about breaking impact
+- **THEN** the workflow SHALL fail with an "invalid Customer impact" error only; it SHALL NOT also emit the error `### Breaking changes section requires Customer impact: breaking; use <!-- /breaking-changes --> as an end marker.`
 
 ### Requirement: Breaking changes subsection may be free-form markdown with optional end marker
-Within the `## Changelog` contract, the optional `### Breaking changes` subsection SHALL allow free-form markdown content, including prose, bullet lists, and fenced code blocks. Validation SHALL treat that subsection as a delimited markdown block rather than a structured schema.
+Within the `## Changelog` contract, the `### Breaking changes` subsection is permitted only when `Customer impact` is `breaking`. When present, it SHALL allow free-form markdown content, including prose, bullet lists, and fenced code blocks. Validation SHALL treat that subsection as a delimited markdown block rather than a structured schema.
 
-The subsection SHALL end at the first of: (a) the HTML comment `<!-- /breaking-changes -->` (case-sensitive, internal whitespace flexible, matching `<!--\s*\/breaking-changes\s*-->`), provided it appears outside a fenced code block; (b) the next `##`- or `###`-level heading outside a fenced code block; or (c) the end of the `## Changelog` section. When `<!-- /breaking-changes -->` appears before `### Breaking changes`, or inside a fenced code block, it SHALL be ignored.
+The subsection SHALL end at the first of: (a) an end marker line, (b) the next `##`- or `###`-level heading outside a fenced code block, or (c) the end of the `## Changelog` section. An end marker line is a line whose full content, after stripping any leading and trailing whitespace, satisfies the pattern `<!--\s*/breaking-changes\s*-->` (case-sensitive) — that is, the line contains nothing except the HTML comment with optional internal whitespace around `/breaking-changes`; it is recognised only when it appears outside a fenced code block and after the `### Breaking changes` heading. In implementation terms this corresponds to the anchored regex `/^\s*<!--\s*\/breaking-changes\s*-->\s*$/`. A marker appearing before the `### Breaking changes` heading, or inside a fenced code block, SHALL be ignored.
 
 #### Scenario: Breaking changes block contains fenced code
 - **WHEN** the pull request body includes `### Breaking changes` with fenced code blocks or migration prose

--- a/openspec/changes/changelog-breaking-changes/specs/ci-pr-changelog-authoring/spec.md
+++ b/openspec/changes/changelog-breaking-changes/specs/ci-pr-changelog-authoring/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: Existing changelog section is validated deterministically
+The workflow SHALL parse and validate the `## Changelog` section from the pull request body using `parseChangelogSectionFull` and `validateChangelogSectionFull`. The validator SHALL require `Customer impact` to be exactly one of `none`, `fix`, `enhancement`, or `breaking` (case-sensitive). The validator SHALL require a `Summary` line when `Customer impact` is not `none`. The validator SHALL reject a `### Breaking changes` subsection that is present but empty. The validator SHALL require that subsection when `Customer impact` is `breaking`. The validator SHALL reject a `### Breaking changes` subsection when `Customer impact` is any valid value other than `breaking`; the error message SHALL be: `### Breaking changes section requires Customer impact: breaking; use <!-- /breaking-changes --> as an end marker.`
+
+When validation fails, the workflow SHALL post or update a PR comment identifying the failure reason. When validation passes, the workflow SHALL update any existing failure comment to indicate the check passed.
+
+#### Scenario: Valid changelog section passes the check
+- **WHEN** the pull request body contains a `## Changelog` section that satisfies all validation rules
+- **THEN** the workflow SHALL succeed, and if a prior failure comment exists it SHALL be updated to a "check passed" message
+
+#### Scenario: Malformed changelog section fails with comment
+- **WHEN** the pull request body contains a `## Changelog` section that does not satisfy the validation rules
+- **THEN** the workflow SHALL fail and SHALL upsert a PR comment listing each validation error
+
+#### Scenario: Missing changelog section fails with comment
+- **WHEN** the pull request body contains no `## Changelog` section and the PR does not carry the `no-changelog` label
+- **THEN** the workflow SHALL fail and SHALL upsert a PR comment stating that no `## Changelog` section was found
+
+#### Scenario: Breaking changes with non-breaking impact fails with descriptive error
+- **WHEN** the pull request body contains `### Breaking changes` content and `Customer impact` is `fix`, `enhancement`, or `none`
+- **THEN** the workflow SHALL fail and SHALL upsert a PR comment containing the error `### Breaking changes section requires Customer impact: breaking; use <!-- /breaking-changes --> as an end marker.`
+
+#### Scenario: Invalid impact value with breaking changes does not emit rule-C error
+- **WHEN** the pull request body contains `### Breaking changes` content and `Customer impact` is an unsupported value (e.g., `patch`)
+- **THEN** the workflow SHALL fail with an "invalid Customer impact" error only; it SHALL NOT also emit the rule-C error about breaking impact
+
+### Requirement: Breaking changes subsection may be free-form markdown with optional end marker
+Within the `## Changelog` contract, the optional `### Breaking changes` subsection SHALL allow free-form markdown content, including prose, bullet lists, and fenced code blocks. Validation SHALL treat that subsection as a delimited markdown block rather than a structured schema.
+
+The subsection SHALL end at the first of: (a) the HTML comment `<!-- /breaking-changes -->` (case-sensitive, internal whitespace flexible, matching `<!--\s*\/breaking-changes\s*-->`), provided it appears outside a fenced code block; (b) the next `##`- or `###`-level heading outside a fenced code block; or (c) the end of the `## Changelog` section. When `<!-- /breaking-changes -->` appears before `### Breaking changes`, or inside a fenced code block, it SHALL be ignored.
+
+#### Scenario: Breaking changes block contains fenced code
+- **WHEN** the pull request body includes `### Breaking changes` with fenced code blocks or migration prose
+- **THEN** the workflow SHALL accept that subsection as valid when the block is non-empty
+
+#### Scenario: End marker stops extraction before the next heading
+- **WHEN** the pull request body includes `<!-- /breaking-changes -->` after breaking-change prose but before the next heading or end of changelog section
+- **THEN** the parser SHALL include only the content before the marker in `breakingChanges` and SHALL exclude any content after the marker
+
+#### Scenario: End marker inside a fenced code block is ignored
+- **WHEN** the pull request body contains `<!-- /breaking-changes -->` inside a backtick- or tilde-fenced code block within the `### Breaking changes` subsection
+- **THEN** the parser SHALL NOT treat it as an end marker; extraction SHALL continue past it
+
+#### Scenario: End marker before the breaking changes heading is ignored
+- **WHEN** the pull request body contains `<!-- /breaking-changes -->` in the `## Changelog` section but before the `### Breaking changes` heading
+- **THEN** the parser SHALL ignore it; it SHALL NOT affect the start or boundary of `### Breaking changes` extraction
+
+#### Scenario: End marker with internal whitespace is recognised
+- **WHEN** the pull request body contains `<!--  /breaking-changes  -->` (extra spaces around the tag name) inside the `### Breaking changes` subsection
+- **THEN** the parser SHALL treat it as a valid end marker and stop extraction at that line
+
+### Requirement: PR template default state fails the changelog check
+The pull request template SHALL pre-fill the `## Changelog` block with placeholder text that is not a valid `Customer impact` value, ensuring contributors must consciously replace it before the PR can pass the changelog check. The placeholder for `Customer impact` SHALL be `<none, fix, enhancement, breaking>` and for `Summary` SHALL be `<single line summary>`.
+
+#### Scenario: Unedited template body fails the check
+- **WHEN** a contributor opens a pull request without editing the `## Changelog` section of the template
+- **THEN** the workflow SHALL fail because `Customer impact: <none, fix, enhancement, breaking>` is not a valid impact value
+
+### Requirement: PR template documents the breaking example and end marker
+The pull request template SHALL include a "Good example" block for the `breaking` impact level that shows: a `Customer impact: breaking` line, a `Summary:` line, a `### Breaking changes` block with a short prose description, and the `<!-- /breaking-changes -->` end marker immediately after the breaking-change content. The template instructions SHALL note that `<!-- /breaking-changes -->` is optional and ends the breaking-changes block early.
+
+#### Scenario: Contributor can copy the breaking example as a starting point
+- **WHEN** a contributor opens a pull request intending to document a breaking change
+- **THEN** the template SHALL provide a concrete, copyable example of the complete `breaking` format including the end marker
+
+### Requirement: Verifier failure comment documents the end marker
+The failure comment posted by the PR changelog check workflow SHALL include `<!-- /breaking-changes -->` in its "Expected format" block, immediately after the `<free-form markdown>` line for the `### Breaking changes` section.
+
+#### Scenario: Failure comment shows end marker in expected format
+- **WHEN** the PR changelog check fails and posts a failure comment
+- **THEN** the comment's "Expected format" block SHALL show `<!-- /breaking-changes -->` on the line after `<free-form markdown>  (required when Customer impact is "breaking")`

--- a/openspec/changes/changelog-breaking-changes/tasks.md
+++ b/openspec/changes/changelog-breaking-changes/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Parser: end marker support
 
-- [ ] 1.1 In `extractBreakingChanges` in `pr-changelog-parser.js`, add a check inside the `inBreaking` loop: when `fenceType === null` and the line matches `/^<!--\s*\/breaking-changes\s*-->/`, break out of the loop (before the heading check)
+- [ ] 1.1 In `extractBreakingChanges` in `pr-changelog-parser.js`, add a check inside the `inBreaking` loop: when `fenceType === null` and the line matches `/^\s*<!--\s*\/breaking-changes\s*-->\s*$/`, break out of the loop (before the heading check). The full-line anchor prevents partial matches; `\s*` before `<!--` and after `-->` allows indentation and trailing whitespace; `\s*` around `/breaking-changes` allows internal spacing.
 - [ ] 1.2 Add tests to `pr-changelog-parser.test.mjs` for `extractBreakingChanges` end marker behaviour:
   - End marker stops extraction mid-content (content before marker included, content after excluded)
   - End marker with extra internal whitespace (`<!--  /breaking-changes  -->`) is recognised

--- a/openspec/changes/changelog-breaking-changes/tasks.md
+++ b/openspec/changes/changelog-breaking-changes/tasks.md
@@ -1,0 +1,33 @@
+## 1. Parser: end marker support
+
+- [ ] 1.1 In `extractBreakingChanges` in `pr-changelog-parser.js`, add a check inside the `inBreaking` loop: when `fenceType === null` and the line matches `/^<!--\s*\/breaking-changes\s*-->/`, break out of the loop (before the heading check)
+- [ ] 1.2 Add tests to `pr-changelog-parser.test.mjs` for `extractBreakingChanges` end marker behaviour:
+  - End marker stops extraction mid-content (content before marker included, content after excluded)
+  - End marker with extra internal whitespace (`<!--  /breaking-changes  -->`) is recognised
+  - End marker inside a backtick-fenced code block is NOT treated as a stop
+  - End marker inside a tilde-fenced code block is NOT treated as a stop
+  - End marker before the `### Breaking changes` heading (outside `inBreaking`) is ignored
+
+## 2. Validator: breaking changes require breaking impact
+
+- [ ] 2.1 In `validateChangelogSectionFull` in `pr-changelog-parser.js`, add rule C after the existing two rules: if `parsed.breakingChangesHeadingPresent` is true, `parsed.customerImpact` is non-null, `VALID_CUSTOMER_IMPACTS.has(parsed.customerImpact)` is true, and `parsed.customerImpact !== 'breaking'`, push the error `"### Breaking changes section requires Customer impact: breaking; use <!-- /breaking-changes --> as an end marker."`
+- [ ] 2.2 Add tests to `pr-changelog-parser.test.mjs` for rule C:
+  - `Customer impact: fix` + `### Breaking changes` present → invalid, correct error message
+  - `Customer impact: enhancement` + `### Breaking changes` present → invalid, correct error message
+  - `Customer impact: none` + `### Breaking changes` present → invalid, correct error message
+  - `Customer impact: patch` (unsupported value) + `### Breaking changes` present → only the "invalid impact" error, NOT the rule-C error
+  - `Customer impact: breaking` + `### Breaking changes` present + content → still valid (no regression)
+
+## 3. Verifier comment: document end marker
+
+- [ ] 3.1 In `buildFailureCommentBody` in `pr-changelog-check.js`, add `'<!-- /breaking-changes -->'` as a line in the "Expected format" block immediately after `'<free-form markdown>  (required when Customer impact is "breaking")'`
+
+## 4. PR template: invalid default and breaking example
+
+- [ ] 4.1 In `.github/pull_request_template.md`, replace the pre-filled default `Customer impact: none\nSummary:` with `Customer impact: <none, fix, enhancement, breaking>\nSummary: <single line summary>`
+- [ ] 4.2 In `.github/pull_request_template.md`, add a second "Good example" block for the `breaking` case showing `Customer impact: breaking`, `Summary:`, `### Breaking changes`, a single-line description, and `<!-- /breaking-changes -->`
+- [ ] 4.3 In `.github/pull_request_template.md`, add a bullet to the format instructions noting that `<!-- /breaking-changes -->` optionally ends the `### Breaking changes` block early (prevents trailing PR content from entering the changelog)
+
+## 5. Verify
+
+- [ ] 5.1 Run `npm test` (or equivalent) in `.github/workflows-src/` and confirm all existing and new tests pass


### PR DESCRIPTION
## Changelog
Customer impact: none
Summary:

## Detailed changes

Adds an OpenSpec change proposal for three improvements to the PR changelog system:

1. **Optional `<!-- /breaking-changes -->` end marker** — lets contributors cap what gets extracted from their `### Breaking changes` block, preventing trailing content (OpenSpec notes, bot summaries, separators) from leaking into the generated changelog.

2. **Enforce `Customer impact: breaking` for `### Breaking changes`** — `validateChangelogSectionFull` will reject a `### Breaking changes` subsection when the impact is `fix`, `enhancement`, or `none`.

3. **Invalid-by-default PR template** — changes the pre-filled default from `Customer impact: none` (which silently passes) to angle-bracket placeholder text that fails the check, forcing conscious authorship. Adds a concrete breaking example with the end marker.

### Artifacts

- `openspec/changes/changelog-breaking-changes/proposal.md`
- `openspec/changes/changelog-breaking-changes/design.md`
- `openspec/changes/changelog-breaking-changes/specs/ci-pr-changelog-authoring/spec.md`
- `openspec/changes/changelog-breaking-changes/tasks.md`

Motivated by: https://github.com/elastic/terraform-provider-elasticstack/commit/cef0234a27adc5131541be82776ab23de62f9178

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add proposal and spec for changelog breaking-changes improvements
> Adds a set of OpenSpec documents defining planned improvements to PR changelog handling for breaking changes.
>
> - [proposal.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2683/files#diff-35f73df352717cf232b2339a09d4b7cf1160eb4438a0cba3f5be03b2d0008751) outlines motivation and planned changes: HTML end-marker support for the parser, a validation rule tying the breaking section to breaking impact labels, PR template default text, and verifier comment updates.
> - [design.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2683/files#diff-1bd182ef698d05a15031fd466b1a514b4e41a1bf83fa797c7665c35fadc80649) covers decisions, risks, migration plan, and open questions.
> - [specs/ci-pr-changelog-authoring/spec.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2683/files#diff-62981d3b78f50b63523c0113b6543625bdb6376acdd733a00cc4a7b7a3c4955e) defines new validation scenarios, end-marker regex, error messaging, and expected verifier comment content.
> - [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2683/files#diff-7a8cab1c15478a97dcb6b94498f2c06d76c9f7d593a1c6ddcbff7c147994f2d2) provides the implementation checklist.
>
> No runtime code is changed; this PR contains only planning and specification documents.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d69517d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->