### PR TITLE
openspec: propose dispatching code-factory after producer issue creation

### DIFF
--- a/openspec/changes/dispatch-code-factory-after-issue-creation/.openspec.yaml
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/design.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The repository has a `code-factory` issue-intake workflow that currently activates from `issues.opened` and `issues.labeled` events when an issue carries the `code-factory` label. Three other repository-authored analysis workflows (`semantic-function-refactor`, `schema-coverage-rotation`, and `flaky-test-catcher`) use safe outputs to create follow-up issues and currently attach the `code-factory` label so those issues can be implemented automatically.
+
+That trigger strategy fails in practice because the issues are created by GitHub Actions safe-output processing using `GITHUB_TOKEN`, which does not trigger downstream issue-event workflows. The producer workflows therefore create actionable issues, but no implementation workflow run follows. We now know the producer workflows already emit `/tmp/gh-aw/temporary-id-map.json`, whose entries contain the real created issue numbers and repository slugs for every created issue. That artifact provides a deterministic handoff surface after safe-output processing has completed.
+
+The repository also needs to preserve the manual maintainer path where adding `code-factory` to an existing issue should still trigger the implementation workflow. The design therefore needs two entry modes: manual issue-event intake and internal workflow dispatch intake. In both cases, `code-factory` must continue to implement exactly one issue per run and keep duplicate linked-PR suppression deterministic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve manual `code-factory` label-based issue intake for maintainers.
+- Replace producer-side reliance on issue-label trigger side effects with explicit deterministic dispatch after issue creation.
+- Support true fan-out so one producer run can dispatch `code-factory` once per created issue.
+- Keep the issue itself as the canonical source of implementation scope by fetching live issue data in dispatch mode.
+- Reuse the existing duplicate-PR guardrail so redispatches or partial retries do not create duplicate work.
+- Remove `code-factory` from producer-created issue labels so label semantics return to “manual intake trigger” rather than overloaded metadata.
+
+**Non-Goals:**
+- Changing `code-factory` from a single-issue-per-run workflow into a batch worker.
+- Introducing cross-repository dispatch; all dispatches remain within the current repository.
+- Replacing the existing duplicate-PR linkage contract (`code-factory/issue-<n>` plus `Closes #<n>`).
+- Reworking unrelated producer workflow issue-selection logic, prioritization logic, or issue-slot caps.
+
+## Decisions
+
+### 1. Use `workflow_dispatch` as the automated `code-factory` entrypoint
+`code-factory` will add a `workflow_dispatch` trigger with typed inputs for at least `issue_number`, `issue_repo`, and optional provenance such as `source_workflow`. This keeps the workflow invocable from deterministic repository jobs after issue creation.
+
+**Why this choice:**
+- `workflow_call` is a poor fit for this handoff because the producer workflows can create up to three issues and need true fan-out. The gh-aw `call-workflow` output path does not naturally support “dispatch once per created issue” after safe-output processing.
+- `workflow_dispatch` creates independent downstream runs, which is operationally clearer and matches the single-issue-per-run contract.
+
+**Alternatives considered:**
+- **`workflow_call` / safe-output call-workflow**: rejected because it does not model post-create N-way fan-out cleanly and depends on information the agent does not have during reasoning.
+- **Keep relying on `code-factory` labels on created issues**: rejected because `GITHUB_TOKEN`-created issue events do not trigger the downstream workflow.
+
+### 2. Dispatch from a deterministic post-safe_outputs job, not from agent-emitted safe outputs
+Each producer workflow will add a deterministic job after `safe_outputs` that downloads or reads the safe-output artifacts, parses `temporary-id-map.json`, and dispatches one `code-factory` run per created issue.
+
+**Why this choice:**
+- The real issue numbers exist only after safe-output processing has completed.
+- The temporary ID map is already structured as the authoritative mapping from temporary issue IDs to `{ repo, number }` and therefore supports deterministic fan-out without heuristic searches.
+- Keeping dispatch logic outside the agent avoids coupling the agent prompt to post-processing mechanics and preserves least privilege for the reasoning phase.
+
+**Alternatives considered:**
+- **Agent emits dispatch outputs directly**: rejected because the agent does not know the final issue numbers yet.
+- **Search GitHub after safe outputs using title/labels/time windows**: rejected because it is less deterministic than using the temporary ID map.
+
+### 3. Remove `code-factory` from producer-created issue labels
+The semantic refactor, schema coverage rotation, and flaky test catcher workflows will stop adding `code-factory` to the labels they apply to newly created issues.
+
+**Why this choice:**
+- It restores a clean meaning for the `code-factory` label: manual maintainer-triggered intake.
+- It avoids a confusing partial semantic where some `code-factory`-related issues are label-triggered and others are dispatch-triggered.
+- The new dispatch mechanism no longer needs the label for automation.
+
+**Alternatives considered:**
+- **Keep `code-factory` as a metadata label on producer-created issues**: rejected to avoid overloading the label with two incompatible meanings and two different lifecycle behaviors.
+
+### 4. Normalize intake context inside `code-factory`
+`code-factory` will resolve a normalized intake context during pre-activation, producing outputs such as issue number, issue title, issue body, intake mode, and gate reason. The implementation prompt and downstream deterministic steps will consume these normalized outputs instead of directly referencing `github.event.issue.*`.
+
+**Why this choice:**
+- `workflow_dispatch` runs do not have `github.event.issue` payloads.
+- A normalized intake model lets the workflow preserve one implementation prompt and one downstream duplicate-PR contract across both entry modes.
+- This keeps the workflow’s “issue is the sole source of truth” rule intact while still allowing multiple entry mechanisms.
+
+**Alternatives considered:**
+- **Branch the entire workflow into separate manual and dispatch implementations**: rejected because it would duplicate prompt and guardrail logic.
+- **Trust issue title/body passed through dispatch inputs**: rejected because the live issue should remain authoritative, and dispatch inputs only need to identify which issue to load.
+
+### 5. Split deterministic gating by entry mode while preserving duplicate-PR suppression
+Manual issue-event runs will continue to use event qualification, actor-trust checks, duplicate-PR checks, and trigger-label removal. Dispatch-triggered runs will skip label qualification and actor-trust logic, validate dispatch inputs, fetch the live issue, and then apply the same duplicate-PR suppression used by manual runs.
+
+**Why this choice:**
+- The trust boundary is different for internal dispatch than for label-triggered issue events.
+- Reusing duplicate-PR suppression ensures retries, partial failures, or repeated dispatches do not open duplicate implementation PRs.
+- Keeping trigger-label removal only in manual mode matches the new semantics where dispatch-triggered producer issues no longer carry the `code-factory` label.
+
+**Alternatives considered:**
+- **Reusing actor-trust checks in dispatch mode**: rejected because `workflow_dispatch` is intentionally a repository-authored internal handoff, not a user-applied label event.
+
+## Risks / Trade-offs
+
+- **Dispatch job parses the wrong artifact shape** → Mitigation: treat `temporary-id-map.json` as the required contract, add focused tests for map parsing, and fail clearly when the file is missing or malformed.
+- **Producer workflow reruns redispatch already-dispatched issues** → Mitigation: rely on the existing duplicate linked-PR guardrail in `code-factory`, and ensure dispatch mode still checks for canonical linked PRs before agent activation.
+- **Manual and dispatch entry modes drift behaviorally** → Mitigation: normalize intake outputs and keep shared duplicate-PR logic and prompt contract in one workflow path.
+- **Issue changes between creation and dispatch** → Mitigation: this is an acceptable trade-off because the live issue should be authoritative; dispatch mode intentionally fetches the current title/body.
+- **Dispatch introduces more workflow runs to observe** → Mitigation: accept this as a feature of true fan-out; separate runs provide clearer per-issue traceability and retry behavior.

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/proposal.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Three repository-authored analysis workflows currently create follow-up issues intended for `code-factory` automation by attaching a `code-factory` label at issue creation time. Because those issues are created through GitHub Actions `GITHUB_TOKEN`-backed safe-output processing, the downstream issue-triggered `code-factory` workflow is not activated, so the issues are opened but never handed off to the implementation worker.
+
+## What Changes
+
+- Remove `code-factory` from the issue labels created by the semantic function refactor, schema coverage rotation, and flaky test catcher workflows.
+- Add a deterministic post-safe-outputs dispatch phase to each of those producer workflows that reads the safe-output temporary issue ID map and dispatches the `code-factory` workflow once per created issue.
+- Extend the `code-factory` issue intake workflow to support a `workflow_dispatch` entrypoint for internally dispatched single-issue runs, alongside the existing manual issue-event entrypoint.
+- Refactor `code-factory` intake so implementation context is derived from normalized intake data rather than directly from `github.event.issue.*`, and so dispatch-triggered runs fetch the live issue body/title by issue number before proceeding.
+- Preserve the existing manual `code-factory` label-based intake path for maintainers while clearly separating it from producer-driven automation.
+
+## Capabilities
+
+### New Capabilities
+- `ci-code-factory-dispatch-fanout`: Deterministic fan-out from issue-producing analysis workflows into one `workflow_dispatch` run of `code-factory` per created issue using the safe-output temporary ID map.
+
+### Modified Capabilities
+- `ci-code-factory-issue-intake`: Add a `workflow_dispatch` intake mode, normalize issue context resolution across entrypoints, and keep duplicate-PR suppression and single-issue PR semantics for dispatched runs.
+- `ci-semantic-refactor-workflow`: Change follow-up issue behavior from label-trigger handoff to explicit post-safe-outputs dispatch and remove `code-factory` from created issue labels.
+- `flaky-test-catcher`: Change follow-up issue behavior from label-trigger handoff to explicit post-safe-outputs dispatch and remove `code-factory` from created issue labels.
+- `ci-schema-coverage-rotation-issue-slots`: Extend the schema coverage workflow contract so created follow-up issues are dispatched to `code-factory` explicitly rather than relying on `code-factory` labels at creation time.
+
+## Impact
+
+- Affected workflow sources under `.github/workflows-src/` for `code-factory-issue`, `semantic-function-refactor`, `schema-coverage-rotation`, and `flaky-test-catcher`.
+- Affected generated workflow artifacts under `.github/workflows/` and compiled `.lock.yml` files.
+- Shared workflow helper logic and tests under `.github/workflows-src/lib/` for intake normalization and dispatch metadata handling.
+- OpenSpec capability specs for `code-factory` intake and the three producer workflows.

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-code-factory-dispatch-fanout/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-code-factory-dispatch-fanout/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Producer workflows dispatch `code-factory` once per created issue
+Repository-authored issue-producing analysis workflows that hand off implementation to `code-factory` SHALL perform explicit post-safe-outputs fan-out by dispatching the `code-factory` workflow once for each issue created in the current run.
+
+#### Scenario: Multiple created issues are fanned out deterministically
+- **WHEN** a producer workflow creates multiple issues in one run
+- **THEN** the workflow SHALL dispatch one independent `code-factory` workflow run per created issue
+- **AND** each dispatch SHALL target exactly one issue number
+
+#### Scenario: No issues created means no dispatches
+- **WHEN** a producer workflow completes without creating any issues
+- **THEN** it SHALL NOT dispatch `code-factory`
+
+### Requirement: Fan-out uses the safe-output temporary issue ID map
+The producer-side dispatch phase SHALL use the safe-output temporary issue ID map as the source of truth for created issue identities. For each created issue entry, the workflow SHALL read the repository slug and issue number from the map rather than inferring newly created issues by search, title, or label matching.
+
+#### Scenario: Temporary issue ID map contains three created issues
+- **WHEN** the producer workflow's safe-output artifacts include three temporary issue ID map entries with repository and issue-number values
+- **THEN** the dispatch phase SHALL dispatch `code-factory` exactly three times using those repository and issue-number values
+
+#### Scenario: Temporary issue ID map is missing or malformed
+- **WHEN** the dispatch phase cannot read a valid temporary issue ID map
+- **THEN** the workflow SHALL fail or stop dispatch fan-out rather than guessing which issues were created
+
+### Requirement: Fan-out dispatch remains deterministic and repository-authored
+The fan-out dispatch logic SHALL be implemented in deterministic repository-authored workflow jobs or scripts under `.github/workflows-src/` and SHALL NOT depend on agent-emitted safe outputs to determine which created issues to dispatch.
+
+#### Scenario: Maintainer inspects dispatch handoff implementation
+- **WHEN** maintainers review the producer workflow source
+- **THEN** the logic that parses created issue identities and dispatches `code-factory` SHALL be repository-authored and deterministic
+- **AND** it SHALL run after safe-output issue creation has completed

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-code-factory-issue-intake/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: Workflow activates the implementation agent only for qualifying `code-factory` issue events
-The workflow MAY subscribe to GitHub `issues.opened` and `issues.labeled` events, and it SHALL also support internal single-issue activation through `workflow_dispatch`. For issue-event intake, eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `code-factory`, and `issues.opened` when the issue already includes the `code-factory` label at creation time.
+The workflow MAY subscribe to GitHub `issues.opened` and `issues.labeled` events. For issue-event intake, eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `code-factory`, and `issues.opened` when the issue already includes the `code-factory` label at creation time.
 
 #### Scenario: Label applied after issue creation
 - **WHEN** an `issues.labeled` event is received and `github.event.label.name` is `code-factory`
