### PR TITLE
chore(ci): reliable CI gates — OpenSpec change proposal

### DIFF
--- a/openspec/changes/reliable-ci-gates/.openspec.yaml
+++ b/openspec/changes/reliable-ci-gates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/reliable-ci-gates/design.md
+++ b/openspec/changes/reliable-ci-gates/design.md
@@ -61,11 +61,9 @@ The `Build/Lint/Test` workflow (`test.yml`) is compiled from a single template a
 
 ### Extend classify skip-paths beyond `openspec/`
 
-**Decision**: `provider_changes=false` when all changed files match: `CHANGELOG.md`, `openspec/**`, `.agents/**`, or `.github/**` except `.github/workflows/test.yml` (and its successors).
+**Decision**: `provider_changes=false` when all changed files match: `CHANGELOG.md`, `openspec/**`, `.agents/**`, or `.github/**` except `.github/workflows/provider.yml`.
 
-**Rationale**: Changes to changelog, agent prompts, or non-CI `.github/` files (issue templates, dependabot config) cannot affect the provider binary or its test behaviour. The current openspec-only rule is too narrow and causes unnecessary acceptance-test runs on changelog and `.agents/` PRs.
-
-**Note on `.github/workflows/test.yml` (and successors)**: Changes to the CI workflow definition itself require a full CI run to validate the new workflow against the provider. When this change lands, the relevant file becomes `.github/workflows/provider.yml`.
+**Rationale**: Changes to changelog, agent prompts, or non-CI `.github/` files (issue templates, dependabot config) cannot affect the provider binary or its test behaviour. The current openspec-only rule is too narrow and causes unnecessary acceptance-test runs on changelog and `.agents/` PRs. Changes to `.github/workflows/provider.yml` itself require a full CI run to validate the new workflow against the provider.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/reliable-ci-gates/design.md
+++ b/openspec/changes/reliable-ci-gates/design.md
@@ -1,0 +1,97 @@
+## Context
+
+The `Build/Lint/Test` workflow (`test.yml`) is compiled from a single template and handles every CI scenario — feature branch pushes, Copilot bot pushes, draft PRs, `ready_for_review` transitions, changelog-only bot PRs, and post-merge CI on `main` — through a 100-line `preflight` job with six conditional branches. This approach has produced three active bugs:
+
+1. `ready_for_review` fires → `preflight` sets `should_run=false` → `build` and `lint` are skipped → GitHub records a new "skipped" check run for each, overwriting the prior passing run → PR blocked.
+2. Push to a PR branch fires both `push` and `pull_request:synchronize` → `push` preflight skips CI but still emits a successful `test-validation` check run → race: if the push check run is recorded after a failing synchronize check run, it overwrites the failure → PR appears mergeable.
+3. `classifyChanges` only recognises `openspec/` as a skip-worthy path → changelog-only PRs either run 48+ acceptance-test jobs (regular PRs) or hit the preflight shortcut that skips `build`/`lint` required checks (generated-changelog bot PRs).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Required checks are always present and accurate for every PR type, including changelog-only, openspec-only, draft-to-ready, and bot PRs.
+- No race conditions between push and pull_request check runs.
+- Acceptance tests are skipped when the change set cannot affect provider behaviour.
+- A single required check per workflow, not one per intermediate job.
+- `auto-approve` continues to work for dependabot and copilot PRs.
+
+**Non-Goals:**
+- CI for branches without open PRs on every push (available via `workflow_dispatch`).
+- Preserving the generated-changelog auto-merge path (removed; out of scope for this change).
+- Changing the acceptance test matrix, stack versions, or test sharding.
+- Changing how `make check-lint` or `make check-openspec` work internally.
+
+## Decisions
+
+### Split into three workflows
+
+**Decision**: Replace `test.yml` with `provider.yml`, `openspec.yml`, and `workflows.yml`.
+
+**Rationale**: A single gate job per workflow is the only reliable pattern for required checks when some jobs are conditionally skipped. With a monolithic workflow, the gate must absorb the logic for every domain (Go CI, openspec validation, workflow tests). Splitting by domain makes each workflow's gate simple and self-contained. It also means openspec validation (fast, no stack) no longer queues behind acceptance tests (35 min), and workflow tests no longer share runner budget with the matrix.
+
+**Alternative considered**: Keep a single workflow with a multi-domain gate. Rejected — the gate would still need to reason about `should_run` (push vs. PR), `provider_changes`, and `workflow_changes` simultaneously, which is the same complexity that created the current bugs.
+
+### Remove `push` on PR branches; keep `push: [main]` only
+
+**Decision**: `push` triggers only on `main`. Use `workflow_dispatch` for ad-hoc CI on branches without PRs.
+
+**Rationale**: The race condition (Bug 2) is caused by the same workflow running for both `push` and `pull_request:synchronize` on the same commit. The only way to eliminate it cleanly is to stop the workflow from running on PR-branch pushes. Copilot commits to a PR branch trigger `pull_request:synchronize` — they do not require a `push` trigger. Post-merge validation on `main` remains valuable; keeping `push: [main]` provides that without the race.
+
+**Alternative considered**: Run push only for bot emails (current approach). Rejected — this still creates two competing check runs for bot commits, and the allowlist maintenance burden grows as bots are added.
+
+### Single `gate` job per workflow as the required check
+
+**Decision**: Each workflow has one `gate` job (`if: always()`) that is the only required check. Intermediate jobs (`build`, `lint`, `test`) are never required checks.
+
+**Rationale**: GitHub evaluates required checks by looking at the most recent check run for each required check name per commit. When an intermediate job is skipped (e.g., `build` on a changelog-only PR), GitHub records a "skipped" conclusion, which does not satisfy a required check. A `gate` job that explicitly passes when skipping is justified solves this permanently — the gate always emits a concrete `success` or `failure`.
+
+**Alternative considered**: Configure branch protection to allow skipped checks. Rejected — this would allow any check to be skipped for any reason, including unexpected failures, with no gate to catch it.
+
+### Always run everything on `push: [main]`; classify only for `pull_request`
+
+**Decision**: On `push` to `main` and on `workflow_dispatch`, skip classify and default to `provider_changes=true` / `workflow_changes=true`. Run all jobs unconditionally.
+
+**Rationale**: Post-merge CI on `main` should be comprehensive regardless of what files changed. The purpose of classify is to save CI time on clearly non-impactful PRs — that optimisation is irrelevant after a merge. Defaulting to `true` on push/dispatch makes the gate logic uniform: if classify ran, trust its output; if it didn't (push/dispatch), treat as fully impactful.
+
+### Remove `preflight` entirely
+
+**Decision**: No `preflight` job in any of the three workflows.
+
+**Rationale**: `preflight` existed to (a) suppress duplicate runs when both `push` and `pull_request` fire for the same commit, and (b) short-circuit the generated-changelog bot PR path. With `push` limited to `main` and `ready_for_review` removed from PR types, (a) is no longer needed. With the generated-changelog path removed, (b) is no longer needed. The job has no remaining purpose.
+
+### Extend classify skip-paths beyond `openspec/`
+
+**Decision**: `provider_changes=false` when all changed files match: `CHANGELOG.md`, `openspec/**`, `.agents/**`, or `.github/**` except `.github/workflows/test.yml` (and its successors).
+
+**Rationale**: Changes to changelog, agent prompts, or non-CI `.github/` files (issue templates, dependabot config) cannot affect the provider binary or its test behaviour. The current openspec-only rule is too narrow and causes unnecessary acceptance-test runs on changelog and `.agents/` PRs.
+
+**Note on `.github/workflows/test.yml` (and successors)**: Changes to the CI workflow definition itself require a full CI run to validate the new workflow against the provider. When this change lands, the relevant file becomes `.github/workflows/provider.yml`.
+
+## Risks / Trade-offs
+
+**[Risk] Transition window: old required checks still configured while new workflows deploy.**
+→ Mitigation: deploy all three new workflow files in a single PR; update branch protection in the same session immediately after the PR merges to `main`. Keep old `test.yml` active (do not delete) until branch protection is updated.
+
+**[Risk] `workflow_dispatch` is a worse DX than automatic push CI for branches without PRs.**
+→ Mitigation: acceptable trade-off; developers can trigger manually. Document this in the contributing guide.
+
+**[Risk] The `push: [main]` run doubles CI cost for every PR merge (a push to main fires after each merge).**
+→ Accepted trade-off: post-merge CI catches integration issues that PR CI may miss. The matrix is unchanged, so cost is the same as current main-branch push CI.
+
+**[Risk] `workflows.yml` classify may trigger workflow tests on any `.github/**` change, including issue templates.**
+→ Mitigation: workflow tests are fast (no stack); triggering them on non-workflow `.github/` changes is a minor over-trigger, not a blocking problem.
+
+## Migration Plan
+
+1. Implement all source template and script changes on a feature branch.
+2. Merge to `main` — the three new workflow files are created; `test.yml` remains active for the existing required checks.
+3. Immediately after merge, update branch protection:
+   - Remove required checks: `Build/Lint/Test / Build`, `Build/Lint/Test / Lint`, `Build/Lint/Test / Test Validation`
+   - Add required checks: `provider / gate`, `openspec / gate`, `workflows / gate`
+4. Delete `test.yml` and the `test/` workflow source directory in a follow-up cleanup PR.
+
+**Rollback**: Restore the `test.yml` source template from git and revert branch protection changes.
+
+## Open Questions
+
+None — all design decisions were resolved during exploration.

