### PR TITLE
fix: ILM delete when policy is referenced by indices (#1999)

### DIFF
--- a/internal/fleet/integration/acc_test.go
+++ b/internal/fleet/integration/acc_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
 	"github.com/elastic/terraform-provider-elasticstack/internal/acctest"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	esclient "github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients/fleet"
 	"github.com/elastic/terraform-provider-elasticstack/internal/fleet/integration"
 	"github.com/elastic/terraform-provider-elasticstack/internal/versionutils"
@@ -567,6 +568,88 @@ func TestAccResourceIntegration_SpaceAwareDrift(t *testing.T) {
 				},
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceIntegration_destroyWithILMCrossDependency reproduces the cross-
+// dependency failure described in
+// https://github.com/elastic/terraform-provider-elasticstack/issues/1999.
+//
+// When a Fleet integration is installed it creates index templates, component
+// templates and ingest pipelines. If data is ingested into a data stream that
+// matches those templates, Elasticsearch creates backing indices. When an ILM
+// policy is attached to the Fleet-managed template (via
+// elasticstack_elasticsearch_index_template_ilm_attachment) those backing indices
+// carry the ILM policy reference. On terraform destroy, Fleet successfully
+// uninstalls the package, but the backing indices remain. Terraform-managed
+// resources that reference the ILM policy (e.g.
+// elasticstack_elasticsearch_index_lifecycle) then fail to destroy because ES
+// refuses to delete an ILM policy that is still in use by one or more indices.
+func TestAccResourceIntegration_destroyWithILMCrossDependency(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.PreCheck(t) },
+		Steps: []resource.TestStep{
+			// Step 1: Install the system integration, create an ILM policy and
+			// attach it to the Fleet-managed index template.
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "system"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "version", "1.18.0"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "name", "test-fleet-ilm-policy"),
+				),
+			},
+			// Step 2: Create a data stream and index a document so Elasticsearch
+			// creates a backing index that references the ILM policy via the
+			// Fleet-managed template.
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				PreConfig: func() {
+					client, err := clients.NewAcceptanceTestingElasticsearchScopedClient()
+					require.NoError(t, err)
+					ctx := context.Background()
+
+					diags := esclient.PutDataStream(ctx, client, "logs-system.syslog-default")
+					require.Empty(t, diags)
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "system"),
+				),
+			},
+			// Step 3: Try to destroy the ILM policy. Because the backing index
+			// still references the ILM policy, Elasticsearch rejects the deletion
+			// and the provider surfaces an error.
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				ResourceName:             "elasticstack_elasticsearch_index_lifecycle.test",
+				Destroy:                  true,
+				ExpectError:              regexp.MustCompile("(?i)cannot delete policy|in use by"),
+			},
+			// Step 4: Remove the data stream so the implicit terraform destroy at
+			// the end of the test case can clean up the remaining resources.
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				PreConfig: func() {
+					client, err := clients.NewAcceptanceTestingElasticsearchScopedClient()
+					require.NoError(t, err)
+					ctx := context.Background()
+
+					diags := esclient.DeleteDataStream(ctx, client, "logs-system.syslog-default")
+					require.Empty(t, diags)
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_fleet_integration.test_integration", "name", "system"),
+				),
 			},
 		},
 	})

--- a/internal/fleet/integration/acc_test.go
+++ b/internal/fleet/integration/acc_test.go
@@ -603,9 +603,8 @@ func TestAccResourceIntegration_destroyWithILMCrossDependency(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_index_lifecycle.test", "name", "test-fleet-ilm-policy"),
 				),
 			},
