### PR TITLE
openspec: propose read-after-write in ElasticsearchResource envelope

### DIFF
--- a/openspec/changes/es-read-after-write/.openspec.yaml
+++ b/openspec/changes/es-read-after-write/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/es-read-after-write/design.md
+++ b/openspec/changes/es-read-after-write/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`ElasticsearchResource[T]`'s `writeFromPlan` currently calls the concrete callback and writes state directly from the returned model. Each callback is expected to call `readFunc` itself and handle the not-found case. This produces duplicated boilerplate in every resource's write function and creates an implicit contract that isn't enforced.
+
+The read function is already registered with the envelope (for the standalone `Read` handler). This change moves the read-after-write step into `writeFromPlan` so the envelope owns the full create/update lifecycle.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `writeFromPlan` invokes `readFunc` after a successful concrete callback, using the callback's returned model as the prior state passed to `readFunc`
+- Not-found after write produces a standard error diagnostic identifying the resource type
+- Concrete callbacks no longer call `readFunc` or handle not-found
+- No change to callback signatures
+
+**Non-Goals:**
+- Changing callback signatures to return only `diag.Diagnostics` (Path B — not viable because create-only fields such as API key secrets must travel from the callback to `readFunc` via the returned model)
+- Refactoring `readFunc` implementations to compute composite IDs themselves
+- Migrating resources not currently using the envelope
+
+## Decisions
+
+### Keep `(T, diag.Diagnostics)` callback signature
+
+The concrete callback must still return the written model so the envelope can pass it to `readFunc` as prior state. This is necessary for resources where:
+- The read function carries non-API fields through from the state parameter (composite ID, `ElasticsearchConnection`, create-only values)
+- The create API response includes fields that will never be returned by a subsequent GET (e.g., API key secret values)
+
+Changing to a `diag.Diagnostics`-only return (Path B) would make these resources impossible to implement correctly.
+
+### Pass `writtenModel` (not plan model) to `readFunc`
+
+`readFunc` takes a prior-state `T` to carry through fields the API does not return. Using the callback's returned model (`writtenModel`) rather than the original plan model ensures that:
+- The composite ID is set correctly (callbacks that need it still call `client.ID()` and set it before returning)
+- Create-only fields set by the callback survive into state
+- `ElasticsearchConnection` is preserved
+
+### Error message uses component and resource name from `ResourceBase`
+
+`writeFromPlan` runs inside the `entitycore` package and has direct access to `r.component` and `r.resourceName`. The not-found error uses `fmt.Sprintf("%s_%s", r.component, r.resourceName)` to produce a type-qualified identifier (e.g. `elasticsearch_security_role`) without hardcoding the provider name.
+
+## Risks / Trade-offs
+
+**Callback must still set composite ID where readFunc carries it through** → Existing callbacks already do this; no behavior change required, but the implicit contract remains. Future callbacks must know to call `client.ID()` before returning. This is documented in the callback type's godoc.
+
+**rolemapping readFunc computes its own ID via `client.ID()`** → This means `writeRoleMapping` no longer needs to call `client.ID()` at all, and can be simplified further. This is a minor bonus, not a risk.
+
+## Open Questions
+
+_None._

