### PR TITLE
docs: split agentic dev workflow across overview and deep dives

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -2,12 +2,21 @@
 
 ## High level
 
-This directory details the high level concepts for the provider repository. 
-For example:
+Starting-point docs for contributors. They stay high-level and link to canonical sources elsewhere in the repo:
+
 * [A contributing guide](./high-level/contributing.md)
-* [Testing expectations](./high-level/testing.md) 
+* [Testing expectations](./high-level/testing.md)
 * [Coding standards](./high-level/coding-standards.md)
+
+## Agentic development
+
+The repository combines OpenSpec for requirements with GitHub Agentic Workflows for issue intake, scheduled quality scans, and PR verification. Start with the overview, then drop into the deeper docs as needed:
+
+* [Agentic development workflow (overview)](./high-level/agentic-development-workflow.md)
+* [Factory workflows (label-triggered CI)](./high-level/factory-workflows.md)
+* [Continuous quality workflows (scheduled scans)](./high-level/continuous-quality-workflows.md)
+* [OpenSpec workflows (prepare / implement / verify)](./high-level/openspec-workflows.md)
 
 ## Requirements (OpenSpec)
 
-Canonical functional requirements live under [`openspec/specs/`](../openspec/specs/) (OpenSpec). See [`high-level/openspec-requirements.md`](./high-level/openspec-requirements.md) for how to add or validate specs. 
+Canonical functional requirements live under [`openspec/specs/`](../openspec/specs/) (OpenSpec). See [`high-level/openspec-requirements.md`](./high-level/openspec-requirements.md) for how to add or validate specs.

--- a/dev-docs/high-level/README.md
+++ b/dev-docs/high-level/README.md
@@ -11,3 +11,11 @@ They intentionally stay high-level and link to deeper, canonical docs elsewhere 
 - Repo structure: [`repo-structure.md`](./repo-structure.md)
 - ML resource template: [`ml-resource-template.md`](./ml-resource-template.md)
 
+Agentic development (CI factories + OpenSpec loop):
+
+- Overview: [`agentic-development-workflow.md`](./agentic-development-workflow.md)
+- Factory workflows (label-triggered): [`factory-workflows.md`](./factory-workflows.md)
+- Continuous quality workflows (scheduled): [`continuous-quality-workflows.md`](./continuous-quality-workflows.md)
+- OpenSpec workflows (prepare / implement / verify): [`openspec-workflows.md`](./openspec-workflows.md)
+- Maintainer view of `verify-openspec`: [`code-review.md`](./code-review.md)
+

