### PR TITLE
Proposal for create/update support in entitycore

### DIFF
--- a/openspec/changes/elasticsearch-resource-create-update/.openspec.yaml
+++ b/openspec/changes/elasticsearch-resource-create-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/elasticsearch-resource-create-update/design.md
+++ b/openspec/changes/elasticsearch-resource-create-update/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`NewElasticsearchResource` currently owns common Elasticsearch resource behavior for Metadata, Schema, Read, Delete, and Configure. Concrete resources still implement `Create` and `Update`, and several migrated resources repeat the same thin Plugin Framework wrapper around a shared upsert helper.
+
+The duplicate wrappers are visible in `security_role`, `security_role_mapping`, `security_system_user`, and `cluster_script`. Their create and update operations share a common shape: decode the plan, resolve an Elasticsearch client from `elasticsearch_connection`, perform an API write, and persist the resulting model to state.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `NewElasticsearchResource` a complete `resource.Resource` for Elasticsearch-backed resources that fit the standard lifecycle.
+- Require separate create and update callbacks so resources can pass the same function when behavior is identical or distinct functions when behavior diverges.
+- Keep state persistence centralized in the envelope by having callbacks return the final model.
+- Pass the resource ID to create and update callbacks, matching the existing read and delete callback style while allowing create plans whose computed `id` is not yet known.
+- Migrate only the four duplicated resources identified in the issue.
+
+**Non-Goals:**
+
+- Do not introduce `NewUpsertableElasticsearchResource` or a generic Create/Update embeddable.
+- Do not migrate unrelated Elasticsearch, Kibana, Fleet, or APM resources opportunistically.
+- Do not change public Terraform schemas, state formats, IDs, or API behavior.
+- Do not make create or update callbacks optional; resources that do not fit the envelope should continue to use `ResourceBase` directly.
+
+## Decisions
+
+### Extend the Elasticsearch envelope instead of adding a second embeddable
+
+`NewElasticsearchResource` already owns the common Elasticsearch request prelude for Read and Delete: model decoding, composite ID parsing, scoped client resolution, and state mutation. Extending the same envelope to Create and Update keeps the abstraction boundary coherent.
+
+Alternative considered: add an `UpsertableResource` embeddable that implements Create and Update from a `func(context.Context, tfsdk.Plan, *tfsdk.State) diag.Diagnostics`. This would remove the thin wrapper methods but leave client resolution and state mutation inside concrete resources, and receiver-bound initialization would be awkward because existing helpers call `r.Client()`.
+
+### Require two lifecycle callbacks
+
+The constructor should accept both create and update callbacks. The duplicated resources can pass the same function twice, but the API should not assume create and update are always identical.
+
+Alternative considered: accept a single upsert callback. This would fit the four initial resources but would make the envelope less useful for resources whose create and update operations diverge later.
+
+### Return the final model from callbacks
+
+Create and update callbacks should return `(T, diag.Diagnostics)` instead of mutating `*tfsdk.State` directly. The envelope should append diagnostics and call `resp.State.Set(ctx, &resultModel)` only after the callback succeeds.
+
+This mirrors the existing Read contract, where concrete logic returns a model and the envelope owns persistence. It also makes callback tests less coupled to Plugin Framework state plumbing.
+
+### Derive resource ID from the planned model for create and update
+
+The create and update prelude should decode the planned model, resolve the scoped Elasticsearch client, derive the write resource ID from the planned model, and invoke the callback with `(ctx, client, resourceID, model)`.
+
+Create cannot generally parse `model.GetID()`, because `id` is computed for these resources and may be unknown in the plan. The envelope should therefore extend `ElasticsearchResourceModel` with a plan-safe resource identity accessor, for example `GetResourceID() types.String`, implemented by each model from its natural write identity field (`name`, `username`, or `script_id`). Read and Delete should continue to parse the composite state ID via `GetID()`.
+
+This keeps callback signatures consistent with Read and Delete without forcing create callbacks to recover the same identity from the model themselves. Callbacks remain responsible for assigning the final composite `ID` on the returned model after successful API writes.
+
+## Risks / Trade-offs
+
+- Constructor signature churn → Update all current `NewElasticsearchResource` call sites in the same implementation change so compile errors surface missed migrations.
+- Existing envelope models do not expose a separate write identity accessor → Add the accessor to the model constraint and update current envelope model types in the same change.
+- Larger refactor than thin wrapper extraction → Keep migration scoped to the four issue examples and preserve existing acceptance-visible behavior.
+- Existing spec currently says the envelope does not implement Create or Update → Update the delta spec to make the contract change explicit.

