### PR TITLE
Add allow_restricted_indices to security role remote_indices

### DIFF
--- a/docs/data-sources/elasticsearch_security_role.md
+++ b/docs/data-sources/elasticsearch_security_role.md
@@ -103,6 +103,7 @@ Read-Only:
 
 Read-Only:
 
+- `allow_restricted_indices` (Boolean) Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.
 - `clusters` (Set of String) A list of cluster aliases to which the permissions in this entry apply.
 - `field_security` (Attributes List) The document fields that the owners of the role have read access to. (see [below for nested schema](#nestedatt--remote_indices--field_security))
 - `names` (Set of String) A list of indices (or index name patterns) to which the permissions in this entry apply.

--- a/docs/data-sources/kibana_security_role.md
+++ b/docs/data-sources/kibana_security_role.md
@@ -90,6 +90,7 @@ Read-Only:
 
 Read-Only:
 
+- `allow_restricted_indices` (Boolean) Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.
 - `clusters` (Set of String) A list of cluster aliases to which the permissions in this entry apply.
 - `field_security` (Attributes) The document fields that the owners of the role have read access to. (see [below for nested schema](#nestedatt--elasticsearch--remote_indices--field_security))
 - `names` (Set of String) A list of indices (or index name patterns) to which the permissions in this entry apply.

--- a/docs/resources/elasticsearch_security_role.md
+++ b/docs/resources/elasticsearch_security_role.md
@@ -120,6 +120,7 @@ Required:
 
 Optional:
 
+- `allow_restricted_indices` (Boolean) Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.
 - `field_security` (Block, Optional) The document fields that the owners of the role have read access to. (see [below for nested schema](#nestedblock--remote_indices--field_security))
 - `query` (String) A search query that defines the documents the owners of the role have read access to.
 

--- a/docs/resources/kibana_security_role.md
+++ b/docs/resources/kibana_security_role.md
@@ -161,6 +161,7 @@ Required:
 
 Optional:
 
+- `allow_restricted_indices` (Boolean) Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.
 - `field_security` (Block, Optional) The document fields that the owners of the role have read access to. (see [below for nested schema](#nestedblock--elasticsearch--remote_indices--field_security))
 - `query` (String) A search query that defines the documents the owners of the role have read access to.
 

--- a/internal/elasticsearch/security/role/acc_test.go
+++ b/internal/elasticsearch/security/role/acc_test.go
@@ -155,6 +155,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "metadata", `{"version":1}`),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.*.clusters.*", "test-cluster"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.*.names.*", "sample"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.0.allow_restricted_indices", "true"),
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.0.query", `{"match_all":{}}`),
 				),
 			},
@@ -177,6 +178,7 @@ func TestAccResourceSecurityRole(t *testing.T) {
 					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "metadata", `{"version":1}`),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.*.clusters.*", "test-cluster2"),
 					resource.TestCheckTypeSetElemAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.*.names.*", "sample2"),
+					resource.TestCheckResourceAttr("elasticstack_elasticsearch_security_role.test", "remote_indices.0.allow_restricted_indices", "false"),
 				),
 			},
 			{

--- a/internal/elasticsearch/security/role/data_source.go
+++ b/internal/elasticsearch/security/role/data_source.go
@@ -204,6 +204,10 @@ func getDataSourceSchema(_ context.Context) dsschema.Schema {
 							Computed:            true,
 							CustomType:          jsontypes.NormalizedType{},
 						},
+						attrAllowRestrictedIndices: dsschema.BoolAttribute{
+							MarkdownDescription: allowRestrictedIndicesDescription,
+							Computed:            true,
+						},
 					},
 				},
 			},
@@ -446,6 +450,13 @@ func (config *roleDataSourceModel) fromAPIModel(ctx context.Context, role *esTyp
 				return diags
 			}
 
+			var allowRestrictedVal types.Bool
+			if remoteIndex.AllowRestrictedIndices != nil {
+				allowRestrictedVal = types.BoolValue(*remoteIndex.AllowRestrictedIndices)
+			} else {
+				allowRestrictedVal = types.BoolNull()
+			}
+
 			fieldSecList, d := buildFieldSecurityDSList(ctx, remoteIndex.FieldSecurity)
 			diags.Append(d...)
 			if diags.HasError() {
@@ -453,11 +464,12 @@ func (config *roleDataSourceModel) fromAPIModel(ctx context.Context, role *esTyp
 			}
 
 			remoteIndexObj, d := types.ObjectValue(getRemoteIndexPermsDSAttrTypes(), map[string]attr.Value{
-				attrClusters:      clustersSet,
-				attrFieldSecurity: fieldSecList,
-				attrNames:         namesSet,
-				attrPrivileges:    privSet,
-				attrQuery:         queryVal,
+				attrAllowRestrictedIndices: allowRestrictedVal,
+				attrClusters:               clustersSet,
+				attrFieldSecurity:          fieldSecList,
+				attrNames:                  namesSet,
+				attrPrivileges:             privSet,
+				attrQuery:                  queryVal,
 			})
 			diags.Append(d...)
 			if diags.HasError() {
@@ -539,7 +551,8 @@ func getIndexPermsDSAttrTypes() map[string]attr.Type {
 
 func getRemoteIndexPermsDSAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		attrClusters: types.SetType{ElemType: types.StringType},
+		attrAllowRestrictedIndices: types.BoolType,
+		attrClusters:               types.SetType{ElemType: types.StringType},
 		attrFieldSecurity: types.ListType{
 			ElemType: types.ObjectType{AttrTypes: getFieldSecurityDSAttrTypes()},
 		},

--- a/internal/elasticsearch/security/role/data_source_test.go
+++ b/internal/elasticsearch/security/role/data_source_test.go
@@ -66,6 +66,7 @@ func TestAccDataSourceSecurityRole(t *testing.T) {
 					resource.TestCheckResourceAttr("data.elasticstack_elasticsearch_security_role.test", "metadata", `{"version":1}`),
 					resource.TestCheckTypeSetElemAttr("data.elasticstack_elasticsearch_security_role.test", "remote_indices.*.clusters.*", "test-cluster2"),
 					resource.TestCheckTypeSetElemAttr("data.elasticstack_elasticsearch_security_role.test", "remote_indices.*.names.*", "sample2"),
+					resource.TestCheckResourceAttr("data.elasticstack_elasticsearch_security_role.test", "remote_indices.0.allow_restricted_indices", "true"),
 				),
 			},
 			{

--- a/internal/elasticsearch/security/role/models.go
+++ b/internal/elasticsearch/security/role/models.go
@@ -71,7 +71,8 @@ type IndexPermsData struct {
 
 type RemoteIndexPermsData struct {
 	CommonIndexPermsData
-	Clusters types.Set `tfsdk:"clusters"`
+	AllowRestrictedIndices types.Bool `tfsdk:"allow_restricted_indices"`
+	Clusters               types.Set  `tfsdk:"clusters"`
 }
 
 type FieldSecurityData struct {
@@ -182,14 +183,17 @@ func (data *Data) toAPIModel(ctx context.Context) (*estypes.Role, diag.Diagnosti
 				return nil, diags
 			}
 
-			remoteIndices[i] = estypes.RemoteIndicesPrivileges{
-				Names:                  idx.Names,
-				Privileges:             idx.Privileges,
-				Query:                  idx.Query,
-				FieldSecurity:          idx.FieldSecurity,
-				AllowRestrictedIndices: idx.AllowRestrictedIndices,
-				Clusters:               clusters,
+			remoteEntry := estypes.RemoteIndicesPrivileges{
+				Names:         idx.Names,
+				Privileges:    idx.Privileges,
+				Query:         idx.Query,
+				FieldSecurity: idx.FieldSecurity,
+				Clusters:      clusters,
 			}
+			if typeutils.IsKnown(remoteIdx.AllowRestrictedIndices) {
+				remoteEntry.AllowRestrictedIndices = remoteIdx.AllowRestrictedIndices.ValueBoolPointer()
+			}
+			remoteIndices[i] = remoteEntry
 		}
 		role.RemoteIndices = remoteIndices
 	}
@@ -486,6 +490,13 @@ func (data *Data) fromAPIModel(ctx context.Context, role *estypes.Role) diag.Dia
 				return diags
 			}
 
+			var allowRestrictedVal types.Bool
+			if remoteIndex.AllowRestrictedIndices != nil {
+				allowRestrictedVal = types.BoolValue(*remoteIndex.AllowRestrictedIndices)
+			} else {
+				allowRestrictedVal = types.BoolNull()
+			}
+
 			var fieldSecObj types.Object
 			if remoteIndex.FieldSecurity != nil {
 				grantSet, d := types.SetValueFrom(ctx, types.StringType, typeutils.NonNilSlice(remoteIndex.FieldSecurity.Grant))
@@ -513,11 +524,12 @@ func (data *Data) fromAPIModel(ctx context.Context, role *estypes.Role) diag.Dia
 			}
 
 			remoteIndexObj, d := types.ObjectValue(getRemoteIndexPermsAttrTypes(), map[string]attr.Value{
-				attrClusters:      clustersSet,
-				attrFieldSecurity: fieldSecObj,
-				attrQuery:         queryVal,
-				attrNames:         namesSet,
-				attrPrivileges:    privSet,
+				attrAllowRestrictedIndices: allowRestrictedVal,
+				attrClusters:               clustersSet,
+				attrFieldSecurity:          fieldSecObj,
+				attrQuery:                  queryVal,
+				attrNames:                  namesSet,
+				attrPrivileges:             privSet,
 			})
 			diags.Append(d...)
 			if diags.HasError() {

--- a/internal/elasticsearch/security/role/models_test.go
+++ b/internal/elasticsearch/security/role/models_test.go
@@ -50,11 +50,12 @@ func TestModel_GetVersionRequirements(t *testing.T) {
 		namesSet := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("logs-*")})
 		privilegesSet := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("read")})
 		remoteIndexObj := types.ObjectValueMust(attrTypes, map[string]attr.Value{
-			"clusters":       clustersSet,
-			"field_security": types.ObjectNull(getFieldSecurityAttrTypes()),
-			"query":          jsontypes.NewNormalizedNull(),
-			"names":          namesSet,
-			"privileges":     privilegesSet,
+			attrAllowRestrictedIndices: types.BoolNull(),
+			attrClusters:               clustersSet,
+			attrFieldSecurity:          types.ObjectNull(getFieldSecurityAttrTypes()),
+			attrQuery:                  jsontypes.NewNormalizedNull(),
+			attrNames:                  namesSet,
+			attrPrivileges:             privilegesSet,
 		})
 		elements := make([]attr.Value, count)
 		for i := range elements {

--- a/internal/elasticsearch/security/role/schema.go
+++ b/internal/elasticsearch/security/role/schema.go
@@ -188,6 +188,14 @@ func GetSchema(version int64) schema.Schema {
 								setvalidator.SizeAtLeast(1),
 							},
 						},
+						attrAllowRestrictedIndices: schema.BoolAttribute{
+							MarkdownDescription: allowRestrictedIndicesDescription,
+							Optional:            true,
+							Computed:            true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
+						},
 					},
 				},
 			},

