### PR TITLE
proposal(elasticsearch-index): fix import settings hydration (#1587)

### DIFF
--- a/openspec/changes/fix-index-import-settings-hydration/.openspec.yaml
+++ b/openspec/changes/fix-index-import-settings-hydration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/fix-index-import-settings-hydration/design.md
+++ b/openspec/changes/fix-index-import-settings-hydration/design.md
@@ -28,7 +28,7 @@ Private state is already used by this resource for `sort_config` (written by `sa
 Three approaches were considered:
 - **Always-populate** (`setSettingsFromAPI` always writes individual fields): Fixes import but causes regression — users who don't configure `number_of_replicas` would suddenly see it appear in state after a regular refresh, showing drift.
 - **Two-pass Read** (hydrate after `resp.State.Set`, then `Set` again): Works mechanically but is inelegant — two state writes per import read cycle.
-- **Private state flag** (chosen): `ImportState` writes `"import_hydration"` to private state; `Read` checks for it, passes `hydrateAll=true` down the call stack, populates before the single `resp.State.Set`, then clears the flag. Precisely scoped, no regressions, follows the existing `sort_config` pattern.
+- **Private state flag** (chosen): `ImportState` writes `"import_hydration"` to private state; `Read` checks for it, passes `hydrateAll=true` down the call stack, and populates all settings before the single `resp.State.Set` — but does NOT clear the flag. `ModifyPlan` then prunes hydrated values for Optional-only settings not in the user's config, and finally clears the flag. Precisely scoped, no regressions, follows the existing `sort_config` pattern.
 
 ### D2: `hydrateAll bool` flows through `readIndex` → `populateFromAPI`
 
@@ -46,11 +46,19 @@ With `FlatSettings(true)`, Elasticsearch returns analysis settings as a single n
 
 `hydrateAllSettingsFromRaw` and `populateOperationalDefaults` live in a new `settings_read.go` following the exact pattern of `sort_read.go`. This keeps read-path helpers co-located and separate from the main model file.
 
+### D6: `ModifyPlan` prunes unconfigured Optional-only settings to prevent post-import drift
+
+Individual settings attributes (`number_of_replicas`, `refresh_interval`, etc.) are `Optional` (not `Computed`) in the schema. If `Read` hydrates them from ES, the plan comparison sees state=<ES value> vs config=null for any setting the user did not configure, producing unwanted drift.
+
+`ModifyPlan` (resource-level, `resource.ResourceWithModifyPlan`) resolves this: it checks for the `"import_hydration"` flag and, for each Optional-only settings field where the config value is null, overrides the planned state value to null. Only the fields the user actually configured survive into the applied state.
+
+The provider-side operational defaults (`deletion_protection`, `wait_for_active_shards`, `master_timeout`, `timeout`) are `Optional+Computed` — the plan keeps prior-state values for unset Computed fields — so they are unaffected by this pruning step.
+
 ## Risks / Trade-offs
 
-- **Type conversion edge cases** → The flat settings map returns all scalar values as JSON strings (e.g., `"1"` for integers, `"true"` for booleans). Conversion uses `strconv.ParseInt` and `strconv.ParseBool`. An unexpected non-numeric/non-bool string from a future ES version would produce a diagnostic error on import. Mitigation: skip fields that fail conversion rather than erroring, and log the issue — consistent with how the provider handles unexpected values in other places.
-- **Re-import** → If a resource is re-imported, the flag is set again and hydration runs again. This is benign — it re-hydrates all settings from the current ES state.
-- **Private state key lifecycle** → The `"import_hydration"` key exists in private state for exactly one read cycle (set in `ImportState`, cleared in the following `Read`). If `Read` errors before clearing the flag, the key persists and hydration retries on the next read — also benign.
+- **Type conversion edge cases** → The flat settings map stores all scalar values as JSON strings (raw bytes for `number_of_replicas = 1` are `"1"` including the surrounding quotes). Conversion first `json.Unmarshal`s the raw bytes into a Go `string`, then applies `strconv.ParseInt` for `types.Int64` fields or `strconv.ParseBool` for `types.Bool` fields. A non-numeric/non-bool string from a future ES version would leave the field unset. Mitigation: skip fields that fail conversion, consistent with how the provider handles unexpected values elsewhere.
+- **Re-import** → If a resource is re-imported, the flag is set again, hydration runs again, and `ModifyPlan` prunes unconfigured settings again. This is benign.
+- **Private state key lifecycle** → The `"import_hydration"` key exists in private state for one read+plan cycle: set in `ImportState`, read in `Read` to trigger hydration (not cleared there), read and cleared in the following `ModifyPlan`. If `Read` errors, the key persists and hydration retries on the next read — benign. If `ModifyPlan` errors before clearing, the key persists and the pruning retries on the next plan — also benign.
 
 ## Migration Plan
 

--- a/openspec/changes/fix-index-import-settings-hydration/design.md
+++ b/openspec/changes/fix-index-import-settings-hydration/design.md
@@ -1,0 +1,61 @@
+## Context
+
+The `elasticstack_elasticsearch_index` resource uses Terraform Plugin Framework. Its `Read` method calls `readIndex`, which calls `populateFromAPI` on the current state model. `populateFromAPI` populates `name`, `concrete_name`, `alias`, `mappings`, and (via `setSettingsFromAPI`) `settings_raw`. It does not populate individual setting fields (`number_of_replicas`, `refresh_interval`, analysis attributes, etc.) because those fields are `Optional` (not `Computed`) — the resource only tracks them when the user explicitly configures them.
+
+This is correct for regular read/plan/apply cycles: after `apply`, those fields are already in state from the plan. After `terraform import`, however, only `id` is in state (set by `ImportStatePassthroughID`). The following `Read` call leaves all individual fields null, causing drift against any configured values.
+
+The Elasticsearch Get Indices API is called with `FlatSettings(true)`, which returns all settings as dot-prefixed flat strings (`index.number_of_replicas`, `index.refresh_interval`, etc.). The `go-elasticsearch` `IndexSettings.UnmarshalJSON` stores unrecognised flat keys in a catch-all `map[string]json.RawMessage`; `MarshalJSON` inlines them back. This is what produces `settings_raw`. The data needed for hydration is therefore already present in `settings_raw` — it just needs to be parsed into the individual model fields.
+
+Private state is already used by this resource for `sort_config` (written by `saveSortConfig` in `Read`, consumed by `sortMigrationPlanModifier` during planning). The `ImportStateResponse.Private` field is pre-initialised to `EmptyProviderData` by the framework before `ImportState` is called, so writing to it is safe without any additional initialisation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- After `terraform import`, a subsequent `terraform plan` produces no changes when the user's config matches the imported index.
+- Individual settings fields, analysis attributes, and provider-side operational defaults are populated in state after import.
+- Regular read/plan/apply cycles are completely unaffected.
+
+**Non-Goals:**
+- Full drift detection for settings not in the user's config (that would require always-populating, which is a separate behaviour change and out of scope).
+- Changing the `settings_raw` format (remains flat with `index.*` prefix).
+- Populating the deprecated `settings { setting { } }` block on import.
+- Populating `use_existing` (not meaningful on import).
+
+## Decisions
+
+### D1: Import-scoped hydration via private state flag (over always-populate or two-pass Read)
+
+Three approaches were considered:
+- **Always-populate** (`setSettingsFromAPI` always writes individual fields): Fixes import but causes regression — users who don't configure `number_of_replicas` would suddenly see it appear in state after a regular refresh, showing drift.
+- **Two-pass Read** (hydrate after `resp.State.Set`, then `Set` again): Works mechanically but is inelegant — two state writes per import read cycle.
+- **Private state flag** (chosen): `ImportState` writes `"import_hydration"` to private state; `Read` checks for it, passes `hydrateAll=true` down the call stack, populates before the single `resp.State.Set`, then clears the flag. Precisely scoped, no regressions, follows the existing `sort_config` pattern.
+
+### D2: `hydrateAll bool` flows through `readIndex` → `populateFromAPI`
+
+Rather than checking the private state flag in `Read` and calling hydration after `resp.State.Set`, the flag is resolved once in `Read` and passed as a parameter so hydration happens inside `populateFromAPI` before the model is returned. This keeps all model-population logic within `populateFromAPI` and avoids a second `resp.State.Set` call.
+
+### D3: `hydrateAllSettingsFromRaw` parses `settings_raw` (not the `IndexSettings` struct directly)
+
+`settings_raw` is already the correct flat JSON representation. Parsing it is consistent with the existing `populateSortFromSettings` / `extractSortSetting` pattern in `sort_read.go`. The alternative (using the typed `IndexSettings.Index.*` struct fields, which requires removing `FlatSettings(true)`) would change the `settings_raw` format and have wide blast radius across all index read operations — better left as a future refactor.
+
+### D4: Analysis settings handled as a nested JSON object under `"index.analysis"`
+
+With `FlatSettings(true)`, Elasticsearch returns analysis settings as a single nested JSON object under the flat key `"index.analysis"` (not further flattened). `hydrateAllSettingsFromRaw` looks up this key and extracts sub-keys `analyzer`, `tokenizer`, `char_filter`, `filter`, `normalizer`, marshalling each to `jsontypes.Normalized` for the corresponding model fields.
+
+### D5: New file `settings_read.go` alongside `sort_read.go`
+
+`hydrateAllSettingsFromRaw` and `populateOperationalDefaults` live in a new `settings_read.go` following the exact pattern of `sort_read.go`. This keeps read-path helpers co-located and separate from the main model file.
+
+## Risks / Trade-offs
+
+- **Type conversion edge cases** → The flat settings map returns all scalar values as JSON strings (e.g., `"1"` for integers, `"true"` for booleans). Conversion uses `strconv.ParseInt` and `strconv.ParseBool`. An unexpected non-numeric/non-bool string from a future ES version would produce a diagnostic error on import. Mitigation: skip fields that fail conversion rather than erroring, and log the issue — consistent with how the provider handles unexpected values in other places.
+- **Re-import** → If a resource is re-imported, the flag is set again and hydration runs again. This is benign — it re-hydrates all settings from the current ES state.
+- **Private state key lifecycle** → The `"import_hydration"` key exists in private state for exactly one read cycle (set in `ImportState`, cleared in the following `Read`). If `Read` errors before clearing the flag, the key persists and hydration retries on the next read — also benign.
+
+## Migration Plan
+
+No migration required. This is a purely additive change to the import path. Existing managed resources are unaffected. No state upgrades, no schema version bumps.
+
+## Open Questions
+
+_(none — design is fully resolved)_

--- a/openspec/changes/fix-index-import-settings-hydration/proposal.md
+++ b/openspec/changes/fix-index-import-settings-hydration/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+After `terraform import`, the `elasticstack_elasticsearch_index` resource saves only `id`, `name`, `concrete_name`, `alias`, `mappings`, and `settings_raw` to state — all individual setting fields (`number_of_replicas`, `refresh_interval`, `analysis_analyzer`, slowlog thresholds, blocks, etc.) and provider-side operational attributes (`deletion_protection`, `wait_for_active_shards`, `master_timeout`, `timeout`) remain null. Every subsequent `terraform plan` shows drift for whichever of those attributes the user has configured, making import unusable in practice (issue #1587).
+
+## What Changes
+
+- **Override `ImportState`** to write a private state flag (`"import_hydration"`) signalling that the next read must fully hydrate all settings from the Elasticsearch API response.
+- **Extend `readIndex` and `populateFromAPI`** with a `hydrateAll bool` parameter. When true (import path only), two new functions are called after the existing population logic:
+  - `hydrateAllSettingsFromRaw` — parses `settings_raw` (flat JSON map with `index.*` keys) and populates every individual setting field in the model. Handles string→int64 and string→bool conversions; extracts analysis sub-categories (analyzer, tokenizer, char_filter, filter, normalizer) from the nested `index.analysis` object; handles array-valued fields (`query_default_field`) using the same pattern as the existing `extractSortSetting`. Does not touch the deprecated `settings` block or `use_existing`.
+  - `populateOperationalDefaults` — sets provider-side defaults for fields that have no Elasticsearch equivalent: `deletion_protection=true`, `wait_for_active_shards="1"`, `master_timeout="30s"`, `timeout="30s"`.
+- **Clear the flag** in `Read` after hydration by setting the key to nil, so the behaviour is strictly scoped to the single read that follows an import.
+- **Add acceptance test coverage** verifying that a `terraform plan` immediately after `terraform import` shows no changes for an index with settings and analysis configured.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this change fixes existing import behaviour, no new surface area)_
+
+### Modified Capabilities
+
+- `elasticsearch-index`: Adding an import-hydration requirement — after import, all individual setting fields and operational defaults SHALL be fully populated in state so that a subsequent plan produces no changes when the config matches the imported index.
+
+## Impact
+
+- **Code**: `internal/elasticsearch/index/index/` — `constants.go`, `resource.go`, `read.go`, `models.go`, `create.go`, plus a new `settings_read.go`.
+- **Private state**: A new key `"import_hydration"` is written to provider private state during `ImportState` and cleared in the following `Read`. It does not affect the `sort_config` key or any other existing private state.
+- **Behaviour**: Regular read/plan/apply cycles are unaffected — the `hydrateAll` flag is only set on the import path.
+- **No breaking changes**.

--- a/openspec/changes/fix-index-import-settings-hydration/specs/elasticsearch-index/spec.md
+++ b/openspec/changes/fix-index-import-settings-hydration/specs/elasticsearch-index/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Import settings hydration (REQ-IMPORT-HYDRATE)
+
+After a successful `terraform import`, the read that follows SHALL fully populate all individual index setting fields and provider-side operational defaults in state, so that a subsequent `terraform plan` produces no changes when the user's configuration matches the imported index.
+
+The resource SHALL implement this via a private state flag (`"import_hydration"`) written during `ImportState` and consumed (then cleared) in the following `Read`:
+
+1. During `ImportState`, in addition to setting `id` via `ImportStatePassthroughID`, the resource SHALL write the `"import_hydration"` key to provider private state.
+2. During the `Read` that follows, if `"import_hydration"` is present in private state, the resource SHALL:
+   a. Parse `settings_raw` (flat JSON map with `index.*`-prefixed keys) and populate every individual setting field (`number_of_replicas`, `refresh_interval`, `analysis_analyzer`, `analysis_tokenizer`, `analysis_char_filter`, `analysis_filter`, `analysis_normalizer`, all slowlog thresholds, all block settings, and all other attributes in the settings schema) into the model.
+   b. Set provider-side operational defaults for attributes that have no Elasticsearch equivalent: `deletion_protection = true`, `wait_for_active_shards = "1"`, `master_timeout = "30s"`, `timeout = "30s"`.
+   c. Clear the `"import_hydration"` private state key so subsequent reads are unaffected.
+3. The deprecated `settings` block SHALL NOT be populated during import hydration.
+4. The `use_existing` attribute SHALL NOT be populated during import hydration.
+5. Regular read operations (not preceded by an import) SHALL NOT be affected by this mechanism.
+
+#### Scenario: Import produces fully-hydrated state for configured settings
+
+- **GIVEN** an Elasticsearch index exists with `number_of_replicas = 1`, `refresh_interval = "30s"`, and a custom analyzer defined in `analysis_analyzer`
+- **WHEN** the user runs `terraform import` with the index's composite id
+- **THEN** the saved state SHALL contain `number_of_replicas = 1`, `refresh_interval = "30s"`, and `analysis_analyzer` set to the JSON representation of the custom analyzer
+
+#### Scenario: Plan is clean after import when config matches
+
+- **GIVEN** the user's Terraform config specifies `number_of_replicas`, `refresh_interval`, and `analysis_analyzer` values that match the existing index
+- **WHEN** `terraform import` completes and `terraform plan` runs
+- **THEN** the plan SHALL show no changes
+
+#### Scenario: Operational defaults populated after import
+
+- **GIVEN** a `terraform import` has just completed
+- **WHEN** the following `terraform plan` runs
+- **THEN** `deletion_protection`, `wait_for_active_shards`, `master_timeout`, and `timeout` SHALL each have their default values in state (`true`, `"1"`, `"30s"`, `"30s"` respectively) and SHALL NOT appear as changes in the plan when the user's config omits or matches those defaults
+
+#### Scenario: Regular read is unaffected
+
+- **GIVEN** a resource managed by Terraform (not just imported) with `number_of_replicas = 2` in config and state
+- **WHEN** `terraform plan` runs a refresh read
+- **THEN** `number_of_replicas` SHALL remain `2` in state and no drift SHALL be introduced for settings not present in the user's config

--- a/openspec/changes/fix-index-import-settings-hydration/specs/elasticsearch-index/spec.md
+++ b/openspec/changes/fix-index-import-settings-hydration/specs/elasticsearch-index/spec.md
@@ -4,16 +4,20 @@
 
 After a successful `terraform import`, the read that follows SHALL fully populate all individual index setting fields and provider-side operational defaults in state, so that a subsequent `terraform plan` produces no changes when the user's configuration matches the imported index.
 
-The resource SHALL implement this via a private state flag (`"import_hydration"`) written during `ImportState` and consumed (then cleared) in the following `Read`:
+The resource SHALL implement this via a private state flag (`"import_hydration"`) written during `ImportState`, consumed in the following `Read` to trigger full hydration, and cleared in the subsequent `ModifyPlan` after unconfigured Optional settings are pruned from the planned state:
 
 1. During `ImportState`, in addition to setting `id` via `ImportStatePassthroughID`, the resource SHALL write the `"import_hydration"` key to provider private state.
 2. During the `Read` that follows, if `"import_hydration"` is present in private state, the resource SHALL:
    a. Parse `settings_raw` (flat JSON map with `index.*`-prefixed keys) and populate every individual setting field (`number_of_replicas`, `refresh_interval`, `analysis_analyzer`, `analysis_tokenizer`, `analysis_char_filter`, `analysis_filter`, `analysis_normalizer`, all slowlog thresholds, all block settings, and all other attributes in the settings schema) into the model.
    b. Set provider-side operational defaults for attributes that have no Elasticsearch equivalent: `deletion_protection = true`, `wait_for_active_shards = "1"`, `master_timeout = "30s"`, `timeout = "30s"`.
-   c. Clear the `"import_hydration"` private state key so subsequent reads are unaffected.
-3. The deprecated `settings` block SHALL NOT be populated during import hydration.
-4. The `use_existing` attribute SHALL NOT be populated during import hydration.
-5. Regular read operations (not preceded by an import) SHALL NOT be affected by this mechanism.
+   (The `"import_hydration"` key is NOT cleared in `Read`; it persists to `ModifyPlan`.)
+3. During `ModifyPlan`, if `"import_hydration"` is present in private state, the resource SHALL:
+   a. For each `Optional` (non-`Computed`) settings attribute that is null in the user's config, override the planned state value to null, so that settings the user has not configured do not appear as drift.
+   b. Clear the `"import_hydration"` private state key.
+   (Provider-side operational defaults — `deletion_protection`, `wait_for_active_shards`, `master_timeout`, `timeout` — are `Optional+Computed` and are unaffected by this clearing step.)
+4. The deprecated `settings` block SHALL NOT be populated during import hydration.
+5. The `use_existing` attribute SHALL NOT be populated during import hydration.
+6. Regular read operations (not preceded by an import) SHALL NOT be affected by this mechanism.
 
 #### Scenario: Import produces fully-hydrated state for configured settings
 

--- a/openspec/changes/fix-index-import-settings-hydration/tasks.md
+++ b/openspec/changes/fix-index-import-settings-hydration/tasks.md
@@ -13,14 +13,17 @@
 - [ ] 3.3 Update the two `readIndex` call sites in `create.go` to pass `false`
 - [ ] 3.4 Update the direct `populateFromAPI` call in `create.go` (`adoptExistingIndexOnCreate`) to pass `false`
 
-## 4. Read: flag check and clear
+## 4. Read: flag check (do not clear here)
 
-- [ ] 4.1 In `resource.go Read`, read `req.Private.GetKey(ctx, importHydrationPrivateStateKey)` to determine `hydrateAll` and pass it to `readIndex`
-- [ ] 4.2 In `resource.go Read`, after `resp.State.Set`, if `hydrateAll` clear the flag: `resp.Private.SetKey(ctx, importHydrationPrivateStateKey, nil)`
+- [ ] 4.1 In `resource.go Read`, read `req.Private.GetKey(ctx, importHydrationPrivateStateKey)` to determine `hydrateAll` and pass it to `readIndex`; do NOT clear the flag in `Read` — it is cleared in `ModifyPlan`
+
+## 4b. ModifyPlan: selective clearing of unconfigured Optional settings
+
+- [ ] 4b.1 Implement `ModifyPlan` on the index resource in `resource.go` (`resource.ResourceWithModifyPlan` interface): check `req.Private.GetKey(ctx, importHydrationPrivateStateKey)`; if nil, return immediately; otherwise unmarshal both the config and plan models via `req.Config.Get` and `req.Plan.Get`; for each `Optional` (non-`Computed`) settings field populated by `hydrateAllSettingsFromRaw` — all fields from `allSettingsKeys` (e.g. `number_of_replicas`, `refresh_interval`, slowlog thresholds, block settings) plus the analysis fields (`analysis_analyzer`, `analysis_tokenizer`, `analysis_char_filter`, `analysis_filter`, `analysis_normalizer`) — if the corresponding config field is null, set the plan model field to null; write back via `resp.Plan.Set` and clear the flag via `resp.Private.SetKey(ctx, importHydrationPrivateStateKey, nil)`; leave operational defaults (`deletion_protection`, `wait_for_active_shards`, `master_timeout`, `timeout`) untouched (they are `Optional+Computed` and keep their hydrated values)
 
 ## 5. Settings hydration functions
 
-- [ ] 5.1 Create `settings_read.go` with `hydrateAllSettingsFromRaw(ctx context.Context, model *tfModel) diag.Diagnostics`: unmarshal `model.SettingsRaw` into a flat `map[string]json.RawMessage`; for each key in `allSettingsKeys`, look up `"index."+key` in the map; use `convertSettingsKeyToTFFieldKey` to find the struct field; type-convert the raw JSON string value (`strconv.ParseInt` for `types.Int64` fields, `strconv.ParseBool` for `types.Bool` fields, unquote for `types.String` fields); skip keys not present in the map; skip fields that fail conversion
+- [ ] 5.1 Create `settings_read.go` with `hydrateAllSettingsFromRaw(ctx context.Context, model *tfModel) diag.Diagnostics`: unmarshal `model.SettingsRaw` into a flat `map[string]json.RawMessage`; for each key in `allSettingsKeys`, look up `"index."+key` in the map; use `convertSettingsKeyToTFFieldKey` to find the struct field; all flat-settings values are JSON strings (the raw bytes for `number_of_replicas = 1` are `"1"` including the quotes), so type-convert by first calling `json.Unmarshal(rawValue, &s)` to get a Go `string`, then `strconv.ParseInt(s, 10, 64)` for `types.Int64` fields, `strconv.ParseBool(s)` for `types.Bool` fields, or use `s` directly for `types.String` fields; skip keys not present in the map; skip fields that fail conversion
 - [ ] 5.2 In `hydrateAllSettingsFromRaw`, handle `"index.analysis"` separately: unmarshal its value as `map[string]json.RawMessage` and populate `model.AnalysisAnalyzer`, `model.AnalysisTokenizer`, `model.AnalysisCharFilter`, `model.AnalysisFilter`, `model.AnalysisNormalizer` from sub-keys `analyzer`, `tokenizer`, `char_filter`, `filter`, `normalizer` respectively (marshal each to `jsontypes.NewNormalizedValue`)
 - [ ] 5.3 In `hydrateAllSettingsFromRaw`, handle `"index.query.default_field"` (maps to `QueryDefaultField types.Set`) using the same array-extraction pattern as `extractSortSetting` in `sort_read.go`
 - [ ] 5.4 Create `populateOperationalDefaults(model *tfModel)` in `settings_read.go`: set `deletion_protection = true`, `wait_for_active_shards = "1"`, `master_timeout = "30s"`, `timeout = "30s"` when each field is null

--- a/openspec/changes/fix-index-import-settings-hydration/tasks.md
+++ b/openspec/changes/fix-index-import-settings-hydration/tasks.md
@@ -1,0 +1,40 @@
+## 1. Constant and private state key
+
+- [ ] 1.1 Add `importHydrationPrivateStateKey = "import_hydration"` constant to `constants.go`
+
+## 2. ImportState override
+
+- [ ] 2.1 Override `ImportState` in `resource.go` to call `resource.ImportStatePassthroughID` and then write `[]byte("true")` to `resp.Private` under `importHydrationPrivateStateKey`
+
+## 3. Propagate hydrateAll parameter
+
+- [ ] 3.1 Add `hydrateAll bool` parameter to `readIndex` in `read.go`; pass it through to `populateFromAPI`
+- [ ] 3.2 Add `hydrateAll bool` parameter to `populateFromAPI` in `models.go`
+- [ ] 3.3 Update the two `readIndex` call sites in `create.go` to pass `false`
+- [ ] 3.4 Update the direct `populateFromAPI` call in `create.go` (`adoptExistingIndexOnCreate`) to pass `false`
+
+## 4. Read: flag check and clear
+
+- [ ] 4.1 In `resource.go Read`, read `req.Private.GetKey(ctx, importHydrationPrivateStateKey)` to determine `hydrateAll` and pass it to `readIndex`
+- [ ] 4.2 In `resource.go Read`, after `resp.State.Set`, if `hydrateAll` clear the flag: `resp.Private.SetKey(ctx, importHydrationPrivateStateKey, nil)`
+
+## 5. Settings hydration functions
+
+- [ ] 5.1 Create `settings_read.go` with `hydrateAllSettingsFromRaw(ctx context.Context, model *tfModel) diag.Diagnostics`: unmarshal `model.SettingsRaw` into a flat `map[string]json.RawMessage`; for each key in `allSettingsKeys`, look up `"index."+key` in the map; use `convertSettingsKeyToTFFieldKey` to find the struct field; type-convert the raw JSON string value (`strconv.ParseInt` for `types.Int64` fields, `strconv.ParseBool` for `types.Bool` fields, unquote for `types.String` fields); skip keys not present in the map; skip fields that fail conversion
+- [ ] 5.2 In `hydrateAllSettingsFromRaw`, handle `"index.analysis"` separately: unmarshal its value as `map[string]json.RawMessage` and populate `model.AnalysisAnalyzer`, `model.AnalysisTokenizer`, `model.AnalysisCharFilter`, `model.AnalysisFilter`, `model.AnalysisNormalizer` from sub-keys `analyzer`, `tokenizer`, `char_filter`, `filter`, `normalizer` respectively (marshal each to `jsontypes.NewNormalizedValue`)
+- [ ] 5.3 In `hydrateAllSettingsFromRaw`, handle `"index.query.default_field"` (maps to `QueryDefaultField types.Set`) using the same array-extraction pattern as `extractSortSetting` in `sort_read.go`
+- [ ] 5.4 Create `populateOperationalDefaults(model *tfModel)` in `settings_read.go`: set `deletion_protection = true`, `wait_for_active_shards = "1"`, `master_timeout = "30s"`, `timeout = "30s"` when each field is null
+
+## 6. Wire hydration into populateFromAPI
+
+- [ ] 6.1 At the end of `populateFromAPI` in `models.go`, when `hydrateAll` is true, call `hydrateAllSettingsFromRaw(ctx, model)` then `populateOperationalDefaults(model)`
+
+## 7. Build verification
+
+- [ ] 7.1 Run `make build` and confirm no compilation errors
+
+## 8. Acceptance test
+
+- [ ] 8.1 Add a new test config directory `testdata/TestAccResourceIndexImport/` with an index config that sets `number_of_replicas`, `refresh_interval`, and `analysis_analyzer`
+- [ ] 8.2 Add `TestAccResourceIndexImport` acceptance test in `acc_test.go` with two steps: (1) create the index, (2) import it with `ImportState: true` and verify no plan drift for `number_of_replicas`, `refresh_interval`, `analysis_analyzer`, `deletion_protection`, `wait_for_active_shards`, `master_timeout`, and `timeout`
+- [ ] 8.3 Run the acceptance test against a live Elasticsearch cluster to confirm it passes


### PR DESCRIPTION
## Summary

- Adds an OpenSpec change proposal for fixing post-import state drift in `elasticstack_elasticsearch_index` (issue #1587)
- After `terraform import`, individual settings fields (`number_of_replicas`, `refresh_interval`, `analysis_analyzer`, etc.) are null in state, causing drift on every subsequent plan
- Proposes import-scoped hydration via a private state flag: `ImportState` writes `"import_hydration"` to private state; the following `Read` detects it, parses `settings_raw` to populate all individual fields and operational defaults, then clears the flag — regular reads are unaffected

## Artifacts

- `openspec/changes/fix-index-import-settings-hydration/proposal.md` — what & why
- `openspec/changes/fix-index-import-settings-hydration/design.md` — key decisions (private-state-flag approach vs always-populate vs two-pass Read)
- `openspec/changes/fix-index-import-settings-hydration/specs/elasticsearch-index/spec.md` — delta spec adding REQ-IMPORT-HYDRATE
- `openspec/changes/fix-index-import-settings-hydration/tasks.md` — 18 implementation tasks

## Test plan

- [ ] Proposal and design docs reviewed for accuracy
- [ ] Delta spec scenarios are testable and complete
- [ ] No implementation code included (proposal-only PR)

## Changelog

Customer impact: none

Closes #1587

🤖 Generated with [Claude Code](https://claude.com/claude-code)