--- a/openspec/changes/reliable-ci-gates/proposal.md
+++ b/openspec/changes/reliable-ci-gates/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The `Build/Lint/Test` workflow has three active bugs — broken required checks when a PR moves from draft to ready, a race condition where a push event can overwrite a failing acceptance-test result with a spurious success, and changelog-only PRs that either run 48+ unnecessary acceptance-test jobs or get their `build`/`lint` required checks stuck in a skipped state. All three bugs share the same root cause: a monolithic 100-line `preflight` job with six conditional branches trying to handle every event shape in one place.
+
+## What Changes
+
+- **BREAKING** — Replace `.github/workflows/test.yml` (`Build/Lint/Test`) with three focused workflows: `provider.yml`, `openspec.yml`, and `workflows.yml`, each backed by its own source template under `.github/workflows-src/`.
+- Remove the `preflight` job and all its branching logic.
+- Remove the `test-validation` job; replace with a `gate` job in each workflow.
+- Change workflow triggers: keep `push` only on `main` (post-merge CI); use `pull_request: [opened, synchronize, reopened]` (drop `ready_for_review`); add `workflow_dispatch`.
+- Extend change classification to skip provider CI for CHANGELOG-only, `openspec/`, `.agents/`, and non-test `.github/` changes (currently only `openspec/` skips).
+- Remove `build` and `lint` as standalone required checks; replace with three gate required checks (`provider / gate`, `openspec / gate`, `workflows / gate`).
+- Remove the `auto-approve` changelog special-case (generated-changelog branch detection, auto-merge step).
+- Move workflow tests and hook tests from the `build` job into the dedicated `workflows.yml`.
+- Update `scripts/auto-approve`: remove the `generated-changelog` category.
+- Update `.github/workflows-src/manifest.json` and the compile script to reflect the new three-workflow layout; delete the `test/` source directory.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-openspec-workflow`: New `openspec.yml` workflow that runs `make check-openspec` and always publishes a `gate` result as the required check.
+- `ci-workflows-workflow`: New `workflows.yml` workflow that runs `make workflow-test` and `make hook-test` for `.github/` changes and always publishes a `gate` result as the required check.
+
+### Modified Capabilities
+
+- `ci-build-lint-test`: Restructured into `provider.yml`; new triggers (push main-only, PR without `ready_for_review`), no `preflight`, extended classify logic, new `gate` job, `auto-approve` job updated to drop changelog path.
+- `ci-pr-auto-approve`: Remove the `generated-changelog` category selector, commit-author gate, and file-allowlist gate.
+
+## Impact
+
+- **`.github/workflows/`**: `test.yml` deleted; `provider.yml`, `openspec.yml`, `workflows.yml` added.
+- **`.github/workflows-src/`**: `test/` directory replaced by `provider/`, `openspec/`, `workflows/` directories; `manifest.json` updated.
+- **`scripts/auto-approve/`**: `generated-changelog` category and its unit tests removed.
+- **`internal/lib/classify-changes.js`** (or equivalent): skip-path set extended.
+- **GitHub branch protection**: required checks updated from `Build/Lint/Test / Build`, `Build/Lint/Test / Lint`, `Build/Lint/Test / Test Validation` to `provider / gate`, `openspec / gate`, `workflows / gate` (manual step post-deploy).

--- a/openspec/changes/reliable-ci-gates/proposal.md
+++ b/openspec/changes/reliable-ci-gates/proposal.md
@@ -32,5 +32,5 @@ The `Build/Lint/Test` workflow has three active bugs — broken required checks 
 - **`.github/workflows/`**: `test.yml` deleted; `provider.yml`, `openspec.yml`, `workflows.yml` added.
 - **`.github/workflows-src/`**: `test/` directory replaced by `provider/`, `openspec/`, `workflows/` directories; `manifest.json` updated.
 - **`scripts/auto-approve/`**: `generated-changelog` category and its unit tests removed.
-- **`internal/lib/classify-changes.js`** (or equivalent): skip-path set extended.
+- **`.github/workflows-src/lib/classify-changes.js`**: skip-path set extended.
 - **GitHub branch protection**: required checks updated from `Build/Lint/Test / Build`, `Build/Lint/Test / Lint`, `Build/Lint/Test / Test Validation` to `provider / gate`, `openspec / gate`, `workflows / gate` (manual step post-deploy).

--- a/openspec/changes/reliable-ci-gates/specs/ci-build-lint-test/spec.md
+++ b/openspec/changes/reliable-ci-gates/specs/ci-build-lint-test/spec.md
@@ -8,7 +8,7 @@ The workflow name SHALL be `Provider CI`. The workflow file SHALL be `.github/wo
 
 - **GIVEN** a push to the `main` branch
 - **WHEN** the workflow evaluates its trigger
