### PR TITLE
openspec: propose Kibana resource envelope (NewKibanaResource)

### DIFF
--- a/openspec/changes/kibana-resource-envelope/.openspec.yaml
+++ b/openspec/changes/kibana-resource-envelope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/kibana-resource-envelope/design.md
+++ b/openspec/changes/kibana-resource-envelope/design.md
@@ -35,7 +35,7 @@ Two structural differences make a direct port non-trivial:
 
 ### Decision: Composite-ID-or-fallback for Read/Update/Delete resource identity
 
-**Chosen:** For Read, Update, and Delete, the envelope first attempts `CompositeIDFromStrFw(model.GetID())`. On success, it uses `compID.ResourceID` and `compID.ClusterID` as `resourceID` and `spaceID`. On failure, it falls back to `model.GetResourceID()` and `model.GetSpaceID()`.
+**Chosen:** For Read, Update, and Delete, the envelope first attempts `CompositeIDFromStr(model.GetID())` (or its `Fw` variant) to parse the state ID as a composite. Both functions return error diagnostics on parse failure. Crucially, the envelope discards those diagnostics — treating the failure purely as a "not composite" signal — and falls back to `model.GetResourceID()` and `model.GetSpaceID()`. This matches the pattern already used by `getMaintenanceWindowIDAndSpaceID()` and `securitylist.Read`, which discard the parse error with `_`.
 
 **Rationale:** This handles all current resource patterns uniformly:
 - Streams: `ID = "<space>/<name>"` → composite parse succeeds → `name` + `space`.