@@ -11,16 +11,12 @@ The workflow MAY subscribe to GitHub `issues.opened` and `issues.labeled` events
 - **WHEN** an `issues.opened` event is received and the issue's initial labels include `code-factory`
 - **THEN** the workflow SHALL treat the event as eligible to activate the implementation agent
 
-#### Scenario: Internal workflow dispatch requests issue intake
-- **WHEN** the workflow is triggered by `workflow_dispatch` with a valid issue number for the current repository
-- **THEN** the workflow SHALL treat that dispatch as eligible to activate the implementation agent subject to its dispatch-mode deterministic gates
-
 #### Scenario: Non-trigger issue event is ignored
 - **WHEN** an `issues` event is received without the `code-factory` label in the qualifying position for that event type
 - **THEN** the workflow SHALL NOT activate the implementation agent for that event
 
 ### Requirement: Trigger actor must be trusted
-Before agent activation, the workflow SHALL determine whether the triggering actor is trusted for issue-event intake. The actor SHALL be trusted if the sender is `github-actions[bot]`; otherwise the workflow SHALL query repository collaborator permissions and SHALL require effective repository permission `write`, `maintain`, or `admin`. This trust policy applies to issue-event intake and SHALL NOT be required for repository-authored `workflow_dispatch` intake.
+Before agent activation, the workflow SHALL determine whether the triggering actor is trusted for issue-event intake. The actor SHALL be trusted if the sender is `github-actions[bot]`; otherwise the workflow SHALL query repository collaborator permissions and SHALL require effective repository permission `write`, `maintain`, or `admin`. This trust policy applies only to issue-event intake and SHALL NOT be required for repository-authored `workflow_dispatch` intake.
 
 #### Scenario: GitHub Actions opens a labeled issue
 - **WHEN** the sender is `github-actions[bot]` and the event otherwise qualifies for `code-factory` issue intake
