### PR TITLE
proposal: split provider CI lint job using golangci/golangci-lint-action

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,4 @@
-version: v2.11.4
+version: v2.12.2
 name: golangci-lint-custom
 destination: ./bin
 plugins:

--- a/.github/scripts/workflows/lib/gate-provider.js
+++ b/.github/scripts/workflows/lib/gate-provider.js
@@ -1,10 +1,10 @@
 /**
  * Evaluate whether the provider workflow gate passed or failed.
  *
- * @param {{ classifyResult: string, buildResult: string, lintResult: string, testResult: string }} params
+ * @param {{ classifyResult: string, buildResult: string, lintResult: string, golangciLintResult: string, testResult: string }} params
  * @returns {{ passed: boolean, reason: string }}
  */
-function gateProvider({ classifyResult, buildResult, lintResult, testResult }) {
+function gateProvider({ classifyResult, buildResult, lintResult, golangciLintResult, testResult }) {
   if (classifyResult !== 'true' && classifyResult !== 'false') {
     return {
       passed: false,
@@ -12,7 +12,7 @@ function gateProvider({ classifyResult, buildResult, lintResult, testResult }) {
     };
   }
 
-  const jobResults = [buildResult, lintResult, testResult];
+  const jobResults = [buildResult, lintResult, golangciLintResult, testResult];
   const validResults = ['success', 'skipped', 'failure', 'cancelled'];
 
   for (const result of jobResults) {
@@ -45,7 +45,7 @@ function gateProvider({ classifyResult, buildResult, lintResult, testResult }) {
   if (anyFailureOrCancelled) {
     return {
       passed: false,
-      reason: `One or more jobs failed or were cancelled (build=${buildResult}, lint=${lintResult}, test=${testResult}). Gate failed.`,
+      reason: `One or more jobs failed or were cancelled (build=${buildResult}, lint=${lintResult}, golangci-lint=${golangciLintResult}, test=${testResult}). Gate failed.`,
     };
   }
 
@@ -53,14 +53,14 @@ function gateProvider({ classifyResult, buildResult, lintResult, testResult }) {
   if (classifyResult === 'true' && anySkipped) {
     return {
       passed: false,
-      reason: `Unexpected skip: provider changes detected but one or more jobs were skipped (build=${buildResult}, lint=${lintResult}, test=${testResult}). Gate failed.`,
+      reason: `Unexpected skip: provider changes detected but one or more jobs were skipped (build=${buildResult}, lint=${lintResult}, golangci-lint=${golangciLintResult}, test=${testResult}). Gate failed.`,
     };
   }
 
   // Fallback for any other unexpected combination
   return {
     passed: false,
-    reason: `Unexpected job result combination (build=${buildResult}, lint=${lintResult}, test=${testResult}). Gate failed.`,
+    reason: `Unexpected job result combination (build=${buildResult}, lint=${lintResult}, golangci-lint=${golangciLintResult}, test=${testResult}). Gate failed.`,
   };
 }
 

--- a/.github/scripts/workflows/lib/gate-provider.test.mjs
+++ b/.github/scripts/workflows/lib/gate-provider.test.mjs
@@ -15,6 +15,7 @@ test('all-pass (classify=true, all success) → passed', () => {
     classifyResult: 'true',
     buildResult: 'success',
     lintResult: 'success',
+    golangciLintResult: 'success',
     testResult: 'success',
   });
   assert.equal(result.passed, true);
@@ -26,6 +27,7 @@ test('all-skipped-legitimately (classify=false, all skipped) → passed', () => 
     classifyResult: 'false',
     buildResult: 'skipped',
     lintResult: 'skipped',
+    golangciLintResult: 'skipped',
     testResult: 'skipped',
   });
   assert.equal(result.passed, true);
@@ -37,6 +39,7 @@ test('unexpected-skip (classify=true, build=skipped, others=success) → failed'
     classifyResult: 'true',
     buildResult: 'skipped',
     lintResult: 'success',
+    golangciLintResult: 'success',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
@@ -48,6 +51,7 @@ test('any-failure (classify=true, build=failure) → failed', () => {
     classifyResult: 'true',
     buildResult: 'failure',
     lintResult: 'success',
+    golangciLintResult: 'success',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
@@ -59,6 +63,7 @@ test('cancelled (classify=true, test=cancelled) → failed', () => {
     classifyResult: 'true',
     buildResult: 'success',
     lintResult: 'success',
+    golangciLintResult: 'success',
     testResult: 'cancelled',
   });
   assert.equal(result.passed, false);
@@ -72,6 +77,7 @@ test('invalid classifyResult → failed', () => {
     classifyResult: 'maybe',
     buildResult: 'success',
     lintResult: 'success',
+    golangciLintResult: 'success',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
@@ -83,6 +89,7 @@ test('invalid job result → failed', () => {
     classifyResult: 'true',
     buildResult: 'success',
     lintResult: 'unknown',
+    golangciLintResult: 'success',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
@@ -94,6 +101,7 @@ test('classify=false but not all skipped → failed', () => {
     classifyResult: 'false',
     buildResult: 'skipped',
     lintResult: 'skipped',
+    golangciLintResult: 'skipped',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
@@ -104,6 +112,19 @@ test('lint failure → failed', () => {
     classifyResult: 'true',
     buildResult: 'success',
     lintResult: 'failure',
+    golangciLintResult: 'success',
+    testResult: 'success',
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.reason, /failed or were cancelled/);
+});
+
+test('golangci-lint failure → failed', () => {
+  const result = gateProvider({
+    classifyResult: 'true',
+    buildResult: 'success',
+    lintResult: 'success',
+    golangciLintResult: 'failure',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
@@ -115,6 +136,7 @@ test('all cancelled → failed', () => {
     classifyResult: 'true',
     buildResult: 'cancelled',
     lintResult: 'cancelled',
+    golangciLintResult: 'cancelled',
     testResult: 'cancelled',
   });
   assert.equal(result.passed, false);
@@ -126,9 +148,22 @@ test('failure takes priority over unexpected skip', () => {
     classifyResult: 'true',
     buildResult: 'failure',
     lintResult: 'skipped',
+    golangciLintResult: 'success',
     testResult: 'success',
   });
   assert.equal(result.passed, false);
   assert.match(result.reason, /failed or were cancelled/);
   assert.doesNotMatch(result.reason, /Unexpected skip/);
+});
+
+test('golangci-lint unexpectedly skipped → failed', () => {
+  const result = gateProvider({
+    classifyResult: 'true',
+    buildResult: 'success',
+    lintResult: 'success',
+    golangciLintResult: 'skipped',
+    testResult: 'success',
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.reason, /Unexpected skip/);
 });

--- a/.github/scripts/workflows/lib/runners/gate.js
+++ b/.github/scripts/workflows/lib/runners/gate.js
@@ -6,11 +6,12 @@ const { gateWorkflows } = require('../gate-workflows.js');
 const GATES = {
   provider: {
     envPrefix: 'PROVIDER_GATE_',
-    fields: ['CLASSIFY_RESULT', 'BUILD_RESULT', 'LINT_RESULT', 'TEST_RESULT'],
+    fields: ['CLASSIFY_RESULT', 'BUILD_RESULT', 'LINT_RESULT', 'GOLANGCI_LINT_RESULT', 'TEST_RESULT'],
     evaluate: (env) => gateProvider({
       classifyResult: env.CLASSIFY_RESULT,
       buildResult: env.BUILD_RESULT,
       lintResult: env.LINT_RESULT,
+      golangciLintResult: env.GOLANGCI_LINT_RESULT,
       testResult: env.TEST_RESULT,
     }),
   },

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -77,7 +77,28 @@ jobs:
           terraform_wrapper: false
 
       - name: Lint
-        run: make check-lint
+        run: make check-openspec check-fmt gen check-docs
+
+  golangci-lint:
+    name: Go Lint (golangci-lint)
+    needs: classify
+    if: needs.classify.outputs.provider_changes == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.12.2
 
   test:
     name: Matrix Acceptance Test
@@ -315,7 +336,7 @@ jobs:
 
   gate:
     name: Provider Gate
-    needs: [classify, build, lint, test]
+    needs: [classify, build, lint, golangci-lint, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -329,6 +350,7 @@ jobs:
           PROVIDER_GATE_CLASSIFY_RESULT: ${{ needs.classify.outputs.provider_changes }}
           PROVIDER_GATE_BUILD_RESULT: ${{ needs.build.result }}
           PROVIDER_GATE_LINT_RESULT: ${{ needs.lint.result }}
+          PROVIDER_GATE_GOLANGCI_LINT_RESULT: ${{ needs.golangci-lint.result }}
           PROVIDER_GATE_TEST_RESULT: ${{ needs.test.result }}
         with:
           script: |

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -77,7 +77,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Lint
-        run: make check-openspec check-fmt gen check-docs
+        run: make setup check-openspec check-fmt gen check-docs
 
   golangci-lint:
     name: Go Lint (golangci-lint)

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,6 +35,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - goconst
+          - govet
   settings:
     lll:
       line-length: 200

--- a/openspec/changes/golangci-lint-action/.openspec.yaml
+++ b/openspec/changes/golangci-lint-action/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/golangci-lint-action/README.md
+++ b/openspec/changes/golangci-lint-action/README.md
@@ -1,0 +1,3 @@
+# golangci-lint-action
+
+Split the provider CI lint job: run golangci-lint via golangci/golangci-lint-action in a dedicated parallel job, and run remaining lint checks (openspec, fmt, gen, docs) in a separate job

--- a/openspec/changes/golangci-lint-action/proposal.md
+++ b/openspec/changes/golangci-lint-action/proposal.md
@@ -28,7 +28,7 @@ None — this is a CI infrastructure change only.
 
 ### Modified Capabilities
 
-None — no spec-level behaviour changes.
+- `workflow-script-modules` — to require the provider gate to evaluate `golangci-lint` as a distinct job result alongside the existing lint, build, and test jobs.
 
 ## Impact
 

--- a/openspec/changes/golangci-lint-action/proposal.md
+++ b/openspec/changes/golangci-lint-action/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The provider CI `lint` job currently runs all lint checks sequentially in a single job: OpenSpec validation, golangci-lint (with a custom binary), format checking, code generation, and docs generation. This is slow and means a fast check like `check-fmt` has to wait for golangci-lint to finish before it runs.
+
+`golangci/golangci-lint-action` is the official GitHub Action for golangci-lint. It provides better caching of the linter binary and lint cache between runs, and adds inline PR annotations. It natively supports the module plugin system — it detects `.custom-gcl.yml`, builds the custom binary via `golangci-lint custom`, and runs that binary automatically.
+
+Splitting golangci-lint into its own job lets it run in parallel with the remaining lint checks, reducing overall CI wall-clock time.
+
+## What Changes
+
+- **New `golangci-lint` job** in `.github/workflows/provider.yml`: a dedicated job that runs `golangci/golangci-lint-action` with the pinned version (`v2.12.2`), `pull-requests: read` permission for inline annotations, and `needs: classify` (same gate as the existing `lint` job).
+
+- **Modified `lint` job**: removes the `golangci-lint` Make target call and calls the remaining targets directly (`make check-openspec check-fmt gen check-docs`). The Node, Go, and Terraform setup steps are unchanged.
+
+- **`make check-lint` target removed** from the CI workflow invocation — the targets are called directly. The Makefile target itself is not changed (it remains as a local dev convenience).
+
+- **`gate` job updated**: adds `golangci-lint` to its `needs` list alongside `build`, `lint`, and `test`.
+
+- **`gate-provider.js` updated**: adds `golangciLintResult` as a required input alongside `lintResult`. Both must pass (or both must be skipped) for the gate to pass.
+
+- **`.custom-gcl.yml` updated**: bumps `version` from `v2.11.4` to `v2.12.2` to align with the action's `version` input and the Makefile's installed binary version.
+
+## Capabilities
+
+### New Capabilities
+
+None — this is a CI infrastructure change only.
+
+### Modified Capabilities
+
+None — no spec-level behaviour changes.
+
+## Impact
+
+- `.github/workflows/provider.yml`: `golangci-lint` job added; `lint` job steps changed; `gate` job `needs` and env updated.
+- `.github/scripts/workflows/lib/gate-provider.js`: signature and logic extended to accept and validate `golangciLintResult`.
+- `.github/scripts/workflows/lib/runners/gate.js`: `fields` array for the `provider` gate updated to include `GOLANGCI_LINT_RESULT`.
+- `.custom-gcl.yml`: version bump to `v2.12.2`.

--- a/openspec/changes/golangci-lint-action/specs/workflow-script-modules/spec.md
+++ b/openspec/changes/golangci-lint-action/specs/workflow-script-modules/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Provider gate evaluates golangci-lint as a distinct job result
+
+The `gateProvider` function in `lib/gate-provider.js` SHALL accept a `golangciLintResult` parameter alongside the existing `lintResult` parameter. Both results SHALL be included in the set of job results that the gate validates and evaluates. The gate SHALL fail if either `lintResult` or `golangciLintResult` is `failure` or `cancelled`. The gate SHALL pass when both are `success`. The gate SHALL treat both as legitimately skipped (returning `passed: true`) when `classifyResult` is `false` and all job results — including both lint results — are `skipped`.
+
+The `fields` array for the `provider` gate in `lib/runners/gate.js` SHALL include `GOLANGCI_LINT_RESULT` alongside `LINT_RESULT`.
+
+The `gate` job in `provider.yml` SHALL pass `PROVIDER_GATE_GOLANGCI_LINT_RESULT` as an environment variable sourced from the `golangci-lint` job result.
+
+#### Scenario: Both lint jobs succeed
+
+- **GIVEN** `golangciLintResult=success` and `lintResult=success`
+- **AND** `classifyResult=true`, `buildResult=success`, `testResult=success`
+- **WHEN** `gateProvider` is called
+- **THEN** it SHALL return `passed: true`
+
+#### Scenario: golangci-lint job fails
+
+- **GIVEN** `golangciLintResult=failure` and `lintResult=success`
+- **AND** all other results are `success`
+- **WHEN** `gateProvider` is called
+- **THEN** it SHALL return `passed: false`
+
+#### Scenario: Other lint job fails
+
+- **GIVEN** `golangciLintResult=success` and `lintResult=failure`
+- **AND** all other results are `success`
+- **WHEN** `gateProvider` is called
+- **THEN** it SHALL return `passed: false`
+
+#### Scenario: Non-provider change — all jobs skipped
+
+- **GIVEN** `classifyResult=false`
+- **AND** `buildResult=skipped`, `golangciLintResult=skipped`, `lintResult=skipped`, `testResult=skipped`
+- **WHEN** `gateProvider` is called
+- **THEN** it SHALL return `passed: true`
+
+#### Scenario: Provider change but golangci-lint unexpectedly skipped
+
+- **GIVEN** `classifyResult=true`
+- **AND** `golangciLintResult=skipped`
+- **AND** `lintResult=success`, `buildResult=success`, `testResult=success`
+- **WHEN** `gateProvider` is called
+- **THEN** it SHALL return `passed: false`

--- a/openspec/changes/golangci-lint-action/specs/workflow-script-modules/spec.md
+++ b/openspec/changes/golangci-lint-action/specs/workflow-script-modules/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Provider gate evaluates golangci-lint as a distinct job result
 
-The `gateProvider` function in `lib/gate-provider.js` SHALL accept a `golangciLintResult` parameter alongside the existing `lintResult` parameter. Both results SHALL be included in the set of job results that the gate validates and evaluates. The gate SHALL fail if either `lintResult` or `golangciLintResult` is `failure` or `cancelled`. The gate SHALL pass when both are `success`. The gate SHALL treat both as legitimately skipped (returning `passed: true`) when `classifyResult` is `false` and all job results — including both lint results — are `skipped`.
+The `gateProvider` function in `lib/gate-provider.js` SHALL accept a `golangciLintResult` parameter alongside the existing `lintResult` parameter. Both results SHALL be included in the set of job results that the gate validates and evaluates, together with `buildResult` and `testResult`. The gate SHALL pass only when `classifyResult=true` and all evaluated job results (`buildResult`, `lintResult`, `golangciLintResult`, and `testResult`) are `success`. The gate SHALL fail if any evaluated job result is `failure` or `cancelled`. The gate SHALL treat all four jobs as legitimately skipped (returning `passed: true`) when `classifyResult` is `false` and all job results — including both lint results — are `skipped`.
 
 The `fields` array for the `provider` gate in `lib/runners/gate.js` SHALL include `GOLANGCI_LINT_RESULT` alongside `LINT_RESULT`.
 

--- a/openspec/changes/golangci-lint-action/tasks.md
+++ b/openspec/changes/golangci-lint-action/tasks.md
@@ -1,0 +1,69 @@
+## Tasks
+
+### Task 1: Bump `.custom-gcl.yml` version to `v2.12.2`
+
+**File:** `.custom-gcl.yml`
+
+Change the `version` field from `v2.11.4` to `v2.12.2` to align with the golangci-lint version used by the Makefile and the version to be passed to `golangci/golangci-lint-action`.
+
+---
+
+### Task 2: Add `golangci-lint` job to `provider.yml`
+
+**File:** `.github/workflows/provider.yml`
+
+Add a new job named `golangci-lint` with the following properties:
+
+- `name: Go Lint (golangci-lint)`
+- `needs: classify`
+- `if: needs.classify.outputs.provider_changes == 'true'`
+- `runs-on: ubuntu-latest`
+- `permissions: contents: read, pull-requests: read`
+- Steps:
+  1. `actions/checkout` (pinned SHA, `persist-credentials: false`)
+  2. `actions/setup-go` (pinned SHA, `go-version-file: 'go.mod'`, `cache: true`)
+  3. `golangci/golangci-lint-action` — use the latest pinned SHA for `v9`, with `version: v2.12.2`
+
+The action will auto-detect `.custom-gcl.yml` and build/run the custom binary.
+
+---
+
+### Task 3: Modify the `lint` job in `provider.yml`
+
+**File:** `.github/workflows/provider.yml`
+
+Replace the single `run: make check-lint` step with a step that calls the remaining targets directly:
+
+```yaml
+- name: Lint
+  run: make check-openspec check-fmt gen check-docs
+```
+
+No other steps in the `lint` job change (Node, Go, Terraform setup remain).
+
+---
+
+### Task 4: Update the `gate` job in `provider.yml`
+
+**File:** `.github/workflows/provider.yml`
+
+1. Add `golangci-lint` to the `needs` list of the `gate` job (alongside `classify`, `build`, `lint`, `test`).
+2. Add `PROVIDER_GATE_GOLANGCI_LINT_RESULT: ${{ needs.golangci-lint.result }}` to the `env` block of the `gate` step.
+
+---
+
+### Task 5: Extend `gate-provider.js`
+
+**File:** `.github/scripts/workflows/lib/gate-provider.js`
+
+1. Add `golangciLintResult` to the function parameter destructuring.
+2. Include `golangciLintResult` in the `jobResults` array alongside `buildResult`, `lintResult`, and `testResult`.
+3. Update the failure message string to include `golangciLintResult` where other results are reported.
+
+---
+
+### Task 6: Extend `gate.js` fields for the provider gate
+
+**File:** `.github/scripts/workflows/lib/runners/gate.js`
+
+Add `'GOLANGCI_LINT_RESULT'` to the `fields` array for the `provider` gate entry. Update the `evaluate` call to pass `golangciLintResult: env.GOLANGCI_LINT_RESULT` to `gateProvider`.

--- a/openspec/changes/golangci-lint-action/tasks.md
+++ b/openspec/changes/golangci-lint-action/tasks.md
@@ -22,7 +22,7 @@ Add a new job named `golangci-lint` with the following properties:
 - Steps:
   1. `actions/checkout` (pinned SHA, `persist-credentials: false`)
   2. `actions/setup-go` (pinned SHA, `go-version-file: 'go.mod'`, `cache: true`)
-  3. `golangci/golangci-lint-action` — use the latest pinned SHA for `v9`, with `version: v2.12.2`
+  3. `golangci/golangci-lint-action` — pin to commit `1e7e51e771db61008b38414a730f564565cf7c20` (`v9.2.0`), with `version: v2.12.2`
 
 The action will auto-detect `.custom-gcl.yml` and build/run the custom binary.
 
@@ -32,11 +32,11 @@ The action will auto-detect `.custom-gcl.yml` and build/run the custom binary.
 
 **File:** `.github/workflows/provider.yml`
 
-Replace the single `run: make check-lint` step with a step that calls the remaining targets directly:
+Replace the single `run: make check-lint` step with a step that keeps the required setup prerequisites while calling only the remaining targets:
 
 ```yaml
 - name: Lint
-  run: make check-openspec check-fmt gen check-docs
+  run: make setup check-openspec check-fmt gen check-docs
 ```
 
 No other steps in the `lint` job change (Node, Go, Terraform setup remain).
@@ -48,7 +48,7 @@ No other steps in the `lint` job change (Node, Go, Terraform setup remain).
 **File:** `.github/workflows/provider.yml`
 
 1. Add `golangci-lint` to the `needs` list of the `gate` job (alongside `classify`, `build`, `lint`, `test`).
-2. Add `PROVIDER_GATE_GOLANGCI_LINT_RESULT: ${{ needs.golangci-lint.result }}` to the `env` block of the `gate` step.
+2. Add `PROVIDER_GATE_GOLANGCI_LINT_RESULT: ${{ needs['golangci-lint'].result }}` to the `env` block of the `gate` step.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an OpenSpec change proposal to split the provider CI `lint` job into two parallel jobs:

1. **`golangci-lint`** — dedicated job using `golangci/golangci-lint-action`, which auto-detects `.custom-gcl.yml` and builds/runs the custom binary
2. **`lint`** — remaining checks: `check-openspec`, `check-fmt`, `gen`, `check-docs`

Also covers extending the provider gate to accept both lint results independently.

## Change artifacts

- `openspec/changes/golangci-lint-action/proposal.md`
- `openspec/changes/golangci-lint-action/specs/workflow-script-modules/spec.md`
- `openspec/changes/golangci-lint-action/tasks.md`

_This PR contains only the proposal. Implementation is a follow-up._