### PR TITLE
proposal: kibana dashboard guides (#1722)

### DIFF
--- a/openspec/changes/kibana-dashboard-guides/.openspec.yaml
+++ b/openspec/changes/kibana-dashboard-guides/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/kibana-dashboard-guides/design.md
+++ b/openspec/changes/kibana-dashboard-guides/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The `elasticstack_kibana_dashboard` resource launched in the `dashboard-guides` branch. Its generated reference doc (`docs/resources/kibana_dashboard.md`) covers every field and panel type but is not approachable for first-time users. The project already has a guides pattern — `docs/guides/security-roles.md` and `docs/guides/elasticstack-kibana-rule.md` — that pairs prose with inline Terraform code blocks and demonstrates scenario-based use.
+
+Guides live in `docs/guides/` as Markdown files and are registered in the provider's Terraform Registry template system via `make docs-generate`. Screenshots are static PNGs committed alongside the guide.
+
+The dashboard resource's `vis` panels embed Lens visualization JSON, which is complex and not hand-authorable from scratch. The practical workflow is: create a visualization in the Kibana UI, use Inspect → Request to extract the serialized `attributes` JSON, then embed it in Terraform. Guides must document this workflow explicitly.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Three guides covering distinct experience levels: getting-started, operations patterns, advanced features
+- All examples use Kibana's built-in sample data (logs + eCommerce) — no custom data pipeline required
+- Each guide is self-contained and runnable with `terraform apply`
+- Screenshots are reproducible via committed Playwright scripts
+- Kibana 9.4+ baseline throughout
+
+**Non-Goals:**
+- Covering feature-gated panels (SLO, Synthetics, ML) — out of scope for general guides
+- Geographic/Maps panels — geo-specific, narrow audience
+- Modifying any provider resource code or schemas
+- Replacing the generated reference documentation
+
+## Decisions
+
+### Decision: By-value panels only in examples
+
+**Choice**: All guide examples use `vis_config.by_value`, `markdown_config.by_value`, `discover_session_config.by_value` — no by-reference patterns.
+
+**Why**: By-reference panels require pre-existing saved objects created outside Terraform, making examples non-runnable in isolation. By-value configs are self-contained and directly applicable. A brief callout in guide 1 mentions that by-reference exists and links to the reference docs.
+
+**Alternative considered**: Show by-reference in guide 3 as an "advanced" pattern. Rejected — the overhead of explaining saved object management outweighs the benefit; by-reference patterns are sufficiently covered by the reference docs.
+
+### Decision: Kibana sample data as the dataset
+
+**Choice**: Guide 1 uses `kibana_sample_data_logs`; guides 2 and 3 use `kibana_sample_data_ecommerce`. Both are installable with one click from the Kibana home page.
+
+**Why**: Every Kibana instance ships with these datasets. Using them avoids any prerequisite data pipeline setup. The field names and data shapes are stable across Kibana versions. Elastic's own tutorial content already uses these datasets, so users can cross-reference.
+
+**Alternative considered**: Custom synthetic data via `elasticstack_elasticsearch_index` + bulk ingest. Rejected — significantly increases prerequisite complexity and makes guides longer without adding value to the dashboard-specific content.
+
+### Decision: Lens visualization JSON sourced from Kibana UI export
+
+**Choice**: Guide 1 includes an explicit section explaining how to create a Lens visualization in the Kibana UI and extract its JSON via Inspect → Request → Response, then embed it in `vis_config.by_value.*_chart_config`. The TF examples include complete, verbatim Lens JSON.
+
+**Why**: Lens chart specs are not hand-authorable — they contain internal Kibana state fields. Users will always need to start in the UI. Making this workflow explicit prevents confusion about why the JSON is complex.
+
+**Alternative considered**: Provide a minimal hand-crafted Lens spec. Rejected — minimal specs often break across Kibana minor versions as internal field requirements change. Full exported specs are stable.
+
+### Decision: Playwright for screenshots, committed as static PNGs
+
+**Choice**: Screenshot scripts under `scripts/screenshots/` using Playwright. Output PNGs committed to `docs/guides/images/`. Scripts reference dashboards by their Kibana-assigned `dashboard_id`.
+
+**Why**: Playwright handles Kibana's JavaScript-heavy rendering and authentication. Scripts are committed so any contributor can regenerate screenshots when the UI or TF config changes. Static PNGs mean the guides work without running a live stack.
+
+**Alternative considered**: Manual screenshots only (no automation). Rejected — manual screenshots are not reproducible and become stale as Kibana UI evolves.
+
+### Decision: One spec for all three guides
+
+**Choice**: Single capability `kibana-dashboard-guides` with one delta spec covering requirements for all three guides.
+
+**Why**: The three guides are closely related — same resource, same output format, same screenshot mechanism. A single spec avoids duplication of shared requirements (guide format, screenshot reproducibility, `make docs-generate` integration) while keeping requirements organized by guide within the spec.
+
+## Risks / Trade-offs
+
+- **Lens JSON stability** → Kibana may change internal Lens field requirements between minor versions. Mitigation: pin the Kibana version in the prerequisites callout (9.4+); note in the guide that JSON was tested against a specific version and may need re-export for other versions.
+- **Screenshot rendering timing** → Kibana panels load asynchronously; a screenshot taken too early shows spinners. Mitigation: Playwright scripts use `waitForSelector('[data-test-subj="embeddablePanel"]')` + `waitForLoadState('networkidle')` before capture, with a fallback timeout.
+- **Sample data field name drift** → If Elastic changes the sample data schema, examples break. Mitigation: sample data schemas are stable across all Kibana 8.x/9.x versions; this risk is low.
+- **Guide maintenance burden** → Guides with embedded screenshots and Lens JSON can become stale. Mitigation: the Playwright scripts lower the cost of regenerating screenshots; Lens JSON must be re-exported when the resource schema changes (which is infrequent for stable charts).
+
+## Open Questions
+
+- Should guide 3 cover `sections` with a tech-preview callout, or defer until sections GA? **Current plan**: include with a prominent tech-preview callout, as it is already supported by the resource schema.
+- Should the Playwright scripts be wired into CI (e.g., run on PR with a Kibana service container)? **Current plan**: scripts are committed but not wired into CI for this change; CI integration is a follow-up.

--- a/openspec/changes/kibana-dashboard-guides/design.md
+++ b/openspec/changes/kibana-dashboard-guides/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The `elasticstack_kibana_dashboard` resource launched in the `dashboard-guides` branch. Its generated reference doc (`docs/resources/kibana_dashboard.md`) covers every field and panel type but is not approachable for first-time users. The project already has a guides pattern — `docs/guides/security-roles.md` and `docs/guides/elasticstack-kibana-rule.md` — that pairs prose with inline Terraform code blocks and demonstrates scenario-based use.
+The `elasticstack_kibana_dashboard` resource was recently introduced. Its generated reference doc (`docs/resources/kibana_dashboard.md`) covers every field and panel type but is not approachable for first-time users. The project already has a guides pattern — `docs/guides/security-roles.md` and `docs/guides/elasticstack-kibana-rule.md` — that pairs prose with inline Terraform code blocks and demonstrates scenario-based use.
 
 Guides live in `docs/guides/` as Markdown files and are registered in the provider's Terraform Registry template system via `make docs-generate`. Screenshots are static PNGs committed alongside the guide.
 
@@ -33,9 +33,9 @@ The dashboard resource's `vis` panels embed Lens visualization JSON, which is co
 
 ### Decision: Kibana sample data as the dataset
 
-**Choice**: Guide 1 uses `kibana_sample_data_logs`; guides 2 and 3 use `kibana_sample_data_ecommerce`. Both are installable with one click from the Kibana home page.
+**Choice**: Guide 1 uses `kibana_sample_data_logs`; guide 2 uses `kibana_sample_data_ecommerce`; guide 3 uses `kibana_sample_data_logs`. Both datasets are installable with one click from the Kibana home page.
 
-**Why**: Every Kibana instance ships with these datasets. Using them avoids any prerequisite data pipeline setup. The field names and data shapes are stable across Kibana versions. Elastic's own tutorial content already uses these datasets, so users can cross-reference.
+**Why**: Every Kibana instance ships with these datasets. Using them avoids any prerequisite data pipeline setup while letting each guide use the sample data best suited to its scenario. The field names and data shapes are stable across Kibana versions. Elastic's own tutorial content already uses these datasets, so users can cross-reference.
 
 **Alternative considered**: Custom synthetic data via `elasticstack_elasticsearch_index` + bulk ingest. Rejected — significantly increases prerequisite complexity and makes guides longer without adding value to the dashboard-specific content.
 

--- a/openspec/changes/kibana-dashboard-guides/proposal.md
+++ b/openspec/changes/kibana-dashboard-guides/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `elasticstack_kibana_dashboard` resource has extensive generated reference documentation but no use-case-focused guides. Users must read several hundred lines of API reference to accomplish common tasks — issue [#1722](https://github.com/elastic/terraform-provider-elasticstack/issues/1722) specifically requests simplified guides that solve everyday problems concisely, with screenshots of the resulting dashboards.
+
+## What Changes
+
+- **New guide**: `docs/guides/kibana-dashboard-getting-started.md` — step-by-step construction of a web server log monitoring dashboard using Kibana sample data, introducing every core concept one panel at a time
+- **New guide**: `docs/guides/kibana-dashboard-operations.md` — an interactive eCommerce monitoring dashboard demonstrating controls panels, a Discover session, and dashboard-level options
+- **New guide**: `docs/guides/kibana-dashboard-advanced.md` — advanced patterns covering collapsible sections, ES|QL controls, image panels, gauge and heatmap chart types, and access control
+- **New example configs**: `examples/guides/guide1-getting-started/main.tf`, `examples/guides/guide2-operations/main.tf`, `examples/guides/guide3-advanced/main.tf` — fully runnable Terraform configurations for each guide
+- **New Playwright scripts**: `scripts/screenshots/guide{1,2,3}.mjs` — reproducible screenshot scripts for capturing dashboard images from a local Kibana instance
+- **New screenshots**: `docs/guides/images/g{1,2,3}-*.png` — 16 embedded screenshots across the three guides
+
+No changes to provider resource code or existing documentation.
+
+## Capabilities
+
+### New Capabilities
+
+- `kibana-dashboard-guides`: Three progressive guides covering the `elasticstack_kibana_dashboard` resource from first panel to advanced features, with runnable Terraform examples, embedded screenshots, and Playwright automation scripts for screenshot generation. Requires Kibana 9.4+.
+
+### Modified Capabilities
+
+<!-- No existing requirement specs are changing. -->
+
+## Impact
+
+- **New files only** — no modifications to existing provider code, resource schemas, or generated docs
+- **Kibana version baseline**: Kibana 9.4+ (minimum required by the dashboard API and resource)
+- **Dependencies**: Kibana sample data (logs + eCommerce datasets, installable from Kibana home); Playwright for screenshot generation
+- **Guide format**: Follows the established pattern of existing guides (`security-roles.md`, `elasticstack-kibana-rule.md`) — frontmatter, prerequisites, prose with inline Terraform code blocks, embedded images

--- a/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
+++ b/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
@@ -1,0 +1,178 @@
+# Kibana Dashboard Guides
+
+Guide implementation: `docs/guides/kibana-dashboard-getting-started.md`, `docs/guides/kibana-dashboard-operations.md`, `docs/guides/kibana-dashboard-advanced.md`
+
+## ADDED Requirements
+
+### Requirement: Three guide files exist and are linked from the dashboard resource docs
+
+Three standalone provider guides SHALL exist and be rendered by `make docs-generate`:
+- `docs/guides/kibana-dashboard-getting-started.md`
+- `docs/guides/kibana-dashboard-operations.md`
+- `docs/guides/kibana-dashboard-advanced.md`
+
+The `elasticstack_kibana_dashboard` resource documentation SHALL include a "See also" section linking to all three guides.
+
+Each guide SHALL declare `subcategory: ""` and an appropriate `page_title` and `description` in its frontmatter.
+
+#### Scenario: Guides render without error
+
+- **WHEN** `make docs-generate` is run
+- **THEN** all three guide files are created under `docs/guides/` with no generation errors
+
+#### Scenario: make check-docs passes
+
+- **WHEN** all three guide files and their referenced example files are committed
+- **THEN** `make check-docs` exits with code 0
+
+---
+
+### Requirement: Guide 1 — Getting started guide builds a dashboard step by step
+
+Guide 1 (`kibana-dashboard-getting-started.md`) SHALL demonstrate building a web server log monitoring dashboard using `kibana_sample_data_logs`, adding panels incrementally so each step is independently reproducible.
+
+The guide SHALL cover these topics in order:
+1. Prerequisites — provider setup, Kibana 9.4+ version requirement, sample data installation
+2. Dashboard shell — `title`, `time_range`, `refresh_interval`, `query`, and the grid coordinate system
+3. Markdown panel — `markdown_config.by_value` with `content`, `title`, and `settings.open_links_in_new_tab`
+4. Lens Metric panels — `vis_config.by_value.metric_chart_config` for count and cardinality metrics
+5. Lens Line chart — `vis_config.by_value.xy_chart_config` for time-series request volume
+6. Lens Bar chart (horizontal) — `vis_config.by_value.xy_chart_config` for top-N URL breakdown
+7. Lens Donut chart — `vis_config.by_value.partition_chart_config` for response code distribution
+
+The guide SHALL include an explicit section explaining how to obtain Lens visualization JSON from the Kibana UI using Inspect → Request → Response.
+
+Each panel addition step SHALL include:
+- A complete Terraform snippet showing the full `panels` list up to that step
+- An embedded screenshot of the dashboard after applying that step
+
+#### Scenario: Guide 1 Terraform config applies cleanly
+
+- **WHEN** `terraform apply` is run with `examples/guides/guide1-getting-started/main.tf`
+- **THEN** the apply completes without errors
+- **THEN** the dashboard is visible in Kibana at `http://localhost:5601` with all 6 panels rendered
+
+#### Scenario: Guide 1 covers at least 4 distinct Lens chart subtypes
+
+- **WHEN** the guide is read
+- **THEN** it demonstrates at least 4 distinct Lens visualization types: metric, line/area, bar, and pie/donut
+
+#### Scenario: Guide 1 explains the grid coordinate system
+
+- **WHEN** the grid section is read
+- **THEN** it explains that Kibana uses a 48-column grid and defines `x`, `y`, `w`, `h` fields
+
+---
+
+### Requirement: Guide 2 — Operations guide demonstrates interactive controls and Discover sessions
+
+Guide 2 (`kibana-dashboard-operations.md`) SHALL demonstrate an interactive eCommerce monitoring dashboard using `kibana_sample_data_ecommerce` with controls and an embedded Discover session.
+
+The guide SHALL cover:
+- `pinned_panels` with `options_list_control` wired to a data field, filtering all panels simultaneously
+- At least 3 Lens Metric panels forming a KPI row
+- Lens Stacked Area chart for trend analysis
+- Lens Data Table panel
+- `discover_session_config.by_value` with `tab.dsl`, including `data_view_reference` via `ref_id`, `column_order`, and `view_mode`
+- Dashboard `options` block: `use_margins`, `sync_colors`, `sync_tooltips`
+
+The guide SHALL include a before/after screenshot pair showing the dashboard with no filter applied and with an options_list_control filter active.
+
+#### Scenario: Guide 2 Terraform config applies cleanly
+
+- **WHEN** `terraform apply` is run with `examples/guides/guide2-operations/main.tf`
+- **THEN** the apply completes without errors
+- **THEN** the dashboard is visible in Kibana with controls panel, KPI row, area chart, data table, and Discover session
+
+#### Scenario: Guide 2 demonstrates pinned_panels
+
+- **WHEN** the guide is read
+- **THEN** it includes a Terraform snippet using `pinned_panels` with at least one control panel
+- **THEN** the guide explains the difference between `pinned_panels` (controls) and `panels` (content panels)
+
+#### Scenario: Guide 2 demonstrates discover_session panel
+
+- **WHEN** the guide is read
+- **THEN** it includes a `discover_session` panel using `by_value.tab.dsl` with `data_view_reference`
+- **THEN** it explains the `ref_id` field and how it links to a Kibana data view
+
+---
+
+### Requirement: Guide 3 — Advanced guide covers sections, ES|QL controls, and production patterns
+
+Guide 3 (`kibana-dashboard-advanced.md`) SHALL demonstrate advanced dashboard features targeting users building production-grade dashboards.
+
+The guide SHALL cover:
+- Collapsible `sections` grouping panels, with a tech-preview callout
+- `image_config.by_value` with `url` source for branding
+- Lens Gauge chart (`vis_config.by_value.gauge_chart_config`) with a goal value
+- Lens Heatmap chart (`vis_config.by_value.heatmap_chart_config`) showing activity by day-of-week and hour
+- `esql_control` in `pinned_panels` with a named variable, and a panel query referencing that variable
+- `access_control` with `access_mode = "write_restricted"` and its replacement-on-change implication
+- `tags` field for dashboard organisation
+
+The guide SHALL include a screenshot showing one section collapsed and another expanded.
+
+#### Scenario: Guide 3 Terraform config applies cleanly
+
+- **WHEN** `terraform apply` is run with `examples/guides/guide3-advanced/main.tf`
+- **THEN** the apply completes without errors
+- **THEN** the dashboard is visible in Kibana with collapsible sections, a gauge, a heatmap, and an image panel
+
+#### Scenario: Guide 3 covers sections with a tech-preview callout
+
+- **WHEN** the sections portion of the guide is read
+- **THEN** it includes a callout stating that `sections` is a Kibana technical preview feature
+- **THEN** it links to the Kibana release notes or docs for current feature status
+
+#### Scenario: Guide 3 covers access_control replacement behavior
+
+- **WHEN** the access_control portion of the guide is read
+- **THEN** it notes that changing `access_mode` forces replacement of the dashboard resource
+
+---
+
+### Requirement: Runnable example configs exist for all three guides
+
+Each guide SHALL have a corresponding self-contained Terraform configuration under `examples/guides/`:
+- `examples/guides/guide1-getting-started/main.tf`
+- `examples/guides/guide2-operations/main.tf`
+- `examples/guides/guide3-advanced/main.tf`
+
+Each config SHALL include a provider block, all required resource arguments, and use `kibana_sample_data_logs` or `kibana_sample_data_ecommerce` as the data source.
+
+All `vis_config.by_value.*_chart_config` blocks SHALL reference `kibana_sample_data_logs` or `kibana_sample_data_ecommerce` index patterns with correct field names for those datasets.
+
+#### Scenario: Example configs are syntactically valid Terraform
+
+- **WHEN** `terraform validate` is run in each example directory
+- **THEN** validation succeeds with no errors
+
+---
+
+### Requirement: Playwright screenshot scripts are committed and documented
+
+A `scripts/screenshots/` directory SHALL exist containing:
+- `package.json` declaring `playwright` as a dependency
+- `README.md` explaining prerequisites and how to run the scripts
+- `guide1.mjs`, `guide2.mjs`, `guide3.mjs` — one script per guide
+
+Each script SHALL:
+- Accept `KIBANA_URL`, `KIBANA_USER`, and `KIBANA_PASS` environment variables with sensible defaults
+- Handle the Kibana login flow before navigating to the dashboard
+- Wait for panel rendering to complete (`networkidle` + panel selector) before capturing
+- Write output PNGs to `docs/guides/images/`
+
+Screenshot PNG files SHALL be committed to the repository at `docs/guides/images/`.
+
+#### Scenario: Screenshot scripts produce output PNGs
+
+- **WHEN** a local Kibana 9.4+ instance is running with sample data installed and the guide configs applied
+- **WHEN** `node scripts/screenshots/guide1.mjs` is run
+- **THEN** PNG files are written to `docs/guides/images/` with no errors
+
+#### Scenario: README documents the full screenshot workflow
+
+- **WHEN** `scripts/screenshots/README.md` is read
+- **THEN** it lists the prerequisites: running Kibana, sample data installed, terraform applied, `npm install`
+- **THEN** it documents the environment variables and an example invocation

--- a/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
+++ b/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
@@ -109,9 +109,9 @@ Guide 3 (`kibana-dashboard-advanced.md`) SHALL demonstrate advanced dashboard fe
 
 The guide SHALL cover:
 - Collapsible `sections` grouping panels, with a tech-preview callout
-- `image_config.by_value` with `url` source for branding
-- Lens Gauge chart (`vis_config.by_value.gauge_chart_config`) with a goal value
-- Lens Heatmap chart (`vis_config.by_value.heatmap_chart_config`) showing activity by day-of-week and hour
+- `image_config.src.url` for branding
+- Lens Gauge chart (`vis_config.by_value.gauge_config`) with a goal value
+- Lens Heatmap chart (`vis_config.by_value.heatmap_config`) showing activity by day-of-week and hour
 - `esql_control` in `pinned_panels` with a named variable, and a panel query referencing that variable
 - `access_control` with `access_mode = "write_restricted"` and its replacement-on-change implication
 - `tags` field for dashboard organisation

--- a/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
+++ b/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
@@ -1,28 +1,33 @@
 # Kibana Dashboard Guides
 
-Guide implementation: `docs/guides/kibana-dashboard-getting-started.md`, `docs/guides/kibana-dashboard-operations.md`, `docs/guides/kibana-dashboard-advanced.md`
+Guide implementation: `templates/guides/kibana-dashboard-getting-started.md.tmpl`, `templates/guides/kibana-dashboard-operations.md.tmpl`, `templates/guides/kibana-dashboard-advanced.md.tmpl`, rendered to `docs/guides/kibana-dashboard-getting-started.md`, `docs/guides/kibana-dashboard-operations.md`, and `docs/guides/kibana-dashboard-advanced.md`
 
 ## ADDED Requirements
 
-### Requirement: Three guide files exist and are linked from the dashboard resource docs
+### Requirement: Three guide templates exist, render to guide files, and are linked from the dashboard resource docs
 
-Three standalone provider guides SHALL exist and be rendered by `make docs-generate`:
+Three standalone provider guide templates SHALL exist as sources consumed by `make docs-generate`:
+- `templates/guides/kibana-dashboard-getting-started.md.tmpl`
+- `templates/guides/kibana-dashboard-operations.md.tmpl`
+- `templates/guides/kibana-dashboard-advanced.md.tmpl`
+
+Running `make docs-generate` SHALL render those templates to these guide files:
 - `docs/guides/kibana-dashboard-getting-started.md`
 - `docs/guides/kibana-dashboard-operations.md`
 - `docs/guides/kibana-dashboard-advanced.md`
 
 The `elasticstack_kibana_dashboard` resource documentation SHALL include a "See also" section linking to all three guides.
 
-Each guide SHALL declare `subcategory: ""` and an appropriate `page_title` and `description` in its frontmatter.
+Each guide template SHALL declare `subcategory: ""` and an appropriate `page_title` and `description` in its frontmatter so the rendered guide preserves those values.
 
 #### Scenario: Guides render without error
 
-- **WHEN** `make docs-generate` is run
+- **WHEN** the three template files under `templates/guides/` are present and `make docs-generate` is run
 - **THEN** all three guide files are created under `docs/guides/` with no generation errors
 
 #### Scenario: make check-docs passes
 
-- **WHEN** all three guide files and their referenced example files are committed
+- **WHEN** all three guide template files, the rendered guide files, and their referenced example files are committed
 - **THEN** `make check-docs` exits with code 0
 
 ---

--- a/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
+++ b/openspec/changes/kibana-dashboard-guides/specs/kibana-dashboard-guides/spec.md
@@ -43,7 +43,7 @@ The guide SHALL cover these topics in order:
 4. Lens Metric panels — `vis_config.by_value.metric_chart_config` for count and cardinality metrics
 5. Lens Line chart — `vis_config.by_value.xy_chart_config` for time-series request volume
 6. Lens Bar chart (horizontal) — `vis_config.by_value.xy_chart_config` for top-N URL breakdown
-7. Lens Donut chart — `vis_config.by_value.partition_chart_config` for response code distribution
+7. Lens Donut chart — `vis_config.by_value.pie_chart_config` for response code distribution
 
 The guide SHALL include an explicit section explaining how to obtain Lens visualization JSON from the Kibana UI using Inspect → Request → Response.
 

--- a/openspec/changes/kibana-dashboard-guides/tasks.md
+++ b/openspec/changes/kibana-dashboard-guides/tasks.md
@@ -1,0 +1,82 @@
+## 1. Infrastructure & Setup
+
+- [ ] 1.1 Create `scripts/screenshots/` directory with `package.json` declaring `playwright` dependency
+- [ ] 1.2 Write `scripts/screenshots/README.md` documenting prerequisites, environment variables, and example invocations
+- [ ] 1.3 Create `examples/guides/guide1-getting-started/`, `examples/guides/guide2-operations/`, `examples/guides/guide3-advanced/` directories
+- [ ] 1.4 Register the three guide templates in the provider's docs generation system (frontmatter + template file wiring) so `make docs-generate` picks them up
+
+## 2. Guide 1 — Terraform Config & Screenshots
+
+- [ ] 2.1 Write `examples/guides/guide1-getting-started/main.tf` — dashboard shell with `kibana_sample_data_logs` data view, `time_range`, `refresh_interval`, `query`
+- [ ] 2.2 Add markdown panel to `main.tf` and verify it renders in Kibana
+- [ ] 2.3 Add two Lens Metric panels (count + cardinality) to `main.tf` and verify
+- [ ] 2.4 Add Lens Line chart panel to `main.tf` and verify
+- [ ] 2.5 Add Lens horizontal Bar chart panel (top-10 URLs) to `main.tf` and verify
+- [ ] 2.6 Add Lens Donut chart panel (response codes) to `main.tf` and verify
+- [ ] 2.7 Write `scripts/screenshots/guide1.mjs` — login, navigate, wait for panels, capture 8 PNGs to `docs/guides/images/`
+- [ ] 2.8 Run Playwright script and commit all `g1-*.png` screenshots to `docs/guides/images/`
+
+## 3. Guide 2 — Terraform Config & Screenshots
+
+- [ ] 3.1 Write `examples/guides/guide2-operations/main.tf` — dashboard with `kibana_sample_data_ecommerce`, `options` block, `pinned_panels` with `options_list_control`
+- [ ] 3.2 Add three Lens Metric panels (revenue, order count, AOV) to `main.tf` and verify
+- [ ] 3.3 Add Lens Stacked Area chart panel to `main.tf` and verify
+- [ ] 3.4 Add Lens Data Table panel to `main.tf` and verify
+- [ ] 3.5 Add Lens Donut panel to `main.tf` and verify
+- [ ] 3.6 Add `discover_session` panel with `by_value.tab.dsl` to `main.tf` and verify
+- [ ] 3.7 Write `scripts/screenshots/guide2.mjs` — capture 4 PNGs including before/after filter screenshots
+- [ ] 3.8 Run Playwright script and commit all `g2-*.png` screenshots to `docs/guides/images/`
+
+## 4. Guide 3 — Terraform Config & Screenshots
+
+- [ ] 4.1 Write `examples/guides/guide3-advanced/main.tf` — dashboard with `sections`, `image` panel, `access_control`, `tags`
+- [ ] 4.2 Add Lens Gauge panel with goal value to `main.tf` and verify
+- [ ] 4.3 Add Lens Heatmap panel (requests by day/hour) to `main.tf` and verify
+- [ ] 4.4 Add multi-layer Lens Area+Line chart to `main.tf` and verify
+- [ ] 4.5 Add `esql_control` to `pinned_panels` and a panel query referencing its variable — verify filtering works
+- [ ] 4.6 Wire panels into `sections` blocks and verify collapse/expand in Kibana
+- [ ] 4.7 Write `scripts/screenshots/guide3.mjs` — capture 4 PNGs including collapsed/expanded section states
+- [ ] 4.8 Run Playwright script and commit all `g3-*.png` screenshots to `docs/guides/images/`
+
+## 5. Guide 1 — Prose
+
+- [ ] 5.1 Write prerequisites section: provider setup, Kibana 9.4+ requirement, sample data installation steps
+- [ ] 5.2 Write dashboard shell section: explain `time_range`, `refresh_interval`, `query`; introduce the 48-column grid with a visual diagram
+- [ ] 5.3 Write "How to get Lens visualization JSON" section: Kibana UI → Inspect → Request → copy attributes
+- [ ] 5.4 Write markdown panel step with snippet and `g1-02-markdown.png`
+- [ ] 5.5 Write Metric panels step (count + cardinality) with snippet and `g1-04-metric2.png`
+- [ ] 5.6 Write Line chart step with snippet and `g1-05-line.png`
+- [ ] 5.7 Write Bar chart step with snippet and `g1-06-bar.png`
+- [ ] 5.8 Write Donut chart step with snippet and `g1-07-final.png` (final dashboard)
+- [ ] 5.9 Write "Next steps" section linking to guides 2 and 3 and the reference docs
+
+## 6. Guide 2 — Prose
+
+- [ ] 6.1 Write prerequisites section and overview of what the dashboard will show
+- [ ] 6.2 Write `pinned_panels` and `options_list_control` section — explain controls vs. content panels, show before/after screenshots `g2-01-full.png` and `g2-02-filtered.png`
+- [ ] 6.3 Write KPI row section (three Metric panels) with snippet
+- [ ] 6.4 Write Stacked Area chart section with snippet
+- [ ] 6.5 Write Data Table section with `g2-04-table.png`
+- [ ] 6.6 Write `discover_session` section — explain `ref_id`, `column_order`, `view_mode`; include `g2-03-discover.png`
+- [ ] 6.7 Write dashboard `options` section explaining `use_margins`, `sync_colors`, `sync_tooltips`
+
+## 7. Guide 3 — Prose
+
+- [ ] 7.1 Write prerequisites section and overview of advanced features covered
+- [ ] 7.2 Write `sections` section with tech-preview callout; include `g3-01-full.png` and `g3-02-collapsed.png`
+- [ ] 7.3 Write `image` panel section (branding use-case)
+- [ ] 7.4 Write Gauge chart section with goal value explanation; include `g3-03-gauge.png`
+- [ ] 7.5 Write Heatmap chart section; include `g3-04-heatmap.png`
+- [ ] 7.6 Write `esql_control` section — explain variable declaration and `?variable` query syntax
+- [ ] 7.7 Write `access_control` section — explain `write_restricted`, replacement-on-change behavior
+- [ ] 7.8 Write `tags` section — explain tag IDs and dashboard organisation
+
+## 8. Validation & Polish
+
+- [ ] 8.1 Run `terraform validate` in all three example directories; fix any schema errors
+- [ ] 8.2 Run `make docs-generate` and verify all three guides appear in `docs/guides/`
+- [ ] 8.3 Run `make check-docs` and fix any broken references or missing example files
+- [ ] 8.4 Review all screenshots — no loading spinners, no empty panels; re-run scripts if needed
+- [ ] 8.5 Verify all Terraform code blocks in the guides match the final `main.tf` configs
+- [ ] 8.6 Check frontmatter in all three guides matches the format of existing guides
+- [ ] 8.7 Verify `docs/resources/kibana_dashboard.md` includes "See also" links to the three guides


### PR DESCRIPTION
## Summary

- Adds an OpenSpec change (`openspec/changes/kibana-dashboard-guides/`) with proposal, design, spec, and tasks artifacts for three progressive dashboard guides
- Adds an HTML planning document (`docs/guides/dashboard-guides-plan.html`) covering guide structure, panel type selection rationale, screenshot strategy, and delivery plan
- No changes to provider code or existing documentation

## Guides planned

| Guide | File | Dataset | Highlights |
|---|---|---|---|
| 1 — Getting Started | `kibana-dashboard-getting-started.md` | `kibana_sample_data_logs` | Step-by-step construction; markdown, 2× metric, line, bar, donut |
| 2 — Operations | `kibana-dashboard-operations.md` | `kibana_sample_data_ecommerce` | `pinned_panels` controls, Discover session, data table, stacked area |
| 3 — Advanced | `kibana-dashboard-advanced.md` | `kibana_sample_data_logs` | Collapsible sections, ES\|QL control, gauge, heatmap, image, access control |

Screenshots will be captured via committed Playwright scripts against a local Kibana 9.4+ instance.

## Test plan

- [ ] Review proposal, design, spec, and tasks artifacts in `openspec/changes/kibana-dashboard-guides/`
- [ ] Review HTML plan document at `docs/guides/dashboard-guides-plan.html`
- [ ] Confirm scope and panel selection choices align with issue #1722
- [ ] Approve to unblock guide implementation

Related to #1722 (partially — this PR covers the proposal; guide implementation follows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)