-- **THEN** the workflow SHALL run all jobs unconditionally (no classification)
+- **THEN** the `classify` job SHALL run and output `provider_changes=true` unconditionally, and all downstream jobs SHALL run
 
 #### Scenario: Pull request opened, synchronised, or reopened triggers workflow
 
@@ -149,7 +149,7 @@ Any change set containing a path outside this set SHALL produce `provider_change
 
 ### Requirement: Gate job
 
-The workflow SHALL include a `gate` job that always runs (`if: always()`) and depends on `classify`, `build`, `lint`, and `test`. The `gate` job SHALL be the sole required check for this workflow. The `gate` job SHALL succeed when any of the following is true:
+The workflow SHALL include a `gate` job that always runs (`if: always()`) and depends on `classify`, `build`, `lint`, and `test`. The `gate` job SHALL be the sole required check for this workflow (`provider / gate`). The `gate` job SHALL succeed when any of the following is true:
 
 - `classify` reported `provider_changes=false` and `build`, `lint`, and `test` were all skipped
 - `build`, `lint`, and `test` all completed successfully

--- a/openspec/changes/reliable-ci-gates/specs/ci-build-lint-test/spec.md
+++ b/openspec/changes/reliable-ci-gates/specs/ci-build-lint-test/spec.md
@@ -1,0 +1,216 @@
+## MODIFIED Requirements
+
+### Requirement: Workflow identity and triggers (REQ-001–REQ-006)
+
+The workflow name SHALL be `Provider CI`. The workflow file SHALL be `.github/workflows/provider.yml`. The workflow SHALL run on `push` to the `main` branch only. The workflow SHALL run on `pull_request` events of types `opened`, `synchronize`, and `reopened`. The workflow SHALL support manual execution via `workflow_dispatch`. The workflow SHALL NOT use `paths-ignore` at the trigger level; change filtering is handled by the change-classification job.
+
+#### Scenario: Push to main triggers workflow
+
+- **GIVEN** a push to the `main` branch
+- **WHEN** the workflow evaluates its trigger
+- **THEN** the workflow SHALL run all jobs unconditionally (no classification)
+
+#### Scenario: Pull request opened, synchronised, or reopened triggers workflow
+
+- **GIVEN** a pull request event of type `opened`, `synchronize`, or `reopened`
+- **WHEN** the workflow evaluates its trigger
+- **THEN** the workflow SHALL run starting with the classify job
+
+#### Scenario: ready_for_review does not trigger workflow
+
+- **GIVEN** a pull request is converted from draft to ready for review
+- **WHEN** GitHub evaluates workflow triggers
+- **THEN** the `provider.yml` workflow SHALL NOT be triggered
+- **AND** the existing check results for the HEAD commit SHALL remain valid
+
+#### Scenario: Push to non-main branch does not trigger workflow
+
+- **GIVEN** a push to any branch other than `main`
+- **WHEN** GitHub evaluates workflow triggers
+- **THEN** the `provider.yml` workflow SHALL NOT be triggered automatically
+
+### Requirement: Build job (REQ-007)
+
+The `build` job SHALL run on `ubuntu-latest`, depend on the `classify` job, execute only when `classify` outputs `provider_changes=true`, set up Go from `go.mod`, set up Node.js (24.x), run `make vendor`, and run `make build-ci`. The `build` job SHALL NOT run `make workflow-test` or `make hook-test`; those steps belong in `workflows.yml`.
+
+#### Scenario: Build runs for provider changes
+
+- **GIVEN** the classify job reports `provider_changes=true`
+- **WHEN** the build job evaluates its condition
+- **THEN** `make vendor` and `make build-ci` SHALL run
+
+#### Scenario: Build is skipped for non-provider changes
+
+- **GIVEN** the classify job reports `provider_changes=false`
+- **WHEN** the build job evaluates its condition
+- **THEN** the build job SHALL be skipped
+
+### Requirement: Lint job (REQ-008, REQ-031)
+
+The `lint` job SHALL run on `ubuntu-latest`, depend on the `classify` job, execute only when `classify` outputs `provider_changes=true`, set up Go from `go.mod`, read the Terraform CLI version from `.terraform-version`, set up Terraform without wrapper mode, install Node.js (24.x) with npm cache, run `npm ci`, and run `make check-lint` (which includes OpenSpec validation).
+
+#### Scenario: Lint runs for provider changes
+
+- **GIVEN** the classify job reports `provider_changes=true`
+- **WHEN** the lint job evaluates its condition
+- **THEN** `npm ci` and `make check-lint` SHALL run
+
+#### Scenario: Lint is skipped for non-provider changes
+
+- **GIVEN** the classify job reports `provider_changes=false`
+- **WHEN** the lint job evaluates its condition
+- **THEN** the lint job SHALL be skipped
+
+### Requirement: Acceptance test job structure (REQ-009–REQ-014)
+
+The matrix acceptance test job SHALL depend on successful completion of the `build` job and the `classify` job. The acceptance test job SHALL execute only when `classify` outputs `provider_changes=true`. The job SHALL NOT depend on a `preflight` job. All other requirements regarding the matrix, stack versions, environment variables, Fleet setup, snapshot handling, disk-space cleanup, and teardown remain unchanged.
+
+#### Scenario: Provider change runs stack and tests
+
+- **GIVEN** `classify` reports `provider_changes=true`
+- **WHEN** the test job evaluates its execution condition
+- **THEN** the stack SHALL be provisioned and `make testacc` SHALL run per the existing matrix and shard policy
+
+#### Scenario: Non-provider change skips matrix acceptance
+
+- **GIVEN** `classify` reports `provider_changes=false`
+- **WHEN** the acceptance test job evaluates its condition
+- **THEN** the matrix acceptance `test` job SHALL be skipped
+
+### Requirement: Auto-approve job
+
+The `auto-approve` job SHALL depend on the `gate` job and SHALL only run on `pull_request` events. It SHALL run only when the `gate` job succeeds. The `auto-approve` job SHALL execute `go run ./scripts/auto-approve`; approval policy is defined in [`openspec/specs/ci-pr-auto-approve/spec.md`](../../../../../../../openspec/specs/ci-pr-auto-approve/spec.md). The job SHALL NOT include a step to enable auto-merge for the `generated-changelog` branch.
+
+#### Scenario: Auto-approve after gate success
+
+- **GIVEN** a pull request workflow run where `gate` succeeds
+- **WHEN** `auto-approve` evaluates its condition
+- **THEN** it SHALL invoke `go run ./scripts/auto-approve` with `contents: read` and `pull-requests: write` permissions
+
+#### Scenario: Auto-approve does not run when gate fails
+
+- **GIVEN** a pull request workflow run where `gate` fails
+- **WHEN** `auto-approve` evaluates its condition
+- **THEN** `auto-approve` SHALL NOT run
+
+### Requirement: Change classification job
+
+The workflow SHALL include a `classify` job that always runs (no upstream dependencies) and outputs `provider_changes`. On `push` to `main` and on `workflow_dispatch`, the job SHALL output `provider_changes=true` unconditionally. On `pull_request` events, the job SHALL compute `provider_changes` from the PR file list: `provider_changes=false` when all changed files match the non-impacting path set; `provider_changes=true` otherwise.
+
+The non-impacting path set is:
+- `CHANGELOG.md`
+- Any path under `openspec/`
+- Any path under `.agents/`
+- Any path under `.github/` **except** `.github/workflows/provider.yml`
+
+Any change set containing a path outside this set SHALL produce `provider_changes=true`. An empty file list (e.g., force-push with no commit payload) SHALL default to `provider_changes=true`.
+
+#### Scenario: Changelog-only pull request skips provider CI
+
+- **GIVEN** a PR whose changed files are limited to `CHANGELOG.md`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `provider_changes=false`
+
+#### Scenario: Agents-only pull request skips provider CI
+
+- **GIVEN** a PR whose changed files are all under `.agents/`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `provider_changes=false`
+
+#### Scenario: Non-test GitHub config change skips provider CI
+
+- **GIVEN** a PR whose changed files are all under `.github/` and none are `.github/workflows/provider.yml`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `provider_changes=false`
+
+#### Scenario: Provider workflow file change runs provider CI
+
+- **GIVEN** a PR that changes `.github/workflows/provider.yml`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `provider_changes=true`
+
+#### Scenario: OpenSpec-only pull request skips provider CI
+
+- **GIVEN** a PR whose changed files are all under `openspec/`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `provider_changes=false`
+
+#### Scenario: Mixed change runs provider CI
+
+- **GIVEN** a PR that changes a Go source file alongside `CHANGELOG.md`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `provider_changes=true`
+
+#### Scenario: Push to main always runs provider CI
+
+- **GIVEN** a push event to the `main` branch
+- **WHEN** the classify job runs
+- **THEN** it SHALL output `provider_changes=true` unconditionally
+
+### Requirement: Gate job
+
+The workflow SHALL include a `gate` job that always runs (`if: always()`) and depends on `classify`, `build`, `lint`, and `test`. The `gate` job SHALL be the sole required check for this workflow. The `gate` job SHALL succeed when any of the following is true:
+
+- `classify` reported `provider_changes=false` and `build`, `lint`, and `test` were all skipped
+- `build`, `lint`, and `test` all completed successfully
+
+The `gate` job SHALL fail when any of the following is true:
+
+- `classify` reported `provider_changes=true` but any of `build`, `lint`, or `test` was skipped (unexpected skip)
+- Any of `build`, `lint`, or `test` failed or was cancelled
+
+#### Scenario: All jobs pass for provider change
+
+- **GIVEN** `classify` reports `provider_changes=true` and `build`, `lint`, `test` all succeed
+- **WHEN** the gate evaluates outcomes
+- **THEN** `gate` SHALL succeed
+
+#### Scenario: Non-provider change — all jobs skipped
+
+- **GIVEN** `classify` reports `provider_changes=false` and `build`, `lint`, `test` are all skipped
+- **WHEN** the gate evaluates outcomes
+- **THEN** `gate` SHALL succeed
+
+#### Scenario: Acceptance tests fail
+
+- **GIVEN** `classify` reports `provider_changes=true` and the `test` matrix has at least one failure
+- **WHEN** the gate evaluates outcomes
+- **THEN** `gate` SHALL fail
+
+#### Scenario: Unexpected skip fails gate
+
+- **GIVEN** `classify` reports `provider_changes=true` but `build` was skipped
+- **WHEN** the gate evaluates outcomes
+- **THEN** `gate` SHALL fail
+
+## REMOVED Requirements
+
+### Requirement: Preflight gate (REQ-023–REQ-027)
+
+**Reason**: The `preflight` job existed to suppress duplicate CI runs when both `push` and `pull_request` events fired for the same commit, and to short-circuit the generated-changelog bot PR path. With `push` restricted to `main` and `ready_for_review` removed from PR types, the duplicate-run scenario no longer exists. With the generated-changelog path removed, the short-circuit path no longer exists. The job has no remaining purpose.
+
+**Migration**: All `should_run` output references in downstream jobs are replaced by direct `classify` output checks or `if: always()` gate logic.
+
+### Requirement: Ready-for-review behavior (REQ-030)
+
+**Reason**: `ready_for_review` is removed from the workflow's `pull_request` trigger types. When a PR is un-drafted, no new workflow run fires; existing check results on the HEAD commit remain valid. The preflight suppression that caused required checks to enter a "skipped" state is no longer needed.
+
+**Migration**: No downstream change required. Draft PRs accumulate check results via `synchronize` events as commits are pushed.
+
+### Requirement: Test validation job (REQ-034–REQ-036)
+
+**Reason**: Replaced by the `gate` job, which covers `build`, `lint`, and `test` outcomes rather than only `test`. The `gate` job is the required check for this workflow.
+
+**Migration**: Update branch protection required checks from `Build/Lint/Test / Test Validation` to `provider / gate`.
+
+### Requirement: Generated changelog pull requests can reach auto-approve without full CI
+
+**Reason**: The `generated-changelog` special case in `preflight` is removed along with the entire `preflight` job. Changelog-only PRs are now handled uniformly by `classify` (which reports `provider_changes=false` for CHANGELOG-only changes), and the gate succeeds without running any CI jobs.
+
+**Migration**: The `generated-changelog` bot PR no longer gets an explicit fast-path. It goes through `classify`, skips all provider CI, and the gate succeeds. The auto-merge step is removed; the generated-changelog PR merges via the normal auto-approve path for dependabot/copilot if it matches those categories, or requires a manual merge otherwise.
+
+### Requirement: Changelog-only bypass remains narrowly scoped
+
+**Reason**: The narrowly-scoped bypass no longer exists; it is replaced by the general-purpose classify skip-path that applies to all changelog-only PRs regardless of branch name or author.
+
+**Migration**: None required.

--- a/openspec/changes/reliable-ci-gates/specs/ci-openspec-workflow/spec.md
+++ b/openspec/changes/reliable-ci-gates/specs/ci-openspec-workflow/spec.md
@@ -1,0 +1,67 @@
+# `ci-openspec-workflow` — Workflow Requirements
+
+Workflow implementation: `.github/workflows/openspec.yml`
+
+## Purpose
+
+Define the OpenSpec validation workflow: run `make check-openspec` on every PR and post-merge push to `main`, and publish a `gate` result as the sole required check.
+
+## ADDED Requirements
+
+### Requirement: Workflow identity and triggers
+
+The workflow name SHALL be `OpenSpec CI`. The workflow file SHALL be `.github/workflows/openspec.yml`. The workflow SHALL run on `push` to the `main` branch only. The workflow SHALL run on `pull_request` events of types `opened`, `synchronize`, and `reopened`. The workflow SHALL support manual execution via `workflow_dispatch`. The workflow SHALL NOT use `paths-ignore` at the trigger level.
+
+#### Scenario: Pull request triggers OpenSpec validation
+
+- **GIVEN** a pull request event of type `opened`, `synchronize`, or `reopened`
+- **WHEN** the workflow evaluates its trigger
+- **THEN** the `validate` and `gate` jobs SHALL run
+
+#### Scenario: Push to main triggers OpenSpec validation
+
+- **GIVEN** a push to the `main` branch
+- **WHEN** the workflow evaluates its trigger
+- **THEN** the `validate` and `gate` jobs SHALL run
+
+### Requirement: Validate job
+
+The `validate` job SHALL run on `ubuntu-latest`, set up Node.js (24.x) with npm cache, run `npm ci`, and run `make check-openspec` with `OPENSPEC_TELEMETRY=0`. The `validate` job SHALL always run (no skip condition); it is fast and provides value on all change sets.
+
+#### Scenario: Validate runs on every trigger
+
+- **GIVEN** any workflow trigger (push to main, pull request, or workflow_dispatch)
+- **WHEN** the validate job runs
+- **THEN** `make check-openspec` SHALL execute and fail the job if validation fails
+
+#### Scenario: OpenSpec validation failure fails job
+
+- **GIVEN** one or more OpenSpec specs fail validation
+- **WHEN** `make check-openspec` runs
+- **THEN** the validate job SHALL fail
+
+### Requirement: Gate job
+
+The workflow SHALL include a `gate` job that always runs (`if: always()`) and depends on `validate`. The `gate` job SHALL be the sole required check for this workflow (`openspec / gate`). The `gate` job SHALL succeed when `validate` succeeded. The `gate` job SHALL fail when `validate` failed or was cancelled.
+
+#### Scenario: Validation passes — gate succeeds
+
+- **GIVEN** the validate job completes successfully
+- **WHEN** the gate evaluates the outcome
+- **THEN** `gate` SHALL succeed
+
+#### Scenario: Validation fails — gate fails
+
+- **GIVEN** the validate job fails
+- **WHEN** the gate evaluates the outcome
+- **THEN** `gate` SHALL fail
+
+### Requirement: Supply chain for actions
+
+Third-party actions in the workflow SHALL be pinned by commit SHA.
+
+#### Scenario: Action references are SHA-pinned
+
+- **GIVEN** a third-party action is used in the workflow
+- **WHEN** the workflow YAML is inspected
+- **THEN** the action reference SHALL use a commit SHA

--- a/openspec/changes/reliable-ci-gates/specs/ci-pr-auto-approve/spec.md
+++ b/openspec/changes/reliable-ci-gates/specs/ci-pr-auto-approve/spec.md
@@ -1,0 +1,19 @@
+## REMOVED Requirements
+
+### Requirement: Generated changelog selector
+
+**Reason**: The `generated-changelog` category is removed. Changelog-only PRs are now handled by the workflow's classify job, which skips provider CI and lets the gate succeed without special-casing the auto-approve script. The auto-approve script no longer needs to recognise this PR shape.
+
+**Migration**: Remove the `generated-changelog` category selector, its commit-author gate, and its file-allowlist gate from `scripts/auto-approve/`. Remove all unit tests specific to this category.
+
+### Requirement: Generated changelog commit authors
+
+**Reason**: Removed with the `generated-changelog` category (see above).
+
+**Migration**: See above.
+
+### Requirement: Generated changelog file allowlist
+
+**Reason**: Removed with the `generated-changelog` category (see above).
+
+**Migration**: See above.

--- a/openspec/changes/reliable-ci-gates/specs/ci-workflows-workflow/spec.md
+++ b/openspec/changes/reliable-ci-gates/specs/ci-workflows-workflow/spec.md
@@ -16,7 +16,7 @@ The workflow name SHALL be `Workflows CI`. The workflow file SHALL be `.github/w
 
 - **GIVEN** a pull request event of type `opened`, `synchronize`, or `reopened`
 - **WHEN** the workflow evaluates its trigger