@@ -70,6 +66,13 @@ When the deterministic gate passes, the workflow agent SHALL treat the resolved 
 
 ## ADDED Requirements
 
+### Requirement: Workflow activates the implementation agent for valid internal dispatch requests
+The workflow SHALL support internal single-issue activation through `workflow_dispatch` when the dispatch provides valid current-repository issue identity and the run passes its dispatch-mode deterministic gates.
+
+#### Scenario: Internal workflow dispatch requests issue intake
+- **WHEN** the workflow is triggered by `workflow_dispatch` with a valid issue number for the current repository
+- **THEN** the workflow SHALL treat that dispatch as eligible to activate the implementation agent subject to its dispatch-mode deterministic gates
+
 ### Requirement: Dispatch intake resolves live issue context from workflow inputs
 For `workflow_dispatch` intake, the workflow SHALL accept enough typed input to identify one issue in the current repository and SHALL resolve the live issue title and body from GitHub before activating the implementation agent. The workflow SHALL use the live issue as the canonical source of scope rather than trusting issue body or title text passed through dispatch inputs.
 
@@ -91,3 +94,14 @@ The workflow SHALL normalize issue intake into downstream-consumable outputs tha
 #### Scenario: Dispatch intake exposes normalized outputs
 - **WHEN** the workflow is triggered from `workflow_dispatch`
 - **THEN** the workflow SHALL publish the same normalized outputs for the resolved issue number, title, body, intake mode, and gate reason
