### PR TITLE
fix(clients): honor framework elasticsearch_connection credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Adds optional `time_range`, `hide_title`, `hide_border`, `references_json`, and 
 
 ### Changes
 
+- Fix scoped Plugin Framework Elasticsearch clients built from an `elasticsearch_connection` block so `ELASTICSEARCH_*` environment variables no longer override Terraform credentials or merge across incompatible auth modes (basic, API key, bearer). ([#2882](https://github.com/elastic/terraform-provider-elasticstack/pull/2882))
 - Fix ILM policy delete failures when the policy is still referenced by indices (e.g. Fleet-managed data stream backing indices) ([#2714](https://github.com/elastic/terraform-provider-elasticstack/pull/2714))
 - Migrated `elasticstack_elasticsearch_data_stream` resource from Plugin SDK to Plugin Framework ([#2744](https://github.com/elastic/terraform-provider-elasticstack/pull/2744))
 - Add elasticstack_apm_source_map resource for managing APM source maps via Kibana API ([#2712](https://github.com/elastic/terraform-provider-elasticstack/pull/2712))

--- a/internal/clients/config/framework_elasticsearch_resource_connection.go
+++ b/internal/clients/config/framework_elasticsearch_resource_connection.go
@@ -30,8 +30,14 @@ import (
 // one [ElasticsearchConnection] element).
 //
 // Unlike [NewFromFramework], credentials from the connection block are not replaced by
-// ELASTICSEARCH_USERNAME / ELASTICSEARCH_PASSWORD / ELASTICSEARCH_API_KEY / ELASTICSEARCH_BEARER_TOKEN
-// when those environment variables are set and the corresponding field is non-empty in the block.
+// ELASTICSEARCH_USERNAME / ELASTICSEARCH_PASSWORD / ELASTICSEARCH_API_KEY / ELASTICSEARCH_BEARER_TOKEN /
+// ELASTICSEARCH_ES_CLIENT_AUTHENTICATION when those environment variables are set and the corresponding
+// field is non-empty in the block.
+//
+// When the block selects an auth mode (bearer token, API key, or username/password), environment
+// variables for other auth mechanisms are not applied, so the client does not silently pick a
+// different credential type than the one configured in Terraform.
+//
 // Empty fields still pick up environment defaults so optional credentials behave like the provider.
 func NewFromFrameworkElasticsearchResourceConnection(ctx context.Context, esConns []ElasticsearchConnection, version string) (Client, diag.Diagnostics) {
 	if len(esConns) == 0 {
@@ -51,10 +57,14 @@ func NewFromFrameworkElasticsearchResourceConnection(ctx context.Context, esConn
 	}
 
 	if esCfg != nil {
+		// newElasticsearchConfigFromFramework ends with withEnvironmentOverrides(), which can still
+		// overwrite bearer / ES-Client-Authentication from process env even when the connection block
+		// chose basic auth or API keys. Re-align typed auth with the connection block.
+		scopedRestoreElasticsearchAuthFromElasticsearchConnection(esCfg, esConns[0])
 		client.Elasticsearch = new(esCfg.toElasticsearchConfiguration())
 	}
 
-	return client, nil
+	return client, diags
 }
 
 func newBaseConfigForElasticsearchFrameworkConnection(config ProviderConfiguration, version string) baseConfig {
@@ -78,25 +88,90 @@ func newBaseConfigForElasticsearchFrameworkConnection(config ProviderConfigurati
 }
 
 func mergeElasticsearchCredentialEnvDefaultsWhenEmpty(b baseConfig) baseConfig {
-	if b.Username == "" {
-		if v, ok := os.LookupEnv("ELASTICSEARCH_USERNAME"); ok {
-			b.Username = v
+	usingBearer := b.BearerToken != ""
+	usingAPIKey := b.APIKey != ""
+	usingBasic := b.Username != "" || b.Password != ""
+
+	switch {
+	case usingBearer:
+		return b
+	case usingAPIKey:
+		if b.APIKey == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_API_KEY"); ok {
+				b.APIKey = v
+			}
 		}
-	}
-	if b.Password == "" {
-		if v, ok := os.LookupEnv("ELASTICSEARCH_PASSWORD"); ok {
-			b.Password = v
+		return b
+	case usingBasic:
+		if b.Username == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_USERNAME"); ok {
+				b.Username = v
+			}
 		}
-	}
-	if b.APIKey == "" {
-		if v, ok := os.LookupEnv("ELASTICSEARCH_API_KEY"); ok {
-			b.APIKey = v
+		if b.Password == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_PASSWORD"); ok {
+				b.Password = v
+			}
 		}
-	}
-	if b.BearerToken == "" {
-		if v, ok := os.LookupEnv("ELASTICSEARCH_BEARER_TOKEN"); ok {
-			b.BearerToken = v
+		return b
+	default:
+		if b.Username == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_USERNAME"); ok {
+				b.Username = v
+			}
 		}
+		if b.Password == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_PASSWORD"); ok {
+				b.Password = v
+			}
+		}
+		if b.APIKey == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_API_KEY"); ok {
+				b.APIKey = v
+			}
+		}
+		if b.BearerToken == "" {
+			if v, ok := os.LookupEnv("ELASTICSEARCH_BEARER_TOKEN"); ok {
+				b.BearerToken = v
+			}
+		}
+		return b
 	}
-	return b
+}
+
+func scopedRestoreElasticsearchAuthFromElasticsearchConnection(esCfg *elasticsearchConfig, es ElasticsearchConnection) {
+	blockBearer := es.BearerToken.ValueString()
+	blockAPIKey := es.APIKey.ValueString()
+	blockUser := es.Username.ValueString()
+	blockPass := es.Password.ValueString()
+
+	usingBearer := blockBearer != ""
+	usingAPIKey := blockAPIKey != ""
+	usingBasic := blockUser != "" || blockPass != ""
+
+	switch {
+	case usingBearer:
+		esCfg.bearerToken = blockBearer
+		if es.ESClientAuthentication.ValueString() != "" {
+			esCfg.esClientAuthentication = es.ESClientAuthentication.ValueString()
+		} else {
+			esCfg.esClientAuthentication = ""
+		}
+	case usingAPIKey:
+		esCfg.config.APIKey = blockAPIKey
+		esCfg.bearerToken = ""
+		esCfg.esClientAuthentication = ""
+	case usingBasic:
+		if blockUser != "" {
+			esCfg.config.Username = blockUser
+		}
+		if blockPass != "" {
+			esCfg.config.Password = blockPass
+		}
+		esCfg.bearerToken = ""
+		esCfg.esClientAuthentication = ""
+	default:
+		// No explicit auth in the connection block: leave bearer / ES-Client-Authentication as set by
+		// withEnvironmentOverrides (env-driven defaults).
+	}
 }

--- a/internal/clients/config/framework_elasticsearch_resource_connection.go
+++ b/internal/clients/config/framework_elasticsearch_resource_connection.go
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// NewFromFrameworkElasticsearchResourceConnection builds a minimal [Client] whose Elasticsearch
+// field is set from a Plugin Framework entity's decoded elasticsearch_connection block (exactly
+// one [ElasticsearchConnection] element).
+//
+// Unlike [NewFromFramework], credentials from the connection block are not replaced by
+// ELASTICSEARCH_USERNAME / ELASTICSEARCH_PASSWORD / ELASTICSEARCH_API_KEY / ELASTICSEARCH_BEARER_TOKEN
+// when those environment variables are set and the corresponding field is non-empty in the block.
+// Empty fields still pick up environment defaults so optional credentials behave like the provider.
+func NewFromFrameworkElasticsearchResourceConnection(ctx context.Context, esConns []ElasticsearchConnection, version string) (Client, diag.Diagnostics) {
+	if len(esConns) == 0 {
+		return Client{}, nil
+	}
+
+	cfg := ProviderConfiguration{Elasticsearch: esConns}
+	base := newBaseConfigForElasticsearchFrameworkConnection(cfg, version)
+
+	client := Client{
+		UserAgent: base.UserAgent,
+	}
+
+	esCfg, diags := newElasticsearchConfigFromFramework(ctx, cfg, base)
+	if diags.HasError() {
+		return Client{}, diags
+	}
+
+	if esCfg != nil {
+		client.Elasticsearch = new(esCfg.toElasticsearchConfiguration())
+	}
+
+	return client, nil
+}
+
+func newBaseConfigForElasticsearchFrameworkConnection(config ProviderConfiguration, version string) baseConfig {
+	userAgent := buildUserAgent(version)
+	out := baseConfig{
+		UserAgent: userAgent,
+		Header:    http.Header{"User-Agent": []string{userAgent}},
+	}
+
+	if len(config.Elasticsearch) == 0 {
+		return out
+	}
+
+	es := config.Elasticsearch[0]
+	out.Username = es.Username.ValueString()
+	out.Password = es.Password.ValueString()
+	out.APIKey = es.APIKey.ValueString()
+	out.BearerToken = es.BearerToken.ValueString()
+
+	return mergeElasticsearchCredentialEnvDefaultsWhenEmpty(out)
+}
+
+func mergeElasticsearchCredentialEnvDefaultsWhenEmpty(b baseConfig) baseConfig {
+	if b.Username == "" {
+		if v, ok := os.LookupEnv("ELASTICSEARCH_USERNAME"); ok {
+			b.Username = v
+		}
+	}
+	if b.Password == "" {
+		if v, ok := os.LookupEnv("ELASTICSEARCH_PASSWORD"); ok {
+			b.Password = v
+		}
+	}
+	if b.APIKey == "" {
+		if v, ok := os.LookupEnv("ELASTICSEARCH_API_KEY"); ok {
+			b.APIKey = v
+		}
+	}
+	if b.BearerToken == "" {
+		if v, ok := os.LookupEnv("ELASTICSEARCH_BEARER_TOKEN"); ok {
+			b.BearerToken = v
+		}
+	}
+	return b
+}

--- a/internal/clients/config/framework_elasticsearch_resource_connection_test.go
+++ b/internal/clients/config/framework_elasticsearch_resource_connection_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromFrameworkElasticsearchResourceConnection_preservesCredentialsWhenEnvSet(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_USERNAME", "env-user")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "env-pass")
+
+	esConns := []ElasticsearchConnection{
+		{
+			Username: types.StringValue("scoped-user"),
+			Password: types.StringValue("scoped-pass"),
+			Endpoints: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("https://127.0.0.1:9200"),
+			}),
+			Insecure: types.BoolValue(true),
+		},
+	}
+
+	client, diags := NewFromFrameworkElasticsearchResourceConnection(context.Background(), esConns, "unit-testing")
+	require.False(t, diags.HasError())
+	require.NotNil(t, client.Elasticsearch)
+	require.Equal(t, "scoped-user", client.Elasticsearch.Username)
+	require.Equal(t, "scoped-pass", client.Elasticsearch.Password)
+}
+
+func TestNewFromFrameworkElasticsearchResourceConnection_fillsMissingFromEnv(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_USERNAME", "from-env-user")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "from-env-pass")
+
+	esConns := []ElasticsearchConnection{
+		{
+			Username: types.StringNull(),
+			Password: types.StringNull(),
+			Endpoints: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("https://127.0.0.1:9200"),
+			}),
+			Insecure: types.BoolValue(true),
+		},
+	}
+
+	client, diags := NewFromFrameworkElasticsearchResourceConnection(context.Background(), esConns, "unit-testing")
+	require.False(t, diags.HasError())
+	require.NotNil(t, client.Elasticsearch)
+	require.Equal(t, "from-env-user", client.Elasticsearch.Username)
+	require.Equal(t, "from-env-pass", client.Elasticsearch.Password)
+}