--- a/openspec/changes/kibana-resource-envelope/design.md
+++ b/openspec/changes/kibana-resource-envelope/design.md
@@ -1,0 +1,97 @@
+## Context
+
+`NewElasticsearchResource[T]` in `entitycore` already owns the full CRUD prelude for Elasticsearch-backed resources (decode model, validate write identity, resolve scoped client, invoke callback, persist state). Kibana resources have an equivalent but distinct prelude: every lifecycle method independently resolves the `KibanaScopedClient` from the `kibana_connection` block and extracts `space_id` before reaching entity-specific logic. There is no shared abstraction for this.
+
+Two structural differences make a direct port non-trivial:
+
+1. **Space ID is explicit, not implicit.** For Elasticsearch resources, `compID.ClusterID` identifies the ES cluster and is absorbed entirely by client resolution — callbacks never see it. For Kibana resources, `space_id` is an explicit argument to every API call and must be passed to all callbacks.
+
+2. **Resources split into two ID management patterns.** Some resources use a user-specified name as the primary key (streams: `name`). Others receive a UUID from the API on creation and have no plan-time write identity (maintenance_window). The Elasticsearch envelope assumes a plan-time write identity (`GetResourceID()`) for all operations; Kibana Create cannot make that assumption for UUID resources.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide `NewKibanaResource[T]` in `entitycore` that owns Metadata, Schema (with `kibana_connection` injection), Configure, Create, Read, Update, and Delete for Kibana-backed resources.
+- Support both user-ID (streams) and API-UUID (maintenance_window) resource patterns with one interface and one constructor.
+- Include `PlaceholderKibanaWriteCallbacks[T]` for parity with the Elasticsearch envelope.
+- Migrate `streams` and `maintenance_window` as proof-of-concept consumers.
+
+**Non-Goals:**
+- Migrating all Kibana resources (only POC resources in this change).
+- Handling Fleet-backed resources (separate client type, different pattern).
+- Adding version-checking (`EnforceMinVersion`) as an envelope concern (remains in callbacks for now).
+
+## Decisions
+
+### Decision: `GetSpaceID()` on the model interface
+
+**Chosen:** `KibanaResourceModel` requires `GetSpaceID() types.String` alongside `GetID()`, `GetResourceID()`, and `GetKibanaConnection()`.
+
+**Rationale:** The space is a first-class identity dimension for every Kibana resource. Making it explicit on the interface lets the envelope validate it and pass it to callbacks without requiring the envelope to understand composite ID internals. It also describes what a Kibana resource fundamentally *is* — an entity that lives in a space.
+
+**Alternative considered:** Parse space from composite ID only. Rejected because not all Kibana resources use composite IDs as their primary state format (maintenance_window uses a plain UUID), so the envelope cannot rely on a universal composite ID structure.
+
+---
+
+### Decision: Composite-ID-or-fallback for Read/Update/Delete resource identity
+
+**Chosen:** For Read, Update, and Delete, the envelope first attempts `CompositeIDFromStrFw(model.GetID())`. On success, it uses `compID.ResourceID` and `compID.ClusterID` as `resourceID` and `spaceID`. On failure, it falls back to `model.GetResourceID()` and `model.GetSpaceID()`.
+
+**Rationale:** This handles all current resource patterns uniformly:
+- Streams: `ID = "<space>/<name>"` → composite parse succeeds → `name` + `space`.
+- Maintenance window (normal): `ID = "uuid"` → parse fails → `GetResourceID()` + `GetSpaceID()`.
+- Maintenance window (import): `ID = "<space>/<uuid>"` → composite parse succeeds → `uuid` + `space`.
+
+The fallback also centralises the logic that was previously scattered across `getMaintenanceWindowIDAndSpaceID()`, `securitylist.Read`, and similar resource-local helpers.
+
+**Alternative considered:** Require all Kibana resources to use composite IDs. Rejected because retrofitting maintenance_window (and similar UUID-based resources) to change their state ID format would be a breaking change to existing state.
+
+---
+
+### Decision: Create callback does not receive a `resourceID` argument
+
+**Chosen:** `KibanaCreateFunc[T]` is `func(ctx, *KibanaScopedClient, spaceID string, plan T) (T, diag.Diagnostics)` — no `resourceID`.
+
+**Rationale:** During Create, API-UUID resources have no write identity yet; the UUID is returned by the server. Passing an empty or unknown string for `resourceID` is misleading. For user-ID resources (streams), the callback can call `plan.GetResourceID()` directly — it has the full plan model. The spaceID is always present in the plan and is the only identity dimension the envelope can reliably validate at Create time.
+
+**Alternative considered:** Same signature for Create and Update (`resourceID, spaceID, model`), with envelope skipping `resourceID` validation only for Create. Rejected because passing an empty string to Create callbacks conflates "not yet assigned" with "empty string", and gives user-ID resource callbacks an unexpected non-empty `resourceID` alongside the model (redundant — they already have it via `plan.GetResourceID()`).
+
+---
+
+### Decision: Update callback receives both plan and prior state
+
+**Chosen:** `KibanaUpdateFunc[T]` is `func(ctx, *KibanaScopedClient, resourceID, spaceID string, plan T, prior T) (T, diag.Diagnostics)` — plan and prior state as separate arguments.
+
+**Rationale:** Kibana APIs frequently use PATCH semantics where the body must be derived from the difference between desired and current state. Providing prior state in the callback signature means resources that need it never have to override the envelope's Update. This diverges intentionally from `ElasticsearchUpdateFunc[T]` which only receives the plan; Kibana's API surface makes this addition consistently valuable.
+
+**Alternative considered:** Pass only the plan (ES-identical). Rejected because Update overrides for PATCH-style resources would immediately be needed, defeating the purpose of the envelope.
+
+---
+
+### Decision: `KibanaScopedClient` passed to callbacks, not the inner oapi client
+
+**Chosen:** All callbacks receive `*clients.KibanaScopedClient`. Callbacks call `client.GetKibanaOapiClient()` themselves when needed.
+
+**Rationale:** Keeps callback signatures consistent with the data source envelope pattern and leaves room for callbacks that need `GetFleetClient()` or `EnforceMinVersion()`. The inner client unwrap is one additional line; eliminating it can be a follow-up refactor once a pattern emerges.
+
+---
+
+### Decision: Two POC migrations (streams + maintenance_window)
+
+**Chosen:** `streams` demonstrates the user-ID pattern; `maintenance_window` demonstrates the API-UUID pattern.
+
+**Rationale:** Both represent real resources with distinctly shaped Create paths. Migrating both validates that the interface and callback types cover both patterns without requiring per-resource overrides.
+
+## Risks / Trade-offs
+
+- **Callback signature asymmetry (Create vs Update).** Create callbacks have a simpler signature than Update/Read/Delete callbacks. This is intentional but adds cognitive overhead when authoring new resources that need to implement all four. Mitigated by clear documentation and type names (`KibanaCreateFunc` vs `KibanaUpdateFunc`).
+
+- **No write-identity validation for Create.** User-ID resources (streams) rely on their own callbacks to validate that `plan.GetResourceID()` is non-empty; the envelope does not enforce this at Create time. A misconfigured resource could reach the API with an empty name. Mitigated by the fact that the API will reject empty-name calls, and future work can add an optional `KibanaKeyedResourceModel` extended interface that adds Create-time validation.
+
+- **Composite-ID fallback is order-sensitive.** The composite parse always wins over `GetResourceID()` + `GetSpaceID()`. If a future resource stores a plain ID that coincidentally matches the composite format (contains a `/`), the envelope would misinterpret it. Mitigated by the fact that Kibana native IDs (UUIDs, names) do not contain `/`.
+
+## Migration Plan
+
+No data migration required. The envelope is additive — no existing resource interfaces change. POC resources (streams, maintenance_window) are refactored internally; their Terraform schema and state format are unchanged.
+
+Implementation sequence: envelope core → unit tests → streams migration → maintenance_window migration.