--- a/openspec/changes/elasticsearch-resource-create-update/proposal.md
+++ b/openspec/changes/elasticsearch-resource-create-update/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Several Plugin Framework Elasticsearch resources duplicate thin `Create` and `Update` methods that only delegate to a shared upsert implementation. Centralizing this lifecycle behavior in `NewElasticsearchResource` keeps the resource envelope responsible for common Terraform request handling and prevents further drift across migrated resources.
+
+## What Changes
+
+- Extend `NewElasticsearchResource[T]` so callers provide required create and update callbacks in addition to schema, read, and delete callbacks.
+- Have the Elasticsearch resource envelope implement `Create` and `Update` by decoding the planned model, deriving the write resource ID from the model, resolving the scoped Elasticsearch client, invoking the relevant callback with the resource ID, and persisting the returned model to state.
+- Migrate the four duplicated issue examples to pass create and update callbacks to the envelope, using the same callback for both operations where create and update are currently identical.
+- Update the `entitycore-resource-envelope` specification to describe the envelope as a complete `resource.Resource` for resources that fit the common Elasticsearch lifecycle.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `entitycore-resource-envelope`: `NewElasticsearchResource` will own Create and Update behavior through required callbacks instead of requiring concrete resources to implement thin wrappers.
+
+## Impact
+
+- Affected code: `internal/entitycore`, the four issue examples in `internal/elasticsearch/security/role`, `internal/elasticsearch/security/rolemapping`, `internal/elasticsearch/security/systemuser`, and `internal/elasticsearch/cluster/script`, plus any existing `NewElasticsearchResource` call sites that need constructor or model constraint updates.
+- Affected tests: entitycore resource envelope unit tests and targeted tests for the migrated resources where available.
+- Public Terraform behavior should remain unchanged; this is an internal Plugin Framework resource abstraction refactor.

--- a/openspec/changes/elasticsearch-resource-create-update/specs/entitycore-resource-envelope/spec.md
+++ b/openspec/changes/elasticsearch-resource-create-update/specs/entitycore-resource-envelope/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Envelope owns the Create and Update preludes
+
+The system SHALL implement `Create` and `Update` on `NewElasticsearchResource[T]` by deserializing the planned model into `T`, deriving the write resource ID from the model, resolving the scoped Elasticsearch client from the model's connection block via `GetElasticsearchClient`, and invoking the corresponding concrete callback. The concrete create and update callbacks SHALL be invoked with `(context, *clients.ElasticsearchScopedClient, resourceID string, T)`.
+
+#### Scenario: Successful create sets state from returned model
+
+- **WHEN** the concrete create function returns `(model, nil)`
+- **THEN** `resp.State.Set` SHALL be called with the returned model `T`
+- **AND** response diagnostics SHALL contain no errors
+
+#### Scenario: Successful update sets state from returned model
+
+- **WHEN** the concrete update function returns `(model, nil)`
+- **THEN** `resp.State.Set` SHALL be called with the returned model `T`
+- **AND** response diagnostics SHALL contain no errors
+
+#### Scenario: Create function error short-circuits state mutation
+
+- **WHEN** the concrete create function returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Update function error short-circuits state mutation
+
+- **WHEN** the concrete update function returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Client resolution failure short-circuits create
+
+- **WHEN** `GetElasticsearchClient` returns error diagnostics during `Create`
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete create function SHALL NOT be invoked
+- **AND** state SHALL remain untouched
+
+#### Scenario: Client resolution failure short-circuits update
+
+- **WHEN** `GetElasticsearchClient` returns error diagnostics during `Update`
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete update function SHALL NOT be invoked
+- **AND** state SHALL remain untouched
+
+#### Scenario: Create and update may use the same callback
+
+- **WHEN** a concrete Elasticsearch resource has identical create and update API behavior
+- **THEN** the resource SHALL be able to pass the same callback as both the create and update callback
+
+### Requirement: Envelope keeps ImportState opt-in
+
+The system SHALL NOT implement `ImportState` on the envelope. Import support SHALL remain opt-in for concrete resources, matching the provider-wide convention. Concrete resources that support import SHALL implement `ImportState` themselves, typically as a passthrough on the `id` attribute.
+
+#### Scenario: Envelope resource without ImportState does not satisfy ResourceWithImportState
+
+- **WHEN** an envelope is constructed via `NewElasticsearchResource[T]`
+- **THEN** the returned resource SHALL satisfy `resource.Resource`
+- **AND** SHALL satisfy `resource.ResourceWithConfigure`
+- **AND** SHALL NOT satisfy `resource.ResourceWithImportState`
+
+#### Scenario: Concrete resource adds ImportState passthrough
+
+- **WHEN** a concrete resource that embeds `*ElasticsearchResource[T]` defines its own `ImportState` method using `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)`
+- **THEN** that resource SHALL satisfy `resource.ResourceWithImportState`
+- **AND** the `id` attribute SHALL be set to the supplied import identifier
+
+## MODIFIED Requirements
+
+### Requirement: Envelope constructor produces shared Elasticsearch resource behavior
+
+The system SHALL provide a generic constructor `NewElasticsearchResource[T]()` that returns an envelope owning shared Elasticsearch resource behavior. The envelope SHALL provide Metadata, Schema, Create, Read, Update, Delete, and Configure behavior, and SHALL satisfy `resource.Resource`. Concrete resources SHALL embed the envelope and may choose to implement additional Plugin Framework interfaces such as ImportState or state upgrade support.
+
+#### Scenario: Constructor returns complete resource envelope
+
+- **WHEN** `NewElasticsearchResource[T](component, name, schemaFactory, readFunc, deleteFunc, createFunc, updateFunc)` is called with non-nil callbacks
+- **THEN** the returned value SHALL provide the shared Metadata, Schema, Create, Read, Update, Delete, and Configure methods
+- **AND** the returned value SHALL satisfy `resource.Resource`
+- **AND** concrete resources embedding the returned value SHALL NOT need thin Create or Update wrappers when their behavior fits the callback contract
+
+### Requirement: Model type constraint exposes ID and connection block
+
+The system SHALL define a type constraint `ElasticsearchResourceModel` requiring `GetID() types.String`, `GetResourceID() types.String`, and `GetElasticsearchConnection() types.List`. Concrete `Data` types SHALL satisfy this constraint by declaring value-receiver getter methods over their existing `ID`, natural write identity, and `ElasticsearchConnection` fields.
+
+#### Scenario: Concrete model satisfies the constraint
+
+- **WHEN** a concrete `Data` struct declares `GetID() types.String` returning `d.ID`, `GetResourceID() types.String` returning its plan-safe write identity field, and `GetElasticsearchConnection() types.List` returning `d.ElasticsearchConnection`
+- **THEN** that struct SHALL satisfy `ElasticsearchResourceModel`
+- **AND** SHALL be usable as the type parameter to `NewElasticsearchResource[T]`
+
+## REMOVED Requirements
+
+### Requirement: Envelope does not implement Create, Update, or ImportState
+
+**Reason**: The envelope now owns Create and Update for resources that fit the standard Elasticsearch lifecycle. Keeping this requirement would contradict the new complete-resource contract.
+
+**Migration**: ImportState remains opt-in under `Envelope keeps ImportState opt-in`. Concrete resources that previously supplied thin Create and Update wrappers SHALL migrate to create and update callbacks passed to `NewElasticsearchResource`.

