### PR TITLE
fix(security_detection_rule): add rule_default and endpoint_trusted_devices to exceptions_list type validator

### DIFF
--- a/docs/resources/kibana_security_detection_rule.md
+++ b/docs/resources/kibana_security_detection_rule.md
@@ -285,7 +285,7 @@ Required:
 - `id` (String) The exception container ID.
 - `list_id` (String) The exception container's list ID.
 - `namespace_type` (String) The namespace type for the exception container.
-- `type` (String) The type of exception container.
+- `type` (String) The type of exception container. Valid values are `detection`, `endpoint`, `endpoint_events`, `endpoint_host_isolation_exceptions`, `endpoint_blocklists`, `endpoint_trusted_apps`, `endpoint_trusted_devices`, and `rule_default`.
 
 
 <a id="nestedblock--kibana_connection"></a>

--- a/internal/kibana/security_detection_rule/schema.go
+++ b/internal/kibana/security_detection_rule/schema.go
@@ -567,10 +567,21 @@ func GetSchema() schema.Schema {
 							},
 						},
 						"type": schema.StringAttribute{
-							MarkdownDescription: "The type of exception container.",
-							Required:            true,
+							MarkdownDescription: "The type of exception container. Valid values are `detection`, `endpoint`, " +
+								"`endpoint_events`, `endpoint_host_isolation_exceptions`, `endpoint_blocklists`, " +
+								"`endpoint_trusted_apps`, `endpoint_trusted_devices`, and `rule_default`.",
+							Required: true,
 							Validators: []validator.String{
-								stringvalidator.OneOf("detection", "endpoint", "endpoint_events", "endpoint_host_isolation_exceptions", "endpoint_blocklists", "endpoint_trusted_apps"),
+								stringvalidator.OneOf(
+									"detection",
+									"endpoint",
+									"endpoint_events",
+									"endpoint_host_isolation_exceptions",
+									"endpoint_blocklists",
+									"endpoint_trusted_apps",
+									"endpoint_trusted_devices",
+									"rule_default",
+								),
 							},
 						},
 					},


### PR DESCRIPTION
## Summary

- Add `rule_default` to the `exceptions_list[].type` validator
- Add `endpoint_trusted_devices` to the `exceptions_list[].type` validator
- Update the `MarkdownDescription` to list all valid values

## Problem

The `OneOf` validator on `exceptions_list[].type` in `schema.go` was missing two values that are valid in the Kibana API and already defined as enum constants in the generated `kbapi` client (`SecurityDetectionsAPIExceptionListTypeRuleDefault` and `SecurityDetectionsAPIExceptionListTypeEndpointTrustedDevices`).

This caused `terraform plan` to fail with an `Invalid Attribute Value Match` error for any rule that uses a `rule_default` exception list — the most common type for user-defined rule-local exceptions created via the Kibana UI.

```
│ Error: Invalid Attribute Value Match
│
│   with elasticstack_kibana_security_detection_rule.example
│
│ Attribute exceptions_list[0].type value must be one of: ["detection"
│ "endpoint" "endpoint_events" "endpoint_host_isolation_exceptions"
│ "endpoint_blocklists" "endpoint_trusted_apps"], got: "rule_default"
```

## Solution

Added both missing values to `stringvalidator.OneOf(...)` in `internal/kibana/security_detection_rule/schema.go`. The API conversion path in `models_to_api_type_utils.go` performs a direct cast with no additional type mapping, so no further changes are needed.

Fixes #2995

## Changelog
Customer impact: fix
Summary: `exceptions_list[].type` on `elasticstack_kibana_security_detection_rule` now accepts `rule_default` and `endpoint_trusted_devices`, fixing plan-time failures for rules with user-defined rule-local exception lists.