-- **THEN** the `classify`, `test`, and `gate` jobs SHALL run
+- **THEN** `classify` and `gate` SHALL always run; `test` SHALL run only when `workflow_changes=true`
 
 #### Scenario: Push to main triggers workflows CI
 

--- a/openspec/changes/reliable-ci-gates/specs/ci-workflows-workflow/spec.md
+++ b/openspec/changes/reliable-ci-gates/specs/ci-workflows-workflow/spec.md
@@ -1,0 +1,103 @@
+# `ci-workflows-workflow` — Workflow Requirements
+
+Workflow implementation: `.github/workflows/workflows.yml`
+
+## Purpose
+
+Define the workflow-and-hook test CI: classify whether `.github/` files changed, run `make workflow-test` and `make hook-test` when they have, and publish a `gate` result as the sole required check.
+
+## ADDED Requirements
+
+### Requirement: Workflow identity and triggers
+
+The workflow name SHALL be `Workflows CI`. The workflow file SHALL be `.github/workflows/workflows.yml`. The workflow SHALL run on `push` to the `main` branch only. The workflow SHALL run on `pull_request` events of types `opened`, `synchronize`, and `reopened`. The workflow SHALL support manual execution via `workflow_dispatch`. The workflow SHALL NOT use `paths-ignore` at the trigger level.
+
+#### Scenario: Pull request triggers workflows CI
+
+- **GIVEN** a pull request event of type `opened`, `synchronize`, or `reopened`
+- **WHEN** the workflow evaluates its trigger
+- **THEN** the `classify`, `test`, and `gate` jobs SHALL run
+
+#### Scenario: Push to main triggers workflows CI
+
+- **GIVEN** a push to the `main` branch
+- **WHEN** the workflow evaluates its trigger
+- **THEN** all jobs SHALL run with `workflow_changes=true` unconditionally
+
+### Requirement: Change classification job
+
+The workflow SHALL include a `classify` job that always runs and outputs `workflow_changes`. On `push` to `main` and on `workflow_dispatch`, the job SHALL output `workflow_changes=true` unconditionally. On `pull_request` events, the job SHALL set `workflow_changes=true` when any changed file is under `.github/`; otherwise `workflow_changes=false`.
+
+#### Scenario: GitHub directory change sets workflow_changes=true
+
+- **GIVEN** a PR that changes any file under `.github/`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `workflow_changes=true`
+
+#### Scenario: No GitHub directory change sets workflow_changes=false
+
+- **GIVEN** a PR whose changed files contain no path under `.github/`
+- **WHEN** the classify job evaluates the file list
+- **THEN** it SHALL report `workflow_changes=false`
+
+#### Scenario: Push to main always runs workflow tests
+
+- **GIVEN** a push event to the `main` branch
+- **WHEN** the classify job runs
+- **THEN** it SHALL output `workflow_changes=true` unconditionally
+
+### Requirement: Test job
+
+The `test` job SHALL run on `ubuntu-latest`, depend on the `classify` job, execute only when `classify` outputs `workflow_changes=true`, set up Go from `go.mod`, set up Node.js (24.x), run `make vendor`, run `make workflow-test`, and run `make hook-test`.
+
+#### Scenario: Test runs for workflow changes
+
+- **GIVEN** `classify` reports `workflow_changes=true`
+- **WHEN** the test job evaluates its condition
+- **THEN** `make workflow-test` and `make hook-test` SHALL run
+
+#### Scenario: Test is skipped for non-workflow changes
+
+- **GIVEN** `classify` reports `workflow_changes=false`
+- **WHEN** the test job evaluates its condition
+- **THEN** the test job SHALL be skipped
+
+### Requirement: Gate job
+
+The workflow SHALL include a `gate` job that always runs (`if: always()`) and depends on `classify` and `test`. The `gate` job SHALL be the sole required check for this workflow (`workflows / gate`). The `gate` job SHALL succeed when any of the following is true:
+
+- `classify` reported `workflow_changes=false` and `test` was skipped
+- `test` completed successfully
+
+The `gate` job SHALL fail when any of the following is true:
+
+- `classify` reported `workflow_changes=true` but `test` was skipped (unexpected skip)
+- `test` failed or was cancelled
+
+#### Scenario: Workflow tests pass — gate succeeds
+
+- **GIVEN** `classify` reports `workflow_changes=true` and `test` succeeds
+- **WHEN** the gate evaluates the outcome
+- **THEN** `gate` SHALL succeed
+
+#### Scenario: No workflow changes — gate succeeds
+
+- **GIVEN** `classify` reports `workflow_changes=false` and `test` is skipped
+- **WHEN** the gate evaluates the outcome
+- **THEN** `gate` SHALL succeed
+
+#### Scenario: Workflow tests fail — gate fails
+
+- **GIVEN** `classify` reports `workflow_changes=true` and `test` fails
+- **WHEN** the gate evaluates the outcome
+- **THEN** `gate` SHALL fail
+
+### Requirement: Supply chain for actions
+
+Third-party actions in the workflow SHALL be pinned by commit SHA.
+
+#### Scenario: Action references are SHA-pinned
+
+- **GIVEN** a third-party action is used in the workflow
+- **WHEN** the workflow YAML is inspected
+- **THEN** the action reference SHALL use a commit SHA