--- a/openspec/changes/es-read-after-write/proposal.md
+++ b/openspec/changes/es-read-after-write/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `ElasticsearchResource` envelope's `Create` and `Update` preludes currently delegate all post-write state population to the concrete callbacks. Every callback independently calls `readFunc` and handles the not-found case, duplicating the same boilerplate across every resource that uses the envelope and creating a trap for new resources that forget to do so.
+
+## What Changes
+
+- The envelope's `writeFromPlan` (shared by `Create` and `Update`) will invoke `readFunc` after the concrete callback returns successfully, and append a standard error diagnostic if the resource is not found after the write.
+- Concrete create and update callbacks no longer call `readFunc` or handle not-found. They return the written model with enough state for `readFunc` to proceed (composite ID, any create-only field values such as API key secrets, `ElasticsearchConnection`).
+- Existing concrete callbacks for `role`, `script`, `role_mapping`, and `system_user` are simplified to remove their inline read and not-found handling.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `entitycore-resource-envelope`: the Create and Update prelude requirements change — read-after-write becomes the envelope's responsibility; the callback contract narrows to "write and return state for readFunc to build on".
+
+## Impact
+
+- `internal/entitycore/resource_envelope.go` — `writeFromPlan` gains the read-after-write step
+- `internal/entitycore/resource_envelope_test.go` — new tests for the read-after-write path; existing write happy-path tests updated
+- `internal/elasticsearch/security/role/update.go` — remove inline `readRole` call and not-found handling
+- `internal/elasticsearch/cluster/script/update.go` — remove inline `readScriptPayload` call, field-carrying, and not-found handling
+- `internal/elasticsearch/security/rolemapping/update.go` — remove inline `readRoleMappingResource` call and nil check
+- `internal/elasticsearch/security/systemuser/update.go` — remove inline `readSystemUser` call and not-found handling

--- a/openspec/changes/es-read-after-write/specs/entitycore-resource-envelope/spec.md
+++ b/openspec/changes/es-read-after-write/specs/entitycore-resource-envelope/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: Envelope owns the Create and Update preludes
+
+The system SHALL implement `Create` and `Update` on `NewElasticsearchResource[T]` by deserializing the planned model into `T`, deriving the write resource ID from the model, resolving the scoped Elasticsearch client from the model's connection block via `GetElasticsearchClient`, invoking the corresponding concrete callback, and then invoking `readFunc` with the model returned by the callback. The concrete create and update callbacks SHALL be invoked with `(context, *clients.ElasticsearchScopedClient, resourceID string, T)`. After a successful callback invocation, `readFunc` SHALL be invoked with `(context, *clients.ElasticsearchScopedClient, resourceID string, writtenModel)` where `writtenModel` is the model returned by the concrete callback. State SHALL be set from the model returned by `readFunc`, not directly from the concrete callback.
+
+#### Scenario: Successful create sets state from read result
+
+- **WHEN** the concrete create function returns `(writtenModel, nil)` and `readFunc` returns `(stateModel, true, nil)`
+- **THEN** `resp.State.Set` SHALL be called with `stateModel` (the model returned by `readFunc`)
+- **AND** response diagnostics SHALL contain no errors
+
+#### Scenario: Successful update sets state from read result
+
+- **WHEN** the concrete update function returns `(writtenModel, nil)` and `readFunc` returns `(stateModel, true, nil)`
+- **THEN** `resp.State.Set` SHALL be called with `stateModel` (the model returned by `readFunc`)
+- **AND** response diagnostics SHALL contain no errors
+
+#### Scenario: Resource not found after create produces error
+
+- **WHEN** the concrete create function returns `(writtenModel, nil)` and `readFunc` returns `(_, false, nil)`
+- **THEN** an error diagnostic SHALL be appended to `resp.Diagnostics` identifying the resource type using the envelope's component and resource name
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Resource not found after update produces error
+
+- **WHEN** the concrete update function returns `(writtenModel, nil)` and `readFunc` returns `(_, false, nil)`
+- **THEN** an error diagnostic SHALL be appended to `resp.Diagnostics` identifying the resource type using the envelope's component and resource name
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: readFunc error after create short-circuits state mutation
+
+- **WHEN** the concrete create function returns `(writtenModel, nil)` and `readFunc` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: readFunc error after update short-circuits state mutation
+
+- **WHEN** the concrete update function returns `(writtenModel, nil)` and `readFunc` returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Create function error short-circuits state mutation
+
+- **WHEN** the concrete create function returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `readFunc` SHALL NOT be invoked
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Update function error short-circuits state mutation
+
+- **WHEN** the concrete update function returns error diagnostics
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** `readFunc` SHALL NOT be invoked
+- **AND** `resp.State.Set` SHALL NOT be called
+
+#### Scenario: Client resolution failure short-circuits create
+
+- **WHEN** `GetElasticsearchClient` returns error diagnostics during `Create`
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete create function SHALL NOT be invoked
+- **AND** state SHALL remain untouched
+
+#### Scenario: Client resolution failure short-circuits update
+
+- **WHEN** `GetElasticsearchClient` returns error diagnostics during `Update`
+- **THEN** the diagnostics SHALL be appended to `resp.Diagnostics`
+- **AND** the concrete update function SHALL NOT be invoked
+- **AND** state SHALL remain untouched
+
+#### Scenario: Create and update may use the same callback
+
+- **WHEN** a concrete Elasticsearch resource has identical create and update API behavior
+- **THEN** the resource SHALL be able to pass the same callback as both the create and update callback