--- a/internal/clients/config/framework_elasticsearch_resource_connection_test.go
+++ b/internal/clients/config/framework_elasticsearch_resource_connection_test.go
@@ -69,3 +69,72 @@ func TestNewFromFrameworkElasticsearchResourceConnection_fillsMissingFromEnv(t *
 	require.Equal(t, "from-env-user", client.Elasticsearch.Username)
 	require.Equal(t, "from-env-pass", client.Elasticsearch.Password)
 }
+
+func TestNewFromFrameworkElasticsearchResourceConnection_basicAuthDoesNotPickAPIKeyOrBearerFromEnv(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_USERNAME", "env-user")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "env-pass")
+	t.Setenv("ELASTICSEARCH_API_KEY", "env-api-key")
+	t.Setenv("ELASTICSEARCH_BEARER_TOKEN", "env-bearer")
+
+	esConns := []ElasticsearchConnection{
+		{
+			Username: types.StringValue("scoped-user"),
+			Password: types.StringValue("scoped-pass"),
+			Endpoints: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("https://127.0.0.1:9200"),
+			}),
+			Insecure: types.BoolValue(true),
+		},
+	}
+
+	client, diags := NewFromFrameworkElasticsearchResourceConnection(context.Background(), esConns, "unit-testing")
+	require.False(t, diags.HasError())
+	require.NotNil(t, client.Elasticsearch)
+	require.Equal(t, "scoped-user", client.Elasticsearch.Username)
+	require.Equal(t, "scoped-pass", client.Elasticsearch.Password)
+	require.Empty(t, client.Elasticsearch.APIKey)
+	authz := client.Elasticsearch.Header.Get("Authorization")
+	require.NotContains(t, authz, "env-bearer")
+}
+
+func TestNewFromFrameworkElasticsearchResourceConnection_apiKeyDoesNotPickUsernameFromEnv(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_USERNAME", "env-user")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "env-pass")
+
+	esConns := []ElasticsearchConnection{
+		{
+			APIKey: types.StringValue("scoped-api-key"),
+			Endpoints: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("https://127.0.0.1:9200"),
+			}),
+			Insecure: types.BoolValue(true),
+		},
+	}
+
+	client, diags := NewFromFrameworkElasticsearchResourceConnection(context.Background(), esConns, "unit-testing")
+	require.False(t, diags.HasError())
+	require.NotNil(t, client.Elasticsearch)
+	require.Equal(t, "scoped-api-key", client.Elasticsearch.APIKey)
+	require.Empty(t, client.Elasticsearch.Username)
+	require.Empty(t, client.Elasticsearch.Password)
+}
+
+func TestNewFromFrameworkElasticsearchResourceConnection_preservesBearerWhenBasicEnvSet(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_USERNAME", "env-user")
+	t.Setenv("ELASTICSEARCH_PASSWORD", "env-pass")
+
+	esConns := []ElasticsearchConnection{
+		{
+			BearerToken: types.StringValue("scoped-bearer"),
+			Endpoints: types.ListValueMust(types.StringType, []attr.Value{
+				types.StringValue("https://127.0.0.1:9200"),
+			}),
+			Insecure: types.BoolValue(true),
+		},
+	}
+
+	client, diags := NewFromFrameworkElasticsearchResourceConnection(context.Background(), esConns, "unit-testing")
+	require.False(t, diags.HasError())
+	require.NotNil(t, client.Elasticsearch)
+	require.Equal(t, "Bearer scoped-bearer", client.Elasticsearch.Header.Get("Authorization"))
+}

