### PR TITLE
fix(security_exception_list): add rule_default to type validator

### DIFF
--- a/docs/resources/kibana_security_exception_list.md
+++ b/docs/resources/kibana_security_exception_list.md
@@ -35,7 +35,7 @@ resource "elasticstack_kibana_security_exception_list" "endpoint" {
 
 - `description` (String) Describes the exception list.
 - `name` (String) The name of the exception list.
-- `type` (String) The type of exception list. Can be one of: `detection`, `endpoint`, `endpoint_trusted_apps`, `endpoint_events`, `endpoint_host_isolation_exceptions`, `endpoint_blocklists`.
+- `type` (String) The type of exception list. Can be one of: `detection`, `endpoint`, `endpoint_trusted_apps`, `endpoint_events`, `endpoint_host_isolation_exceptions`, `endpoint_blocklists`, `rule_default`.
 
 ### Optional
 

--- a/internal/kibana/securityexceptionlist/schema.go
+++ b/internal/kibana/securityexceptionlist/schema.go
@@ -43,6 +43,7 @@ var validExceptionListTypes = []string{
 	"endpoint_events",
 	"endpoint_host_isolation_exceptions",
 	"endpoint_blocklists",
+	"rule_default",
 }
 
 func getSchema(_ context.Context) schema.Schema {


### PR DESCRIPTION
## Summary

The `elasticstack_kibana_security_exception_list` resource's `type`
attribute validator only accepted six types; `rule_default` was missing
even though the underlying Kibana API accepts it and the generated
`kbapi` client already exposes `SecurityExceptionsAPIExceptionListType`
constants for it.

Without this, terraform-managed detection rules that ship with exception
items cannot reliably deploy: the detection_rule resource accepts an
`exceptions_list` reference of type `rule_default` (added in #3000),
but Kibana does **not** auto-create the container from a rule POST, so
any follow-on `elasticstack_kibana_security_exception_item` calls fail
with 404 because the container does not exist. With this change, the
container can be managed explicitly via terraform.

This is the symmetric fix on the standalone exception list resource for
the validator widening that #3000 made on the detection_rule resource's
`exceptions_list[].type` field.

## Reproducer (Kibana 8.x)

```bash
curl -X POST '/api/exception_lists' -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d '{
  "list_id": "my-rule-default",
  "name": "Exceptions for rule - my-rule",
  "description": "...",
  "type": "rule_default",
  "namespace_type": "single"
}'
```

Returns 200 with a generated id. The API supports it; only the
client-side validator blocked it.

## Implementation

Single-line addition to `validExceptionListTypes` in `internal/kibana/securityexceptionlist/schema.go`, plus the corresponding line in the generated docs. The model's `toCreateRequest` is type-agnostic and uses `kbapi.SecurityExceptionsAPIExceptionListType(m.Type.ValueString())`, which accepts any string the API supports — no conversion changes needed.

Fixes #3347

## Changelog
Customer impact: fix
Summary: `elasticstack_kibana_security_exception_list` now accepts `type=rule_default`, allowing terraform to explicitly manage per-rule exception list containers that were previously expected to auto-create from a detection rule POST (which does not actually happen).