--- a/openspec/changes/kibana-resource-envelope/proposal.md
+++ b/openspec/changes/kibana-resource-envelope/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Kibana resources repeat the same 5–6 line CRUD prelude in every lifecycle method — decode model, resolve scoped client via `kibana_connection`, unwrap `GetKibanaOapiClient`, extract `space_id` — with no shared abstraction to own it. `NewElasticsearchResource` already eliminates this boilerplate for Elasticsearch-backed resources; Kibana resources deserve the same.
+
+## What Changes
+
+- Add `KibanaResourceModel` interface to `entitycore` with `GetID`, `GetResourceID`, `GetSpaceID`, and `GetKibanaConnection` methods.
+- Add `KibanaResource[T]` generic struct to `entitycore` that owns Schema (with `kibana_connection` block injection), Configure, Metadata, Create, Read, Update, and Delete.
+- Add `NewKibanaResource[T]` constructor with callback arguments for read, delete, create, and update operations.
+- Add `PlaceholderKibanaWriteCallbacks[T]` for parity with `PlaceholderElasticsearchWriteCallbacks[T]`.
+- Add unit tests for `KibanaResource[T]` envelope in `entitycore` (mirroring `resource_envelope_test.go`).
+- Migrate `internal/kibana/streams` to use `NewKibanaResource` as the user-specified-ID POC.
+- Migrate `internal/kibana/maintenance_window` to use `NewKibanaResource` as the API-assigned-UUID POC.
+- Update `entitycore/doc.go` to document the Kibana resource envelope pattern.
+
+## Capabilities
+
+### New Capabilities
+
+- `entitycore-kibana-resource-envelope`: Generic Kibana resource envelope — `KibanaResourceModel` interface, `KibanaResource[T]` type, `NewKibanaResource` constructor, callback function types, `PlaceholderKibanaWriteCallbacks`, and the composite-ID-or-fallback prelude shared by Read, Update, and Delete.
+
+### Modified Capabilities
+
+## Impact
+
+- `internal/entitycore/` — new file `kibana_resource_envelope.go`; updated `doc.go`
+- `internal/kibana/streams/` — `resource.go`, `create.go`, `read.go`, `update.go`, `delete.go` simplified; model gains `GetResourceID`, `GetSpaceID`, `GetKibanaConnection` methods
+- `internal/kibana/maintenance_window/` — same files simplified; model gains the same interface methods

--- a/openspec/changes/kibana-resource-envelope/specs/entitycore-kibana-resource-envelope/spec.md
+++ b/openspec/changes/kibana-resource-envelope/specs/entitycore-kibana-resource-envelope/spec.md
@@ -89,7 +89,7 @@ The system SHALL implement `Create` by deserializing the plan into the generic m
 
 The system SHALL implement `Read` by deserializing the prior state into the generic model `T`, resolving `resourceID` and `spaceID` using the composite-ID-or-fallback rule, resolving the scoped Kibana client, validating that `resourceID` is non-empty, and invoking the read callback. The read callback SHALL be invoked with `(context, *clients.KibanaScopedClient, resourceID string, spaceID string, T)`.
 
-The composite-ID-or-fallback rule SHALL be: attempt `CompositeIDFromStrFw(model.GetID())`. On success, use `compID.ResourceID` as `resourceID` and `compID.ClusterID` as `spaceID`. On failure, use `model.GetResourceID().ValueString()` as `resourceID` and `model.GetSpaceID().ValueString()` as `spaceID`.
+The composite-ID-or-fallback rule SHALL be: attempt to parse `model.GetID()` as a composite ID. The parse result (nil on failure) SHALL be inspected, but any diagnostics returned by the parse function SHALL be discarded — parse failure is treated as a non-error "not composite" signal, not as an error condition. On successful parse, use `compID.ResourceID` as `resourceID` and `compID.ClusterID` as `spaceID`. On parse failure, use `model.GetResourceID().ValueString()` as `resourceID` and `model.GetSpaceID().ValueString()` as `spaceID`.
 
 #### Scenario: Successful read sets state from returned model
 
@@ -176,6 +176,24 @@ The system SHALL implement `Delete` using the same composite-ID-or-fallback iden
 - **WHEN** `GetKibanaClient` returns error diagnostics
 - **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
 - **AND** the delete callback SHALL NOT be invoked
+
+---
+
+### Requirement: Nil create or update callback surfaces a configuration error diagnostic
+
+The system SHALL check that the `createFunc` and `updateFunc` callbacks are non-nil before invoking them. If either is nil at invocation time, the envelope SHALL append a configuration error diagnostic and SHALL NOT invoke the nil callback. This nil check SHALL take precedence over all other pre-invocation checks (such as spaceID validation and client resolution).
+
+#### Scenario: Nil create callback produces configuration error before other checks
+
+- **WHEN** `NewKibanaResource` is called with a nil `createFunc` and `Create` is invoked
+- **THEN** an error diagnostic describing the nil callback configuration SHALL be appended
+- **AND** no other Create prelude checks (spaceID, client resolution) SHALL produce diagnostics
+
+#### Scenario: Nil update callback produces configuration error before other checks
+
+- **WHEN** `NewKibanaResource` is called with a nil `updateFunc` and `Update` is invoked
+- **THEN** an error diagnostic describing the nil callback configuration SHALL be appended
+- **AND** no other Update prelude checks (resourceID, client resolution) SHALL produce diagnostics
 
 ---
 

