### PR TITLE
fix(kibana-dashboard): make panel-level time_range optional (issue #3424)

### DIFF
--- a/openspec/changes/optional-panel-time-range/.openspec.yaml
+++ b/openspec/changes/optional-panel-time-range/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/optional-panel-time-range/design.md
+++ b/openspec/changes/optional-panel-time-range/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Every typed Lens chart panel write goes through `lenscommon.LensChartPresentationWritesFor`, which calls `resolver.ResolveChartTimeRange(chartLevel)` and unconditionally assigns the result to `writes.TimeRange`. The `Resolver` interface returns a value type (`kbapi.KibanaHTTPAPIsKbnEsQueryServerTimeRangeSchema`), making it impossible to signal "omit this field". The `ResolveChartTimeRange` implementation falls back to the dashboard-level time range and ultimately to `now-15m`/`now`, so a non-empty struct is always produced and always sent.
+
+For by-reference vis panels, `LensByReferenceAttributes()` marks `time_range` as `Required: true`, and `VisByReferenceModelToAPIConfig1` always dereferences `byRef.TimeRange` without a nil check. Both the API type (`KibanaHTTPAPIsKbnDashboardPanelTypeVisConfig1.TimeRange`) and the by-value chart types (`KibanaHTTPAPIsXyChartNoESQL.TimeRange`, etc.) declare the field as `*Type, omitempty`, confirming the API has always been willing to accept absence.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Omit `time_range` from the Kibana API payload when the practitioner has not configured it on the panel.
+- Make `vis_config.by_reference.time_range` optional in the Terraform schema.
+- Update the `Resolver` interface and `ResolveChartTimeRange` so callers get a pointer that is nil when no chart-level time range is configured.
+- Remove the dashboard-inheritance fallback and the hardcoded `now-15m`/`now` fallback.
+- Update the read path to drop the now-unnecessary dashboard-comparable null-preservation check.
+
+**Non-Goals:**
+- Changing dashboard-level `time_range` (remains required).
+- Changing raw `config_json` panel behavior.
+- Introducing a migration path for practitioners who relied on implicit inheritance (they must now set `time_range` explicitly on each panel if desired).
+
+## Decisions
+
+### 1. Change `Resolver.ResolveChartTimeRange` to return a pointer
+
+**Decision**: Change the return type from `kbapi.KibanaHTTPAPIsKbnEsQueryServerTimeRangeSchema` to `*kbapi.KibanaHTTPAPIsKbnEsQueryServerTimeRangeSchema`.
+
+**Rationale**: The existing value-type return forced callers to always have a non-nil result. A pointer return lets `nil` mean "omit from API payload". The `LensChartPresentationWrites.TimeRange` field is already `*Type`, so callers (`chart.TimeRange = writes.TimeRange`) require no changes — nil flows through naturally and `omitempty` handles the rest.
+
+**Alternative considered**: Keep value return, add a separate boolean flag. Rejected — pointer is idiomatic Go for "optional value".
+
+### 2. `ResolveChartTimeRange` returns nil when chart-level is unset
+
+**Decision**: When `chartLevel == nil`, return `nil`. Remove dashboard inheritance and the hardcoded fallback entirely.
+
+**Rationale**: The inheritance was a workaround for a perceived API requirement that never existed. Removing it makes the write path honest: "send exactly what the practitioner configured".
+
+### 3. `VisByReferenceModel.TimeRange` becomes a pointer
+
+**Decision**: Change `TimeRange VisByReferenceTimeRangeModel` to `TimeRange *VisByReferenceTimeRangeModel` in `models/lens.go`.
+
+**Rationale**: Terraform Plugin Framework represents an absent `Optional` single-nested attribute as a nil pointer in the Go model. Making the field a pointer is the standard PF pattern for optional nested attributes.
+
+**Alternative considered**: Keep the value type and use a separate `TimeRangeSet bool` field. Rejected — PF pointer convention is simpler and consistent with the rest of the codebase.
+
+### 4. Remove dashboard-comparable null-preservation from the read path
+
+**Decision**: Remove the `DashboardLensComparableTimeRange` check inside `chartTimeRangeFromAPI`.
+
+**Rationale**: That check existed to prevent drift when the API echoed back the dashboard time range (which we had written). Once we stop writing the dashboard time range, Kibana will not echo it back for panels that don't have one configured. The check becomes dead code. The remaining nil/empty guard is still correct and sufficient.
+
+**Alternative considered**: Keep the check as a safety net. Rejected — dead code obscures intent and the nil guard already handles the case.
+
+### 5. `HasLensByReferenceShapeAtRoot` detects by `ref_id` only
+
+**Decision**: Remove the `time_range` presence check from `HasLensByReferenceShapeAtRoot`; detect by-reference shape solely by the presence of a non-empty `ref_id` string.
+
+**Rationale**: `time_range` is no longer a defining characteristic of the by-reference wire format. `ref_id` is the only required field (`json:"ref_id"` without omitempty), so it remains a reliable discriminator.
+
+## Risks / Trade-offs
+
+[Behavioral breaking change for implicit inheritance users] → No Terraform state migration needed, but practitioners relying on implicit dashboard time range inheritance will see panels lose their custom time range on next apply. This is the correct behavior — the mitigation is clear release notes and a changelog entry.
+
+[`HasLensByReferenceShapeAtRoot` false positives] → A raw `config_json` blob that happens to contain `ref_id` but is not a by-reference vis panel could now be misdetected. In practice, `ref_id` is a Kibana by-reference convention that does not appear in by-value payloads, so the risk is low. If needed, a follow-up can add a secondary discriminator.
+
+[`VisByReferenceModel` model pointer change] → Any code that dereferences `byRef.TimeRange` without a nil check will panic. The write path in `VisByReferenceModelToAPIConfig1` and the read path in `PopulateVisByReferenceTFModelFromAPIConfig1` must both be updated to guard against nil. These are the only two call sites.
+
+## Migration Plan
+
+No Terraform state migration is required:
+- Making `Required → Optional` for `by_reference.time_range` is backward-compatible; existing state with a value continues to work.
+- By-value panels that had an implicitly-inherited time range will have it omitted on the next apply; Kibana will then return no panel-level time range on the following read, producing a stable null state that matches the practitioner's config.
+
+A changelog entry in `CHANGELOG.md` under **Bug Fixes** should describe the behavioral change and note that practitioners who want an explicit panel-level time range must now set it in config.

--- a/openspec/changes/optional-panel-time-range/proposal.md
+++ b/openspec/changes/optional-panel-time-range/proposal.md
@@ -6,7 +6,7 @@ The provider unconditionally forces a `time_range` onto every typed Lens panel i
 
 - **By-value Lens charts**: When a chart-level `time_range` is null in Terraform configuration, the provider SHALL omit `time_range` from the API payload entirely (no inheritance from dashboard, no hardcoded fallback).
 - **By-value Lens charts**: When a chart-level `time_range` is set in configuration, the provider SHALL send it verbatim to the API as before.
-- **By-reference vis panels**: `time_range` becomes optional (`Optional: true`) in the `vis_config.by_reference` Terraform schema — **BREAKING** for existing configs that omit it expecting it to be required (they will still work; only plan-time validation changes).
+- **By-reference vis panels**: `time_range` becomes optional (`Optional: true`) in the `vis_config.by_reference` Terraform schema — backward-compatible (existing configs that set `time_range` continue to work; only plan-time validation is relaxed).
 - **By-reference vis panels**: `VisByReferenceModelToAPIConfig1` only sets `TimeRange` on the API payload when the model has a configured value.
 - **Shape detection**: `HasLensByReferenceShapeAtRoot` detects by-reference config using `ref_id` alone; `time_range` presence is no longer part of the heuristic.
 - **Read path**: The dashboard-comparable null-preservation logic (`DashboardLensComparableTimeRange`) in the chart read path is removed — it was compensating for the forced-inheritance write behavior.

--- a/openspec/changes/optional-panel-time-range/proposal.md
+++ b/openspec/changes/optional-panel-time-range/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The provider unconditionally forces a `time_range` onto every typed Lens panel in the Kibana API payload — either inherited from the dashboard-level value or falling back to a hardcoded `now-15m`/`now` window. This means practitioners cannot create panels that use the dashboard's global time range, manually removing the custom time range in the Kibana UI produces no drift, and the `vis_config.by_reference` schema incorrectly marks `time_range` as a required Terraform attribute. The Kibana API has always declared `time_range` as optional (`*Type, omitempty`) on both by-value chart types and by-reference vis config, so the inheritance behavior was never necessary.
+
+## What Changes
+
+- **By-value Lens charts**: When a chart-level `time_range` is null in Terraform configuration, the provider SHALL omit `time_range` from the API payload entirely (no inheritance from dashboard, no hardcoded fallback).
+- **By-value Lens charts**: When a chart-level `time_range` is set in configuration, the provider SHALL send it verbatim to the API as before.
+- **By-reference vis panels**: `time_range` becomes optional (`Optional: true`) in the `vis_config.by_reference` Terraform schema — **BREAKING** for existing configs that omit it expecting it to be required (they will still work; only plan-time validation changes).
+- **By-reference vis panels**: `VisByReferenceModelToAPIConfig1` only sets `TimeRange` on the API payload when the model has a configured value.
+- **Shape detection**: `HasLensByReferenceShapeAtRoot` detects by-reference config using `ref_id` alone; `time_range` presence is no longer part of the heuristic.
+- **Read path**: The dashboard-comparable null-preservation logic (`DashboardLensComparableTimeRange`) in the chart read path is removed — it was compensating for the forced-inheritance write behavior.
+- **Spec**: REQ-013 in `openspec/specs/kibana-dashboard/spec.md` is updated to require omission (not inheritance) when chart-level `time_range` is null.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `kibana-dashboard`: REQ-013 behavior changes — chart-level `time_range` omitted from API when null (was: inherited from dashboard or hardcoded fallback). By-reference `time_range` becomes optional in TF schema.
+
+## Impact
+
+- **`internal/kibana/dashboard/lenscommon/`**: `iface.go` (Resolver interface), `time_range.go` (ResolveChartTimeRange), `presentation.go` (write and read paths), `by_reference.go` (schema, write, read, shape detection)
+- **`internal/kibana/dashboard/models/`**: `VisByReferenceModel.TimeRange` field pointer change
+- **All typed Lens panel `api_conv.go` files**: No code changes needed — `writes.TimeRange` is already `*Type`, nil will omit via `omitempty`
+- **`openspec/specs/kibana-dashboard/spec.md`**: REQ-013 update
+- **Unit and acceptance tests**: Updated to remove inherited-time-range assertions; new nil-omission assertions added

--- a/openspec/changes/optional-panel-time-range/specs/kibana-dashboard/spec.md
+++ b/openspec/changes/optional-panel-time-range/specs/kibana-dashboard/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: XY chart panel behavior and typed `vis` `time_range` (REQ-013)
+
+For **typed** `vis` panels (those built through the provider's typed `*_config` blocks and the shared typed visualization write path, not panels managed solely through raw `config_json`), the resource SHALL expose `time_range` as an optional flat sibling attribute on every typed Lens chart block (`xy_chart_config`, `metric_chart_config`, `legacy_metric_config`, `gauge_config`, `heatmap_config`, `tagcloud_config`, `region_map_config`, `datatable_config`, `pie_chart_config`, `mosaic_config`, `treemap_config`, `waffle_config`). The attribute SHALL match the dashboard-level `time_range` shape: required `from` (string), required `to` (string), and optional `mode` enum (`absolute` | `relative`).
+
+When the chart-level `time_range` is null in configuration and state, the provider SHALL omit `time_range` from the API payload entirely. The provider SHALL NOT inherit the dashboard-level `time_range` and SHALL NOT use any hardcoded fallback window. Kibana will apply its own default (global dashboard time range) for panels with no panel-level override.
+
+When the chart-level `time_range` is set in configuration, the provider SHALL pass the configured values to the API verbatim, overriding the dashboard-level value for that panel only.
+
+The `vis_config.by_reference` block SHALL expose `time_range` as an **optional** attribute (same shape: required `from`, required `to`, optional `mode`). When `time_range` is null in `by_reference` configuration, the provider SHALL omit it from the API payload. When set, the provider SHALL send it verbatim.
+
+For XY chart `vis` panels specifically, the resource SHALL require `axis`, `decorations`, `fitting`, `legend`, and at least one `layers` entry. The axis object SHALL use `x`, optional primary `y`, and optional secondary `y2`; `axis.x.domain_json` SHALL represent the X-axis domain, and each configured Y axis SHALL require `domain_json`. Each layer SHALL represent either a data layer or a reference-line layer, not both. **`query` SHALL be optional** on the XY chart schema so that ES|QL XY panels (which carry no `query` in the API) are valid without a dummy query block.
+
+REQ-025 governs raw `config_json` `vis` panels; the typed-vs-raw distinction is unchanged.
+
+#### Scenario: Typed `vis` write omits time_range when chart time_range is null
+
+- GIVEN a typed `vis` panel on create or update whose chart-level `time_range` is null in configuration
+- AND the dashboard-level `time_range` is `{ from = "now-7d", to = "now" }`
+- WHEN the provider builds the visualization payload through the typed converter path
+- THEN it SHALL NOT include `time_range` in the API payload for that panel
+
+#### Scenario: Typed `vis` write uses configured chart-level time_range when set
+
+- GIVEN a typed `vis` panel on create or update whose chart-level `time_range` is set to `{ from = "now-30d", to = "now-1d" }` in configuration
+- AND the dashboard-level `time_range` is `{ from = "now-7d", to = "now" }`
+- WHEN the provider builds the visualization payload through the typed converter path
+- THEN it SHALL set `time_range` on the API payload to the chart-level value `{ from = "now-30d", to = "now-1d" }`
+
+#### Scenario: by_reference write omits time_range when not configured
+
+- GIVEN a `vis_config.by_reference` panel on create or update where `time_range` is null in configuration
+- WHEN the provider builds the API payload
+- THEN it SHALL NOT include `time_range` in the by-reference config payload
+
+#### Scenario: by_reference write sends time_range when configured
+
+- GIVEN a `vis_config.by_reference` panel on create or update where `time_range` is set to `{ from = "now-7d", to = "now" }`
+- WHEN the provider builds the API payload
+- THEN it SHALL include `time_range = { from = "now-7d", to = "now" }` in the by-reference config payload
+
+#### Scenario: Read preserves null time_range when API returns none
+
+- GIVEN a typed `vis` panel where `time_range` is null in Terraform state
+- AND the Kibana API returns no `time_range` field for that panel on read
+- WHEN the provider processes the read response
+- THEN it SHALL keep `time_range` as null in state (no drift)
+
+#### Scenario: XY panel requires layers
+
+- GIVEN an XY chart panel configuration
+- WHEN Terraform validates the resource schema
+- THEN the configuration SHALL require at least one layer and the fixed XY sub-blocks needed by the schema
+
+#### Scenario: ES|QL XY panel omits query
+
+- GIVEN an XY chart panel configured for ES|QL mode (no usable query expression)
+- WHEN Terraform validates the resource schema
+- THEN the configuration SHALL be accepted without a `query` block

--- a/openspec/changes/optional-panel-time-range/tasks.md
+++ b/openspec/changes/optional-panel-time-range/tasks.md
@@ -1,0 +1,48 @@
+## 1. Spec Update
+
+- [ ] 1.1 Update `openspec/specs/kibana-dashboard/spec.md` REQ-013: replace the dashboard-inheritance paragraph with "omit when null"; add by-reference optionality text; replace inherited-dashboard scenario with omit scenario; add by-reference nil/set scenarios
+
+## 2. Model Change
+
+- [ ] 2.1 In `internal/kibana/dashboard/models/lens.go`, change `VisByReferenceModel.TimeRange` from `VisByReferenceTimeRangeModel` (value) to `*VisByReferenceTimeRangeModel` (pointer)
+
+## 3. Resolver Interface and Implementation
+
+- [ ] 3.1 In `internal/kibana/dashboard/lenscommon/iface.go`, change `Resolver.ResolveChartTimeRange` return type from `kbapi.KibanaHTTPAPIsKbnEsQueryServerTimeRangeSchema` to `*kbapi.KibanaHTTPAPIsKbnEsQueryServerTimeRangeSchema`
+- [ ] 3.2 In `internal/kibana/dashboard/lenscommon/time_range.go`, rewrite `ResolveChartTimeRange` to return nil when `chartLevel == nil`; remove dashboard inheritance and hardcoded fallback; update `TimeRangeModelToAPI` return to pointer if needed
+- [ ] 3.3 In `internal/kibana/dashboard/panel/visconfig/populate_vis_by_value.go`, update `chartPresentationResolver.ResolveChartTimeRange` to match new interface signature
+
+## 4. Write Path — By-Value Charts
+
+- [ ] 4.1 In `internal/kibana/dashboard/lenscommon/presentation.go`, update `LensChartPresentationWritesFor` to assign `writes.TimeRange` only when resolver returns non-nil (nil → leave `writes.TimeRange` nil)
+- [ ] 4.2 Verify all typed panel `api_conv.go` files (`lensxy`, `lensmetric`, `lenslegacymetric`, `lensdatatable`, `lensgauge`, `lensheatmap`, `lensmosaic`, `lenspie`, `lensregionmap`, `lenstreemap`, `lenstagcloud`, `lenswaffle`) — `chart.TimeRange = writes.TimeRange` already passes a pointer, nil flows through `omitempty` correctly; no changes needed beyond confirming
+
+## 5. Write Path — By-Reference Panels
+
+- [ ] 5.1 In `internal/kibana/dashboard/lenscommon/by_reference.go`, change `LensByReferenceAttributes()` `time_range` from `Required: true` to `Optional: true`; update markdown description
+- [ ] 5.2 In `internal/kibana/dashboard/lenscommon/by_reference.go`, update `VisByReferenceModelToAPIConfig1` to only set `api1.TimeRange` when `byRef.TimeRange != nil`
+- [ ] 5.3 In `internal/kibana/dashboard/lenscommon/by_reference.go`, update `PopulateVisByReferenceTFModelFromAPIConfig1` to handle nil `cfg1.TimeRange` (keep `VisByReferenceModel.TimeRange` nil when API returns none; populate only when non-nil)
+- [ ] 5.4 In `internal/kibana/dashboard/lenscommon/by_reference.go`, simplify `HasLensByReferenceShapeAtRoot` to detect by-reference shape using `ref_id` presence only; remove `time_range` check
+- [ ] 5.5 In `internal/kibana/dashboard/panel/visconfig/schema.go`, update description strings that reference "required `time_range`" for `by_reference`
+
+## 6. Read Path Cleanup
+
+- [ ] 6.1 In `internal/kibana/dashboard/lenscommon/presentation.go`, remove the `DashboardLensComparableTimeRange` comparison block from `chartTimeRangeFromAPI` (the nil/empty guard is sufficient; the dashboard-comparison was compensating for the forced-write behavior)
+- [ ] 6.2 In `internal/kibana/dashboard/lenscommon/time_range.go`, remove `DashboardLensComparableTimeRange` function if no longer referenced; remove `ResolveChartTimeRange` dashboard/fallback logic
+- [ ] 6.3 In `internal/kibana/dashboard/lenscommon/iface.go`, remove `DashboardLensComparableTimeRange` from the `Resolver` interface if no longer called by the read path
+- [ ] 6.4 In `internal/kibana/dashboard/panel/visconfig/populate_vis_by_value.go`, remove `DashboardLensComparableTimeRange` from `chartPresentationResolver` if the method is dropped from the interface
+
+## 7. Tests
+
+- [ ] 7.1 Update unit tests in `internal/kibana/dashboard/lenscommon/` (time_range_test, presentation tests) to assert nil return when chart-level is unset, and correct pointer return when set
+- [ ] 7.2 Update `internal/kibana/dashboard/lenscommon/detect_test.go` to cover `HasLensByReferenceShapeAtRoot` with configs that have `ref_id` but no `time_range`
+- [ ] 7.3 Update `internal/kibana/dashboard/panel/visconfig/api_test.go` and `fromapi_all_converters_test.go` to reflect by-reference `time_range` being optional
+- [ ] 7.4 Update or add converter unit tests in affected typed panel packages to assert `TimeRange` is nil in API payload when chart-level is unset
+- [ ] 7.5 Update acceptance tests (e.g., `lensxy/acc_test.go TestAccResourceDashboardXYChart_chartTimeRangeLifecycle`) to reflect new behavior: no inherited time range when chart-level is null; explicit time range still sent when set
+- [ ] 7.6 Update `visconfig/acc_test.go` by-reference test assertions to not require `time_range` when omitted from config
+
+## 8. Build and Validate
+
+- [ ] 8.1 Run `make build` and confirm no compilation errors
+- [ ] 8.2 Run `make check-lint` (includes `make check-openspec`) and confirm no lint or spec errors
+- [ ] 8.3 Run targeted acceptance tests for affected panel types to confirm correct behavior end-to-end


### PR DESCRIPTION
## Summary

- Proposes removing the forced panel-level `time_range` inheritance behavior from typed Lens chart panels and `vis_config.by_reference`
- When a chart-level `time_range` is not configured, the provider will omit it from the Kibana API payload entirely (rather than inheriting from the dashboard or falling back to `now-15m`/`now`)
- Makes `vis_config.by_reference.time_range` optional in the Terraform schema to match the API

## Background

Related to #3424. The Kibana API has always declared `time_range` as optional (`*Type, omitempty`) on panel config types, but the provider unconditionally forced a value — either inherited from dashboard-level or from a hardcoded fallback. This meant practitioners could not create panels without a custom time range, and manually removing one in the Kibana UI produced no drift.

## This PR

Contains the OpenSpec change proposal, design, delta spec, and task list for the fix. Implementation follows in a subsequent PR.

**Change**: `openspec/changes/optional-panel-time-range/`

## Test plan

- [ ] Review proposal, design, and updated REQ-013 spec scenarios
- [ ] Implementation PR will include unit + acceptance test updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)