--- a/internal/elasticsearch/security/role/testdata/TestAccDataSourceSecurityRole/read/main.tf
+++ b/internal/elasticsearch/security/role/testdata/TestAccDataSourceSecurityRole/read/main.tf
@@ -18,8 +18,9 @@ resource "elasticstack_elasticsearch_security_role" "test" {
       grant  = ["sample"]
       except = []
     }
-    names      = ["sample2"]
-    privileges = ["create", "read", "write"]
+    names                    = ["sample2"]
+    privileges               = ["create", "read", "write"]
+    allow_restricted_indices = true
   }
 
   applications {

--- a/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRole/remote_indices_create/main.tf
+++ b/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRole/remote_indices_create/main.tf
@@ -18,8 +18,9 @@ resource "elasticstack_elasticsearch_security_role" "test" {
       grant  = ["sample"]
       except = []
     }
-    names      = ["sample"]
-    privileges = ["create", "read", "write"]
+    names                    = ["sample"]
+    privileges               = ["create", "read", "write"]
+    allow_restricted_indices = true
     query = jsonencode({
       match_all = {}
     })

--- a/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRole/remote_indices_update/main.tf
+++ b/internal/elasticsearch/security/role/testdata/TestAccResourceSecurityRole/remote_indices_update/main.tf
@@ -17,8 +17,9 @@ resource "elasticstack_elasticsearch_security_role" "test" {
       grant  = ["sample"]
       except = []
     }
-    names      = ["sample2"]
-    privileges = ["create", "read", "write"]
+    names                    = ["sample2"]
+    privileges               = ["create", "read", "write"]
+    allow_restricted_indices = false
   }
 
   metadata = jsonencode({

--- a/internal/kibana/security_role/acc_test.go
+++ b/internal/kibana/security_role/acc_test.go
@@ -131,6 +131,7 @@ func TestAccResourceKibanaSecurityRole(t *testing.T) {
 					}),
 					checks.TestCheckResourceListAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.names", []string{"sample"}),
 					checks.TestCheckResourceListAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.privileges", []string{"create", "read", "write"}),
+					resource.TestCheckResourceAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.allow_restricted_indices", "true"),
 				),
 			},
 			{
@@ -150,6 +151,7 @@ func TestAccResourceKibanaSecurityRole(t *testing.T) {
 					checks.TestCheckResourceListAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.field_security.grant", []string{"sample2"}),
 					checks.TestCheckResourceListAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.names", []string{"sample2"}),
 					checks.TestCheckResourceListAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.privileges", []string{"create", "read", "write"}),
+					resource.TestCheckResourceAttr("elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.allow_restricted_indices", "false"),
 				),
 			},
 		},
@@ -297,6 +299,7 @@ func TestAccDataSourceKibanaSecurityRole(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs("data.elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.*", map[string]string{
 						"query": `{"match_all":{}}`,
 					}),
+					resource.TestCheckResourceAttr("data.elasticstack_kibana_security_role.test", "elasticsearch.remote_indices.0.allow_restricted_indices", "true"),
 				),
 			},
 			{

--- a/internal/kibana/security_role/attr_types.go
+++ b/internal/kibana/security_role/attr_types.go
@@ -45,11 +45,12 @@ func esIndexResourceAttrTypes() map[string]attr.Type {
 
 func esRemoteIndexResourceAttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
-		attrClusters:      types.SetType{ElemType: types.StringType},
-		attrNames:         types.SetType{ElemType: types.StringType},
-		attrPrivileges:    types.SetType{ElemType: types.StringType},
-		attrQuery:         jsontypes.NormalizedType{},
-		attrFieldSecurity: fieldSecurityObjectType(),
+		attrAllowRestrictedIndices: types.BoolType,
+		attrClusters:               types.SetType{ElemType: types.StringType},
+		attrNames:                  types.SetType{ElemType: types.StringType},
+		attrPrivileges:             types.SetType{ElemType: types.StringType},
+		attrQuery:                  jsontypes.NormalizedType{},
+		attrFieldSecurity:          fieldSecurityObjectType(),
 	}
 }
 