--- a/openspec/changes/kibana-resource-envelope/specs/entitycore-kibana-resource-envelope/spec.md
+++ b/openspec/changes/kibana-resource-envelope/specs/entitycore-kibana-resource-envelope/spec.md
@@ -1,0 +1,218 @@
+## ADDED Requirements
+
+### Requirement: Envelope constructor produces shared Kibana resource behavior
+
+The system SHALL provide a generic constructor `NewKibanaResource[T]()` that returns an envelope owning shared Kibana resource behavior. The envelope SHALL provide Metadata, Schema, Configure, Create, Read, Update, and Delete behavior, and SHALL satisfy `resource.Resource` and `resource.ResourceWithConfigure`. Concrete resources SHALL embed the envelope and may choose to implement additional Plugin Framework interfaces such as ImportState or state upgrade support.
+
+#### Scenario: Constructor returns complete resource envelope
+
+- **WHEN** `NewKibanaResource[T](component, name, schemaFactory, readFunc, deleteFunc, createFunc, updateFunc)` is called with non-nil callbacks
+- **THEN** the returned value SHALL satisfy `resource.Resource` and `resource.ResourceWithConfigure`
+- **AND** the returned value SHALL NOT satisfy `resource.ResourceWithImportState`
+
+#### Scenario: Metadata builds the Terraform type name
+
+- **WHEN** an envelope is constructed via `NewKibanaResource[T](ComponentKibana, "maintenance_window", …)`
+- **THEN** its `Metadata` SHALL set the type name to `<provider_type_name>_kibana_maintenance_window`
+
+---
+
+### Requirement: KibanaResourceModel interface defines the model contract
+
+The system SHALL define a `KibanaResourceModel` interface with four value-receiver methods: `GetID() types.String`, `GetResourceID() types.String`, `GetSpaceID() types.String`, and `GetKibanaConnection() types.List`. Concrete resource models SHALL satisfy this interface to be used with `NewKibanaResource[T]`.
+
+- `GetID` SHALL return the verbatim Terraform state identifier (may be a composite `<space>/<resourceID>` string or a plain ID, depending on the resource).
+- `GetResourceID` SHALL return the primary API key used in write and read operations — either a user-specified name (user-ID resources) or the API-assigned UUID (UUID resources). For UUID resources, `GetResourceID` MAY return the same value as `GetID`.
+- `GetSpaceID` SHALL return the Kibana space identifier for API calls.
+- `GetKibanaConnection` SHALL return the decoded `kibana_connection` block list.
+
+#### Scenario: User-ID resource implements the interface
+
+- **WHEN** a model struct provides `GetID()` returning the composite state ID, `GetResourceID()` returning the user-specified name, `GetSpaceID()` returning the space, and `GetKibanaConnection()` returning the connection block
+- **THEN** it SHALL satisfy `KibanaResourceModel` and be usable as the type parameter `T` for `NewKibanaResource[T]`
+
+#### Scenario: API-UUID resource implements the interface
+
+- **WHEN** a model struct provides `GetID()` and `GetResourceID()` both returning the API-assigned UUID (same value), `GetSpaceID()` returning the space, and `GetKibanaConnection()` returning the connection block
+- **THEN** it SHALL satisfy `KibanaResourceModel` and be usable as the type parameter `T` for `NewKibanaResource[T]`
+
+---
+
+### Requirement: Envelope injects kibana_connection block into schema
+
+The system SHALL inject the `kibana_connection` block into the schema returned by the concrete schema factory before exposing it via the `Schema` method.
+
+#### Scenario: Schema includes injected connection block
+
+- **WHEN** an envelope is constructed with a schema factory that returns a schema lacking a `kibana_connection` block
+- **THEN** calling `Schema` on the envelope SHALL return a schema that includes the `kibana_connection` block produced by the canonical provider helper
+- **AND** the concrete schema attributes and other blocks SHALL remain unchanged
+
+#### Scenario: Schema injection does not mutate the factory's return value
+
+- **WHEN** the schema factory is called multiple times via repeated `Schema` calls
+- **THEN** each call SHALL produce an independent schema with the `kibana_connection` block
+- **AND** the original schema value returned by the factory SHALL NOT be mutated
+
+---
+
+### Requirement: Envelope owns the Create prelude
+
+The system SHALL implement `Create` by deserializing the plan into the generic model `T`, resolving `spaceID` from `model.GetSpaceID()`, validating that `spaceID` is non-empty, resolving the scoped Kibana client via `GetKibanaClient`, and invoking the create callback. The create callback SHALL be invoked with `(context, *clients.KibanaScopedClient, spaceID string, plan T)`. The envelope SHALL NOT validate `GetResourceID()` during Create.
+
+#### Scenario: Successful create persists returned model
+
+- **WHEN** the create callback returns `(model, nil)` with no errors
+- **THEN** `resp.State.Set` SHALL be called with the returned model
+
+#### Scenario: Empty spaceID short-circuits create
+
+- **WHEN** `model.GetSpaceID()` returns an empty string
+- **THEN** an error diagnostic SHALL be appended
+- **AND** the create callback SHALL NOT be invoked
+
+#### Scenario: Client resolution failure short-circuits create
+
+- **WHEN** `GetKibanaClient` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the create callback SHALL NOT be invoked
+
+#### Scenario: Create callback error short-circuits state persistence
+
+- **WHEN** the create callback returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `resp.State.Set` SHALL NOT be called
+
+---
+
+### Requirement: Envelope owns the Read prelude with composite-ID-or-fallback identity resolution
+
+The system SHALL implement `Read` by deserializing the prior state into the generic model `T`, resolving `resourceID` and `spaceID` using the composite-ID-or-fallback rule, resolving the scoped Kibana client, validating that `resourceID` is non-empty, and invoking the read callback. The read callback SHALL be invoked with `(context, *clients.KibanaScopedClient, resourceID string, spaceID string, T)`.
+
+The composite-ID-or-fallback rule SHALL be: attempt `CompositeIDFromStrFw(model.GetID())`. On success, use `compID.ResourceID` as `resourceID` and `compID.ClusterID` as `spaceID`. On failure, use `model.GetResourceID().ValueString()` as `resourceID` and `model.GetSpaceID().ValueString()` as `spaceID`.
+
+#### Scenario: Successful read sets state from returned model
+
+- **WHEN** the read callback returns `(model, true, nil)` (entity found, no errors)
+- **THEN** `resp.State.Set` SHALL be called with the returned model
+
+#### Scenario: Not-found read removes resource from state
+
+- **WHEN** the read callback returns `(_, false, nil)` (entity missing, no errors)
+- **THEN** `resp.State.RemoveResource` SHALL be called
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Composite ID parse succeeds — parsed parts used
+
+- **WHEN** `model.GetID()` returns a valid composite ID (e.g. `"default/my-stream"`)
+- **THEN** `resourceID` SHALL be `"my-stream"` and `spaceID` SHALL be `"default"`
+- **AND** `model.GetResourceID()` and `model.GetSpaceID()` SHALL NOT be used for identity resolution
+
+#### Scenario: Composite ID parse fails — fallback to model methods
+
+- **WHEN** `model.GetID()` returns a plain value that is not a valid composite ID (e.g. `"abc-uuid"`)
+- **THEN** `resourceID` SHALL be `model.GetResourceID().ValueString()` and `spaceID` SHALL be `model.GetSpaceID().ValueString()`
+
+#### Scenario: Empty resourceID after resolution short-circuits read
+
+- **WHEN** composite ID parse fails and `model.GetResourceID()` returns an empty string
+- **THEN** an error diagnostic SHALL be appended
+- **AND** the read callback SHALL NOT be invoked
+
+#### Scenario: Client resolution failure short-circuits read
+
+- **WHEN** `GetKibanaClient` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the read callback SHALL NOT be invoked
+
+---
+
+### Requirement: Envelope owns the Update prelude and passes both plan and prior state
+
+The system SHALL implement `Update` using the same composite-ID-or-fallback identity resolution as Read (applied to the plan model), resolving the scoped Kibana client, and invoking the update callback. The update callback SHALL be invoked with `(context, *clients.KibanaScopedClient, resourceID string, spaceID string, plan T, prior T)` where `plan` is decoded from `req.Plan` and `prior` is decoded from `req.State`.
+
+#### Scenario: Successful update persists returned model
+
+- **WHEN** the update callback returns `(model, nil)` with no errors
+- **THEN** `resp.State.Set` SHALL be called with the returned model
+
+#### Scenario: Empty resourceID after resolution short-circuits update
+
+- **WHEN** composite ID parse fails and `plan.GetResourceID()` returns an empty string
+- **THEN** an error diagnostic SHALL be appended
+- **AND** the update callback SHALL NOT be invoked
+
+#### Scenario: Update callback receives prior state
+
+- **WHEN** the update callback is invoked
+- **THEN** the fifth argument SHALL be the decoded plan model
+- **AND** the sixth argument SHALL be the decoded prior state model
+
+#### Scenario: Client resolution failure short-circuits update
+
+- **WHEN** `GetKibanaClient` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the update callback SHALL NOT be invoked
+
+---
+
+### Requirement: Envelope owns the Delete prelude
+
+The system SHALL implement `Delete` using the same composite-ID-or-fallback identity resolution as Read (applied to the state model), resolving the scoped Kibana client, validating that `resourceID` is non-empty, and invoking the delete callback. The delete callback SHALL be invoked with `(context, *clients.KibanaScopedClient, resourceID string, spaceID string, T)`.
+
+#### Scenario: Delete callback is invoked with resolved identity
+
+- **WHEN** the state model resolves to a non-empty `resourceID` and `spaceID`
+- **THEN** the delete callback SHALL be invoked once with those values
+
+#### Scenario: Empty resourceID after resolution short-circuits delete
+
+- **WHEN** composite ID parse fails and `model.GetResourceID()` returns an empty string
+- **THEN** an error diagnostic SHALL be appended
+- **AND** the delete callback SHALL NOT be invoked
+
+#### Scenario: Client resolution failure short-circuits delete
+
+- **WHEN** `GetKibanaClient` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the delete callback SHALL NOT be invoked
+
+---
+
+### Requirement: PlaceholderKibanaWriteCallbacks returns callbacks that error when invoked
+
+The system SHALL provide `PlaceholderKibanaWriteCallbacks[T]()` that returns a `(KibanaCreateFunc[T], KibanaUpdateFunc[T])` pair. Each placeholder SHALL add a predictable error diagnostic if invoked. This function exists for concrete resources that override Create and/or Update on the envelope struct and therefore never intend the envelope's callbacks to be called.
+
+#### Scenario: Placeholder create callback returns error diagnostic
+
+- **WHEN** the placeholder `KibanaCreateFunc[T]` is invoked
+- **THEN** it SHALL return a non-empty `diag.Diagnostics` with an error-level diagnostic describing the misconfiguration
+
+#### Scenario: Placeholder update callback returns error diagnostic
+
+- **WHEN** the placeholder `KibanaUpdateFunc[T]` is invoked
+- **THEN** it SHALL return a non-empty `diag.Diagnostics` with an error-level diagnostic describing the misconfiguration
+
+---
+
+### Requirement: Streams resource migrated to use KibanaResource envelope
+
+The system SHALL migrate `internal/kibana/streams` so that its `Resource` struct embeds `*entitycore.KibanaResource[streamModel]` returned by `NewKibanaResource`. The `streamModel` SHALL implement `KibanaResourceModel` with `GetResourceID()` returning `m.Name` and `GetSpaceID()` returning `m.SpaceID`. The resource's schema, CRUD method bodies, and Terraform schema attributes SHALL remain functionally equivalent after migration.
+
+#### Scenario: Streams resource satisfies envelope interface after migration
+
+- **WHEN** `newResource()` is called for the streams resource
+- **THEN** the returned value SHALL satisfy `resource.Resource` and `resource.ResourceWithConfigure`
+- **AND** the Create, Read, Update, and Delete methods SHALL be owned by the envelope
+
+---
+
+### Requirement: Maintenance window resource migrated to use KibanaResource envelope
+
+The system SHALL migrate `internal/kibana/maintenance_window` so that its `Resource` struct embeds `*entitycore.KibanaResource[Model]` returned by `NewKibanaResource`. The `Model` SHALL implement `KibanaResourceModel` with `GetResourceID()` returning `m.ID` (the API-assigned UUID) and `GetSpaceID()` returning `m.SpaceID`. The resource's schema, CRUD method bodies, and Terraform schema attributes SHALL remain functionally equivalent after migration.
+
+#### Scenario: Maintenance window resource satisfies envelope interface after migration
+
+- **WHEN** `newResource()` is called for the maintenance window resource
+- **THEN** the returned value SHALL satisfy `resource.Resource` and `resource.ResourceWithConfigure`
+- **AND** the Create, Read, Update, and Delete methods SHALL be owned by the envelope