+
+### Requirement: Trigger label removal remains issue-event-only
+The workflow SHALL keep `code-factory` trigger-label removal scoped to the manual issue-event path. Dispatch-triggered runs SHALL NOT require the target issue to carry the `code-factory` label, and the workflow SHALL NOT treat the absence of that label on dispatch-targeted issues as an error.
+
+#### Scenario: Manual issue-event run removes the trigger label when proceeding
+- **WHEN** an eligible trusted issue-event run proceeds past deterministic gates and the issue carries the `code-factory` label
+- **THEN** the workflow SHALL remove the `code-factory` label before agent activation as defined by the base intake behavior
+
+#### Scenario: Dispatch-targeted issue has no `code-factory` label
+- **WHEN** the workflow is triggered by `workflow_dispatch` for an issue that does not carry the `code-factory` label
+- **THEN** the workflow SHALL continue normally and SHALL NOT require trigger-label removal for that run

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-code-factory-issue-intake/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-code-factory-issue-intake/spec.md
@@ -1,0 +1,93 @@
+## MODIFIED Requirements
+
+### Requirement: Workflow activates the implementation agent only for qualifying `code-factory` issue events
+The workflow MAY subscribe to GitHub `issues.opened` and `issues.labeled` events, and it SHALL also support internal single-issue activation through `workflow_dispatch`. For issue-event intake, eligible triggers SHALL include `issues.labeled` when the newly applied label is exactly `code-factory`, and `issues.opened` when the issue already includes the `code-factory` label at creation time.
+
+#### Scenario: Label applied after issue creation
+- **WHEN** an `issues.labeled` event is received and `github.event.label.name` is `code-factory`
+- **THEN** the workflow SHALL treat the event as eligible to activate the implementation agent
+
+#### Scenario: Issue opens with the trigger label already present
+- **WHEN** an `issues.opened` event is received and the issue's initial labels include `code-factory`
+- **THEN** the workflow SHALL treat the event as eligible to activate the implementation agent
+
+#### Scenario: Internal workflow dispatch requests issue intake
+- **WHEN** the workflow is triggered by `workflow_dispatch` with a valid issue number for the current repository
+- **THEN** the workflow SHALL treat that dispatch as eligible to activate the implementation agent subject to its dispatch-mode deterministic gates
+
+#### Scenario: Non-trigger issue event is ignored
+- **WHEN** an `issues` event is received without the `code-factory` label in the qualifying position for that event type
+- **THEN** the workflow SHALL NOT activate the implementation agent for that event
+
+### Requirement: Trigger actor must be trusted
+Before agent activation, the workflow SHALL determine whether the triggering actor is trusted for issue-event intake. The actor SHALL be trusted if the sender is `github-actions[bot]`; otherwise the workflow SHALL query repository collaborator permissions and SHALL require effective repository permission `write`, `maintain`, or `admin`. This trust policy applies to issue-event intake and SHALL NOT be required for repository-authored `workflow_dispatch` intake.
+
+#### Scenario: GitHub Actions opens a labeled issue
+- **WHEN** the sender is `github-actions[bot]` and the event otherwise qualifies for `code-factory` issue intake
+- **THEN** the workflow SHALL treat the trigger as trusted without requiring a collaborator-permission lookup
+
+#### Scenario: Maintainer applies the label
+- **WHEN** a human actor triggers an otherwise eligible `code-factory` issue event and the repository permission lookup returns `write`, `maintain`, or `admin`
+- **THEN** the workflow SHALL treat the trigger as trusted
+
+#### Scenario: Untrusted actor attempts to trigger automation
+- **WHEN** a non-bot actor triggers an otherwise eligible `code-factory` issue event and the repository permission lookup does not return `write`, `maintain`, or `admin`
+- **THEN** the workflow SHALL skip agent activation
+
+#### Scenario: Internal dispatch bypasses issue-event trust lookup
+- **WHEN** the workflow is triggered by repository-authored `workflow_dispatch`
+- **THEN** the workflow SHALL NOT require the issue-event actor trust check as a prerequisite for activation
+
+### Requirement: Workflow suppresses duplicate linked pull requests
+Before agent activation, the workflow SHALL detect whether an open linked `code-factory` pull request already exists for the triggering issue, regardless of whether intake came from an issue event or `workflow_dispatch`. A pull request SHALL be treated as linked only when it is open, carries the `code-factory` label, uses the deterministic branch name `code-factory/issue-<issue-number>`, and includes an explicit reference to the issue in stable metadata such as `Closes #<issue-number>`.
+
+#### Scenario: Existing linked PR prevents a duplicate issue-event run
+- **WHEN** the workflow finds an open pull request that satisfies the linked `code-factory` PR criteria for the triggering issue
+- **THEN** the workflow SHALL skip agent activation instead of opening a duplicate pull request
+
+#### Scenario: Existing linked PR prevents a duplicate dispatch run
+- **WHEN** an internally dispatched run targets an issue that already has an open linked `code-factory` pull request
+- **THEN** the workflow SHALL skip agent activation instead of opening a duplicate pull request
+
+#### Scenario: Unrelated PR does not block issue intake
+- **WHEN** an open pull request mentions the issue or has a similar title but does not satisfy the full linked `code-factory` PR criteria
+- **THEN** the workflow SHALL NOT treat that pull request as the canonical linked PR for duplicate suppression
+
+### Requirement: Agent creates exactly one linked `code-factory` pull request
+When the deterministic gate passes, the workflow agent SHALL treat the resolved issue as the source of truth for implementation, SHALL work on the deterministic branch `code-factory/issue-<issue-number>`, and SHALL create or update exactly one linked pull request labeled `code-factory`. The linked pull request SHALL preserve explicit issue linkage in its title or body so future reruns can deterministically identify it.
+
+#### Scenario: Eligible issue-event intake creates a linked implementation PR
+- **WHEN** the workflow runs for a trusted eligible issue event and no open linked `code-factory` pull request already exists
+- **THEN** the agent SHALL implement the issue on branch `code-factory/issue-<issue-number>` and open one linked pull request carrying the `code-factory` label
+
+#### Scenario: Eligible dispatch intake creates a linked implementation PR
+- **WHEN** the workflow runs from `workflow_dispatch` for a valid issue in the current repository and no open linked `code-factory` pull request already exists
+- **THEN** the agent SHALL implement the issue on branch `code-factory/issue-<issue-number>` and open one linked pull request carrying the `code-factory` label
+
+#### Scenario: Pull request metadata preserves deterministic linkage
+- **WHEN** the agent creates the `code-factory` pull request
+- **THEN** the pull request SHALL include explicit issue linkage metadata so later workflow runs can identify it as the canonical PR for the issue
+
+## ADDED Requirements
+
+### Requirement: Dispatch intake resolves live issue context from workflow inputs
+For `workflow_dispatch` intake, the workflow SHALL accept enough typed input to identify one issue in the current repository and SHALL resolve the live issue title and body from GitHub before activating the implementation agent. The workflow SHALL use the live issue as the canonical source of scope rather than trusting issue body or title text passed through dispatch inputs.
+
+#### Scenario: Dispatch provides issue number and repository
+- **WHEN** `workflow_dispatch` provides a valid issue number and current-repository identifier
+- **THEN** the workflow SHALL fetch the live issue details from GitHub before prompting the agent
+
+#### Scenario: Dispatch input references another repository
+- **WHEN** `workflow_dispatch` provides an issue repository that does not match the current repository
+- **THEN** the workflow SHALL reject or stop that run rather than implementing a cross-repository issue
+
+### Requirement: Workflow normalizes issue intake context across entry modes
+The workflow SHALL normalize issue intake into downstream-consumable outputs that include the resolved issue number, title, body, intake mode, and gate reason so that the implementation prompt and downstream steps do not depend directly on `github.event.issue.*`.
+
+#### Scenario: Issue-event intake exposes normalized outputs
+- **WHEN** the workflow is triggered from an eligible issue event
+- **THEN** the workflow SHALL publish normalized outputs for the resolved issue number, title, body, intake mode, and gate reason
+
+#### Scenario: Dispatch intake exposes normalized outputs
+- **WHEN** the workflow is triggered from `workflow_dispatch`
+- **THEN** the workflow SHALL publish the same normalized outputs for the resolved issue number, title, body, intake mode, and gate reason

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-schema-coverage-rotation-issue-slots/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-schema-coverage-rotation-issue-slots/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Created schema-coverage issues are explicitly dispatched to `code-factory`
+After safe-output issue creation completes, the `schema-coverage-rotation` workflow SHALL explicitly dispatch the `code-factory` workflow once for each schema-coverage issue created in the current run rather than relying on a producer-side `code-factory` label to trigger implementation intake.
+
+#### Scenario: One created schema-coverage issue dispatches one implementation run
+- **WHEN** the workflow creates one schema-coverage issue in a run
+- **THEN** it SHALL dispatch exactly one `code-factory` workflow run for that issue
+
+#### Scenario: Multiple created schema-coverage issues dispatch multiple implementation runs
+- **WHEN** the workflow creates multiple schema-coverage issues in a run
+- **THEN** it SHALL dispatch exactly one independent `code-factory` workflow run per created issue
+
+### Requirement: Schema-coverage issue labels do not include `code-factory`
+The `schema-coverage-rotation` workflow SHALL use schema-coverage-specific issue labels for created issues and SHALL NOT depend on adding `code-factory` to those created issues in order to hand them off for implementation.
+
+#### Scenario: Maintainer inspects schema-coverage issue safe-output configuration
+- **WHEN** maintainers inspect the schema-coverage workflow source or generated artifacts
+- **THEN** the created issue labels SHALL include schema-coverage-specific labels
+- **AND** the created issue labels SHALL NOT include `code-factory`

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-semantic-refactor-workflow/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-semantic-refactor-workflow/spec.md
@@ -21,7 +21,7 @@ Each semantic refactor issue created by the workflow SHALL include a concise sum
 #### Scenario: Issue titles and labels identify the workflow output
 - **WHEN** the workflow creates a semantic refactor issue
 - **THEN** the issue SHALL carry the configured title prefix `[semantic-refactor] ` and the label `semantic-refactor`