--- a/internal/kibana/security_role/constants.go
+++ b/internal/kibana/security_role/constants.go
@@ -20,21 +20,22 @@ package security_role
 // Terraform schema attribute keys shared across the security role resource
 // schema, data source schema, attr types, and flatten helpers.
 const (
-	attrGrant         = "grant"
-	attrExcept        = "except"
-	attrNames         = "names"
-	attrPrivileges    = "privileges"
-	attrQuery         = "query"
-	attrFieldSecurity = "field_security"
-	attrClusters      = "clusters"
-	attrCluster       = "cluster"
-	attrIndices       = "indices"
-	attrRemoteIndices = "remote_indices"
-	attrRunAs         = "run_as"
-	attrName          = "name"
-	attrSpaces        = "spaces"
-	attrBase          = "base"
-	attrFeature       = "feature"
+	attrGrant                  = "grant"
+	attrExcept                 = "except"
+	attrNames                  = "names"
+	attrPrivileges             = "privileges"
+	attrQuery                  = "query"
+	attrFieldSecurity          = "field_security"
+	attrClusters               = "clusters"
+	attrCluster                = "cluster"
+	attrIndices                = "indices"
+	attrRemoteIndices          = "remote_indices"
+	attrRunAs                  = "run_as"
+	attrName                   = "name"
+	attrSpaces                 = "spaces"
+	attrBase                   = "base"
+	attrFeature                = "feature"
+	attrAllowRestrictedIndices = "allow_restricted_indices"
 )
 
 // Schema descriptions repeated in resource and data source definitions.

--- a/internal/kibana/security_role/descriptions/allow_restricted_indices.md
+++ b/internal/kibana/security_role/descriptions/allow_restricted_indices.md
@@ -1,0 +1,1 @@
+Include matching restricted indices in names parameter. Usage is strongly discouraged as it can grant unrestricted operations on critical data, make the entire system unstable or leak sensitive information.

--- a/internal/kibana/security_role/expand.go
+++ b/internal/kibana/security_role/expand.go
@@ -104,11 +104,12 @@ func expandFieldSecurity(ctx context.Context, obj types.Object) (map[string][]st
 // `remote_indices` entries; `Clusters` is only populated for the remote
 // variant.
 type expandedEntry struct {
-	Names      []string
-	Clusters   []string
-	Privileges []string
-	Query      *string
-	FS         *map[string][]string
+	Names                  []string
+	Clusters               []string
+	Privileges             []string
+	Query                  *string
+	AllowRestrictedIndices *bool
+	FS                     *map[string][]string
 }
 
 // expandEntryCommon reads names/privileges/query/field_security (and
@@ -142,6 +143,10 @@ func expandEntryCommon(ctx context.Context, obj types.Object, wantClusters bool)
 			out.FS = &fsMap
 		}
 	}
+	if ari, ok := obj.Attributes()[attrAllowRestrictedIndices].(types.Bool); ok && typeutils.IsKnown(ari) {
+		v := ari.ValueBool()
+		out.AllowRestrictedIndices = &v
+	}
 	return out, diags
 }
 
@@ -164,11 +169,12 @@ func expandRemoteEntry(ctx context.Context, obj types.Object) (kibanaoapi.Securi
 		return kibanaoapi.SecurityRoleESRemoteIndex{}, diags
 	}
 	return kibanaoapi.SecurityRoleESRemoteIndex{
-		Names:         e.Names,
-		Clusters:      e.Clusters,
-		Privileges:    e.Privileges,
-		Query:         e.Query,
-		FieldSecurity: e.FS,
+		Names:                  e.Names,
+		Clusters:               e.Clusters,
+		Privileges:             e.Privileges,
+		Query:                  e.Query,
+		AllowRestrictedIndices: e.AllowRestrictedIndices,
+		FieldSecurity:          e.FS,
 	}, diags
 }
 

--- a/internal/kibana/security_role/flatten.go
+++ b/internal/kibana/security_role/flatten.go
@@ -180,6 +180,21 @@ func objectFromFieldSecurityResource(ctx context.Context, fs *map[string][]strin
 	return obj, diags
 }
 
+// allowRestrictedIndicesFromAPI maps the API value into state. When the config
+// omits allow_restricted_indices (null in the hint entry), state stays null even
+// if Kibana returns false for the unset field.
+func allowRestrictedIndicesFromAPI(apiVal *bool, hint types.Object) types.Bool {
+	if !hint.IsNull() && !hint.IsUnknown() {
+		if hintBool, ok := hint.Attributes()[attrAllowRestrictedIndices].(types.Bool); ok && hintBool.IsNull() {
+			return types.BoolNull()
+		}
+	}
+	if apiVal != nil {
+		return types.BoolValue(*apiVal)
+	}
+	return types.BoolNull()
+}
+
 // flattenIndicesResource builds the resource-side indices set: optional
 // `cluster`/`run_as`-like nested sets are null when absent, and field_security
 // is a single object (or null) rather than a list. `hint` is the plan/state