--- a/internal/clients/provider_client_factory.go
+++ b/internal/clients/provider_client_factory.go
@@ -169,7 +169,7 @@ func (f *ProviderClientFactory) GetElasticsearchClient(ctx context.Context, esCo
 		return nil, diags
 	}
 
-	cfg, diags := config.NewFromFramework(ctx, config.ProviderConfiguration{Elasticsearch: esConns}, f.defaultClient.version)
+	cfg, diags := config.NewFromFrameworkElasticsearchResourceConnection(ctx, esConns, f.defaultClient.version)
 	if diags.HasError() {
 		return nil, diags
 	}

--- a/internal/fleet/integration/acc_test.go
+++ b/internal/fleet/integration/acc_test.go
@@ -117,8 +117,11 @@ func TestAccResourceIntegration(t *testing.T) {
 				ResourceName:             "elasticstack_fleet_integration.test_integration",
 				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
 				ImportState:              true,
-				ImportStateVerify:        true,
-				ExpectError:              regexp.MustCompile("Resource Import Not Implemented"),
+				// Default ImportStatePersist=false runs import in a temp working dir while the harness
+				// replaces the main dir's config with provider stubs; post-test destroy then loses ES config.
+				ImportStatePersist: true,
+				ImportStateVerify:  true,
+				ExpectError:        regexp.MustCompile("Resource Import Not Implemented"),
 			},
 		},
 	})