-			// Step 2: Create a data stream and index a document so Elasticsearch
-			// creates a backing index that references the ILM policy via the
-			// Fleet-managed template.
+			// Step 2: Create a data stream so Elasticsearch creates a backing
+			// index that references the ILM policy via the Fleet-managed template.
 			{
 				ProtoV6ProviderFactories: acctest.Providers,
 				SkipFunc:                 versionutils.CheckIfVersionIsUnsupported(minVersionIntegration),

--- a/internal/fleet/integration/testdata/TestAccResourceIntegration_destroyWithILMCrossDependency/create/main.tf
+++ b/internal/fleet/integration/testdata/TestAccResourceIntegration_destroyWithILMCrossDependency/create/main.tf
@@ -4,9 +4,10 @@ provider "elasticstack" {
 }
 
 resource "elasticstack_fleet_integration" "test_integration" {
-  name    = "system"
-  version = "1.18.0"
-  force   = true
+  name         = "system"
+  version      = "1.18.0"
+  force        = true
+  skip_destroy = true
 }
 
 resource "elasticstack_elasticsearch_index_lifecycle" "test" {

--- a/internal/fleet/integration/testdata/TestAccResourceIntegration_destroyWithILMCrossDependency/create/main.tf
+++ b/internal/fleet/integration/testdata/TestAccResourceIntegration_destroyWithILMCrossDependency/create/main.tf
@@ -1,0 +1,27 @@
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+}
+
+resource "elasticstack_fleet_integration" "test_integration" {
+  name    = "system"
+  version = "1.18.0"
+  force   = true
+}
+
+resource "elasticstack_elasticsearch_index_lifecycle" "test" {
+  name = "test-fleet-ilm-policy"
+
+  hot {
+    rollover {
+      max_age = "1d"
+    }
+  }
+}
+
+resource "elasticstack_elasticsearch_index_template_ilm_attachment" "test" {
+  depends_on = [elasticstack_fleet_integration.test_integration]
+
+  index_template = "logs-system.syslog"
+  lifecycle_name = elasticstack_elasticsearch_index_lifecycle.test.name
+}

--- a/openspec/changes/fix-ilm-delete-in-use-indices/.openspec.yaml
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/fix-ilm-delete-in-use-indices/design.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/design.md
@@ -1,0 +1,96 @@
+## Context
+
+The `elasticstack_elasticsearch_index_lifecycle` resource Delete handler (`internal/elasticsearch/index/ilm/delete.go`) calls the Elasticsearch Delete Lifecycle API directly. Elasticsearch rejects the call with `illegal_argument_exception` when one or more indices still reference the policy in `index.lifecycle.name`.
+
+This failure is common in Fleet-managed data stream workflows:
+
+```
+Fleet integration install ──► index template + component template
+                                    │
+                                    ▼
+                         data stream created (ES auto-creates backing index)
+                                    │
+                                    ▼
+         ILM attachment resource adds lifecycle.name to @custom component template
+                                    │
+                                    ▼
+                         backing index inherits lifecycle.name
+                                    │
+                                    ▼
+Fleet uninstall succeeds but backing index remains ◄── data intentionally preserved
+                                    │
+                                    ▼
+ILM policy delete fails ◄── ES: "in use by one or more indices"
+```
+
+The error is surfaced by the provider as a Terraform diagnostic with the verbatim ES error, forcing the user to manually null `index.lifecycle.name` on every matching index.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make ILM policy Delete succeed when indices happen to reference the policy.
+- Preserve all index data — only remove the ILM reference, not the index.
+- Keep the change localized to the ILM resource and ES client helpers.
+
+**Non-Goals:**
+- Do **not** delete indices, data streams, or Fleet-managed assets. Data deletion is out of scope.
+- Do **not** change Fleet integration uninstall behavior.
+- Do **not** introduce a new schema attribute (e.g., `force`). The fix is transparent.
+
+## Decisions
+
+### Decision: Scan-and-null approach
+
+Before calling `DELETE /_ilm/policy/{name}`, the Delete handler will:
+
+1. Fetch all index settings for the key `index.lifecycle.name` via:
+   `GET /_all/_settings/index.lifecycle.name?flat_settings=true`
+2. Filter to indices whose `index.lifecycle.name` equals the policy name being deleted.
+3. If any matches exist, issue:
+   `PUT /{indices_comma_separated}/_settings {"index.lifecycle.name": null}`
+4. Then proceed with the existing `DELETE /_ilm/policy/{name}` call.
+
+**Rationale**: This is the smallest intervention that solves the problem. It mirrors what users do manually. Using `_all` with `flat_settings` is a single lightweight call.
+
+**Alternative considered**: Maintain a reverse-lookup map of which templates reference this policy and clear ILM from templates first, then rollover indices. Rejected because backing indices can outlive template changes — we must target the indices directly anyway.
+
+### Decision: Batch the settings update per matched policy
+
+If indices match, they are collected into one comma-separated target and cleared in a single `PUT /{indices}/_settings` call rather than N sequential calls.
+
+**Rationale**: Reduces ES API pressure. Terraform destroy may already be deleting many resources; adding N extra round-trips per ILM policy is wasteful.
+
+### Decision: No retry or rollback on partial failure
+
+If the settings-clear call partially succeeds (some indices cleared, some still referencing the policy), the subsequent `DELETE /_ilm/policy/{name}` will still fail with an updated "in use by" message. We surface that error.
+
+**Rationale**: The error message tells the user exactly which indices remain. Adding retry logic adds complexity for an edge case that usually indicates a transient ES state (index closed, relocating, etc.) or a race with another system.
+
+### Decision: ES client helper functions
+
+Three new functions in `internal/clients/elasticsearch/index.go`:
+
+- `GetIndicesWithILMPolicy(ctx, client, policyName) ([]string, diag.Diagnostics)`
+  - Wraps `GET /_all/_settings/index.lifecycle.name?flat_settings=true`
+  - Returns just the index names that reference the given policy
+
+- `ClearILMPolicyFromIndices(ctx, client, indices []string) diag.Diagnostics`
+  - Wraps `PUT /{indices}/_settings {"index.lifecycle.name": null}`
+
+These are general-purpose enough that they may be reused by other resources later (e.g., index template ILM attachment cleanup).
+
+**Rationale**: Keeps the ILM resource handler thin and places ES-API-specific logic in the client layer, consistent with the existing codebase.
+
+## Risks / Trade-offs
+
+- **[Risk] Scale**: On clusters with thousands of indices, `GET /_all/_settings` can be slow or heavy.
+  → **Mitigation**: The request is scoped to a single setting key (`index.lifecycle.name`), which keeps response sizes small. ES handles this efficiently. Future enhancement could add pagination/wildcard targets if profiling shows it is a bottleneck.
+
+- **[Risk] Race condition**: Between the scan and the clear, a new index with the policy could be created.
+  → **Mitigation**: The subsequent `DELETE` will still fail with an updated message. This is the same race window that exists today for users doing manual cleanup; we have not made it worse.
+
+- **[Risk] Fleet-managed indices**: Explicitly mutating settings on Fleet-managed data-stream backing indices via `PUT /_settings` could interfere with Fleet's expectations.
+  → **Mitigation**: Nulling `index.lifecycle.name` is a safe operation that only removes ILM management. The index data, mappings, and aliases are untouched. Fleet does not rely on ILM policy references to function.
+
+- **[Risk] Closed indices**: `PUT /_settings` on closed indices may return an error.
+  → **Mitigation**: `GET /_all/_settings` includes closed indices by default. The `PUT` call is issued to all matched indices. If closed indices fail, the subsequent `DELETE` will report the still-referencing indices. This is acceptable because the root cause is outside Terraform.

--- a/openspec/changes/fix-ilm-delete-in-use-indices/design.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/design.md
@@ -68,7 +68,7 @@ If the settings-clear call partially succeeds (some indices cleared, some still 
 
 ### Decision: ES client helper functions
 
-Three new functions in `internal/clients/elasticsearch/index.go`:
+Two new functions in `internal/clients/elasticsearch/index.go`:
 
 - `GetIndicesWithILMPolicy(ctx, client, policyName) ([]string, diag.Diagnostics)`
   - Wraps `GET /_all/_settings/index.lifecycle.name?flat_settings=true`

--- a/openspec/changes/fix-ilm-delete-in-use-indices/proposal.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When a Fleet integration is installed it creates index templates, component templates and ingest pipelines. If data streams or indices inherit from those templates and an ILM policy is attached via `elasticstack_elasticsearch_index_template_ilm_attachment`, the backing indices carry an `index.lifecycle.name` reference. On `terraform destroy`, Fleet's package uninstall succeeds but the backing indices remain; deleting the Terraform-managed ILM policy then fails with:
+
+> Cannot delete policy [X]. It is in use by one or more indices: [.ds-...]
+
+This is a silent cross-dependency that forces users to run manual cleanup commands (see https://github.com/elastic/terraform-provider-elasticstack/issues/1999). The ILM resource should handle this gracefully.
+
+## What Changes
+
+- **`elasticstack_elasticsearch_index_lifecycle` Delete**: Before calling `DELETE /_ilm/policy/{name}`, scan all indices for references to the policy and null `index.lifecycle.name` on matching indices.
+- Add supporting ES client helper for querying index settings with the `flat_settings` option and for clearing `index.lifecycle.name` on specific indices.
+- Acceptance test that reproduces the cross-dependency scenario (Fleet integration + ILM attachment + data stream) and asserts the ILM policy can still be destroyed.
+
+## Capabilities
+
+### New Capabilities
+- *(none)*
+
+### Modified Capabilities
+- `elasticsearch-index-lifecycle`: The Delete behavior requirement SHALL change so that the resource first removes the policy reference from any indices that use it before deleting the policy. This changes REQ-016 (or a new requirement) in the lifecycle spec.
+
+## Impact
+
+- **Affected packages**: `internal/elasticsearch/index/ilm/`, `internal/clients/elasticsearch/`
+- **Terraform resource**: `elasticstack_elasticsearch_index_lifecycle`
+- **No API changes**: Schema remains identical; behavior change is purely in Delete
+- **No breaking changes**: Resources that already delete successfully will continue to work identically. Resources that previously failed due to in-use indices will now succeed.

--- a/openspec/changes/fix-ilm-delete-in-use-indices/proposal.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/proposal.md
@@ -10,7 +10,7 @@ This is a silent cross-dependency that forces users to run manual cleanup comman
 
 - **`elasticstack_elasticsearch_index_lifecycle` Delete**: Before calling `DELETE /_ilm/policy/{name}`, scan all indices for references to the policy and null `index.lifecycle.name` on matching indices.
 - Add supporting ES client helper for querying index settings with the `flat_settings` option and for clearing `index.lifecycle.name` on specific indices.
-- Acceptance test that reproduces the cross-dependency scenario (Fleet integration + ILM attachment + data stream) and asserts the ILM policy can still be destroyed.
+- Acceptance test that reproduces the cross-dependency scenario (Fleet integration + ILM attachment + data stream) and asserts the ILM policy destroy fails (to be flipped to success after the fix is implemented).
 
 ## Capabilities
 

--- a/openspec/changes/fix-ilm-delete-in-use-indices/specs/elasticsearch-index-lifecycle/spec.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/specs/elasticsearch-index-lifecycle/spec.md
@@ -6,7 +6,7 @@ Delete SHALL call the Delete Lifecycle API with the policy name portion of `id`.
 
 The process for removing in-use references SHALL be:
 
-1. Query `GET /_all/_settings/index.lifecycle.name` to obtain the `index.lifecycle.name` setting for every index.
+1. Query `GET /_all/_settings/index.lifecycle.name?flat_settings=true` to obtain the `index.lifecycle.name` setting for every index.
 2. Filter to indices whose setting value equals the policy name being deleted.
 3. If one or more indices match, issue `PUT /{indices}/_settings` with `{"index.lifecycle.name": null}` where `{indices}` is a comma-separated list of matched index names.
 4. After clearing references, proceed with `DELETE /_ilm/policy/{policy_name}`.

--- a/openspec/changes/fix-ilm-delete-in-use-indices/specs/elasticsearch-index-lifecycle/spec.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/specs/elasticsearch-index-lifecycle/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Read and delete behavior (REQ-013–REQ-016)
+
+Delete SHALL call the Delete Lifecycle API with the policy name portion of `id`. **Before invoking the Delete Lifecycle API, Delete SHALL identify any indices whose `index.lifecycle.name` setting references the policy name and remove that reference by setting `index.lifecycle.name` to `null`.**
+
+The process for removing in-use references SHALL be:
+
+1. Query `GET /_all/_settings/index.lifecycle.name` to obtain the `index.lifecycle.name` setting for every index.
+2. Filter to indices whose setting value equals the policy name being deleted.
+3. If one or more indices match, issue `PUT /{indices}/_settings` with `{"index.lifecycle.name": null}` where `{indices}` is a comma-separated list of matched index names.
+4. After clearing references, proceed with `DELETE /_ilm/policy/{policy_name}`.
+
+If the settings-clear call returns an error, Delete SHALL surface that error as a Terraform diagnostic and SHALL NOT proceed with the Delete Lifecycle API call. If the subsequent Delete Lifecycle API call returns an error (for example, because a new index referencing the policy was created during the clear step), Delete SHALL surface the Elasticsearch error verbatim.
+
+#### Scenario: ILM policy deleted while referenced by backing index
+
+- GIVEN an ILM policy named `"my-policy"` exists
+- AND an index `".ds-logs-test-default-2026.01.01-000001"` has `index.lifecycle.name` set to `"my-policy"`
+- WHEN Delete runs for the ILM policy resource
+- THEN the provider SHALL first set `index.lifecycle.name` to `null` on `.ds-logs-test-default-2026.01.01-000001`
+- AND then call `DELETE /_ilm/policy/my-policy`
+- AND the resource SHALL be destroyed successfully
+
+#### Scenario: No indices reference the policy
+
+- GIVEN an ILM policy named `"unused-policy"` exists
+- AND no index has `index.lifecycle.name` set to `"unused-policy"`
+- WHEN Delete runs for the ILM policy resource
+- THEN the provider SHALL skip the settings-clear step
+- AND call `DELETE /_ilm/policy/unused-policy` directly
+
+#### Scenario: Settings-clear fails before delete
+
+- GIVEN an ILM policy named `"my-policy"` exists
+- AND an index referencing the policy exists
+- AND the `PUT /_settings` call to clear the reference fails (e.g., index is closed or unavailable)
+- WHEN Delete runs
+- THEN the provider SHALL surface the settings-clear error as a Terraform diagnostic
+- AND SHALL NOT call `DELETE /_ilm/policy/my-policy`

--- a/openspec/changes/fix-ilm-delete-in-use-indices/tasks.md
+++ b/openspec/changes/fix-ilm-delete-in-use-indices/tasks.md
@@ -1,0 +1,30 @@
+## 1. ES client helpers
+
+- [ ] 1.1 Add `GetIndicesWithILMPolicy` to `internal/clients/elasticsearch/index.go` — queries `GET /_all/_settings/index.lifecycle.name?flat_settings=true`, parses response and returns index names whose `index.lifecycle.name` matches the given policy.
+- [ ] 1.2 Add `ClearILMPolicyFromIndices` to `internal/clients/elasticsearch/index.go` — issues `PUT /{indices}/_settings` with `{"index.lifecycle.name": null}`.
+- [ ] 1.3 Add unit tests for both helpers or verify via acceptance test coverage.
+
+## 2. ILM resource Delete handler
+
+- [ ] 2.1 Update `internal/elasticsearch/index/ilm/delete.go` to call `GetIndicesWithILMPolicy` before `DeleteIlm`.
+- [ ] 2.2 If indices match, call `ClearILMPolicyFromIndices`; surface any diagnostic and short-circuit if the clear fails.
+- [ ] 2.3 Then proceed with existing `DeleteIlm` call.
+- [ ] 2.4 Verify `go build ./internal/elasticsearch/index/ilm/...` and `go vet` pass.
+
+## 3. Acceptance test
+
+- [ ] 3.1 Create/update `internal/fleet/integration/testdata/TestAccResourceIntegration_destroyWithILMCrossDependency/create/main.tf` (already exists from repro test).
+- [ ] 3.2 Update `internal/fleet/integration/acc_test.go` `TestAccResourceIntegration_destroyWithILMCrossDependency` to expect **success** on ILM policy destroy instead of `ExpectError`, confirming the fix.
+- [ ] 3.3 Add targeted acceptance test for ILM resource itself that creates a policy, an index with the policy reference, and asserts the ILM resource deletes successfully.
+- [ ] 3.4 Run the test against the local stack (`make docker-fleet`) and confirm it passes.
+
+## 4. Existing tests
+
+- [ ] 4.1 Run `go test ./internal/elasticsearch/index/ilm/...` — all unit tests pass.
+- [ ] 4.2 Run `go test ./internal/clients/elasticsearch/...` — all unit tests pass.
+- [ ] 4.3 Run fleet integration acceptance tests (`TestAccResourceIntegration`, `TestAccResourceIndexTemplateIlmAttachment_fleet`) to confirm no regressions.
+
+## 5. Sync and archive
+
+- [ ] 5.1 Sync the delta spec changes into `openspec/specs/elasticsearch-index-lifecycle/spec.md` using the OpenSpec sync workflow.
+- [ ] 5.2 Archive the change with `openspec archive change fix-ilm-delete-in-use-indices`.


### PR DESCRIPTION
## Problem

When a Fleet integration creates data streams and an ILM policy is attached via
`elasticstack_elasticsearch_index_template_ilm_attachment`, the backing indices
inherit the `index.lifecycle.name` reference. On `terraform destroy`, Fleet's
package uninstall succeeds but the backing indices remain. Deleting the
Terraform-managed ILM policy then fails with:

> Cannot delete policy [X]. It is in use by one or more indices: [.ds-...]

This reproduces the cross-dependency failure described in #1999.

## This PR

- **OpenSpec change proposal** with full design, delta spec, and task list at
  `openspec/changes/fix-ilm-delete-in-use-indices/`
- **Acceptance test** `TestAccResourceIntegration_destroyWithILMCrossDependency` that
  reproduces the issue

The fix itself (removing the ILM reference from indices before deleting the
policy) will follow in a subsequent PR based on the tasks in this proposal.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ILM policy deletion when backing indices still reference the policy
> - When deleting an ILM policy, the provider now scans for indices referencing the policy via `index.lifecycle.name` and clears that setting before calling the Delete Lifecycle API, preventing the "policy in use" error.
> - Adds an acceptance test in [acc_test.go](https://github.com/elastic/terraform-provider-elasticstack/pull/2708/files#diff-aaef4b65af6a17f4aea136d36cdc736d23ed916a5c5d331172eac30b25e776bd) that installs a Fleet integration, attaches an ILM policy to its index template, creates a backing data stream, and verifies that destroy fails with an "in use" error before the data stream is removed.
> - Adds OpenSpec design and proposal documents under [openspec/changes/fix-ilm-delete-in-use-indices](https://github.com/elastic/terraform-provider-elasticstack/pull/2708/files#diff-ba01ffd4b37deb23f43476019299f67773d78f26036edba1373e0eaafb2e2165) capturing the rationale and implementation plan.
> - Risk: Clearing `index.lifecycle.name` on referenced indices is a silent side effect of policy deletion that callers may not expect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dcfa45a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->