@@ -257,12 +272,7 @@ func flattenRemoteIndicesResource(ctx context.Context, indices *[]kibanaoapi.Sec
 		if diags.HasError() {
 			return types.SetNull(objType), diags
 		}
-		var allowRestricted types.Bool
-		if index.AllowRestrictedIndices != nil {
-			allowRestricted = types.BoolValue(*index.AllowRestrictedIndices)
-		} else {
-			allowRestricted = types.BoolNull()
-		}
+		allowRestricted := allowRestrictedIndicesFromAPI(index.AllowRestrictedIndices, entryHint)
 		obj, d := types.ObjectValue(esRemoteIndexResourceAttrTypes(), map[string]attr.Value{
 			attrAllowRestrictedIndices: allowRestricted,
 			attrClusters:               clustersSet,

--- a/internal/kibana/security_role/flatten.go
+++ b/internal/kibana/security_role/flatten.go
@@ -257,12 +257,19 @@ func flattenRemoteIndicesResource(ctx context.Context, indices *[]kibanaoapi.Sec
 		if diags.HasError() {
 			return types.SetNull(objType), diags
 		}
+		var allowRestricted types.Bool
+		if index.AllowRestrictedIndices != nil {
+			allowRestricted = types.BoolValue(*index.AllowRestrictedIndices)
+		} else {
+			allowRestricted = types.BoolNull()
+		}
 		obj, d := types.ObjectValue(esRemoteIndexResourceAttrTypes(), map[string]attr.Value{
-			attrClusters:      clustersSet,
-			attrNames:         namesSet,
-			attrPrivileges:    privSet,
-			attrQuery:         normalizedQueryFromAPI(index.Query),
-			attrFieldSecurity: fieldObj,
+			attrAllowRestrictedIndices: allowRestricted,
+			attrClusters:               clustersSet,
+			attrNames:                  namesSet,
+			attrPrivileges:             privSet,
+			attrQuery:                  normalizedQueryFromAPI(index.Query),
+			attrFieldSecurity:          fieldObj,
 		})
 		diags.Append(d...)
 		if diags.HasError() {

--- a/internal/kibana/security_role/flatten_test.go
+++ b/internal/kibana/security_role/flatten_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	kibanaoapi "github.com/elastic/terraform-provider-elasticstack/internal/clients/kibanaoapi"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
@@ -60,6 +61,59 @@ func TestUnitFlattenExpandIndexFieldSecurityRoundTrip(t *testing.T) {
 	b2, err := json.Marshal(out)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(b1), string(b2))
+}
+
+func TestUnitFlattenRemoteIndicesAPIFalseWithNullHint(t *testing.T) {
+	ctx := context.Background()
+	apiFalse := false
+	es := kibanaoapi.SecurityRoleES{
+		RemoteIndices: &[]kibanaoapi.SecurityRoleESRemoteIndex{{
+			Names:                  []string{"sample"},
+			Clusters:               []string{"test-cluster"},
+			Privileges:             []string{"read"},
+			AllowRestrictedIndices: &apiFalse,
+		}},
+	}
+	obj, diags := flattenElasticsearchObject(ctx, &es, nullEsHint())
+	require.False(t, diags.HasError())
+	remoteSet := obj.Attributes()[attrRemoteIndices].(types.Set)
+	require.Equal(t, types.BoolValue(false), remoteSet.Elements()[0].(types.Object).Attributes()[attrAllowRestrictedIndices])
+}
+
+func TestUnitFlattenRemoteIndicesHintNullPreservesNullDespiteAPIFalse(t *testing.T) {
+	ctx := context.Background()
+	apiFalse := false
+	es := kibanaoapi.SecurityRoleES{
+		RemoteIndices: &[]kibanaoapi.SecurityRoleESRemoteIndex{{
+			Names:                  []string{"sample"},
+			Clusters:               []string{"test-cluster"},
+			Privileges:             []string{"read"},
+			AllowRestrictedIndices: &apiFalse,
+		}},
+	}
+	clustersSet := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("test-cluster")})
+	namesSet := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("sample")})
+	privSet := types.SetValueMust(types.StringType, []attr.Value{types.StringValue("read")})
+	hintEntry, d := types.ObjectValue(esRemoteIndexResourceAttrTypes(), map[string]attr.Value{
+		attrAllowRestrictedIndices: types.BoolNull(),
+		attrClusters:               clustersSet,
+		attrNames:                  namesSet,
+		attrPrivileges:             privSet,
+		attrQuery:                  jsontypes.NewNormalizedNull(),
+		attrFieldSecurity:          types.ObjectNull(fieldSecurityAttrTypes()),
+	})
+	require.False(t, d.HasError())
+	hint, d := types.ObjectValue(elasticsearchResourceAttrTypes(), map[string]attr.Value{
+		attrCluster:       types.SetNull(types.StringType),
+		attrRunAs:         types.SetNull(types.StringType),
+		attrIndices:       types.SetNull(types.ObjectType{AttrTypes: esIndexResourceAttrTypes()}),
+		attrRemoteIndices: types.SetValueMust(types.ObjectType{AttrTypes: esRemoteIndexResourceAttrTypes()}, []attr.Value{hintEntry}),
+	})
+	require.False(t, d.HasError())
+	obj, diags := flattenElasticsearchObject(ctx, &es, hint)
+	require.False(t, diags.HasError())
+	remoteSet := obj.Attributes()[attrRemoteIndices].(types.Set)
+	require.Equal(t, types.BoolNull(), remoteSet.Elements()[0].(types.Object).Attributes()[attrAllowRestrictedIndices])
 }
 
 func TestUnitFlattenExpandRemoteIndicesRoundTrip(t *testing.T) {

--- a/internal/kibana/security_role/flatten_test.go
+++ b/internal/kibana/security_role/flatten_test.go
@@ -66,12 +66,14 @@ func TestUnitFlattenExpandRemoteIndicesRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	grant := []string{"sample"}
 	fs := map[string][]string{"grant": grant}
+	allowRestricted := true
 	es := kibanaoapi.SecurityRoleES{
 		RemoteIndices: &[]kibanaoapi.SecurityRoleESRemoteIndex{{
-			Names:         []string{"sample"},
-			Clusters:      []string{"test-cluster"},
-			Privileges:    []string{"create", "read", "write"},
-			FieldSecurity: &fs,
+			Names:                  []string{"sample"},
+			Clusters:               []string{"test-cluster"},
+			Privileges:             []string{"create", "read", "write"},
+			AllowRestrictedIndices: &allowRestricted,
+			FieldSecurity:          &fs,
 		}},
 	}
 	obj, diags := flattenElasticsearchObject(ctx, &es, nullEsHint())

--- a/internal/kibana/security_role/schema.go
+++ b/internal/kibana/security_role/schema.go
@@ -38,6 +38,9 @@ var resourceDescription string
 //go:embed descriptions/remote_indices_permissions.md
 var remoteIndicesPermissionsDescription string
 
+//go:embed descriptions/allow_restricted_indices.md
+var allowRestrictedIndicesDescription string
+
 func fieldSecurityResourceAttrs() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		attrGrant: schema.SetAttribute{
@@ -107,6 +110,10 @@ func remoteIndicesResourceBlock() schema.Block {
 		Description: "A list of cluster aliases to which the permissions in this entry apply.",
 		Required:    true,
 		ElementType: types.StringType,
+	}
+	attrs[attrAllowRestrictedIndices] = schema.BoolAttribute{
+		Description: allowRestrictedIndicesDescription,
+		Optional:    true,
 	}
 	return schema.SetNestedBlock{
 		Description: remoteIndicesPermissionsDescription,

--- a/internal/kibana/security_role/schema_data_source.go
+++ b/internal/kibana/security_role/schema_data_source.go
@@ -138,6 +138,10 @@ func getDataSourceSchema(_ context.Context) schema.Schema {
 									Computed:    true,
 									ElementType: types.StringType,
 								},
+								attrAllowRestrictedIndices: schema.BoolAttribute{
+									Description: allowRestrictedIndicesDescription,
+									Computed:    true,
+								},
 							},
 						},
 					},

--- a/internal/kibana/security_role/testdata/TestAccDataSourceKibanaSecurityRole/remote_indices_extended/main.tf
+++ b/internal/kibana/security_role/testdata/TestAccDataSourceKibanaSecurityRole/remote_indices_extended/main.tf
@@ -17,9 +17,10 @@ resource "elasticstack_kibana_security_role" "test" {
         grant  = ["sample", "restricted"]
         except = ["restricted"]
       }
-      query      = jsonencode({ match_all = {} })
-      names      = ["sample"]
-      privileges = ["create", "read", "write"]
+      query                    = jsonencode({ match_all = {} })
+      names                    = ["sample"]
+      privileges               = ["create", "read", "write"]
+      allow_restricted_indices = true
     }
     run_as = ["kibana", "elastic"]
   }

--- a/internal/kibana/security_role/testdata/TestAccResourceKibanaSecurityRole/remote_indices_create/main.tf
+++ b/internal/kibana/security_role/testdata/TestAccResourceKibanaSecurityRole/remote_indices_create/main.tf
@@ -26,9 +26,10 @@ resource "elasticstack_kibana_security_role" "test" {
         grant  = ["sample", "restricted"]
         except = ["restricted"]
       }