--- a/openspec/changes/elasticsearch-resource-create-update/tasks.md
+++ b/openspec/changes/elasticsearch-resource-create-update/tasks.md
@@ -1,0 +1,21 @@
+## 1. Entitycore Envelope
+
+- [ ] 1.1 Extend `ElasticsearchResourceModel` with a plan-safe resource identity accessor used by Create and Update.
+- [ ] 1.2 Add required create and update callback types to `NewElasticsearchResource`.
+- [ ] 1.3 Implement `Create` and `Update` on `ElasticsearchResource[T]` with plan decode, resource ID derivation, scoped Elasticsearch client resolution, callback invocation, diagnostics handling, and returned-model state persistence.
+- [ ] 1.4 Update entitycore package documentation to describe the complete Elasticsearch resource envelope and callback contract.
+
+## 2. Resource Migrations
+
+- [ ] 2.1 Migrate `security_role` to pass create and update callbacks to `NewElasticsearchResource` and remove thin Create/Update wrapper methods.
+- [ ] 2.2 Migrate `security_role_mapping` to pass create and update callbacks to `NewElasticsearchResource` and remove thin Create/Update wrapper methods.
+- [ ] 2.3 Migrate `security_system_user` to pass create and update callbacks to `NewElasticsearchResource` and remove thin Create/Update wrapper methods.
+- [ ] 2.4 Migrate `cluster_script` to the Elasticsearch resource envelope and pass create and update callbacks to remove its thin Create/Update wrapper methods.
+- [ ] 2.5 Update any remaining `NewElasticsearchResource` call sites and model getter methods required by the new constructor and model constraint.
+
+## 3. Tests and Verification
+
+- [ ] 3.1 Update entitycore resource envelope unit tests for Create and Update success paths, callback diagnostics, client resolution failures, and type/interface assertions.
+- [ ] 3.2 Add or update focused resource tests where existing coverage can verify migrated callback behavior without acceptance-test infrastructure.
+- [ ] 3.3 Run targeted Go tests for `internal/entitycore` and migrated resource packages.
+- [ ] 3.4 Run OpenSpec validation for `elasticsearch-resource-create-update`.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add create/update support proposal for `NewElasticsearchResource` in entitycore
- Adds a design proposal and spec to extend `NewElasticsearchResource` to accept required create/update callbacks and implement those lifecycles natively within the envelope.
- Covers migration of four existing Elasticsearch resources (`security_role`, `security_role_mapping`, `security_system_user`, `cluster_script`) that currently duplicate this logic.
- Updates the entitycore resource envelope spec to require `Create` and `Update` implementations and a model type constraint including `GetResourceID`; `ImportState` remains opt-in.
- Includes a [tasks.md](https://github.com/elastic/terraform-provider-elasticstack/pull/2686/files#diff-46c4adce3d15617e07984557ef19c998bd3f4572409dde60d78957c74eb81087) breaking down envelope changes, resource migrations, and test updates.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d563ccb.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->