-- **AND** the issue SHALL NOT rely on a `code-factory` label for implementation handoff
+- **AND** the issue SHALL NOT include the `code-factory` label
 
 ## ADDED Requirements
 

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-semantic-refactor-workflow/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/ci-semantic-refactor-workflow/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: One issue per semantic refactor opportunity
+The workflow SHALL create at most one issue per distinct semantic refactor opportunity and SHALL NOT create more issues in a run than the computed number of available issue slots. The workflow SHALL create no more than three semantic refactor issues in a run even when no matching issues are already open.
+
+#### Scenario: Multiple opportunities are capped by available slots
+- **WHEN** the workflow identifies more actionable semantic refactor opportunities than the computed number of available issue slots
+- **THEN** it SHALL create issues only for the highest-priority opportunities up to the available slot count
+
+#### Scenario: Distinct opportunities are not bundled
+- **WHEN** the workflow creates an issue for an actionable semantic refactor opportunity
+- **THEN** that issue SHALL describe exactly one distinct opportunity or tightly related refactor cluster rather than bundling unrelated findings together
+
+### Requirement: Semantic-refactor issue contents are actionable
+Each semantic refactor issue created by the workflow SHALL include a concise summary, concrete affected locations, the observed organization or duplication problem, impact assessment, and actionable refactoring guidance sufficient for a follow-up coding agent or maintainer to act on the issue.
+
+#### Scenario: Issue contains evidence and guidance
+- **WHEN** the workflow creates a semantic refactor issue
+- **THEN** the issue body SHALL include affected file paths or symbols, evidence for the finding, impact, and recommended refactoring steps
+
+#### Scenario: Issue titles and labels identify the workflow output
+- **WHEN** the workflow creates a semantic refactor issue
+- **THEN** the issue SHALL carry the configured title prefix `[semantic-refactor] ` and the label `semantic-refactor`
+- **AND** the issue SHALL NOT rely on a `code-factory` label for implementation handoff
+
+## ADDED Requirements
+
+### Requirement: Created semantic-refactor issues are explicitly dispatched to `code-factory`
+After safe-output issue creation completes, the workflow SHALL explicitly dispatch the `code-factory` workflow once for each issue created in the current run rather than relying on producer-side `code-factory` labels to trigger implementation intake.
+
+#### Scenario: One created issue dispatches one implementation run
+- **WHEN** the workflow creates one semantic refactor issue in a run
+- **THEN** it SHALL dispatch exactly one `code-factory` workflow run for that issue
+
+#### Scenario: Three created issues dispatch three implementation runs
+- **WHEN** the workflow creates three semantic refactor issues in a run
+- **THEN** it SHALL dispatch exactly three independent `code-factory` workflow runs, one per created issue

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/specs/flaky-test-catcher/spec.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/specs/flaky-test-catcher/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Issue creation
+The agent SHALL create one GitHub issue per affected resource (up to `issue_slots_available`). Each issue SHALL be labelled `flaky-test`, and SHALL include: broken test list, flaky test list with fail rates, commit analysis result, a sample failure excerpt, and the affected stack versions.
+
+#### Scenario: Issue created for resource with broken and flaky tests
+- **WHEN** `elasticstack_elasticsearch_index` has both broken and flaky tests
+- **THEN** an issue titled `[flaky-test] elasticstack_elasticsearch_index` is created with sections for Broken Tests, Flaky Tests, Commit Analysis, Sample Failure Output, and Affected Stack Versions, labelled `flaky-test`
+
+#### Scenario: Issue cap enforced
+- **WHEN** the agent has already created `issue_slots_available` issues in this run
+- **THEN** no further issues are created regardless of remaining affected resources
+
+## ADDED Requirements
+
+### Requirement: Created flaky-test issues are explicitly dispatched to `code-factory`
+After safe-output issue creation completes, the workflow SHALL explicitly dispatch the `code-factory` workflow once for each flaky-test issue created in the current run rather than relying on a producer-side `code-factory` label to activate implementation intake.
+
+#### Scenario: One created flaky-test issue dispatches one implementation run
+- **WHEN** the workflow creates one flaky-test issue in a run
+- **THEN** it SHALL dispatch exactly one `code-factory` workflow run for that issue
+
+#### Scenario: Multiple created flaky-test issues dispatch multiple implementation runs
+- **WHEN** the workflow creates multiple flaky-test issues in a run
+- **THEN** it SHALL dispatch exactly one independent `code-factory` workflow run per created issue