-      query      = jsonencode({ match_all = {} })
-      names      = ["sample"]
-      privileges = ["create", "read", "write"]
+      query                    = jsonencode({ match_all = {} })
+      names                    = ["sample"]
+      privileges               = ["create", "read", "write"]
+      allow_restricted_indices = true
     }
   }
   kibana {

--- a/internal/kibana/security_role/testdata/TestAccResourceKibanaSecurityRole/remote_indices_update/main.tf
+++ b/internal/kibana/security_role/testdata/TestAccResourceKibanaSecurityRole/remote_indices_update/main.tf
@@ -22,8 +22,9 @@ resource "elasticstack_kibana_security_role" "test" {
         grant  = ["sample2"]
         except = []
       }
-      names      = ["sample2"]
-      privileges = ["create", "read", "write"]
+      names                    = ["sample2"]
+      privileges               = ["create", "read", "write"]
+      allow_restricted_indices = false
     }
     run_as = ["kibana", "elastic"]
   }

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/.openspec.yaml
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/design.md
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Both `elasticstack_elasticsearch_security_role` and `elasticstack_kibana_security_role` model Elasticsearch index privileges via nested `indices` and `remote_indices` blocks. The Elasticsearch security role resource already exposes `allow_restricted_indices` on `indices` (optional, computed, with `UseStateForUnknown`), and maps it through `IndexPermsData` / `estypes.IndicesPrivileges`. The `remote_indices` block omits the attribute from schema and state even though:
+
+- `estypes.RemoteIndicesPrivileges` includes `AllowRestrictedIndices`
+- `kibanaoapi.SecurityRoleESRemoteIndex` already has `AllowRestrictedIndices *bool`
+- `toAPIModel` for Elasticsearch roles reads `idx.AllowRestrictedIndices` from `indexPermissionsToAPIModel` (always nil) rather than a dedicated remote field
+
+The Kibana security role never maps `allow_restricted_indices` for any index type in expand/flatten, though the API client structs are ready.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose `allow_restricted_indices` on `remote_indices` for both security role resources and their data sources.
+- Mirror `indices` semantics on the Elasticsearch resource: optional + computed on the resource, computed on read, `UseStateForUnknown` plan modifier, same description text.
+- Round-trip the value through create, update, and read; cover with acceptance tests.
+
+**Non-Goals:**
+
+- Adding `allow_restricted_indices` to `elasticsearch.indices` on the Kibana security role (out of scope for this change).
+- Changing defaulting behavior for `indices.allow_restricted_indices` on the Elasticsearch resource.
+- Schema version bumps or state upgrade migrations (additive optional attribute only).
+
+## Decisions
+
+### 1. Reuse `IndexPermsData` shape for Elasticsearch remote indices
+
+Add `AllowRestrictedIndices types.Bool` to `RemoteIndexPermsData` (same as `IndexPermsData`) rather than embedding `IndexPermsData` wholesale (which would pull in unused structure). Wire it in `toAPIModel` / `fromAPIModel` and the data source flattener alongside existing remote index fields.
+
+**Alternative considered:** Promote `AllowRestrictedIndices` into `CommonIndexPermsData` — rejected because only `indices` and `remote_indices` use it, not shared query-only helpers.
+
+### 2. Schema parity with existing `indices` block (Elasticsearch)
+
+Add `attrAllowRestrictedIndices` to the `remote_indices` nested block in `schema.go` and data source schema with identical modifiers and embedded description (`descriptions/allow_restricted_indices.md`). `getRemoteIndexPermsAttrTypes()` derives from the block definition, so attr types update automatically.
+
+### 3. Kibana: attribute on `remote_indices` only via shared expand helper
+
+Extend `expandedEntry` with `AllowRestrictedIndices *bool`, read it in `expandEntryCommon`, and set it on `SecurityRoleESRemoteIndex` in `expandRemoteEntry`. In `flattenRemoteIndicesResource`, map API pointer to `types.Bool` (null when absent). Add the attribute to `remoteIndicesResourceBlock()` and data source schema; update `esRemoteIndexResourceAttrTypes()`.
+
+Use optional (not computed) on the Kibana resource to match other remote index optional fields (`query`, `field_security`). No `UseStateForUnknown` unless acceptance tests show plan churn — Elasticsearch resource keeps computed semantics for consistency with its `indices` block.
+
+**Alternative considered:** Also add to `indices` on Kibana for symmetry — deferred; user request targets `remote_indices` only.
+
+### 4. Tests
+
+Extend existing `remote_indices_create` / `remote_indices_update` acceptance configs and checks for both resources. Add or extend unit tests (`flatten_test.go` for Kibana; model round-trip for Elasticsearch if present).
+
+## Risks / Trade-offs
+
+- **[Risk] Enabling restricted index access is dangerous** → Reuse existing warning description from `indices`; no behavioral change beyond exposing an API field users can already set via API/console.
+- **[Risk] Kibana vs Elasticsearch semantic mismatch** (`computed` vs optional) → Documented in design; Kibana follows its existing remote_indices optional-field pattern.
+- **[Risk] Drift for roles created outside Terraform with `allow_restricted_indices: true`** → Read path populates computed/optional value from API; next apply may show diff if user omits the field — same as `indices` on Elasticsearch resource.
+
+## Migration Plan
+
+No migration required. Existing configurations without `remote_indices.allow_restricted_indices` continue to work; Terraform omits the field on write when unset and reads API defaults on refresh.
+
+## Open Questions
+
+None — API support is confirmed in both Elasticsearch typed client and `kibanaoapi` structs.

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/proposal.md
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Elasticsearch and Kibana security roles support an `allow_restricted_indices` flag on both local and remote index privilege entries in their APIs. The provider already exposes this attribute on `indices` blocks for `elasticstack_elasticsearch_security_role`, but not on `remote_indices` for either security role resource. Users configuring cross-cluster roles cannot express restricted-index access for remote indices through Terraform, causing drift or manual workarounds.
+
+## What Changes
+
+- Add optional `allow_restricted_indices` to the `remote_indices` nested block on `elasticstack_elasticsearch_security_role` (resource and data source), matching the existing `indices` attribute semantics (optional, computed, `UseStateForUnknown` on the resource).
+- Add optional `allow_restricted_indices` to `elasticsearch.remote_indices` on `elasticstack_kibana_security_role` (resource and data source), wired through expand/flatten to the Kibana Role Management API.
+- Map the attribute in create/update/read paths and round-trip it in acceptance tests for both resources.
+- Regenerate provider documentation for the new schema fields.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this extends existing security role capabilities._
+
+### Modified Capabilities
+
+- `elasticsearch-security-role`: Add `remote_indices.allow_restricted_indices` to schema, API mapping, plan preservation, and data source read mapping.
+- `kibana-security-role`: Add `elasticsearch.remote_indices.allow_restricted_indices` to schema, API mapping, and read state flattening.
+
+## Impact
+
+- **Code**: `internal/elasticsearch/security/role/` (schema, models, data source), `internal/kibana/security_role/` (schema, expand, flatten, attr types).
+- **APIs**: Elasticsearch Put/Get role and Kibana Role Management PUT/GET — field already exists on API types (`RemoteIndicesPrivileges`, `SecurityRoleESRemoteIndex`).
+- **Docs**: `docs/resources/elasticsearch_security_role.md`, `docs/data-sources/elasticsearch_security_role.md`, `docs/resources/kibana_security_role.md`, `docs/data-sources/kibana_security_role.md`.
+- **Tests**: Acceptance and unit tests for remote indices create/update on both resources.
+- **Breaking changes**: None — additive schema only.

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/specs/elasticsearch-security-role/spec.md
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/specs/elasticsearch-security-role/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: remote_indices allow_restricted_indices schema (REQ-028)
+
+The resource and data source SHALL expose `allow_restricted_indices` on each `remote_indices` entry. On the resource, the attribute SHALL be optional and computed with a `UseStateForUnknown` plan modifier, matching the existing `indices.allow_restricted_indices` definition and description. On the data source, the attribute SHALL be computed.
+
+#### Scenario: Resource schema includes remote allow_restricted_indices
+
+- **GIVEN** a `remote_indices` block on `elasticstack_elasticsearch_security_role`
+- **WHEN** the provider schema is inspected
+- **THEN** `allow_restricted_indices` SHALL be available on that block with the same semantics as `indices.allow_restricted_indices`
+
+#### Scenario: Data source exposes remote allow_restricted_indices
+
+- **GIVEN** a role in Elasticsearch with `remote_indices` entries that set `allow_restricted_indices`
+- **WHEN** `elasticstack_elasticsearch_security_role` data source is read
+- **THEN** `remote_indices.*.allow_restricted_indices` SHALL reflect the API value
+
+### Requirement: remote_indices allow_restricted_indices API mapping (REQ-029)
+
+When `remote_indices.allow_restricted_indices` is known on the resource, the provider SHALL include it in the Put role API payload for that remote index entry. When the attribute is unset or null, the provider SHALL omit `allow_restricted_indices` from the API payload. When reading a role from Elasticsearch, the provider SHALL map `allow_restricted_indices` from each `remote_indices` API entry into Terraform state.
+
+#### Scenario: Write true to API
+
+- **GIVEN** a `remote_indices` entry with `allow_restricted_indices = true`
+- **WHEN** create or update runs
+- **THEN** the Put role payload SHALL include `"allow_restricted_indices": true` for that entry
+
+#### Scenario: Read from API into state
+
+- **GIVEN** Elasticsearch returns a remote index entry with `allow_restricted_indices: false`
+- **WHEN** the resource or data source reads the role
+- **THEN** state SHALL store `allow_restricted_indices = false` for that entry
+
+## MODIFIED Requirements
+
+### Requirement: Data source attribute mapping (DS-REQ-007)
+
+The data source SHALL map the Get Role API response into the following computed attributes: `description`, `cluster`, `run_as`, `global` (as normalized JSON string), `metadata` (as normalized JSON string), `applications` (set of objects), `indices` (set of objects with nested `field_security` list), and `remote_indices` (set of objects with nested `field_security` list and `allow_restricted_indices`). `cluster` privileges SHALL be mapped as strings.
+
+#### Scenario: All attributes mapped
+
+- **GIVEN** a successful API response with all role fields present
+- **WHEN** read completes
+- **THEN** every computed attribute SHALL reflect the corresponding API value
+
+### Requirement: Unknown values in plan (REQ-023–REQ-024)
+
+When `indices.allow_restricted_indices` is unknown during planning, the resource SHALL preserve the prior state value for that field. When `remote_indices.allow_restricted_indices` is unknown during planning, the resource SHALL preserve the prior state value for that field. When `indices.field_security.except` is unknown during planning, the resource SHALL preserve the prior state value for that field.
+
+#### Scenario: Deferred unknowns
+
+- **GIVEN** those attributes are unknown at plan time
+- **WHEN** planning applies preservation rules
+- **THEN** prior state values SHALL be kept for those fields

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/specs/kibana-security-role/spec.md
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/specs/kibana-security-role/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: remote_indices allow_restricted_indices schema (REQ-027)
+
+The resource and data source SHALL expose `allow_restricted_indices` on each `elasticsearch.remote_indices` entry as an optional boolean attribute with the same security warning description used for restricted index access elsewhere in the provider.
+
+#### Scenario: Resource schema includes remote allow_restricted_indices
+
+- **GIVEN** an `elasticsearch.remote_indices` block on `elasticstack_kibana_security_role`
+- **WHEN** the provider schema is inspected
+- **THEN** `allow_restricted_indices` SHALL be available on that block
+
+#### Scenario: Data source exposes remote allow_restricted_indices
+
+- **GIVEN** a Kibana role with `elasticsearch.remote_indices` entries that set `allow_restricted_indices`
+- **WHEN** `elasticstack_kibana_security_role` data source is read
+- **THEN** `elasticsearch.remote_indices.*.allow_restricted_indices` SHALL reflect the API value
+
+## MODIFIED Requirements
+
+### Requirement: Elasticsearch remote index privilege mapping (REQ-021)
+
+When `elasticsearch.remote_indices` entries are configured, the resource SHALL map `clusters`, `names`, `privileges`, `query`, `allow_restricted_indices`, and `field_security` to the corresponding API fields. When `query` is an empty string, the resource SHALL omit `query` from the API payload for that remote index entry. When `allow_restricted_indices` is unset, the resource SHALL omit `allow_restricted_indices` from the API payload for that entry.
+
+#### Scenario: Remote index mapping
+
+- **GIVEN** `remote_indices` entries are configured
+- **WHEN** the API payload is built
+- **THEN** `clusters`, `names`, `privileges`, and optional `query`, `allow_restricted_indices`, and `field_security` SHALL be populated correctly
+
+#### Scenario: allow_restricted_indices round-trip
+
+- **GIVEN** a `remote_indices` entry with `allow_restricted_indices = true`
+- **WHEN** the role is created and subsequently read
+- **THEN** state SHALL retain `allow_restricted_indices = true` for that entry
+
+### Requirement: Read state — elasticsearch block (REQ-022–REQ-023)
+
+When the API response contains an `elasticsearch` object, the resource SHALL set the `elasticsearch` block in state including `cluster`, `indices`, `remote_indices` (with `allow_restricted_indices` when present in the API), and `run_as`. When the API `cluster` list is empty or when `run_as` is empty, those fields SHALL be omitted from the flattened state (not stored as empty lists). When no `elasticsearch` object is present in the response, the resource SHALL store an empty list for the `elasticsearch` attribute.
+
+#### Scenario: Empty cluster and run_as omitted
+
+- **GIVEN** the API returns an empty `cluster` list
+- **WHEN** state is updated from the API
+- **THEN** `cluster` SHALL be omitted from the flattened elasticsearch block

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/tasks.md
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Elasticsearch security role
 
