### PR TITLE
fix(component_template): use MappingsType to normalize implicit type:object

### DIFF
--- a/internal/elasticsearch/index/componenttemplate/acc_test.go
+++ b/internal/elasticsearch/index/componenttemplate/acc_test.go
@@ -53,6 +53,25 @@ func TestAccResourceComponentTemplate(t *testing.T) {
 	})
 }
 
+func TestAccResourceComponentTemplateNestedObjectMappings(t *testing.T) {
+	templateName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceComponentTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				ConfigVariables:          config.Variables{"name": config.StringVariable(templateName)},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_component_template.test", "name", templateName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceComponentTemplateAliasDetails(t *testing.T) {
 	templateName := sdkacctest.RandStringFromCharSet(10, sdkacctest.CharSetAlphaNum)
 

--- a/internal/elasticsearch/index/componenttemplate/flatten.go
+++ b/internal/elasticsearch/index/componenttemplate/flatten.go
@@ -23,6 +23,7 @@ import (
 
 	estypes "github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients/elasticsearch"
+	esindex "github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/index"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils/customtypes"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils/typeutils"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -81,16 +82,16 @@ func flattenTemplateBlock(ctx context.Context, tpl *estypes.ClusterComponentTemp
 	t := tpl.ComponentTemplate.Template
 
 	// Mappings
-	var mappings jsontypes.Normalized
+	var mappings esindex.MappingsValue
 	if t.Mappings != nil {
 		b, err := json.Marshal(t.Mappings)
 		if err != nil {
 			diags.AddError("Failed to marshal template.mappings", err.Error())
 			return types.ObjectNull(templateAttrTypes()), diags
 		}
-		mappings = jsontypes.NewNormalizedValue(string(b))
+		mappings = esindex.NewMappingsValue(string(b))
 	} else {
-		mappings = jsontypes.NewNormalizedNull()
+		mappings = esindex.NewMappingsNull()
 	}
 
 	// Settings

--- a/internal/elasticsearch/index/componenttemplate/models.go
+++ b/internal/elasticsearch/index/componenttemplate/models.go
@@ -18,6 +18,7 @@
 package componenttemplate
 
 import (
+	esindex "github.com/elastic/terraform-provider-elasticstack/internal/elasticsearch/index"
 	"github.com/elastic/terraform-provider-elasticstack/internal/utils/customtypes"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -40,7 +41,7 @@ func (d Data) GetElasticsearchConnection() types.List { return d.ElasticsearchCo
 // TemplateModel is the inner shape of the template block.
 type TemplateModel struct {
 	Alias    types.Set                      `tfsdk:"alias"`
-	Mappings jsontypes.Normalized           `tfsdk:"mappings"`
+	Mappings esindex.MappingsValue           `tfsdk:"mappings"`
 	Settings customtypes.IndexSettingsValue `tfsdk:"settings"`
 }
 

--- a/internal/elasticsearch/index/componenttemplate/models.go
+++ b/internal/elasticsearch/index/componenttemplate/models.go
@@ -41,7 +41,7 @@ func (d Data) GetElasticsearchConnection() types.List { return d.ElasticsearchCo
 // TemplateModel is the inner shape of the template block.
 type TemplateModel struct {
 	Alias    types.Set                      `tfsdk:"alias"`
-	Mappings esindex.MappingsValue           `tfsdk:"mappings"`
+	Mappings esindex.MappingsValue          `tfsdk:"mappings"`
 	Settings customtypes.IndexSettingsValue `tfsdk:"settings"`
 }
 

--- a/internal/elasticsearch/index/componenttemplate/schema.go
+++ b/internal/elasticsearch/index/componenttemplate/schema.go
@@ -50,7 +50,7 @@ func aliasAttrTypes() map[string]attr.Type {
 func templateAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"alias":    types.SetType{ElemType: types.ObjectType{AttrTypes: aliasAttrTypes()}},
-		"mappings": jsontypes.NormalizedType{},
+		"mappings": esindex.MappingsType{},
 		"settings": customtypes.IndexSettingsType{},
 	}
 }
@@ -100,7 +100,7 @@ func getSchema(_ context.Context) schema.Schema {
 							"See the [explicit mapping documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/explicit-mapping.html) " +
 							"for more details.",
 						Optional:   true,
-						CustomType: jsontypes.NormalizedType{},
+						CustomType: esindex.MappingsType{},
 						Validators: []validator.String{
 							esindex.StringIsJSONObject{},
 						},

--- a/internal/elasticsearch/index/componenttemplate/testdata/TestAccResourceComponentTemplateNestedObjectMappings/create/main.tf
+++ b/internal/elasticsearch/index/componenttemplate/testdata/TestAccResourceComponentTemplateNestedObjectMappings/create/main.tf
@@ -1,0 +1,23 @@
+variable "name" {
+  type = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_component_template" "test" {
+  name = var.name
+
+  template {
+    mappings = jsonencode({
+      properties = {
+        event = {
+          properties = {
+            size = { type = "long" }
+          }
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Changelog
Customer impact: fix
Summary: Fix "Provider produced inconsistent result after apply" for component templates with nested object mappings.

## Detailed changes

The component template resource used `jsontypes.NormalizedType` for its mappings field. This type does not strip the implicit `"type":"object"` that Elasticsearch injects on read for properties with sub-properties. On first apply, the planned value lacks `"type":"object"` but the state returned after creation includes it, causing Terraform to reject the result.

The `index` and `index_template` resources already use `MappingsType`/`MappingsValue`, which normalizes this on both construction and semantic equality comparison. The component template was not wired up to use this type when it was migrated to Plugin Framework.

This PR switches the component template's mappings field to use `esindex.MappingsType{}` in the schema and `templateAttrTypes()`, `esindex.MappingsValue` in the model, and `esindex.NewMappingsValue()`/`esindex.NewMappingsNull()` in the flatten logic.

Closes #2967