--- a/openspec/changes/kibana-resource-envelope/tasks.md
+++ b/openspec/changes/kibana-resource-envelope/tasks.md
@@ -1,0 +1,60 @@
+## 1. Envelope Core
+
+- [ ] 1.1 Define `KibanaResourceModel` interface (`GetID`, `GetResourceID`, `GetSpaceID`, `GetKibanaConnection`) in `internal/entitycore/`
+- [ ] 1.2 Define `KibanaCreateFunc[T]`, `KibanaUpdateFunc[T]`, `kibanaReadFunc[T]`, `kibanaDeleteFunc[T]` callback function types
+- [ ] 1.3 Implement `KibanaResource[T]` struct embedding `*ResourceBase` with schema factory and four callback fields
+- [ ] 1.4 Implement `NewKibanaResource[T]` constructor
+- [ ] 1.5 Implement `Schema` method — inject `kibana_connection` block (parallel to `ElasticsearchResource.Schema`)
+- [ ] 1.6 Implement the composite-ID-or-fallback helper: try `CompositeIDFromStrFw(GetID())`, fall back to `GetResourceID()` + `GetSpaceID()`
+- [ ] 1.7 Implement `Create` — decode plan, validate `spaceID` non-empty, resolve `KibanaClient`, invoke `createFunc(ctx, client, spaceID, plan)`, persist state
+- [ ] 1.8 Implement `Read` — decode state, resolve identity via composite-ID-or-fallback, validate `resourceID` non-empty, resolve `KibanaClient`, invoke `readFunc(ctx, client, resourceID, spaceID, model)`, found/not-found branching
+- [ ] 1.9 Implement `Update` — decode plan and prior state, resolve identity via composite-ID-or-fallback on plan model, validate `resourceID` non-empty, resolve `KibanaClient`, invoke `updateFunc(ctx, client, resourceID, spaceID, plan, prior)`, persist state
+- [ ] 1.10 Implement `Delete` — decode state, resolve identity via composite-ID-or-fallback, validate `resourceID` non-empty, resolve `KibanaClient`, invoke `deleteFunc(ctx, client, resourceID, spaceID, model)`
+- [ ] 1.11 Implement `PlaceholderKibanaWriteCallbacks[T]()` returning error-surfacing `KibanaCreateFunc[T]` and `KibanaUpdateFunc[T]`
+- [ ] 1.12 Add `var _ resource.Resource = (*KibanaResource[KibanaResourceModel])(nil)` compile-time assertion
+- [ ] 1.13 Update `entitycore/doc.go` to document the Kibana resource envelope pattern alongside the existing Elasticsearch and data-source patterns
+
+## 2. Envelope Unit Tests
+
+- [ ] 2.1 Add `testKibanaResourceModel` satisfying `KibanaResourceModel` for envelope tests (user-ID variant: `GetResourceID()` returns `m.Name`)
+- [ ] 2.2 Test `NewKibanaResource` type assertions: satisfies `resource.Resource`, `resource.ResourceWithConfigure`, does NOT satisfy `resource.ResourceWithImportState`
+- [ ] 2.3 Test `Metadata` produces the correct Terraform type name
+- [ ] 2.4 Test `Schema` injects `kibana_connection` block and does not mutate the factory return value
+- [ ] 2.5 Test `Configure` — nil provider data, valid factory, invalid provider data
+- [ ] 2.6 Test `Create` happy path — model decoded, spaceID validated, client resolved, callback invoked, state persisted
+- [ ] 2.7 Test `Create` short-circuits: empty spaceID, client resolution failure, callback error
+- [ ] 2.8 Test `Create` with nil and placeholder write callbacks
+- [ ] 2.9 Test `Read` happy path (found) — composite ID parse path (user-ID resource)
+- [ ] 2.10 Test `Read` happy path (found) — fallback path (plain-UUID resource)
+- [ ] 2.11 Test `Read` not-found removes resource from state
+- [ ] 2.12 Test `Read` short-circuits: state decode error, empty resourceID, client resolution failure, read callback error
+- [ ] 2.13 Test `Update` happy path — both plan and prior state decoded, callback receives both
+- [ ] 2.14 Test `Update` short-circuits: empty resourceID, client resolution failure, callback error
+- [ ] 2.15 Test `Update` with nil and placeholder write callbacks
+- [ ] 2.16 Test `Delete` happy path
+- [ ] 2.17 Test `Delete` short-circuits: state decode error, empty resourceID, client resolution failure, delete callback error
+
+## 3. Streams Migration (User-ID POC)
+
+- [ ] 3.1 Add `GetResourceID() types.String` (returns `m.Name`), `GetSpaceID() types.String`, and `GetKibanaConnection() types.List` value-receiver methods to `streamModel`
+- [ ] 3.2 Change `Resource` struct to embed `*entitycore.KibanaResource[streamModel]` instead of `*entitycore.ResourceBase`
+- [ ] 3.3 Update `newResource()` to call `entitycore.NewKibanaResource[streamModel]` with the schema factory and extracted callback functions
+- [ ] 3.4 Extract the Create body into a `KibanaCreateFunc[streamModel]` — receives `(ctx, client, spaceID, plan)`; extracts name from `plan.GetResourceID()`
+- [ ] 3.5 Extract the Read body into a `kibanaReadFunc[streamModel]` — receives `(ctx, client, resourceID, spaceID, model)`; removes the internal composite ID parse (envelope handles it)
+- [ ] 3.6 Extract the Update body into a `KibanaUpdateFunc[streamModel]` — receives `(ctx, client, resourceID, spaceID, plan, prior)`
+- [ ] 3.7 Extract the Delete body into a `kibanaDeleteFunc[streamModel]` — receives `(ctx, client, resourceID, spaceID, model)`
+- [ ] 3.8 Remove now-redundant `resource.go` CRUD method stubs and inline boilerplate
+- [ ] 3.9 Verify `make build` passes and existing streams acceptance tests pass
+
+## 4. Maintenance Window Migration (API-UUID POC)
+
+- [ ] 4.1 Add `GetResourceID() types.String` (returns `m.ID`), `GetSpaceID() types.String`, and `GetKibanaConnection() types.List` value-receiver methods to maintenance window `Model`
+- [ ] 4.2 Change `Resource` struct to embed `*entitycore.KibanaResource[Model]` instead of `*entitycore.ResourceBase`
+- [ ] 4.3 Update `newResource()` to call `entitycore.NewKibanaResource[Model]` with the schema factory and extracted callback functions
+- [ ] 4.4 Extract the Create body into a `KibanaCreateFunc[Model]` — receives `(ctx, client, spaceID, plan)`; UUID from API response is set on the returned model
+- [ ] 4.5 Extract the Read body into a `kibanaReadFunc[Model]` — receives `(ctx, client, resourceID, spaceID, model)`; removes `getMaintenanceWindowIDAndSpaceID()` call (envelope handles composite-ID-or-fallback)
+- [ ] 4.6 Extract the Update body into a `KibanaUpdateFunc[Model]` — receives `(ctx, client, resourceID, spaceID, plan, prior)`
+- [ ] 4.7 Extract the Delete body into a `kibanaDeleteFunc[Model]` — receives `(ctx, client, resourceID, spaceID, model)`; removes `getMaintenanceWindowIDAndSpaceID()` call
+- [ ] 4.8 Remove `getMaintenanceWindowIDAndSpaceID()` helper if no longer needed
+- [ ] 4.9 Remove now-redundant `resource.go` CRUD method stubs and inline boilerplate
+- [ ] 4.10 Verify `make build` passes and existing maintenance window acceptance tests pass