-- [ ] 1.1 Add `allow_restricted_indices` to `remote_indices` in `internal/elasticsearch/security/role/schema.go` (resource) and `data_source.go` (data source), reusing `allow_restricted_indices.md` description and matching `indices` plan modifiers on the resource
-- [ ] 1.2 Add `AllowRestrictedIndices` to `RemoteIndexPermsData`; wire `toAPIModel` and `fromAPIModel` in `models.go` to read/write `estypes.RemoteIndicesPrivileges.AllowRestrictedIndices`
-- [ ] 1.3 Map `allow_restricted_indices` in data source read (`data_source.go` remote indices flattener and `getRemoteIndexPermsDSAttrTypes`)
-- [ ] 1.4 Extend `remote_indices_create` / `remote_indices_update` test configs with `allow_restricted_indices`; add `TestCheckResourceAttr` assertions in `acc_test.go` and `data_source_test.go`
+- [x] 1.1 Add `allow_restricted_indices` to `remote_indices` in `internal/elasticsearch/security/role/schema.go` (resource) and `data_source.go` (data source), reusing `allow_restricted_indices.md` description and matching `indices` plan modifiers on the resource
+- [x] 1.2 Add `AllowRestrictedIndices` to `RemoteIndexPermsData`; wire `toAPIModel` and `fromAPIModel` in `models.go` to read/write `estypes.RemoteIndicesPrivileges.AllowRestrictedIndices`
+- [x] 1.3 Map `allow_restricted_indices` in data source read (`data_source.go` remote indices flattener and `getRemoteIndexPermsDSAttrTypes`)
+- [x] 1.4 Extend `remote_indices_create` / `remote_indices_update` test configs with `allow_restricted_indices`; add `TestCheckResourceAttr` assertions in `acc_test.go` and `data_source_test.go`
 
 ## 2. Kibana security role
 