--- a/openspec/changes/reliable-ci-gates/tasks.md
+++ b/openspec/changes/reliable-ci-gates/tasks.md
@@ -40,7 +40,7 @@
 ## 6. Manifest and Compilation
 
 - [ ] 6.1 Update `.github/workflows-src/manifest.json`: replace the `test/workflow.yml.tmpl → test.yml` entry with three entries mapping `provider/workflow.yml.tmpl → provider.yml`, `openspec/workflow.yml.tmpl → openspec.yml`, and `workflows/workflow.yml.tmpl → workflows.yml`
-- [ ] 6.2 Run `make compile-workflows` (or equivalent) to generate `.github/workflows/provider.yml`, `.github/workflows/openspec.yml`, and `.github/workflows/workflows.yml`
+- [ ] 6.2 Run `make workflow-generate` to generate `.github/workflows/provider.yml`, `.github/workflows/openspec.yml`, and `.github/workflows/workflows.yml`
 - [ ] 6.3 Verify the three generated files are syntactically valid YAML and that action references use commit SHAs
 
 ## 7. Auto-Approve Script

--- a/openspec/changes/reliable-ci-gates/tasks.md
+++ b/openspec/changes/reliable-ci-gates/tasks.md
@@ -1,0 +1,66 @@
+## 1. Library Scripts
+
+- [ ] 1.1 Update `classifyChanges` in `.github/workflows-src/lib/classify-changes.js` to extend the non-impacting path set: `CHANGELOG.md`, `openspec/**`, `.agents/**`, and `.github/**` except `.github/workflows/provider.yml`
+- [ ] 1.2 Add unit tests in the corresponding `.test.mjs` file covering the new skip paths (CHANGELOG, `.agents/`, `.github/` non-workflow, `.github/workflows/provider.yml` triggers CI, mixed changes trigger CI)
+- [ ] 1.3 Create `.github/workflows-src/lib/gate-provider.js` implementing provider gate logic: succeeds when all jobs passed or all were legitimately skipped (`provider_changes=false`); fails otherwise
+- [ ] 1.4 Add unit tests for `gate-provider.js` covering: all-pass, all-skipped-legitimately, unexpected skip, any failure
+- [ ] 1.5 Create `.github/workflows-src/lib/gate-workflows.js` implementing workflows gate logic: succeeds when test passed or was legitimately skipped (`workflow_changes=false`); fails otherwise
+- [ ] 1.6 Add unit tests for `gate-workflows.js` covering: test passed, test skipped legitimately, unexpected skip, test failed
+
+## 2. Inline Scripts
+
+- [ ] 2.1 Create `.github/workflows-src/provider/scripts/classify_changes.inline.js` that reads PR file list (pull_request) or defaults to `provider_changes=true` (push/dispatch), using `classifyChanges` from `../../lib/classify-changes.js`
+- [ ] 2.2 Create `.github/workflows-src/provider/scripts/gate.inline.js` that reads `classify`, `build`, `lint`, and `test` job results and calls `gateProvider` from `../../lib/gate-provider.js`
+- [ ] 2.3 Create `.github/workflows-src/workflows/scripts/classify_changes.inline.js` that reads PR file list (pull_request) or defaults to `workflow_changes=true` (push/dispatch), setting `workflow_changes=true` when any file is under `.github/`
+- [ ] 2.4 Create `.github/workflows-src/workflows/scripts/gate.inline.js` that reads `classify` and `test` job results and calls `gateWorkflows` from `../../lib/gate-workflows.js`
+
+## 3. Provider Workflow Source Template
+
+- [ ] 3.1 Create `.github/workflows-src/provider/` directory and `workflow.yml.tmpl` with triggers: `push: branches: [main]`, `pull_request: types: [opened, synchronize, reopened]`, `workflow_dispatch`
+- [ ] 3.2 Add `classify` job to the template: always runs, uses `classify_changes.inline.js`, outputs `provider_changes`
+- [ ] 3.3 Add `build` job to the template: depends on `classify`, condition `provider_changes == 'true'`, sets up Go and Node 24, runs `make vendor` then `make build-ci` (no workflow-test or hook-test steps)
+- [ ] 3.4 Add `lint` job to the template: depends on `classify`, condition `provider_changes == 'true'`, sets up Go, Node 24, Terraform (pinned from `.terraform-version`), runs `npm ci` then `make check-lint` with `OPENSPEC_TELEMETRY=0`
+- [ ] 3.5 Add `test` matrix job to the template: copy matrix configuration, stack versions, shard strategy, fleet setup, synthetics, wait-readiness, testacc, snapshot PR comment, diagnostics, and teardown steps from `test/workflow.yml.tmpl`; update dependencies to `[classify, build]`; update condition to `provider_changes == 'true'`; remove any reference to `preflight`
+- [ ] 3.6 Add `gate` job to the template: `if: always()`, depends on `[classify, build, lint, test]`, uses `gate.inline.js`
+- [ ] 3.7 Add `auto-approve` job to the template: `if: always() && github.event_name == 'pull_request' && needs.gate.result == 'success'`, depends on `[gate]`, sets up Go, runs `go run ./scripts/auto-approve` with `contents: read` and `pull-requests: write` permissions; do NOT include the auto-merge step
+
+## 4. OpenSpec Workflow Source Template
+
+- [ ] 4.1 Create `.github/workflows-src/openspec/` directory and `workflow.yml.tmpl` with the same triggers as provider.yml
+- [ ] 4.2 Add `validate` job: always runs, sets up Node 24 with npm cache, runs `npm ci`, runs `make check-openspec` with `OPENSPEC_TELEMETRY=0`
+- [ ] 4.3 Add `gate` job: `if: always()`, depends on `[validate]`; succeeds when `validate` succeeded; fails when `validate` failed or cancelled
+
+## 5. Workflows Workflow Source Template
+
+- [ ] 5.1 Create `.github/workflows-src/workflows/` directory and `workflow.yml.tmpl` with the same triggers as provider.yml
+- [ ] 5.2 Add `classify` job: always runs, uses `classify_changes.inline.js`, outputs `workflow_changes`
+- [ ] 5.3 Add `test` job: depends on `classify`, condition `workflow_changes == 'true'`, sets up Go and Node 24, runs `make vendor`, runs `make workflow-test` then `make hook-test`
+- [ ] 5.4 Add `gate` job: `if: always()`, depends on `[classify, test]`, uses `gate.inline.js`
+
+## 6. Manifest and Compilation
+
+- [ ] 6.1 Update `.github/workflows-src/manifest.json`: replace the `test/workflow.yml.tmpl → test.yml` entry with three entries mapping `provider/workflow.yml.tmpl → provider.yml`, `openspec/workflow.yml.tmpl → openspec.yml`, and `workflows/workflow.yml.tmpl → workflows.yml`
+- [ ] 6.2 Run `make compile-workflows` (or equivalent) to generate `.github/workflows/provider.yml`, `.github/workflows/openspec.yml`, and `.github/workflows/workflows.yml`
+- [ ] 6.3 Verify the three generated files are syntactically valid YAML and that action references use commit SHAs
+
+## 7. Auto-Approve Script
+
+- [ ] 7.1 Remove the `generated-changelog` category struct and its registration from `scripts/auto-approve/evaluator.go` (or whichever file defines categories)
+- [ ] 7.2 Remove all unit test cases for the `generated-changelog` category from `scripts/auto-approve/evaluator_test.go` and `scripts/auto-approve/main_test.go`
+- [ ] 7.3 Run `go test ./scripts/auto-approve/...` and confirm all remaining tests pass
+
+## 8. Workflow Tests
+
+- [ ] 8.1 Update `make workflow-test` test fixtures or test cases that reference `test.yml`, the `Build/Lint/Test` workflow name, the `preflight` job, the `test-validation` job, or `ready_for_review` handling to match the new workflow files and job names
+- [ ] 8.2 Add workflow test coverage for the new `gate` job logic in `provider.yml` and `workflows.yml` (legitimate skip succeeds, failure fails gate)
+
+## 9. Build Verification
+
+- [ ] 9.1 Run `make build` and confirm the project compiles cleanly
+- [ ] 9.2 Run `make check-lint` and confirm no lint errors
+- [ ] 9.3 Run `make workflow-test` and `make hook-test` and confirm all pass
+
+## 10. Post-Deploy (Manual)
+
+- [ ] 10.1 After merging to `main`, update GitHub branch protection: remove required checks `Build/Lint/Test / Build`, `Build/Lint/Test / Lint`, `Build/Lint/Test / Test Validation`; add `provider / gate`, `openspec / gate`, `workflows / gate`
+- [ ] 10.2 In a follow-up PR, delete `.github/workflows/test.yml` and `.github/workflows-src/test/` and remove `validate_test_result.inline.js` from the test scripts directory


