### PR TITLE
fix(ingest_pipeline): add semantic equality for processor JSON array normalization

### DIFF
--- a/internal/elasticsearch/ingest/pipeline_pf.go
+++ b/internal/elasticsearch/ingest/pipeline_pf.go
@@ -83,13 +83,13 @@ func GetSchema(_ context.Context) schema.Schema {
 			"processors": schema.ListAttribute{
 				MarkdownDescription: ingestPipelineProcessorsDescription,
 				Required:            true,
-				ElementType:         jsontypes.NormalizedType{},
+				ElementType:         ProcessorJSONType{},
 				Validators:          []validator.List{listvalidator.SizeAtLeast(1)},
 			},
 			"on_failure": schema.ListAttribute{
 				MarkdownDescription: ingestPipelineOnFailureDescription,
 				Optional:            true,
-				ElementType:         jsontypes.NormalizedType{},
+				ElementType:         ProcessorJSONType{},
 				Validators:          []validator.List{listvalidator.SizeAtLeast(1)},
 			},
 			"metadata": schema.StringAttribute{
@@ -256,19 +256,19 @@ func buildPipelineBody(ctx context.Context, data Data) (map[string]any, diag.Dia
 // list so Terraform does not record an empty Optional list as set.
 func jsonListFromSlice[T any](ctx context.Context, items []T, label string) (types.List, diag.Diagnostics) {
 	if len(items) == 0 {
-		return types.ListNull(jsontypes.NormalizedType{}), nil
+		return types.ListNull(ProcessorJSONType{}), nil
 	}
-	values := make([]jsontypes.Normalized, len(items))
+	values := make([]ProcessorJSONValue, len(items))
 	for i, v := range items {
 		b, err := json.Marshal(v)
 		if err != nil {
 			var diags diag.Diagnostics
 			diags.AddError(fmt.Sprintf("Failed to serialize %s", label), err.Error())
-			return types.ListNull(jsontypes.NormalizedType{}), diags
+			return types.ListNull(ProcessorJSONType{}), diags
 		}
-		values[i] = jsontypes.NewNormalizedValue(string(b))
+		values[i] = NewProcessorJSONValue(string(b))
 	}
-	return types.ListValueFrom(ctx, jsontypes.NormalizedType{}, values)
+	return types.ListValueFrom(ctx, ProcessorJSONType{}, values)
 }
 
 // decodeJSONList unmarshals each Normalized element of list into a JSON object.
@@ -278,7 +278,7 @@ func decodeJSONList(ctx context.Context, list types.List, label string) ([]map[s
 	if !typeutils.IsKnown(list) {
 		return nil, diags
 	}
-	var values []jsontypes.Normalized
+	var values []ProcessorJSONValue
 	diags.Append(list.ElementsAs(ctx, &values, false)...)
 	if diags.HasError() {
 		return nil, diags

--- a/internal/elasticsearch/ingest/processor_json_value.go
+++ b/internal/elasticsearch/ingest/processor_json_value.go
@@ -1,0 +1,179 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable                    = ProcessorJSONType{}
+	_ basetypes.StringValuable                   = (*ProcessorJSONValue)(nil)
+	_ basetypes.StringValuableWithSemanticEquals = (*ProcessorJSONValue)(nil)
+)
+
+// ProcessorJSONType is a custom string type for ingest processor JSON.
+type ProcessorJSONType struct {
+	jsontypes.NormalizedType
+}
+
+func (t ProcessorJSONType) String() string {
+	return "ingest.ProcessorJSONType"
+}
+
+func (t ProcessorJSONType) ValueType(_ context.Context) attr.Value {
+	return ProcessorJSONValue{}
+}
+
+func (t ProcessorJSONType) Equal(o attr.Type) bool {
+	other, ok := o.(ProcessorJSONType)
+	if !ok {
+		return false
+	}
+	return t.NormalizedType.Equal(other.NormalizedType)
+}
+
+func (t ProcessorJSONType) ValueFromString(_ context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	if in.IsNull() {
+		return NewProcessorJSONNull(), nil
+	}
+	if in.IsUnknown() {
+		return NewProcessorJSONUnknown(), nil
+	}
+	return NewProcessorJSONValue(in.ValueString()), nil
+}
+
+func (t ProcessorJSONType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.NormalizedType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	normalized, ok := attrValue.(jsontypes.Normalized)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	return ProcessorJSONValue{
+		Normalized: normalized,
+	}, nil
+}
+
+// ProcessorJSONValue is a custom string value for ingest processor JSON.
+//
+// The typed go-elasticsearch client represents fields like remove.field and
+// append.value as slices ([]string, []json.RawMessage). When users write a
+// single string value the client round-trips it as a single-element array,
+// causing "Provider produced inconsistent result after apply". The semantic
+// equality implementation normalizes single-element primitive arrays to scalars
+// before comparison so both forms are treated as equivalent.
+type ProcessorJSONValue struct {
+	jsontypes.Normalized
+}
+
+func (v ProcessorJSONValue) Type(_ context.Context) attr.Type {
+	return ProcessorJSONType{}
+}
+
+func (v ProcessorJSONValue) Equal(o attr.Value) bool {
+	other, ok := o.(ProcessorJSONValue)
+	if !ok {
+		return false
+	}
+	return v.Normalized.Equal(other.Normalized)
+}
+
+// StringSemanticEquals returns true when two processor JSON values are
+// equivalent after normalizing single-element arrays to scalars.
+func (v ProcessorJSONValue) StringSemanticEquals(ctx context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(ProcessorJSONValue)
+	if !ok {
+		return v.Normalized.StringSemanticEquals(ctx, newValuable)
+	}
+
+	if v.IsNull() || v.IsUnknown() || newValue.IsNull() || newValue.IsUnknown() {
+		return v.Normalized.Equal(newValue.Normalized), diags
+	}
+
+	var vMap, newMap any
+	if err := json.Unmarshal([]byte(v.ValueString()), &vMap); err != nil {
+		diags.AddError("Semantic Equality Check Error", err.Error())
+		return false, diags
+	}
+	if err := json.Unmarshal([]byte(newValue.ValueString()), &newMap); err != nil {
+		diags.AddError("Semantic Equality Check Error", err.Error())
+		return false, diags
+	}
+
+	return reflect.DeepEqual(
+		normalizeProcessorJSON(vMap),
+		normalizeProcessorJSON(newMap),
+	), diags
+}
+
+// normalizeProcessorJSON recursively collapses single-element arrays containing
+// a primitive value (string, number, bool) into the scalar value itself. This
+// compensates for the typed go-elasticsearch client converting fields like
+// remove.field from a string to a []string on deserialization.
+func normalizeProcessorJSON(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, vv := range val {
+			out[k] = normalizeProcessorJSON(vv)
+		}
+		return out
+	case []any:
+		if len(val) == 1 {
+			switch val[0].(type) {
+			case string, float64, bool:
+				return val[0]
+			}
+		}
+		out := make([]any, len(val))
+		for i, vv := range val {
+			out[i] = normalizeProcessorJSON(vv)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func NewProcessorJSONNull() ProcessorJSONValue {
+	return ProcessorJSONValue{Normalized: jsontypes.NewNormalizedNull()}
+}
+
+func NewProcessorJSONUnknown() ProcessorJSONValue {
+	return ProcessorJSONValue{Normalized: jsontypes.NewNormalizedUnknown()}
+}
+
+func NewProcessorJSONValue(value string) ProcessorJSONValue {
+	return ProcessorJSONValue{Normalized: jsontypes.NewNormalizedValue(value)}
+}

--- a/internal/elasticsearch/ingest/processor_json_value_test.go
+++ b/internal/elasticsearch/ingest/processor_json_value_test.go
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeProcessorJSON_CollapseSingleElementArrays(t *testing.T) {
+	input := map[string]any{
+		"remove": map[string]any{
+			"field":          []any{"kubernetes.audit.responseObject.status"},
+			"ignore_missing": true,
+		},
+	}
+	want := map[string]any{
+		"remove": map[string]any{
+			"field":          "kubernetes.audit.responseObject.status",
+			"ignore_missing": true,
+		},
+	}
+
+	got := normalizeProcessorJSON(input)
+	assert.Equal(t, want, got)
+}
+
+func TestNormalizeProcessorJSON_PreservesMultiElementArrays(t *testing.T) {
+	input := map[string]any{
+		"remove": map[string]any{
+			"field": []any{"field_a", "field_b"},
+		},
+	}
+
+	got := normalizeProcessorJSON(input)
+	assert.Equal(t, input, got)
+}
+
+func TestNormalizeProcessorJSON_AppendValueCollapse(t *testing.T) {
+	input := map[string]any{
+		"append": map[string]any{
+			"allow_duplicates": false,
+			"field":            "tags",
+			"value":            []any{"preserve_original_event"},
+		},
+	}
+	want := map[string]any{
+		"append": map[string]any{
+			"allow_duplicates": false,
+			"field":            "tags",
+			"value":            "preserve_original_event",
+		},
+	}
+
+	got := normalizeProcessorJSON(input)
+	assert.Equal(t, want, got)
+}
+
+func TestNormalizeProcessorJSON_PreservesNestedOnFailureProcessors(t *testing.T) {
+	input := map[string]any{
+		"remove": map[string]any{
+			"field":          []any{"my_field"},
+			"ignore_missing": true,
+			"on_failure": []any{
+				map[string]any{
+					"set": map[string]any{
+						"field": "error.message",
+						"value": []any{"failed to remove field"},
+					},
+				},
+			},
+		},
+	}
+	want := map[string]any{
+		"remove": map[string]any{
+			"field":          "my_field",
+			"ignore_missing": true,
+			"on_failure": []any{
+				map[string]any{
+					"set": map[string]any{
+						"field": "error.message",
+						"value": "failed to remove field",
+					},
+				},
+			},
+		},
+	}
+
+	got := normalizeProcessorJSON(input)
+	assert.Equal(t, want, got, "on_failure array with one object element should be preserved, but scalar fields inside should collapse")
+}
+
+func TestProcessorJSONValue_SemanticEquality(t *testing.T) {
+	ctx := context.Background()
+
+	configJSON := `{"remove":{"field":"_audit_temp","ignore_missing":true}}`
+	apiJSON := `{"remove":{"field":["_audit_temp"],"ignore_missing":true}}`
+
+	configVal := NewProcessorJSONValue(configJSON)
+	apiVal := NewProcessorJSONValue(apiJSON)
+
+	eq, diags := configVal.StringSemanticEquals(ctx, apiVal)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	assert.True(t, eq, "config and API processor JSON should be semantically equal")
+}
+
+func TestProcessorJSONValue_SemanticEquality_MultiElementDiffers(t *testing.T) {
+	ctx := context.Background()
+
+	a := NewProcessorJSONValue(`{"remove":{"field":"x"}}`)
+	b := NewProcessorJSONValue(`{"remove":{"field":["x","y"]}}`)
+
+	eq, diags := a.StringSemanticEquals(ctx, b)
+	require.False(t, diags.HasError())
+	assert.False(t, eq, "single string should not equal multi-element array")
+}


### PR DESCRIPTION
## Changelog
Customer impact: fix
Summary: Fix "Provider produced inconsistent result after apply" for ingest pipelines when processors use single-string fields that the typed client returns as arrays.

## Detailed changes

The typed go-elasticsearch client deserializes fields like `remove.field` as `[]string` and `append.value` as `[]json.RawMessage`, even when the user wrote a single string. When the provider marshals these back to JSON on read, `"field": "x"` becomes `"field": ["x"]`, causing Terraform to reject the result as inconsistent with the plan.

This PR introduces `ProcessorJSONType`/`ProcessorJSONValue`, a custom string type with `StringSemanticEquals` that normalizes single-element primitive arrays to scalars before comparison. This treats both forms as equivalent without altering what gets sent to Elasticsearch. The approach follows the same pattern as `MappingsType`/`MappingsValue` used by the index and component template resources.

The custom type is used as the `ElementType` for both the `processors` and `on_failure` list attributes.

Closes #2978