-- [ ] 2.1 Add `attrAllowRestrictedIndices` constant and description; add attribute to `remoteIndicesResourceBlock()` and data source schema in `internal/kibana/security_role/`
-- [ ] 2.2 Update `esRemoteIndexResourceAttrTypes()` and data-source attr types for `allow_restricted_indices`
-- [ ] 2.3 Extend `expandedEntry`, `expandEntryCommon`, and `expandRemoteEntry` to map config → `kibanaoapi.SecurityRoleESRemoteIndex.AllowRestrictedIndices`
-- [ ] 2.4 Map API → state in `flattenRemoteIndicesResource` (and data source flattener if separate)
-- [ ] 2.5 Extend `remote_indices_create` / `remote_indices_update` acceptance tests and `flatten_test.go` round-trip coverage
+- [x] 2.1 Add `attrAllowRestrictedIndices` constant and description; add attribute to `remoteIndicesResourceBlock()` and data source schema in `internal/kibana/security_role/`
+- [x] 2.2 Update `esRemoteIndexResourceAttrTypes()` and data-source attr types for `allow_restricted_indices`
+- [x] 2.3 Extend `expandedEntry`, `expandEntryCommon`, and `expandRemoteEntry` to map config → `kibanaoapi.SecurityRoleESRemoteIndex.AllowRestrictedIndices`
+- [x] 2.4 Map API → state in `flattenRemoteIndicesResource` (and data source flattener if separate)
+- [x] 2.5 Extend `remote_indices_create` / `remote_indices_update` acceptance tests and `flatten_test.go` round-trip coverage
 
 ## 3. Documentation and validation
 
-- [ ] 3.1 Run `make generate-docs` (or project doc generation target) and verify `docs/resources/elasticsearch_security_role.md`, `docs/data-sources/elasticsearch_security_role.md`, `docs/resources/kibana_security_role.md`, and `docs/data-sources/kibana_security_role.md` list `allow_restricted_indices` under `remote_indices`
-- [ ] 3.2 Run `make build` and targeted acceptance tests for both security role resources
-- [ ] 3.3 Run `make check-openspec` after syncing or before archive as appropriate
+- [x] 3.1 Run `make generate-docs` (or project doc generation target) and verify `docs/resources/elasticsearch_security_role.md`, `docs/data-sources/elasticsearch_security_role.md`, `docs/resources/kibana_security_role.md`, and `docs/data-sources/kibana_security_role.md` list `allow_restricted_indices` under `remote_indices`
+- [x] 3.2 Run `make build` and targeted acceptance tests for both security role resources
+- [x] 3.3 Run `make check-openspec` after syncing or before archive as appropriate

--- a/openspec/changes/add-remote-indices-allow-restricted-indices/tasks.md
+++ b/openspec/changes/add-remote-indices-allow-restricted-indices/tasks.md
@@ -1,0 +1,20 @@
+## 1. Elasticsearch security role
+
+- [ ] 1.1 Add `allow_restricted_indices` to `remote_indices` in `internal/elasticsearch/security/role/schema.go` (resource) and `data_source.go` (data source), reusing `allow_restricted_indices.md` description and matching `indices` plan modifiers on the resource
+- [ ] 1.2 Add `AllowRestrictedIndices` to `RemoteIndexPermsData`; wire `toAPIModel` and `fromAPIModel` in `models.go` to read/write `estypes.RemoteIndicesPrivileges.AllowRestrictedIndices`
+- [ ] 1.3 Map `allow_restricted_indices` in data source read (`data_source.go` remote indices flattener and `getRemoteIndexPermsDSAttrTypes`)
+- [ ] 1.4 Extend `remote_indices_create` / `remote_indices_update` test configs with `allow_restricted_indices`; add `TestCheckResourceAttr` assertions in `acc_test.go` and `data_source_test.go`
+
+## 2. Kibana security role
+
+- [ ] 2.1 Add `attrAllowRestrictedIndices` constant and description; add attribute to `remoteIndicesResourceBlock()` and data source schema in `internal/kibana/security_role/`
+- [ ] 2.2 Update `esRemoteIndexResourceAttrTypes()` and data-source attr types for `allow_restricted_indices`
+- [ ] 2.3 Extend `expandedEntry`, `expandEntryCommon`, and `expandRemoteEntry` to map config → `kibanaoapi.SecurityRoleESRemoteIndex.AllowRestrictedIndices`
+- [ ] 2.4 Map API → state in `flattenRemoteIndicesResource` (and data source flattener if separate)
+- [ ] 2.5 Extend `remote_indices_create` / `remote_indices_update` acceptance tests and `flatten_test.go` round-trip coverage
+
+## 3. Documentation and validation
+
+- [ ] 3.1 Run `make generate-docs` (or project doc generation target) and verify `docs/resources/elasticsearch_security_role.md`, `docs/data-sources/elasticsearch_security_role.md`, `docs/resources/kibana_security_role.md`, and `docs/data-sources/kibana_security_role.md` list `allow_restricted_indices` under `remote_indices`
+- [ ] 3.2 Run `make build` and targeted acceptance tests for both security role resources
+- [ ] 3.3 Run `make check-openspec` after syncing or before archive as appropriate

