### PR TITLE
Fix for Writable file handle closed without error handling

### DIFF
--- a/scripts/auto-approve/main.go
+++ b/scripts/auto-approve/main.go
@@ -264,7 +264,7 @@ func appendToFile(path, content string) error {
 
 	if _, err := f.WriteString(content); err != nil {
 		if closeErr := f.Close(); closeErr != nil {
-			return fmt.Errorf("write failed: %w; close failed: %v", err, closeErr)
+			return fmt.Errorf("write failed and close failed: %w", errors.Join(err, closeErr))
 		}
 		return err
 	}

--- a/scripts/auto-approve/main.go
+++ b/scripts/auto-approve/main.go
@@ -261,9 +261,18 @@ func appendToFile(path, content string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	_, err = f.WriteString(content)
-	return err
+
+	if _, err := f.WriteString(content); err != nil {
+		if closeErr := f.Close(); closeErr != nil {
+			return fmt.Errorf("write failed: %w; close failed: %v", err, closeErr)
+		}
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func logJSON(kind string, payload map[string]any) {


### PR DESCRIPTION
To fix this class of issue, ensure errors from closing writable file handles are checked and propagated. The best approach here is to avoid a blind `defer f.Close()` and instead close explicitly after writing, while also attempting close on write failure and returning the most relevant error.

In `scripts/auto-approve/main.go`, update `appendToFile` (lines around 259–267) to:

- open the file as before;
- write content;
- if write fails, attempt `f.Close()` and return a combined error if close also fails;
- if write succeeds, call `f.Close()` and return that error if any.

No new imports or dependencies are needed (`fmt` is already imported and can be used for combined error formatting).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._