--- a/openspec/changes/es-read-after-write/specs/entitycore-resource-envelope/spec.md
+++ b/openspec/changes/es-read-after-write/specs/entitycore-resource-envelope/spec.md
@@ -20,13 +20,13 @@ The system SHALL implement `Create` and `Update` on `NewElasticsearchResource[T]
 
 - **WHEN** the concrete create function returns `(writtenModel, nil)` and `readFunc` returns `(_, false, nil)`
 - **THEN** an error diagnostic SHALL be appended to `resp.Diagnostics` identifying the resource type using the envelope's component and resource name
-- **AND** `resp.State.Set` SHALL NOT be called
+- **AND** state SHALL remain untouched (neither `resp.State.Set` nor `resp.State.RemoveResource` SHALL be called)
 
 #### Scenario: Resource not found after update produces error
 
 - **WHEN** the concrete update function returns `(writtenModel, nil)` and `readFunc` returns `(_, false, nil)`
 - **THEN** an error diagnostic SHALL be appended to `resp.Diagnostics` identifying the resource type using the envelope's component and resource name
-- **AND** `resp.State.Set` SHALL NOT be called
+- **AND** state SHALL remain untouched (neither `resp.State.Set` nor `resp.State.RemoveResource` SHALL be called)
 
 #### Scenario: readFunc error after create short-circuits state mutation
 

--- a/openspec/changes/es-read-after-write/tasks.md
+++ b/openspec/changes/es-read-after-write/tasks.md
@@ -8,10 +8,10 @@
 
 ## 2. Concrete callbacks: remove inline read-after-write
 
-- [ ] 2.1 `elasticsearch/security/role/update.go` — remove `readRole` call and not-found handling; ensure composite ID is still set on the returned model before returning
-- [ ] 2.2 `elasticsearch/cluster/script/update.go` — remove `readScriptPayload` call, field-carrying block, and not-found check; ensure composite ID is still set on the returned model before returning
-- [ ] 2.3 `elasticsearch/security/rolemapping/update.go` — remove `readRoleMappingResource` call and nil check; return the plan model directly (rolemapping's `readFunc` computes the composite ID itself so no ID setup is needed)
-- [ ] 2.4 `elasticsearch/security/systemuser/update.go` — remove `readSystemUser` call and not-found handling; ensure composite ID is still set on the returned model before returning
+- [ ] 2.1 `internal/elasticsearch/security/role/update.go` — remove `readRole` call and not-found handling; ensure composite ID is still set on the returned model before returning
+- [ ] 2.2 `internal/elasticsearch/cluster/script/update.go` — remove `readScriptPayload` call, field-carrying block, and not-found check; ensure composite ID is still set on the returned model before returning
+- [ ] 2.3 `internal/elasticsearch/security/rolemapping/update.go` — remove `readRoleMappingResource` call and nil check; return the plan model directly (rolemapping's `readFunc` computes the composite ID itself so no ID setup is needed)
+- [ ] 2.4 `internal/elasticsearch/security/systemuser/update.go` — remove `readSystemUser` call and not-found handling; ensure composite ID is still set on the returned model before returning
 
 ## 3. Spec and godoc
 

--- a/openspec/changes/es-read-after-write/tasks.md
+++ b/openspec/changes/es-read-after-write/tasks.md
@@ -1,0 +1,19 @@
+## 1. Envelope: add read-after-write to writeFromPlan
+
+- [ ] 1.1 In `writeFromPlan`, after a successful concrete callback invocation, call `r.readFunc` with the returned `writtenModel` as prior state
+- [ ] 1.2 If `readFunc` reports `found == false`, append an error diagnostic using `r.component` and `r.resourceName` to identify the resource type
+- [ ] 1.3 Set state from the model returned by `readFunc`, not from the concrete callback's return value
+- [ ] 1.4 Add unit tests for: read-after-write happy path (create), read-after-write happy path (update), not-found-after-create error, not-found-after-update error, readFunc error after create, readFunc error after update
+- [ ] 1.5 Update existing write happy-path tests to assert state is set from the `readFunc` result
+
+## 2. Concrete callbacks: remove inline read-after-write
+
+- [ ] 2.1 `elasticsearch/security/role/update.go` — remove `readRole` call and not-found handling; ensure composite ID is still set on the returned model before returning
+- [ ] 2.2 `elasticsearch/cluster/script/update.go` — remove `readScriptPayload` call, field-carrying block, and not-found check; ensure composite ID is still set on the returned model before returning
+- [ ] 2.3 `elasticsearch/security/rolemapping/update.go` — remove `readRoleMappingResource` call and nil check; return the plan model directly (rolemapping's `readFunc` computes the composite ID itself so no ID setup is needed)
+- [ ] 2.4 `elasticsearch/security/systemuser/update.go` — remove `readSystemUser` call and not-found handling; ensure composite ID is still set on the returned model before returning
+
+## 3. Spec and godoc
+
+- [ ] 3.1 Update the `ElasticsearchCreateFunc` and `ElasticsearchUpdateFunc` type godocs to document the narrowed contract: callbacks call the API and return the written model with composite ID set (where readFunc carries it through) and any create-only fields populated; they must not call readFunc
+- [ ] 3.2 Run `make check-openspec` to confirm the delta spec passes validation


### PR DESCRIPTION
## Summary

- Adds an OpenSpec change proposal (`es-read-after-write`) that moves the read-after-write pattern out of individual concrete callbacks and into the `ElasticsearchResource` envelope's `writeFromPlan`
- After a successful write callback, the envelope calls `readFunc` with the returned model as prior state; state is set from the read result
- Concrete callbacks (`writeRole`, `writeScript`, `writeRoleMapping`, `writeSystemUser`) lose their inline read and not-found boilerplate

## Test plan

- [ ] Review proposal, design, and delta spec artifacts in `openspec/changes/es-read-after-write/`
- [ ] Run `make check-openspec` to validate the delta spec

## Changelog
Customer impact: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propose read-after-write consolidation into `ElasticsearchResource.writeFromPlan`
> Adds an openspec proposal to move read-after-write logic from individual resource callbacks into the shared `writeFromPlan` envelope method.
>
> - `writeFromPlan` will call `readFunc` with the written model after each create/update callback, standardizing not-found handling and error message composition across all resources.
> - Concrete callbacks are updated to remove their inline read-after-write calls, reducing duplication.
> - The [proposal](https://github.com/elastic/terraform-provider-elasticstack/pull/2711/files#diff-706b5f00038e25a52d65afb7be48694b82fa5d6406b42d85b659c8f879c795e6), [design](https://github.com/elastic/terraform-provider-elasticstack/pull/2711/files#diff-12cc13e9e0f5a00925c021d2acca2a43185aa3e6eb10885c9823ee25b350f92b), and [spec](https://github.com/elastic/terraform-provider-elasticstack/pull/2711/files#diff-1c79adaede1f47c2f997b4acc64c495931cc36ab26a511e9e9a16ad38b7755d3) cover success paths, not-found-after-write, readFunc errors, callback errors, and client resolution failures.
> - A [task checklist](https://github.com/elastic/terraform-provider-elasticstack/pull/2711/files#diff-25374c1596d1d59625d1efeedf3bdbdd88cdaf6905385bddac12532135792f36) enumerates implementation steps including callback adjustments, test updates, and godoc changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1513012.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->