--- a/openspec/specs/elasticsearch-security-role/spec.md
+++ b/openspec/specs/elasticsearch-security-role/spec.md
@@ -64,7 +64,8 @@ resource "elasticstack_elasticsearch_security_role" "example" {
     clusters   = <required, set(string)>
     names      = <required, set(string)>
     privileges = <required, set(string)>
-    query = <optional, json string>
+    query                    = <optional, json string>
+    allow_restricted_indices = <optional, computed, bool>
     field_security {
       grant  = <optional, set(string)>
       except = <optional, computed, set(string)>
@@ -126,7 +127,8 @@ data "elasticstack_elasticsearch_security_role" "example" {
     clusters   = <computed, set(string)>
     names      = <computed, set(string)>
     privileges = <computed, set(string)>
-    query      = <computed, string>
+    query                    = <computed, string>
+    allow_restricted_indices = <computed, bool>
     field_security {
       grant  = <computed, set(string)>
       except = <computed, set(string)>
@@ -188,7 +190,7 @@ The data source SHALL use the provider's configured Elasticsearch client by defa
 
 ### Requirement: Data source attribute mapping (DS-REQ-007)
 
-The data source SHALL map the Get Role API response into the following computed attributes: `description`, `cluster`, `run_as`, `global` (as normalized JSON string), `metadata` (as normalized JSON string), `applications` (set of objects), `indices` (set of objects with nested `field_security` list), and `remote_indices` (set of objects with nested `field_security` list). `cluster` privileges SHALL be mapped as strings.
+The data source SHALL map the Get Role API response into the following computed attributes: `description`, `cluster`, `run_as`, `global` (as normalized JSON string), `metadata` (as normalized JSON string), `applications` (set of objects), `indices` (set of objects with nested `field_security` list), and `remote_indices` (set of objects with nested `field_security` list and `allow_restricted_indices`). `cluster` privileges SHALL be mapped as strings.
 
 #### Scenario: All attributes mapped
 
@@ -308,7 +310,7 @@ When `global` is configured, the resource SHALL parse it as JSON; if parsing fai
 
 ### Requirement: Unknown values in plan (REQ-023–REQ-024)
 
-When `indices.allow_restricted_indices` is unknown during planning, the resource SHALL preserve the prior state value for that field. When `indices.field_security.except` is unknown during planning, the resource SHALL preserve the prior state value for that field.
+When `indices.allow_restricted_indices` is unknown during planning, the resource SHALL preserve the prior state value for that field. When `remote_indices.allow_restricted_indices` is unknown during planning, the resource SHALL preserve the prior state value for that field. When `indices.field_security.except` is unknown during planning, the resource SHALL preserve the prior state value for that field.
 
 #### Scenario: Deferred unknowns
 
@@ -375,6 +377,38 @@ When the computed resource `id` would otherwise be unknown during planning, the 
 - GIVEN existing Terraform state contains a computed role `id`
 - WHEN Terraform plans an operation where the computed `id` is otherwise unknown
 - THEN the planned `id` value SHALL remain the prior state value
+
+### Requirement: remote_indices allow_restricted_indices schema (REQ-037)
+
+The resource and data source SHALL expose `allow_restricted_indices` on each `remote_indices` entry. On the resource, the attribute SHALL be optional and computed with a `UseStateForUnknown` plan modifier, matching the existing `indices.allow_restricted_indices` definition and description. On the data source, the attribute SHALL be computed.
+
+#### Scenario: Resource schema includes remote allow_restricted_indices
+
+- GIVEN a `remote_indices` block on `elasticstack_elasticsearch_security_role`
+- WHEN the provider schema is inspected
+- THEN `allow_restricted_indices` SHALL be available on that block with the same semantics as `indices.allow_restricted_indices`
+
+#### Scenario: Data source exposes remote allow_restricted_indices
+
+- GIVEN a role in Elasticsearch with `remote_indices` entries that set `allow_restricted_indices`
+- WHEN `elasticstack_elasticsearch_security_role` data source is read
+- THEN `remote_indices.*.allow_restricted_indices` SHALL reflect the API value
+
+### Requirement: remote_indices allow_restricted_indices API mapping (REQ-038)
+
+When `remote_indices.allow_restricted_indices` is known on the resource, the provider SHALL include it in the Put role API payload for that remote index entry. When the attribute is unset or null, the provider SHALL omit `allow_restricted_indices` from the API payload. When reading a role from Elasticsearch, the provider SHALL map `allow_restricted_indices` from each `remote_indices` API entry into Terraform state.
+
+#### Scenario: Write true to API
+
+- GIVEN a `remote_indices` entry with `allow_restricted_indices = true`
+- WHEN create or update runs
+- THEN the Put role payload SHALL include `"allow_restricted_indices": true` for that entry
+
+#### Scenario: Read from API into state
+
+- GIVEN Elasticsearch returns a remote index entry with `allow_restricted_indices: false`
+- WHEN the resource or data source reads the role
+- THEN state SHALL store `allow_restricted_indices = false` for that entry
 
 ### Requirement: Typed client implementation for security role
 The `elasticstack_elasticsearch_security_role` resource and data source SHALL retrieve and manage roles using the go-elasticsearch Typed API (`elasticsearch.TypedClient.Security.PutRole`, `Security.GetRole`, `Security.DeleteRole`) instead of the raw `esapi` client. The typed API response SHALL be used directly without manual JSON decoding into an intermediate `models.Role` type.

--- a/openspec/specs/kibana-security-role/spec.md
+++ b/openspec/specs/kibana-security-role/spec.md
@@ -33,7 +33,8 @@ resource "elasticstack_kibana_security_role" "example" {
       clusters   = <required, set(string)>
       names      = <required, set(string)>
       privileges = <required, set(string)>
-      query      = <optional, string>      # JSON string, diff-suppressed
+      query                    = <optional, string>      # JSON string, diff-suppressed
+      allow_restricted_indices = <optional, bool>
       field_security {                     # optional, list (max 1)
         grant  = <optional, set(string)>
         except = <optional, set(string)>
@@ -74,7 +75,8 @@ data "elasticstack_kibana_security_role" "example" {
       clusters   = <required, set(string)>
       names      = <required, set(string)>
       privileges = <required, set(string)>
-      query      = <optional, string>      # JSON string, diff-suppressed
+      query                    = <optional, string>      # JSON string, diff-suppressed
+      allow_restricted_indices = <computed, bool>
       field_security {                     # optional, list (max 1)
         grant  = <optional, set(string)>
         except = <optional, set(string)>
@@ -231,17 +233,39 @@ When `elasticsearch.indices` entries are configured, the resource SHALL map `nam
 
 ### Requirement: Elasticsearch remote index privilege mapping (REQ-021)
 
-When `elasticsearch.remote_indices` entries are configured, the resource SHALL map `clusters`, `names`, `privileges`, `query`, and `field_security` to the corresponding API fields. When `query` is an empty string, the resource SHALL omit `query` from the API payload for that remote index entry.
+When `elasticsearch.remote_indices` entries are configured, the resource SHALL map `clusters`, `names`, `privileges`, `query`, `allow_restricted_indices`, and `field_security` to the corresponding API fields. When `query` is an empty string, the resource SHALL omit `query` from the API payload for that remote index entry. When `allow_restricted_indices` is unset, the resource SHALL omit `allow_restricted_indices` from the API payload for that entry.
 
 #### Scenario: Remote index mapping
 
 - GIVEN `remote_indices` entries are configured
 - WHEN the API payload is built
-- THEN `clusters`, `names`, `privileges`, and optional `query` and `field_security` SHALL be populated correctly
+- THEN `clusters`, `names`, `privileges`, and optional `query`, `allow_restricted_indices`, and `field_security` SHALL be populated correctly
+
+#### Scenario: allow_restricted_indices round-trip
+
+- GIVEN a `remote_indices` entry with `allow_restricted_indices = true`
+- WHEN the role is created and subsequently read
+- THEN state SHALL retain `allow_restricted_indices = true` for that entry
+
+### Requirement: remote_indices allow_restricted_indices schema (REQ-027)
+
+The resource and data source SHALL expose `allow_restricted_indices` on each `elasticsearch.remote_indices` entry as an optional boolean attribute with the same security warning description used for restricted index access elsewhere in the provider.
+
+#### Scenario: Resource schema includes remote allow_restricted_indices
+
+- GIVEN an `elasticsearch.remote_indices` block on `elasticstack_kibana_security_role`
+- WHEN the provider schema is inspected
+- THEN `allow_restricted_indices` SHALL be available on that block
+
+#### Scenario: Data source exposes remote allow_restricted_indices
+
+- GIVEN a Kibana role with `elasticsearch.remote_indices` entries that set `allow_restricted_indices`
+- WHEN `elasticstack_kibana_security_role` data source is read
+- THEN `elasticsearch.remote_indices.*.allow_restricted_indices` SHALL reflect the API value
 
 ### Requirement: Read state — elasticsearch block (REQ-022–REQ-023)
 
-When the API response contains an `elasticsearch` object, the resource SHALL set the `elasticsearch` block in state including `cluster`, `indices`, `remote_indices`, and `run_as`. When the API `cluster` list is empty or when `run_as` is empty, those fields SHALL be omitted from the flattened state (not stored as empty lists). When no `elasticsearch` object is present in the response, the resource SHALL store an empty list for the `elasticsearch` attribute.
+When the API response contains an `elasticsearch` object, the resource SHALL set the `elasticsearch` block in state including `cluster`, `indices`, `remote_indices` (with `allow_restricted_indices` when present in the API), and `run_as`. When the API `cluster` list is empty or when `run_as` is empty, those fields SHALL be omitted from the flattened state (not stored as empty lists). When no `elasticsearch` object is present in the response, the resource SHALL store an empty list for the `elasticsearch` attribute.
 
 #### Scenario: Empty cluster and run_as omitted
 


### PR DESCRIPTION
## Changelog

Customer impact: enhancement
Summary: Adds allow_restricted_indices to remote_indices on elasticstack_elasticsearch_security_role and elasticstack_kibana_security_role