--- a/openspec/changes/dispatch-code-factory-after-issue-creation/tasks.md
+++ b/openspec/changes/dispatch-code-factory-after-issue-creation/tasks.md
@@ -1,0 +1,24 @@
+## 1. Extend `code-factory` intake for dispatch mode
+
+- [ ] 1.1 Update `.github/workflows-src/code-factory-issue/workflow.md.tmpl` to add a `workflow_dispatch` entrypoint with typed single-issue inputs and to drive the prompt from normalized intake outputs instead of direct `github.event.issue.*` references
+- [ ] 1.2 Add deterministic pre-activation logic and any shared helper code needed to resolve normalized intake context for both issue-event and dispatch-triggered runs, including live issue fetch for dispatch mode and current-repository validation
+- [ ] 1.3 Preserve and adapt duplicate linked-PR suppression so it applies identically to both issue-event and dispatch-triggered `code-factory` runs
+- [ ] 1.4 Update `code-factory` workflow tests under `.github/workflows-src/lib/` to cover dispatch intake, normalized context resolution, and continued manual issue-event behavior
+
+## 2. Add deterministic producer-side dispatch fan-out
+
+- [ ] 2.1 Add repository-authored post-safe_outputs dispatch logic for `.github/workflows-src/semantic-function-refactor/workflow.md.tmpl` that parses `temporary-id-map.json` and dispatches one `code-factory` run per created issue
+- [ ] 2.2 Add repository-authored post-safe_outputs dispatch logic for `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` that parses `temporary-id-map.json` and dispatches one `code-factory` run per created issue
+- [ ] 2.3 Add repository-authored post-safe_outputs dispatch logic for `.github/workflows-src/flaky-test-catcher/workflow.md.tmpl` that parses `temporary-id-map.json` and dispatches one `code-factory` run per created issue
+- [ ] 2.4 Extract and test any shared helper logic needed to parse the temporary issue ID map and construct dispatch payloads deterministically
+
+## 3. Remove producer-side `code-factory` label handoff
+
+- [ ] 3.1 Remove `code-factory` from semantic refactor created-issue labels in `.github/workflows-src/semantic-function-refactor/workflow.md.tmpl` and update related tests/assertions
+- [ ] 3.2 Remove `code-factory` from schema coverage created-issue labels in `.github/workflows-src/schema-coverage-rotation/workflow.md.tmpl` and update related tests/assertions
+- [ ] 3.3 Remove `code-factory` from flaky test catcher created-issue labels in `.github/workflows-src/flaky-test-catcher/workflow.md.tmpl` and update related tests/assertions
+
+## 4. Regenerate and verify workflow artifacts
+
+- [ ] 4.1 Regenerate workflow markdown and compiled lock artifacts for `code-factory-issue`, `semantic-function-refactor`, `schema-coverage-rotation`, and `flaky-test-catcher`
+- [ ] 4.2 Run the relevant workflow-source/unit test suites and any OpenSpec validation needed to verify the new dispatch-handoff contracts


### PR DESCRIPTION
## Summary
- add the OpenSpec proposal, design, tasks, and delta specs for dispatching code-factory after producer issue creation
- define workflow-dispatch based code-factory intake alongside the existing manual issue-event path
- capture producer-side fan-out from temporary-id-map.json for semantic refactor, schema coverage, and flaky test catcher

## Testing
- not run (proposal artifacts only)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propose dispatching code-factory workflow after producer issue creation
> - Adds a design, proposal, specs, and task checklist for a dual-intake approach to the `code-factory` workflow: retain manual label-based issue triggers and add a `workflow_dispatch` trigger fired by producer workflows after issue creation.
> - Producer workflows (`ci-schema-coverage-rotation`, `ci-semantic-refactor`, `flaky-test-catcher`) will dispatch `code-factory` once per created issue after safe outputs, using a temporary issue ID map as the source of truth.
> - `code-factory` intake is extended to normalize context from both trigger types, enforce exactly one linked PR per issue, and restrict trigger-label removal to issue-event runs only.
> - Producer workflows will no longer apply the `code-factory` label to created issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 513c47b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->