--- a/dev-docs/high-level/agentic-development-workflow.md
+++ b/dev-docs/high-level/agentic-development-workflow.md
@@ -1,0 +1,92 @@
+# Agentic development workflow
+
+This page is the high-level map of how work moves through the repository, from a new GitHub issue all the way to a merged PR. It exists because the repo combines two automation systems that meet in the middle:
+
+- **GitHub Agentic Workflows (AWF)** in [`.github/workflows/`](../../.github/workflows/) run in CI. Some react to labels on issues ("factories"); others run on a schedule ("continuous quality"). They produce sticky comments, PRs, or new issues.
+- **OpenSpec** under [`openspec/`](../../openspec/) holds the canonical functional requirements. Changes flow through `openspec/changes/<id>/` artifacts (proposal, design, tasks, delta specs) and are applied locally using skills under [`.agents/skills/`](../../.agents/skills/).
+
+Use this page when you want the overall picture. The deeper details live in:
+
+- [`factory-workflows.md`](./factory-workflows.md) — label-triggered factories (`research-factory`, `reproducer-factory`, `change-factory`, `code-factory`) and the issue classifier
+- [`continuous-quality-workflows.md`](./continuous-quality-workflows.md) — scheduled scanners that file or fix issues automatically
+- [`openspec-workflows.md`](./openspec-workflows.md) — preparing a change, the local implementation loop, and the verify cycle
+- [`openspec-requirements.md`](./openspec-requirements.md) — authoring rules for OpenSpec specs themselves
+- [`code-review.md`](./code-review.md) — the maintainer view of the `verify-openspec` PR label
+
+## Two tracks
+
+The automation has two distinct entry points:
+
+```mermaid
+flowchart LR
+  subgraph Reactive["Reactive track: human-raised issues"]
+    I[New GitHub issue] --> C[Issue Classifier]
+    C --> RF[research-factory]
+    C --> RP[reproducer-factory]
+    C --> CF[change-factory]
+    C --> H[needs-human]
+    RF --> CF
+    RP --> CF
+    CF --> P[Proposal PR<br/>openspec/changes only]
+  end
+
+  subgraph Proactive["Proactive track: scheduled scans"]
+    S[Cron schedule] --> CQ[Scanner workflow]
+    CQ --> AI[Auto-created issue<br/>already triaged]
+    AI --> CDF[code-factory]
+  end
+
+  P --> L[Local openspec-implementation-loop]
+  L --> IPR[Implementation PR]
+  CDF --> IPR
+  IPR --> CI[CI checks]
+  CI --> V[verify-openspec label]
+  V --> M[Merge]
+```
+
+The reactive track is the canonical path for new features and bugs and goes through OpenSpec. The proactive track is for mechanical quality work — refactors, test coverage gaps, duplicate code, flaky tests — and skips OpenSpec by handing straight to `code-factory`.
+
+## Decision tree: which path applies?
+
+The [issue classifier](./factory-workflows.md#front-door-issue-classifier) makes the first cut by labelling each incoming issue. Use the table below to pick a path once an issue has been classified, or when starting work locally:
+
+| Signal | Path |
+|--------|------|
+| Brand-new resource, data source, ephemeral, or action | Reactive → research-factory → change-factory → loop |
+| Behavioral change to an existing entity needing design discussion | Reactive → change-factory → loop |
+| Reproducible bug | Reactive → reproducer-factory → change-factory → loop |
+| Bug whose fix is one obvious change with no spec impact | Reactive → code-factory (skip OpenSpec) |
+| Refactor, duplicate code, test coverage gap, flaky test | Proactive (or manual `code-factory` apply) |
+| Generated-client drift, docs drift, dead code | Direct cleanup workflow (no issue, no OpenSpec) |
+| Vague, ambiguous, security, or meta | Stays `needs-human` |
+
+When unsure, prefer the OpenSpec path. It is cheap to write a tiny proposal and expensive to merge an undocumented behavior change.
+
+## Phase labels
+
+Each reactive-track issue carries exactly one `phase-*` label after it has entered a pipeline. The label set and behaviour are documented in [`factory-workflows.md`](./factory-workflows.md#phase-labels) and pinned by the [`ci-factory-pipeline-phase-labels`](../../openspec/specs/ci-factory-pipeline-phase-labels/spec.md) spec.
+
+## Where the boundary sits between CI and your laptop
+
+| Concern | In CI (factory / workflow) | On your laptop (skill) |
+|---------|----------------------------|-------------------------|
+| Triage a new issue | `issue-classifier` | — |
+| Author research notes | `research-factory` | `openspec-explore`, `new-entity-requirements` |
+| Confirm a bug reproduces | `reproducer-factory` | — |
+| Draft an OpenSpec proposal | `change-factory` | `openspec-propose`, `openspec-new-change`, `existing-entity-requirements` |
+| Implement an approved change | `code-factory` (quality / mechanical) | `openspec-implementation-loop`, `openspec-apply-change` |
+| Verify implementation before merge | `verify-openspec` label | `openspec-verify-change`, `requirements-verification`, `schema-coverage` |
+| Babysit a PR through CI and review | — | `pr-monitoring-loop` |
+| Detect duplicate code, refactor opportunities, coverage gaps, flaky tests | Continuous-quality scanners | — |
+| Roll up generated client drift into entity follow-ups | `kibana-spec-impact` | — |
+| Clean up dead code, docs drift | `ci-deadcode-removal-rotation`, `security-role-docs-drift` | — |
+
+The design intent: CI handles **intake and first-pass automation**; the local loop is the richer implementation-and-review surface where humans (and locally-launched agents) drive the work to merge.
+
+## Reading order for new contributors
+
+1. [`contributing.md`](./contributing.md) — setup and PR expectations
+2. [`development-workflow.md`](./development-workflow.md) — typical change loop and make targets
+3. [`openspec-workflows.md`](./openspec-workflows.md) — how to take a change through OpenSpec end-to-end
+4. [`factory-workflows.md`](./factory-workflows.md) — what each label-triggered factory does
+5. [`continuous-quality-workflows.md`](./continuous-quality-workflows.md) — what the scheduled workflows do for you in the background

--- a/dev-docs/high-level/code-review.md
+++ b/dev-docs/high-level/code-review.md
@@ -15,8 +15,7 @@ Nothing runs until someone applies that label. The workflow is only meant for PR
 ## Where the details live
 
 - **Behavior and requirements** (what must be true, when the bot skips work, what “approve” implies):  
-  [`openspec/changes/aw-openspec-verification/specs/ci-aw-openspec-verification/spec.md`](../../openspec/changes/aw-openspec-verification/specs/ci-aw-openspec-verification/spec.md)  
-  (When that change is archived, the same capability will live under [`openspec/specs/`](../../openspec/specs/) per project process.)
+  [`openspec/specs/ci-aw-openspec-verification/spec.md`](../../openspec/specs/ci-aw-openspec-verification/spec.md)
 
 - **How it is implemented** (instructions for the automation, triggers, compilation):  
   - Source: [`.github/workflows/openspec-verify-label.md`](../../.github/workflows/openspec-verify-label.md)  
@@ -24,4 +23,4 @@ Nothing runs until someone applies that label. The workflow is only meant for PR
 
 Repository admins may need to adjust **GitHub Actions** settings so workflows can open or update pull requests and push to PR branches; exact needs depend on your org. If pushes from the bot do not trigger your usual CI, see [Triggering CI](https://github.github.io/gh-aw/reference/triggering-ci/) in the GitHub Agentic Workflows docs.
 
-For how OpenSpec changes and specs fit into everyday contribution work, see [`openspec-requirements.md`](./openspec-requirements.md).
+For how OpenSpec changes and specs fit into everyday contribution work, see [`openspec-requirements.md`](./openspec-requirements.md). For the prepare → implement → verify loop that `verify-openspec` sits inside, see [`openspec-workflows.md`](./openspec-workflows.md).

--- a/dev-docs/high-level/continuous-quality-workflows.md
+++ b/dev-docs/high-level/continuous-quality-workflows.md
@@ -16,7 +16,7 @@ For label-triggered factories that react to human-raised issues, see [`factory-w
 | Semantic Function Refactor | Daily | Issue → `code-factory` | [`semantic-function-refactor.md`](../../.github/workflows/semantic-function-refactor.md) |
 | Schema Coverage Rotation | Daily | Issue → `code-factory` | [`schema-coverage-rotation.md`](../../.github/workflows/schema-coverage-rotation.md) |
 | Flaky Test Catcher | Daily | Issue → `code-factory` | [`flaky-test-catcher.md`](../../.github/workflows/flaky-test-catcher.md) |
-| Kibana Spec Impact | Weekly Mon + push to `generated/kbapi/**` | Issue (manual handoff) | [`kibana-spec-impact.md`](../../.github/workflows/kibana-spec-impact.md) |
+| Kibana Spec Impact | Weekly Mon + push to `generated/kbapi/**` or `internal/clients/kibanaoapi/**` | Issue (manual handoff) | [`kibana-spec-impact.md`](../../.github/workflows/kibana-spec-impact.md) |
 | Dead-code Removal Rotation | Daily | Direct cleanup PR | [`ci-deadcode-removal-rotation.md`](../../.github/workflows/ci-deadcode-removal-rotation.md) |
 | Security Role Docs Drift | Weekly Mon + push to `generated/kbapi/**` | Direct cleanup PR | [`security-role-docs-drift.md`](../../.github/workflows/security-role-docs-drift.md) |
 
@@ -48,7 +48,7 @@ Each scanner runs a pre-activation step that counts how many of its own open iss
 | Flaky Test Catcher | `flaky-test` | computed from CI failures | Pre-activation script |
 | Kibana Spec Impact | `kibana`, `generated-clients`, `terraform-provider` | 5 (`issue_cap`) | Pre-activation script |
 
-The pre-activation script is implemented at [`.github/scripts/workflows/issue-slots/compute.js`](../../.github/scripts/workflows/issue-slots/compute.js) and sets `issue_slots_available`. The workflow's job-level `if:` short-circuits when it is zero.
+The three scanners using a fixed `ISSUE_SLOTS_CAP` share the helper at [`.github/scripts/workflows/issue-slots/compute.js`](../../.github/scripts/workflows/issue-slots/compute.js). Flaky Test Catcher computes its own slots in [`.github/scripts/workflows/flaky-test-catcher/catch.js`](../../.github/scripts/workflows/flaky-test-catcher/catch.js) (it needs to weigh CI-failure history in the same step), and Kibana Spec Impact uses the Go pre-activation command at [`scripts/kibana-spec-impact`](../../scripts/kibana-spec-impact). All three paths publish `issue_slots_available`, and the workflow's job-level `if:` short-circuits when it is zero.
 
 ## Scanners that hand off to `code-factory`
 

--- a/dev-docs/high-level/continuous-quality-workflows.md
+++ b/dev-docs/high-level/continuous-quality-workflows.md
@@ -1,0 +1,107 @@
+# Continuous quality workflows
+
+This page describes the **scheduled, proactive** agentic workflows that scan the repository on a cron and produce one of three outputs:
+
+- An auto-filed GitHub issue, then a `code-factory` dispatch to implement it.
+- An auto-filed issue that waits for a human to triage and pick up.
+- A direct cleanup PR with no intermediate issue.
+
+For label-triggered factories that react to human-raised issues, see [`factory-workflows.md`](./factory-workflows.md). For the high-level map, see [`agentic-development-workflow.md`](./agentic-development-workflow.md).
+
+## Index
+
+| Workflow | Schedule | Output type | Source |
+|----------|----------|-------------|--------|
+| Duplicate Code Detector | Daily | Issue → `code-factory` | [`duplicate-code-detector.md`](../../.github/workflows/duplicate-code-detector.md) |
+| Semantic Function Refactor | Daily | Issue → `code-factory` | [`semantic-function-refactor.md`](../../.github/workflows/semantic-function-refactor.md) |
+| Schema Coverage Rotation | Daily | Issue → `code-factory` | [`schema-coverage-rotation.md`](../../.github/workflows/schema-coverage-rotation.md) |
+| Flaky Test Catcher | Daily | Issue → `code-factory` | [`flaky-test-catcher.md`](../../.github/workflows/flaky-test-catcher.md) |
+| Kibana Spec Impact | Weekly Mon + push to `generated/kbapi/**` | Issue (manual handoff) | [`kibana-spec-impact.md`](../../.github/workflows/kibana-spec-impact.md) |
+| Dead-code Removal Rotation | Daily | Direct cleanup PR | [`ci-deadcode-removal-rotation.md`](../../.github/workflows/ci-deadcode-removal-rotation.md) |
+| Security Role Docs Drift | Weekly Mon + push to `generated/kbapi/**` | Direct cleanup PR | [`security-role-docs-drift.md`](../../.github/workflows/security-role-docs-drift.md) |
+
+## The dispatch chain
+
+Four of the scheduled workflows file issues and immediately dispatch `code-factory` for each one. They share the helper at [`.github/workflows/shared/dispatch-code-factory.md`](../../.github/workflows/shared/dispatch-code-factory.md), which adds a `dispatch-code-factory` safe-outputs job to the workflow. After the agent creates issues via the `create-issue` safe output, that job runs [`producer-dispatch.js`](../../.github/scripts/workflows/lib/producer-dispatch.js) to call `gh workflow run code-factory-issue.lock.yml` once per created issue, passing both `issue_number` and a `source_workflow` provenance tag.
+
+```mermaid
+flowchart LR
+  S[Cron schedule] --> PA[Pre-activation:<br/>compute issue slots]
+  PA -->|slots available| A[Agent run]
+  A -->|create-issue safe output| I[New issue<br/>pre-labelled triaged]
+  A -->|dispatch_code_factory safe output| D[Producer dispatch job]
+  D -->|gh workflow run| CF[code-factory-issue]
+  CF --> PR[Implementation PR]
+```
+
+The auto-created issues are pre-labelled `triaged` so the issue classifier skips them. Each scanner also adds a specific topic label (e.g. `duplicate-code`, `semantic-refactor`) used by its slot-cap computation.
+
+## Issue slots: backpressure
+
+Each scanner runs a pre-activation step that counts how many of its own open issues already exist and refuses to create more than the cap. This stops a flaky scan from flooding the issue tracker.
+
+| Scanner | Topic label | Per-run cap | Cap source |
+|---------|-------------|-------------|------------|
+| Duplicate Code Detector | `duplicate-code` | 3 | `ISSUE_SLOTS_CAP` env var |
+| Semantic Function Refactor | `semantic-refactor` | 3 | `ISSUE_SLOTS_CAP` env var |
+| Schema Coverage Rotation | `schema-coverage` | 3 | `ISSUE_SLOTS_CAP` env var |
+| Flaky Test Catcher | `flaky-test` | computed from CI failures | Pre-activation script |
+| Kibana Spec Impact | `kibana`, `generated-clients`, `terraform-provider` | 5 (`issue_cap`) | Pre-activation script |
+
+The pre-activation script is implemented at [`.github/scripts/workflows/issue-slots/compute.js`](../../.github/scripts/workflows/issue-slots/compute.js) and sets `issue_slots_available`. The workflow's job-level `if:` short-circuits when it is zero.
+
+## Scanners that hand off to `code-factory`
+
+Each scanner's heuristics, thresholds, and issue body shape live in its workflow source — link only.
+
+- **Duplicate Code Detector** ([source](../../.github/workflows/duplicate-code-detector.md)) — finds duplicated patterns in recently changed Go files (excluding tests and workflow YAML).
+- **Semantic Function Refactor** ([source](../../.github/workflows/semantic-function-refactor.md)) — Serena + gopls analysis across non-test `.go` files; flags misplaced functions, near-duplicates, scattered helpers, and extraction or generics opportunities.
+- **Schema Coverage Rotation** ([source](../../.github/workflows/schema-coverage-rotation.md), skill: [`schema-coverage`](../../.agents/skills/schema-coverage/SKILL.md)) — rotates coverage analysis across Terraform entities by least-recently-analysed; persists rotation state in a [repo-memory branch](#repo-memory-branches).
+- **Flaky Test Catcher** ([source](../../.github/workflows/flaky-test-catcher.md), skill: [`flaky-test-catcher`](../../.agents/skills/flaky-test-catcher/SKILL.md)) — inspects recent `test.yml` failures on `main`, classifies by fail-rate, deduplicates against open `flaky-test` issues.
+
+## Scanners that file issues for human handoff
+
+- **Kibana Spec Impact** ([source](../../.github/workflows/kibana-spec-impact.md)) — diffs generated `kbapi` symbols against a baseline in the [repo-memory branch](#repo-memory-branches) and maps high-confidence changes to impacted Terraform entities. Does **not** dispatch `code-factory`; maintainer triages and decides between `change-factory` and `code-factory`.
+
+## Workflows that open cleanup PRs directly
+
+- **Dead-code Removal Rotation** ([source](../../.github/workflows/ci-deadcode-removal-rotation.md)) — picks one dead-code candidate per run from a deterministic rotation with cooldown, verifies with `make build` + unit tests, then opens one cleanup PR.
+- **Security Role Docs Drift** ([source](../../.github/workflows/security-role-docs-drift.md)) — diffs `scripts/security-role-docs/kibana-features.json` against the live Kibana features API and regenerates `docs/guides/security-roles.md` when drift exists.
+
+## Repo memory branches
+
+Several scanners persist state on dedicated orphan branches under `memory/` so rotation, dedupe, and baselines survive across runs:
+
+| Branch | Used by | What it stores |
+|--------|---------|----------------|
+| `memory/schema-coverage-rotation` | Schema Coverage Rotation | Per-entity last-analysed timestamps |
+| `memory/ci-deadcode-removal-rotation` | Dead-code Removal Rotation | Candidate attempts, filtered candidates, outcome reasons |
+| `memory/kibana-spec-impact` | Kibana Spec Impact | Analysed baseline SHA and per-entity dedupe fingerprints |
+
+Branches are read via the `repo-memory` tool config in each workflow and written either by helper Go programs under `scripts/<rotation-name>/` or by inline `record` invocations the agent runs near the end of its task. The pattern means the next run begins from durable state rather than re-deriving it.
+
+## Manual dispatch
+
+All scheduled workflows declare `workflow_dispatch`. Useful when:
+
+- A scanner is being iterated on and you want an immediate run.
+- You want to clear a backlog after a long pause.
+- You want to confirm a fix removed a finding before the next cron tick.
+
+Each workflow's pre-activation runs first, so dispatch still honours slot caps, cooldowns, and duplicate-PR suppression.
+
+## Adding a new scanner
+
+When introducing a new scheduled workflow that should hand off to `code-factory`:
+
+1. Import [`shared/dispatch-code-factory.md`](../../.github/workflows/shared/dispatch-code-factory.md) in the workflow's `imports:` list. Do not add a per-workflow `dispatch-code-factory` job.
+2. Compute issue slots in pre-activation using the [`issue-slots/compute.js`](../../.github/scripts/workflows/issue-slots/compute.js) helper, with an `ISSUE_SLOTS_LABEL` and `ISSUE_SLOTS_CAP`.
+3. Pre-label every created issue `triaged` (the safe-output label list) so the classifier skips it.
+4. After creating issues, instruct the agent to call `dispatch_code_factory` once. The shared helper will fan out one `code-factory-issue` dispatch per issue with the `source_workflow` provenance tag.
+5. If state must persist across runs, register a `repo-memory` branch under `memory/<workflow-name>`.
+
+For scanners that open their own cleanup PR (no issue), follow the patterns in `ci-deadcode-removal-rotation.md` and `security-role-docs-drift.md` instead.
+
+## See also
+
+- Label-triggered factories (including `code-factory`, which the scanners dispatch to): [`factory-workflows.md`](./factory-workflows.md)

--- a/dev-docs/high-level/contributing.md
+++ b/dev-docs/high-level/contributing.md
@@ -72,14 +72,12 @@ See [`repo-structure.md`](./repo-structure.md).
 
 ## Factory workflow labels (maintainers)
 
-The repository uses four persistent `phase-*` labels to track which pipeline stage an issue has reached. These labels must be created manually in the GitHub repository before the factory workflows can apply them:
+The repository uses agentic CI workflows ("factories") that react to labels on issues, plus scheduled scanners that dispatch to them. See [`agentic-development-workflow.md`](./agentic-development-workflow.md) for the overview, [`factory-workflows.md`](./factory-workflows.md) for per-factory details, and [`continuous-quality-workflows.md`](./continuous-quality-workflows.md) for the scheduled scanners that hand off to `code-factory`.
 
-- `phase-research` — set by `research-factory`
-- `phase-reproduction` — set by `reproducer-factory`
-- `phase-specification` — set by `change-factory`
-- `phase-coding` — set by `code-factory`
+Before the workflows can run, two label sets must exist in repo settings:
 
-Exactly one `phase-*` label is present on an issue at any time after a factory workflow runs. The labels are not removed on issue closure.
+- **Trigger labels** applied by maintainers: `research-factory`, `reproducer-factory`, `change-factory`, `code-factory`.
+- **Phase labels** applied by the workflows themselves: `phase-research`, `phase-reproduction`, `phase-specification`, `phase-coding`.
 
 ## Releasing (maintainers)
 

--- a/dev-docs/high-level/development-workflow.md
+++ b/dev-docs/high-level/development-workflow.md
@@ -2,6 +2,8 @@
 
 For full contributor guidance (setup, PR expectations), see [`contributing.md`](./contributing.md).
 
+This page covers the local change loop and shared make targets. For the broader picture of how local work and CI automation fit together — issue classification, factory workflows, scheduled quality scanners, and PR verification — start at [`agentic-development-workflow.md`](./agentic-development-workflow.md).
+
 ## Typical change loop
 
 1. Prepare an OpenSpec proposal before writing provider code.

--- a/dev-docs/high-level/factory-workflows.md
+++ b/dev-docs/high-level/factory-workflows.md
@@ -1,93 +1,212 @@
 # Factory workflows
 
-This repository uses agentic GitHub Actions workflows — "factories" — to automate research, proposal authoring, and implementation for issues. Each factory is triggered by a dedicated label.
+This page describes the **label-triggered, issue-scoped** agentic workflows in CI. Each "factory" reacts to a dedicated label on a single GitHub issue, runs a deterministic pre-activation, then delegates work to an agent with bounded outputs (one PR, one sticky comment).
 
-## Labels
+For the broader picture, see [`agentic-development-workflow.md`](./agentic-development-workflow.md). For scheduled scanners that file or fix issues automatically, see [`continuous-quality-workflows.md`](./continuous-quality-workflows.md). For the local OpenSpec loop that picks up after `change-factory`, see [`openspec-workflows.md`](./openspec-workflows.md).
 
-| Label | Color | Description |
-|-------|-------|-------------|
-| `change-factory` | *(existing)* | Trigger the change-factory agent to author an OpenSpec proposal PR for this issue |
-| `code-factory` | *(existing)* | Trigger the code-factory agent to implement this issue in a linked pull request |
-| `research-factory` | `#e6b8a2` | Trigger the research-factory agent to author an implementation-research block for this issue |
+## Front door: issue classifier
 
-> **Note for maintainers:** The `research-factory` label must be created in the repository settings before the workflow can be triggered by label events. Use the color `#e6b8a2` (warm orange) and the description shown above.
+Source: [`.github/workflows/issue-classifier.md`](../../.github/workflows/issue-classifier.md)
 
----
+Every new issue is read by the classifier on `issues.opened`. A daily scheduled run also picks up to **5** oldest untriaged open issues to catch anything that slipped through. The classifier applies exactly one routing label plus `triaged`:
 
-## `research-factory`
+| Label | Means | Typical next step |
+|-------|-------|-------------------|
+| `needs-research` | Specific feature request (named API or clear product area) | Maintainer applies `research-factory` |
+| `needs-reproduction` | Bug with config, error, or repro steps | Maintainer applies `reproducer-factory` |
+| `needs-spec` | Problem **and** solution design fully specified (rare) | Maintainer applies `change-factory` |
+| `needs-human` | Vague, ambiguous, security, or meta | Maintainer judgment |
 
-### What it does
+The classifier never applies factory trigger labels itself. A maintainer (or future automation) promotes the issue by applying `research-factory`, `reproducer-factory`, `change-factory`, or `code-factory`, or by dispatching the workflow with `workflow_dispatch` and the issue number.
 
-`research-factory` adds a deep-research pass **before** `change-factory`. It enriches issues with an implementation-research block that compares at least two candidate approaches, surfaces open questions, and grounds decisions in Elastic documentation and a full repository checkout.
+## Trigger labels
 
-### How to trigger
+| Label | Workflow source | Output |
+|-------|-----------------|--------|
+| `research-factory` | [`research-factory-issue.md`](../../.github/workflows/research-factory-issue.md) | Sticky implementation-research comment on the issue |
+| `reproducer-factory` | [`reproducer-factory-issue.md`](../../.github/workflows/reproducer-factory-issue.md) | Sticky reproducer comment; optional reproduction PR |
+| `change-factory` | [`change-factory-issue.md`](../../.github/workflows/change-factory-issue.md) | One OpenSpec proposal PR |
+| `code-factory` | [`code-factory-issue.md`](../../.github/workflows/code-factory-issue.md) | One implementation PR that closes the issue |
 
-1. **Label trigger:** Apply the `research-factory` label to an existing issue.
-2. **Dispatch trigger:** Run the `research-factory-issue` workflow via `workflow_dispatch` and provide the `issue_number` input. This path is intended for automated chaining (e.g. from a future issue classifier).
+> Maintainer setup: these labels must exist in repo settings before the workflows can be triggered by label events. See [`contributing.md`](./contributing.md#factory-workflow-labels-maintainers).
 
-### What the block looks like
+All factories also support `workflow_dispatch` with an `issue_number` input, which is how the continuous-quality scanners fan out to `code-factory` (see [`continuous-quality-workflows.md`](./continuous-quality-workflows.md)).
 
-The agent appends or rewrites a single gated section in the issue body, delimited by:
+## Phase labels
 
-```markdown
-<!-- implementation-research:start -->
-## Implementation research
+After a factory runs, the issue carries exactly one `phase-*` label so the pipeline stage is visible from the issue list:
 
-_(provenance header with run timestamp, run link, and social-contract notice)_
+| Phase label | Set by |
+|-------------|--------|
+| `phase-research` | `research-factory` |
+| `phase-reproduction` | `reproducer-factory` |
+| `phase-specification` | `change-factory` |
+| `phase-coding` | `code-factory` |
 
-### Problem framing
-...
+Behavior is pinned by the [`ci-factory-pipeline-phase-labels`](../../openspec/specs/ci-factory-pipeline-phase-labels/spec.md) spec.
 
-### Approaches considered
-#### Approach A
-...
-#### Approach B
-...
+## Shared mechanics
 
-### Recommendation
-...
+Every factory uses the same deterministic pre-activation pattern, implemented under [`.github/scripts/workflows/lib/factory-runners/`](../../.github/scripts/workflows/lib/factory-runners/):
 
-### Open questions
-...
+1. **Qualify trigger** — confirms the label or dispatch input is valid.
+2. **Capture context** — reads issue title, body, comments, and any prior sticky comment.
+3. **Suppress duplicate PRs** — refuses to start when an open branch like `<factory>/issue-<N>` already has a linked PR.
+4. **Sanitize context** — strips embedded instructions / prompt-injection patterns from issue content before handing it to the agent.
+5. **Remove trigger label** and **set phase label**.
+6. **Upload context artifact** that the agent job downloads.
 
-### Out of scope
-...
+The agent then runs against an LLM gateway model with the relevant tools (`elastic-docs` MCP, `github` gh-proxy toolset, sometimes a live Elastic Stack) and emits **bounded safe outputs** — usually at most one PR and one comment per run.
 
-### References
-...
-<!-- implementation-research:end -->
-```
+## `research-factory` — feature research
 
-Mandatory subsections in order:
+Adds a deep-research pass **before** `change-factory`. It compares at least two candidate approaches, surfaces open questions, and grounds decisions in Elastic documentation.
 
-- `## Implementation research` — H2 heading with provenance and social-contract notice
-- `### Problem framing`
-- `### Approaches considered` — two or more `#### ` H4 children
-- `### Recommendation`
-- `### Open questions`
-- `### Out of scope`
-- `### References`
+### Trigger
+
+- Apply the `research-factory` label to an issue.
+- Or dispatch the workflow with `issue_number`.
+
+### Output: sticky comment
+
+A single comment delimited by `<!-- gha-research-factory -->` containing problem framing, two or more candidate approaches, a recommendation, open questions, and references. The exact section list and metadata JSON shape are pinned by [`ci-research-factory-comment-format`](../../openspec/specs/ci-research-factory-comment-format/spec.md); the agent prompt is in [`research-factory-issue.md`](../../.github/workflows/research-factory-issue.md).
 
 ### Social contract
 
-- The block is **regenerated on every run**. Edits you make inside the block are read as input on the next re-run but are **not preserved verbatim**.
+- The block is **regenerated on every run**. Edits you make inside it are read as input on the next re-run but are **not preserved verbatim**.
 - For durable feedback, post a comment or edit content **outside** the block.
 - To trigger a fresh research pass, re-apply the `research-factory` label.
 
-### How `change-factory` uses it
+### How `change-factory` consumes it
 
-When an implementation-research block is present in the issue body, `change-factory` treats it as the **exclusive** authoritative scope:
+When the research comment is present, `change-factory` treats it as the **exclusive authoritative scope**:
 
 - `### Recommendation` becomes the proposal spine.
 - `### Open questions` is copied into `design.md` as `## Open questions`.
 - `### Approaches considered` is treated as already-evaluated context.
 
-When the block is absent, `change-factory` falls back to its default behavior: the issue title and body are authoritative.
+If the comment is absent, `change-factory` falls back to issue title + body. `change-factory` never modifies the research comment.
 
-`change-factory` will **not** modify or rewrite the implementation-research block itself.
+### What it does not do
 
-### What the workflow does NOT do
+- Does not open pull requests.
+- Does not write code.
+- Does not apply `change-factory` — promotion is a human action.
 
-- It does **not** open pull requests.
-- It does **not** write code or modify repository files.
-- It does **not** apply the `change-factory` label — promotion from research to proposal is a **human action**.
+## `reproducer-factory` — bug reproduction
+
+Confirms a reported bug reproduces against a live Elastic Stack and (when it does) lands a failing acceptance test on a dedicated branch.
+
+### Trigger
+
+- Apply the `reproducer-factory` label to an issue.
+- Or dispatch with `issue_number`.
+
+### Outputs
+
+Every run emits exactly one **sticky reproducer comment** (`<!-- gha-reproducer-factory -->`) with one of three outcomes:
+
+| Outcome | Comment sections | PR? |
+|---------|------------------|-----|
+| **A — reproduced** | Summary, Root cause, Reproduction test, References, metadata | Yes, on `reproducer-factory/issue-<N>` containing only the reproduction test, body `Related to #<N>` |
+| **B — cannot reproduce** | Summary, three concrete Investigation avenues | No |
+| **C — appears fixed** | Summary, Evidence, References, metadata | No |
+
+The comment format is pinned by [`ci-reproducer-factory-comment-format`](../../openspec/specs/ci-reproducer-factory-comment-format/spec.md).
+
+### Test file placement
+
+- **Default**: `internal/acctest/reproductions/issue_<N>_acc_test.go` defining `TestAccReproduceIssue<N>`.
+- **Resource package** when the issue clearly identifies one Terraform resource (e.g. `internal/kibana/alertingrule/issue_<N>_acc_test.go`).
+
+### Environment
+
+Runs against a provisioned Elastic Stack inside the agent environment, talking to it via proxy ports `9201` (Elasticsearch) and `5602` (Kibana). Direct ports `9200`/`5601` are blocked by the AWF firewall.
+
+### Time budget
+
+Reserves ~55 minutes of agent work with a 65-minute hard kill. If time runs short, the agent prefers a partial-but-valid outcome-B comment over emitting `noop`.
+
+## `change-factory` — OpenSpec proposal authoring
+
+Authors exactly one OpenSpec change directory and opens it as a proposal PR.
+
+### Trigger
+
+- Apply the `change-factory` label.
+- Or post a `/change-factory` slash command on the issue (captured as `human_direction`).
+- Or dispatch with `issue_number`.
+
+### Scope authority (priority order)
+
+1. **Human direction** (slash command text) — final say, overrides everything below.
+2. **Implementation-research comment** (`<!-- gha-research-factory -->`) — exclusive baseline when present.
+3. **Issue title and body** — default.
+
+`change-factory` never modifies the research comment.
+
+### Output: proposal PR
+
+- Branch: `change-factory/issue-<N>`
+- Labels: `change-factory`, `no-changelog`
+- Body: includes the literal phrase `Related to #<N>` (not `Closes`) so merging does not auto-close the issue
+- Contents: **only** files under `openspec/changes/<change-id>/`:
+  - `proposal.md`, `design.md`, `tasks.md`
+  - `.openspec.yaml`
+  - Delta specs under `specs/<capability>/spec.md`
+
+The change is **apply-ready**: an implementer can start from `tasks.md` and delta specs without further research.
+
+### Out of scope for this run
+
+`change-factory` is proposal-only. It deliberately does **not** run `make build`, `go test`, acceptance tests, modify provider source, or touch generated clients.
+
+## `code-factory` — direct implementation
+
+Implements a single GitHub issue end-to-end on a dedicated branch and opens an implementation PR.
+
+### Trigger
+
+- Apply the `code-factory` label.
+- Or dispatch with `issue_number` and `source_workflow` (used by the continuous-quality scanners).
+
+### Intent
+
+This path **bypasses OpenSpec** by design. It is intended for:
+
+- Quality / refactor / test-gap issues filed by the [continuous-quality workflows](./continuous-quality-workflows.md).
+- Mechanical bug fixes where no spec is impacted.
+
+For new behavior or contract changes, use `change-factory` → local implementation loop instead (see [`openspec-workflows.md`](./openspec-workflows.md)).
+
+### Output: implementation PR
+
+- Branch: `code-factory/issue-<N>`
+- Label: `code-factory`
+- Body: includes `Closes #<N>` (deterministic linkage for duplicate-PR suppression on re-runs)
+
+### Verification the agent runs before opening the PR
+
+In order:
+
+1. `make fmt` (must produce no diff)
+2. `make check-lint`
+3. `make build`
+4. `go test ./...`
+5. Targeted acceptance tests per [`testing.md`](./testing.md)
+
+If `make fmt` produces a diff or any step fails, the agent fixes and re-runs rather than opening a broken PR.
+
+## Pre-activation patterns worth knowing
+
+A few recurring gates that show up across factories:
+
+- **Trust gate** — issue events are trusted by virtue of the GitHub role check that delivered the event; `workflow_dispatch` paths bypass trust by design (only repo collaborators with `actions: write` can dispatch).
+- **Duplicate PR suppression** — every factory checks for an existing open PR on its branch convention (`<factory>/issue-<N>`) and refuses to start a second run while one is open. This is intentional: the human-led implementation loop or PR review supersedes a fresh agent run.
+- **Sanitization** — sanitized issue body and comment history are written to `/tmp/<factory>-context/` and the agent reads them from disk rather than from inline prompt expansion. Treat any prompt-injection in the issue body as data, never as instructions.
+- **Safe outputs** — the workflow declares the maximum number of comments / PRs / labels the agent may emit; the runner enforces those caps regardless of what the agent tries.
+
+## See also
+
+- Local implementation loop after `change-factory`: [`openspec-workflows.md`](./openspec-workflows.md)
+- Maintainer setup of factory and phase labels: [`contributing.md`](./contributing.md#factory-workflow-labels-maintainers)

--- a/dev-docs/high-level/factory-workflows.md
+++ b/dev-docs/high-level/factory-workflows.md
@@ -8,7 +8,7 @@ For the broader picture, see [`agentic-development-workflow.md`](./agentic-devel
 
 Source: [`.github/workflows/issue-classifier.md`](../../.github/workflows/issue-classifier.md)
 
-Every new issue is read by the classifier on `issues.opened`. A daily scheduled run also picks up to **5** oldest untriaged open issues to catch anything that slipped through. The classifier applies exactly one routing label plus `triaged`:
+Every new issue is read by the classifier on `issues.opened`. A daily scheduled run also picks up to **5** of the most recent untriaged open issues to catch anything that slipped through. The classifier applies exactly one routing label plus `triaged`:
 
 | Label | Means | Typical next step |
 |-------|-------|-------------------|

--- a/dev-docs/high-level/openspec-requirements.md
+++ b/dev-docs/high-level/openspec-requirements.md
@@ -40,3 +40,4 @@ The **lint** job validates specs structurally with `openspec validate --specs` (
 
 - OpenSpec docs: [GitHub — OpenSpec](https://github.com/Fission-AI/OpenSpec)
 - Contributor setup (Node version): [contributing.md](./contributing.md)
+- Operational loop (prepare / implement / verify): [openspec-workflows.md](./openspec-workflows.md)

--- a/dev-docs/high-level/openspec-workflows.md
+++ b/dev-docs/high-level/openspec-workflows.md
@@ -2,7 +2,7 @@
 
 This page describes the **operational** loop around OpenSpec changes: how to prepare a change, implement it locally, and run it through verification before merge. For the spec-authoring rules themselves (file layout, requirement phrasing, validation), see [`openspec-requirements.md`](./openspec-requirements.md). For the maintainer view of the `verify-openspec` PR label, see [`code-review.md`](./code-review.md). For the broader picture of how this fits with CI factories, see [`agentic-development-workflow.md`](./agentic-development-workflow.md).
 
-The canonical step-by-step procedures live in skill files under [`.agents/skills/`](../../.agents/skills/) and [`.agents/skills/`](../../.agents/skills/). This page describes **which skill to reach for and when**, not the steps inside each skill.
+The canonical step-by-step procedures live in skill files under [`.agents/skills/`](../../.agents/skills/). This page describes **which skill to reach for and when**, not the steps inside each skill.
 
 ## Three phases
 

--- a/dev-docs/high-level/openspec-workflows.md
+++ b/dev-docs/high-level/openspec-workflows.md
@@ -1,0 +1,124 @@
+# OpenSpec workflows
+
+This page describes the **operational** loop around OpenSpec changes: how to prepare a change, implement it locally, and run it through verification before merge. For the spec-authoring rules themselves (file layout, requirement phrasing, validation), see [`openspec-requirements.md`](./openspec-requirements.md). For the maintainer view of the `verify-openspec` PR label, see [`code-review.md`](./code-review.md). For the broader picture of how this fits with CI factories, see [`agentic-development-workflow.md`](./agentic-development-workflow.md).
+
+The canonical step-by-step procedures live in skill files under [`.agents/skills/`](../../.agents/skills/) and [`.agents/skills/`](../../.agents/skills/). This page describes **which skill to reach for and when**, not the steps inside each skill.
+
+## Three phases
+
+```mermaid
+flowchart LR
+  subgraph A[Phase A: prepare]
+    EX[openspec-explore] --> P[openspec-propose]
+    NC[openspec-new-change] --> CC[openspec-continue-change]
+    CF[change-factory CI] --> PR1[Proposal PR]
+    P --> PR1
+    CC --> PR1
+  end
+  PR1 --> M1[Merge proposal]
+  M1 --> B
+  subgraph B[Phase B: implement]
+    LOOP[openspec-implementation-loop]
+    APP[openspec-apply-change]
+    LOOP --> APP
+  end
+  B --> C
+  subgraph C[Phase C: verify]
+    VLOCAL[openspec-verify-change<br/>local]
+    VCI[verify-openspec label<br/>CI]
+    VLOCAL --> VCI
+  end
+  VCI --> M2[Merge implementation]
+```
+
+## Phase A — Prepare the change
+
+Goal: an approved change directory under `openspec/changes/<change-id>/` containing at least `proposal.md`, `design.md`, `tasks.md`, and delta specs.
+
+### Local skills
+
+| Skill | When to use |
+|-------|-------------|
+| [`openspec-explore`](../../.agents/skills/openspec-explore/SKILL.md) | Scope is fuzzy; you want to investigate the codebase, compare approaches, or clarify requirements **without** committing to artifacts yet |
+| [`openspec-propose`](../../.agents/skills/openspec-propose/SKILL.md) | You can describe the desired outcome in one pass and want all artifacts generated together |
+| [`openspec-new-change`](../../.agents/skills/openspec-new-change/SKILL.md) | You want to scaffold the change directory first and then add artifacts incrementally |
+| [`openspec-continue-change`](../../.agents/skills/openspec-continue-change/SKILL.md) | A change exists but is not yet apply-ready; create the next artifact in sequence |
+| [`new-entity-requirements`](../../.agents/skills/new-entity-requirements/SKILL.md) | Drafting a brand-new resource, data source, ephemeral, or action from an API spec |
+| [`existing-entity-requirements`](../../.agents/skills/existing-entity-requirements/SKILL.md) | Capturing the behaviour of an entity that already exists in code |
+
+### CI alternative
+
+For reactive-track work (an issue labelled `change-factory`), the [`change-factory`](./factory-workflows.md#change-factory--openspec-proposal-authoring) workflow drafts the same artifacts in CI and opens the proposal PR. The local skills and the CI workflow produce the same shape of output; pick whichever fits the situation.
+
+### Proposal PR
+
+Send the OpenSpec artifacts for review **before implementation**. The proposal PR should contain only files under `openspec/changes/<change-id>/`. This is the point to resolve scope, requirements, and design questions while the cost of change is still low.
+
+## Phase B — Implement the change
+
+Goal: provider code, tests, and any related generated artifacts that satisfy every task and requirement in the approved change.
+
+### Local skills
+
+| Skill | When to use |
+|-------|-------------|
+| [`openspec-apply-change`](../../.agents/skills/openspec-apply-change/SKILL.md) | You are doing the implementation by hand or with light agent help; reads the change, works the task list, ticks checkboxes |
+| [`openspec-implementation-loop`](../../.agents/skills/openspec-implementation-loop/SKILL.md) | You want an automated end-to-end loop around a single approved change: implement, review, push, watch CI, optionally drive a PR with review handling |
+
+The implementation loop is the heavier, recommended path for non-trivial work. It triages the change into one of three execution strategies (inline, single-implementor, per-task) based on size and coupling, and asks you up front for a **delivery mode**:
+
+- **Commit-only**: push to origin, watch GitHub Actions on the branch.
+- **Pull request**: create a PR after the initial push, then delegate PR monitoring to [`pr-monitoring-loop`](../../.agents/skills/pr-monitoring-loop/SKILL.md).
+
+Strategy thresholds and review cadence are defined in the [`openspec-implementation-loop`](../../.agents/skills/openspec-implementation-loop/SKILL.md) skill itself.
+
+### Validation requirements (all strategies)
+
+The loop always runs at minimum:
+
+- `make lint`
+- `make build`
+- Targeted acceptance tests with `TF_ACC=1` against a live stack (see [`testing.md`](./testing.md))
+
+For Terraform entity changes it also runs the [`schema-coverage`](../../.agents/skills/schema-coverage/SKILL.md) skill as a coverage review. For non-entity changes it uses `go test -cover` analysis instead.
+
+### What the loop never does
+
+- It never **archives** a change. Archiving is the responsibility of the verify phase.
+- It never force-pushes unless you ask.
+- It never starts a second change in the same run.
+
+If the implementor blocks or the loop stalls, it pauses and asks rather than guessing.
+
+### CI alternative
+
+For mechanical work filed by a [continuous-quality scanner](./continuous-quality-workflows.md), the [`code-factory`](./factory-workflows.md#code-factory--direct-implementation) workflow implements directly without the OpenSpec phase. That path skips proposal and verify entirely — use it only when there is no spec impact.
+
+## Phase C — Verify before merge
+
+Goal: confirm the implementation matches the approved change artifacts; on success, archive the change so it moves into `openspec/specs/`.
+
+### Local verification
+
+| Skill | When to use |
+|-------|-------------|
+| [`openspec-verify-change`](../../.agents/skills/openspec-verify-change/SKILL.md) | Run during the implementation loop and before requesting the CI verify label; checks completeness, correctness, and coherence and produces a CRITICAL / WARNING / SUGGESTION report |
+| [`requirements-verification`](../../.agents/skills/requirements-verification/SKILL.md) | Analyse a spec for internal consistency and identify test opportunities |
+| [`openspec-sync-specs`](../../.agents/skills/openspec-sync-specs/SKILL.md) | Sync delta specs into `openspec/specs/` when the implementation needs the canonical specs updated without archiving the change yet |
+
+### CI verification: `verify-openspec` label
+
+A maintainer (or the PR monitoring loop) applies the `verify-openspec` label to a PR. The workflow selects one active change, verifies it against the implementation, posts exactly one PR review, and on APPROVE for same-repo PRs runs `openspec archive` and pushes the result back to the PR branch.
+
+The maintainer view, including what "approve" implies and when the workflow skips work, is in [`code-review.md`](./code-review.md). The normative behaviour is pinned by the [`ci-aw-openspec-verification`](../../openspec/specs/ci-aw-openspec-verification/spec.md) spec; the implementation lives in [`.github/workflows/openspec-verify-label.md`](../../.github/workflows/openspec-verify-label.md) and follows the same [`openspec-verify-change`](../../.agents/skills/openspec-verify-change/SKILL.md) skill the local verify step uses.
+
+### Verify and the PR monitoring loop
+
+When the implementation loop runs in PR mode it delegates monitoring to [`pr-monitoring-loop`](../../.agents/skills/pr-monitoring-loop/SKILL.md). That skill knows how to opt in to verify-openspec behaviour: it applies the `verify-openspec` label when `requiresOpenspecVerification` is true and only treats the PR as ready when `verifyOpenspec.runState == "approved"` and CI is green. It also handles re-triggering after pushes, because the verify workflow removes its own label as soon as it picks up a PR.
+
+## Local-only variations
+
+The reactive-track end-to-end flow is in [`agentic-development-workflow.md`](./agentic-development-workflow.md#two-tracks). Two common local variations:
+
+- **Maintainer-driven local change** — skip the `change-factory` CI step and use [`openspec-propose`](../../.agents/skills/openspec-propose/SKILL.md) directly. The rest of the loop is unchanged.
+- **`code-factory`-only fix** — for mechanical work with no spec impact, skip OpenSpec entirely and go through [`code-factory`](./factory-workflows.md#code-factory--direct-implementation).


### PR DESCRIPTION
## Summary

Documents the end-to-end development process across four `dev-docs/high-level/` pages. Picks Option B from the layout review: a high-level overview plus three focused deep dives, with continuous-quality scanners broken out as their own topic.

- **New** [`agentic-development-workflow.md`](dev-docs/high-level/agentic-development-workflow.md) — reactive vs proactive track diagram, path-selection decision tree, and CI-vs-laptop boundary table. The page you land on when you want the overall picture.
- **Rewritten** [`factory-workflows.md`](dev-docs/high-level/factory-workflows.md) — issue classifier, all four label-triggered factories (`research-`, `reproducer-`, `change-`, `code-factory`), phase labels, and the shared pre-activation / sanitisation / safe-output pattern.
- **New** [`continuous-quality-workflows.md`](dev-docs/high-level/continuous-quality-workflows.md) — every scheduled scanner, the shared `dispatch-code-factory` fanout, issue-slot backpressure, repo-memory branches, and a "how to add a scanner" checklist.
- **New** [`openspec-workflows.md`](dev-docs/high-level/openspec-workflows.md) — prepare → implement → verify loop, deferring step-by-step procedure to the `.agents/skills/` files and pinning sources.

Cross-link touch-ups in `dev-docs/README.md`, `dev-docs/high-level/README.md`, `contributing.md`, `code-review.md`, `development-workflow.md`, and `openspec-requirements.md`. Also fixes a stale spec link in `code-review.md` that still pointed at the pre-archive `openspec/changes/aw-openspec-verification/...` path.

## Design choices

- **Skills, workflow `.md` sources, and OpenSpec specs remain the source of truth.** The new docs name them, link them, and explain *when* / *why* — they do not restate the steps inside (those would drift).
- **`code-factory` lives in `factory-workflows.md`** because it is label-triggered; `continuous-quality-workflows.md` only describes the fanout mechanism that targets it.
- **`verify-openspec` is split across two docs**: the maintainer view stays in `code-review.md`, the prepare → implement → verify loop is in the new `openspec-workflows.md`. Both link the spec and the workflow source rather than restating rules.
- **Skill links standardised on `.agents/skills/`** to match what `openspec/specs/ci-aw-openspec-verification/spec.md` already references.

## Test plan

- [ ] Render the four new / rewritten docs on GitHub and skim for layout (mermaid, tables, links).
- [ ] Click through every cross-link target to confirm the relative paths resolve.
- [ ] Confirm the `agentic-development-workflow.md` decision tree is a useful first read for someone unfamiliar with the factory pipeline.
- [ ] Confirm `factory-workflows.md` is accurate to the latest factory workflows in `.github/workflows/`.
- [ ] Confirm `continuous-quality-workflows.md` correctly describes the scheduled producers and the dispatch chain.


Made with [Cursor](https://cursor.com)