--- a/openspec/changes/kibana-resource-envelope/tasks.md
+++ b/openspec/changes/kibana-resource-envelope/tasks.md
@@ -5,7 +5,7 @@
 - [ ] 1.3 Implement `KibanaResource[T]` struct embedding `*ResourceBase` with schema factory and four callback fields
 - [ ] 1.4 Implement `NewKibanaResource[T]` constructor
 - [ ] 1.5 Implement `Schema` method — inject `kibana_connection` block (parallel to `ElasticsearchResource.Schema`)
-- [ ] 1.6 Implement the composite-ID-or-fallback helper: try `CompositeIDFromStrFw(GetID())`, fall back to `GetResourceID()` + `GetSpaceID()`
+- [ ] 1.6 Implement the composite-ID-or-fallback helper: call `CompositeIDFromStr(GetID())` (or the `Fw` variant) and inspect the returned `*CompositeID` — discard any returned diagnostics (parse failure is a non-error "not composite" signal, same pattern as `getMaintenanceWindowIDAndSpaceID`); fall back to `GetResourceID()` + `GetSpaceID()` when the result is nil
 - [ ] 1.7 Implement `Create` — decode plan, validate `spaceID` non-empty, resolve `KibanaClient`, invoke `createFunc(ctx, client, spaceID, plan)`, persist state
 - [ ] 1.8 Implement `Read` — decode state, resolve identity via composite-ID-or-fallback, validate `resourceID` non-empty, resolve `KibanaClient`, invoke `readFunc(ctx, client, resourceID, spaceID, model)`, found/not-found branching
 - [ ] 1.9 Implement `Update` — decode plan and prior state, resolve identity via composite-ID-or-fallback on plan model, validate `resourceID` non-empty, resolve `KibanaClient`, invoke `updateFunc(ctx, client, resourceID, spaceID, plan, prior)`, persist state