@@ -200,9 +203,10 @@ func TestAccResourceIntegrationWithPolicy(t *testing.T) {
 				ConfigVariables: config.Variables{
 					"policy_name": config.StringVariable(policyName),
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
-				ExpectError:       regexp.MustCompile("Resource Import Not Implemented"),
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateVerify:  true,
+				ExpectError:        regexp.MustCompile("Resource Import Not Implemented"),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary
- Build Framework `elasticsearch_connection` scoped Elasticsearch clients without overwriting non-empty connection-block credentials with `ELASTICSEARCH_*` environment variables.
- Add focused unit tests covering env-vs-config precedence for scoped Framework connections.

## Why
Acceptance tests (and many real deployments) set `ELASTICSEARCH_USERNAME`/`ELASTICSEARCH_PASSWORD` in the process environment. Framework resources that configure `elasticsearch_connection` need those explicit credentials to be used as-is rather than being replaced by the provider process env.

## Test plan
- `go test ./internal/clients/config/... ./internal/clients/...`

## Changelog
Customer impact: fix
Summary: Scoped Framework `elasticsearch_connection` Elasticsearch clients honor Terraform credentials and auth mode and no longer pick up conflicting `ELASTICSEARCH_*` environment variables.

Made with [Cursor](https://cursor.com)