### PR DESCRIPTION
## Summary

- Adds an OpenSpec change proposal under `openspec/changes/reliable-ci-gates/` for replacing the monolithic `Build/Lint/Test` workflow with three focused workflows
- Fixes three active bugs rooted in the `preflight` job: draft→ready check overwrite, push/synchronize race condition, and unnecessary acceptance-test runs on changelog-only PRs
- No code changes in this PR — proposal, design, delta specs, and task list only

## What's proposed

Replace `test.yml` with:

| Workflow | Required check | Runs |
|---|---|---|
| `provider.yml` | `provider / gate` | Go build, lint, acceptance tests |
| `openspec.yml` | `openspec / gate` | `make check-openspec` |
| `workflows.yml` | `workflows / gate` | `make workflow-test` + `make hook-test` |

Key decisions: remove `push` on PR branches (eliminates the race at source), remove `preflight`, add a single `gate` job per workflow as the sole required check, extend classify skip-paths to include `CHANGELOG.md`, `.agents/**`, and non-CI `.github/**`.

## Test plan

- [ ] Review proposal and design docs for correctness and completeness
- [ ] Review delta specs for each of the four modified/new capabilities
- [ ] Confirm tasks list covers all implementation work

🤖 Generated with [Claude Code](https://claude.com/claude-code)