### PR DESCRIPTION
## Summary

- Proposes `NewKibanaResource[T]` in `internal/entitycore`, mirroring `NewElasticsearchResource` for Kibana-backed resources
- Captures all design decisions: `GetSpaceID()` on the model interface, composite-ID-or-fallback identity resolution, asymmetric Create/Update callback signatures, and prior state in Update callbacks
- Includes spec, design doc, and 36 implementation tasks with streams and maintenance_window as POC migration targets

## Key design decisions

- **`KibanaResourceModel` interface** requires `GetID`, `GetResourceID`, `GetSpaceID`, `GetKibanaConnection` — space is explicit on the model, not inferred from composite ID alone
- **Composite-ID-or-fallback** for Read/Update/Delete: try parsing `GetID()` as composite; fall back to `GetResourceID()` + `GetSpaceID()`. Handles streams (always composite), maintenance_window (plain UUID + separate space field), and import (composite override)
- **Create callback** receives `(ctx, client, spaceID, plan)` — no `resourceID`, since API-UUID resources don't have a write identity at plan time
- **Update callback** receives `(ctx, client, resourceID, spaceID, plan, prior)` — prior state included because Kibana PATCH APIs frequently need to diff against current state
- **`PlaceholderKibanaWriteCallbacks[T]`** included for parity with the Elasticsearch envelope

## Test plan

- [ ] Review proposal, design, and spec artifacts in `openspec/changes/kibana-resource-envelope/`
- [ ] Confirm design decisions match intent (especially Create vs Update callback asymmetry)
- [ ] Confirm POC resource choices (streams + maintenance_window) cover both ID patterns

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propose `NewKibanaResource` generic Kibana resource envelope in openspec
> Adds a set of openspec documents (proposal, design, spec, and tasks) defining a generic `KibanaResource[T]` envelope and `NewKibanaResource` constructor for use in entitycore. The envelope standardizes CRUD preludes, schema injection of `kibana_connection`, space ID resolution via `GetSpaceID`, and composite-ID-or-fallback identity resolution across Kibana resources. Migration paths for `streams` and `maintenance_window` resources are included as reference implementations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d36afd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->