### PR TITLE
fix(docs): correct cross-link paths in templates and generated docs

### DIFF
--- a/docs/ephemeral-resources/elasticsearch_security_api_key.md
+++ b/docs/ephemeral-resources/elasticsearch_security_api_key.md
@@ -14,7 +14,7 @@ Creates an Elasticsearch API key during each Terraform plan and apply without pe
 
 See the [security API create API key documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html) and [create cross-cluster API key documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html) for more details.
 
-Use the managed [`elasticstack_elasticsearch_security_api_key`](/docs/resources/elasticsearch_security_api_key) resource when credentials should remain in Terraform state.
+Use the managed [`elasticstack_elasticsearch_security_api_key`](../resources/elasticsearch_security_api_key) resource when credentials should remain in Terraform state.
 
 ~> **Warning:** Do not combine `invalidate_on_close = true` with a persistent secret store (for example HashiCorp Vault or AWS SSM). The key is invalidated when the Terraform run completes, so any credential copied into external storage becomes unusable immediately afterward.
 

--- a/docs/guides/kibana-dashboard-advanced.md
+++ b/docs/guides/kibana-dashboard-advanced.md
@@ -7,9 +7,9 @@ description: |-
 
 # Advanced Kibana dashboard patterns
 
-This guide covers **production-style** patterns for [`elasticstack_kibana_dashboard`](/docs/resources/kibana_dashboard): collapsible **sections**, a branding **image** panel, Lens **gauge** and **heatmap** charts, a multi-layer **area + line** chart, an **ES|QL** pinned control that drives panel queries, optional **write-restricted** access control, and **tags** for organisation in the Kibana UI.
+This guide covers **production-style** patterns for [`elasticstack_kibana_dashboard`](../resources/kibana_dashboard): collapsible **sections**, a branding **image** panel, Lens **gauge** and **heatmap** charts, a multi-layer **area + line** chart, an **ES|QL** pinned control that drives panel queries, optional **write-restricted** access control, and **tags** for organisation in the Kibana UI.
 
-If you are new to the resource, start with [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started) (dashboard shell, grid) and [**Dashboard operations**](/docs/guides/kibana-dashboard-operations) (pinned **options list** controls and Discover sessions).
+If you are new to the resource, start with [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started) (dashboard shell, grid) and [**Dashboard operations**](./kibana-dashboard-operations) (pinned **options list** controls and Discover sessions).
 
 The runnable example lives at [`examples/guides/guide3-advanced/main.tf`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/examples/guides/guide3-advanced/main.tf).
 
@@ -188,7 +188,7 @@ Add a compact **image** panel for logos or headers. The committed example loads 
 | **`hide_border`** | Removes the default panel chrome when `true`. |
 | **`object_fit`** | How the image scales inside the tile (`contain`, `cover`, `fill`, and so on). |
 
-Kibana also supports **`src.file_id`** for images uploaded to Kibana's file library. That path requires uploading the file separately (UI or API) and referencing the returned ID — see the [`image_config` schema](/docs/resources/kibana_dashboard#nestedatt--sections--panels--image_config) in the resource reference.
+Kibana also supports **`src.file_id`** for images uploaded to Kibana's file library. That path requires uploading the file separately (UI or API) and referencing the returned ID — see the [`image_config` schema](../resources/kibana_dashboard#nestedatt--sections--panels--image_config) in the resource reference.
 
 Place this panel in the first section's `panels` list before the heatmap.
 
@@ -784,7 +784,7 @@ To try **write-restricted** mode, follow the [bootstrap user caveat](#bootstrap-
 
 You now have a production-oriented dashboard pattern with sections, ES|QL controls, and optional access restrictions. Review the rest of the series:
 
-- [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
-- [**Dashboard operations**](/docs/guides/kibana-dashboard-operations) — pinned **options list** controls, KPI rows, charts, and an embedded **Discover** session on sample eCommerce data.
+- [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
+- [**Dashboard operations**](./kibana-dashboard-operations) — pinned **options list** controls, KPI rows, charts, and an embedded **Discover** session on sample eCommerce data.
 
-For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide3.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).
+For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide3.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).

--- a/docs/guides/kibana-dashboard-getting-started.md
+++ b/docs/guides/kibana-dashboard-getting-started.md
@@ -7,7 +7,7 @@ description: |-
 
 # Getting started with Kibana dashboards
 
-This guide walks you through building a **web server log monitoring dashboard** with Terraform. You will add panels one at a time—markdown, KPI metrics, a time-series line chart, a horizontal bar chart, and a donut chart—using the [`elasticstack_kibana_dashboard`](/docs/resources/kibana_dashboard) resource and Kibana's built-in **sample logs** dataset.
+This guide walks you through building a **web server log monitoring dashboard** with Terraform. You will add panels one at a time—markdown, KPI metrics, a time-series line chart, a horizontal bar chart, and a donut chart—using the [`elasticstack_kibana_dashboard`](../resources/kibana_dashboard) resource and Kibana's built-in **sample logs** dataset.
 
 Every visualization is defined **by value** in Terraform (no pre-existing saved objects required). Lens chart configuration is exported from the Kibana UI and embedded in `vis_config.by_value`; we explain that workflow explicitly so you can adapt the patterns to your own charts.
 
@@ -124,7 +124,7 @@ locals {
 
 Set `data_source_json = local.logs_data_source` on each `metric_chart_config`, `xy_chart_config`, or `pie_chart_config` that reads from the sample logs.
 
-> **By reference vs by value** — This guide uses only **by value** configs (`markdown_config.by_value`, `vis_config.by_value`, and so on) so `terraform apply` is self-contained. You can also reference existing saved visualizations with `by_reference` blocks; see the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard) for that pattern.
+> **By reference vs by value** — This guide uses only **by value** configs (`markdown_config.by_value`, `vis_config.by_value`, and so on) so `terraform apply` is self-contained. You can also reference existing saved visualizations with `by_reference` blocks; see the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard) for that pattern.
 
 ## Markdown panel
 
@@ -625,7 +625,7 @@ resource "elasticstack_kibana_dashboard" "getting_started" {
 
 You now have a runnable logs dashboard defined entirely in Terraform. Continue with the other guides in this series:
 
-- [**Dashboard operations**](/docs/guides/kibana-dashboard-operations) — pinned **options list** controls, KPI rows, stacked area and data table panels, and an embedded **Discover** session on the sample eCommerce dataset.
-- [**Advanced dashboards**](/docs/guides/kibana-dashboard-advanced) — collapsible **sections**, branding **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
+- [**Dashboard operations**](./kibana-dashboard-operations) — pinned **options list** controls, KPI rows, stacked area and data table panels, and an embedded **Discover** session on the sample eCommerce dataset.
+- [**Advanced dashboards**](./kibana-dashboard-advanced) — collapsible **sections**, branding **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
 
-For every field and panel type, use the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide1.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).
+For every field and panel type, use the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide1.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).

--- a/docs/guides/kibana-dashboard-operations.md
+++ b/docs/guides/kibana-dashboard-operations.md
@@ -9,7 +9,7 @@ description: |-
 
 This guide builds an **interactive eCommerce operations dashboard** with Terraform. You will wire a pinned **options list** control that filters every content panel at once, add a KPI row of Lens metrics, trend and breakdown charts, a Lens **Data Table**, and an embedded **Discover** session—all on the Kibana **sample eCommerce** dataset.
 
-If you have not used `elasticstack_kibana_dashboard` before, start with [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started), which covers the dashboard shell, and the 48-column grid.
+If you have not used `elasticstack_kibana_dashboard` before, start with [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started), which covers the dashboard shell, and the 48-column grid.
 
 The runnable example lives at [`examples/guides/guide2-operations/main.tf`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/examples/guides/guide2-operations/main.tf).
 
@@ -59,7 +59,7 @@ locals {
 }
 ```
 
-That ID is the one Kibana assigns to the sample **eCommerce** data view. For your own dashboards, substitute the real data view ID—for example from an [`elasticstack_kibana_data_view`](/docs/resources/kibana_data_view) resource or from **Stack Management** → **Data views**.
+That ID is the one Kibana assigns to the sample **eCommerce** data view. For your own dashboards, substitute the real data view ID—for example from an [`elasticstack_kibana_data_view`](../resources/kibana_data_view) resource or from **Stack Management** → **Data views**.
 
 Lens panels in this guide use a separate **`data_view_spec`** local (index pattern + time field) embedded in each visualization's `data_source_json`; controls use the UUID form in `data_view_id`.
 
@@ -791,7 +791,7 @@ resource "elasticstack_kibana_dashboard" "operations" {
 
 You now have an interactive eCommerce dashboard with pinned controls and an embedded Discover session. Continue the series:
 
-- [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
-- [**Advanced dashboards**](/docs/guides/kibana-dashboard-advanced) — collapsible **sections**, **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
+- [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
+- [**Advanced dashboards**](./kibana-dashboard-advanced) — collapsible **sections**, **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
 
-For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide2.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).
+For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide2.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).

--- a/docs/guides/security-roles.md
+++ b/docs/guides/security-roles.md
@@ -11,11 +11,11 @@ Use this guide when you need to model least-privilege access across Elasticsearc
 
 ## When to use each resource
 
-Use [`elasticstack_elasticsearch_security_role`](/docs/resources/elasticsearch_security_role) when you need to manage Elasticsearch-native privileges such as cluster privileges, index privileges, field-level security, document-level security, or `run_as`. This is the right resource when the access decision is entirely about Elasticsearch APIs and data.
+Use [`elasticstack_elasticsearch_security_role`](../resources/elasticsearch_security_role) when you need to manage Elasticsearch-native privileges such as cluster privileges, index privileges, field-level security, document-level security, or `run_as`. This is the right resource when the access decision is entirely about Elasticsearch APIs and data.
 
-Use [`elasticstack_kibana_security_role`](/docs/resources/kibana_security_role) when you need to manage Kibana application access such as spaces, base privileges, and feature privileges. A Kibana role also carries an `elasticsearch {}` block, so it is the right choice when the same role should describe both the Elasticsearch privileges and the Kibana feature access a user gets in Kibana.
+Use [`elasticstack_kibana_security_role`](../resources/kibana_security_role) when you need to manage Kibana application access such as spaces, base privileges, and feature privileges. A Kibana role also carries an `elasticsearch {}` block, so it is the right choice when the same role should describe both the Elasticsearch privileges and the Kibana feature access a user gets in Kibana.
 
-Use `role_descriptors` on [`elasticstack_elasticsearch_security_api_key`](/docs/resources/elasticsearch_security_api_key) when you need to issue an API key that is narrower than the privileges of the user or role creating it. API key role descriptors use the Elasticsearch role structure and can only further restrict the owner's privileges; they never expand access beyond what the owner already has.
+Use `role_descriptors` on [`elasticstack_elasticsearch_security_api_key`](../resources/elasticsearch_security_api_key) when you need to issue an API key that is narrower than the privileges of the user or role creating it. API key role descriptors use the Elasticsearch role structure and can only further restrict the owner's privileges; they never expand access beyond what the owner already has.
 
 In practice, a common pattern is to define a human-facing Kibana role for interactive access, then mint API keys with narrower `role_descriptors` for automation that should only read from a subset of the same data.
 

--- a/docs/resources/kibana_dashboard.md
+++ b/docs/resources/kibana_dashboard.md
@@ -20,9 +20,9 @@ Manages Kibana [dashboards](https://www.elastic.co/docs/api/doc/kibana). This fu
 
 ## See also
 
-- [Getting started with Kibana dashboards](/docs/guides/kibana-dashboard-getting-started) — build your first dashboard step by step
-- [Kibana dashboard operations guide](/docs/guides/kibana-dashboard-operations) — pinned controls, KPIs, and Discover sessions
-- [Advanced Kibana dashboard patterns](/docs/guides/kibana-dashboard-advanced) — sections, ES|QL controls, and access control
+- [Getting started with Kibana dashboards](../guides/kibana-dashboard-getting-started) — build your first dashboard step by step
+- [Kibana dashboard operations guide](../guides/kibana-dashboard-operations) — pinned controls, KPIs, and Discover sessions
+- [Advanced Kibana dashboard patterns](../guides/kibana-dashboard-advanced) — sections, ES|QL controls, and access control
 
 ## Example Usage
 

--- a/templates/ephemeral-resources/elasticsearch_security_api_key.md.tmpl
+++ b/templates/ephemeral-resources/elasticsearch_security_api_key.md.tmpl
@@ -14,7 +14,7 @@ Creates an Elasticsearch API key during each Terraform plan and apply without pe
 
 See the [security API create API key documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html) and [create cross-cluster API key documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html) for more details.
 
-Use the managed [`elasticstack_elasticsearch_security_api_key`](/docs/resources/elasticsearch_security_api_key) resource when credentials should remain in Terraform state.
+Use the managed [`elasticstack_elasticsearch_security_api_key`](../resources/elasticsearch_security_api_key) resource when credentials should remain in Terraform state.
 
 ~> **Warning:** Do not combine `invalidate_on_close = true` with a persistent secret store (for example HashiCorp Vault or AWS SSM). The key is invalidated when the Terraform run completes, so any credential copied into external storage becomes unusable immediately afterward.
 

--- a/templates/guides/kibana-dashboard-advanced.md.tmpl
+++ b/templates/guides/kibana-dashboard-advanced.md.tmpl
@@ -7,9 +7,9 @@ description: |-
 
 # Advanced Kibana dashboard patterns
 
-This guide covers **production-style** patterns for [`elasticstack_kibana_dashboard`](/docs/resources/kibana_dashboard): collapsible **sections**, a branding **image** panel, Lens **gauge** and **heatmap** charts, a multi-layer **area + line** chart, an **ES|QL** pinned control that drives panel queries, optional **write-restricted** access control, and **tags** for organisation in the Kibana UI.
+This guide covers **production-style** patterns for [`elasticstack_kibana_dashboard`](../resources/kibana_dashboard): collapsible **sections**, a branding **image** panel, Lens **gauge** and **heatmap** charts, a multi-layer **area + line** chart, an **ES|QL** pinned control that drives panel queries, optional **write-restricted** access control, and **tags** for organisation in the Kibana UI.
 
-If you are new to the resource, start with [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started) (dashboard shell, grid) and [**Dashboard operations**](/docs/guides/kibana-dashboard-operations) (pinned **options list** controls and Discover sessions).
+If you are new to the resource, start with [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started) (dashboard shell, grid) and [**Dashboard operations**](./kibana-dashboard-operations) (pinned **options list** controls and Discover sessions).
 
 The runnable example lives at [`examples/guides/guide3-advanced/main.tf`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/examples/guides/guide3-advanced/main.tf).
 
@@ -188,7 +188,7 @@ Add a compact **image** panel for logos or headers. The committed example loads 
 | **`hide_border`** | Removes the default panel chrome when `true`. |
 | **`object_fit`** | How the image scales inside the tile (`contain`, `cover`, `fill`, and so on). |
 
-Kibana also supports **`src.file_id`** for images uploaded to Kibana's file library. That path requires uploading the file separately (UI or API) and referencing the returned ID — see the [`image_config` schema](/docs/resources/kibana_dashboard#nestedatt--sections--panels--image_config) in the resource reference.
+Kibana also supports **`src.file_id`** for images uploaded to Kibana's file library. That path requires uploading the file separately (UI or API) and referencing the returned ID — see the [`image_config` schema](../resources/kibana_dashboard#nestedatt--sections--panels--image_config) in the resource reference.
 
 Place this panel in the first section's `panels` list before the heatmap.
 
@@ -464,7 +464,7 @@ To try **write-restricted** mode, follow the [bootstrap user caveat](#bootstrap-
 
 You now have a production-oriented dashboard pattern with sections, ES|QL controls, and optional access restrictions. Review the rest of the series:
 
-- [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
-- [**Dashboard operations**](/docs/guides/kibana-dashboard-operations) — pinned **options list** controls, KPI rows, charts, and an embedded **Discover** session on sample eCommerce data.
+- [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
+- [**Dashboard operations**](./kibana-dashboard-operations) — pinned **options list** controls, KPI rows, charts, and an embedded **Discover** session on sample eCommerce data.
 
-For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide3.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).
+For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide3.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).

--- a/templates/guides/kibana-dashboard-getting-started.md.tmpl
+++ b/templates/guides/kibana-dashboard-getting-started.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # Getting started with Kibana dashboards
 
-This guide walks you through building a **web server log monitoring dashboard** with Terraform. You will add panels one at a time—markdown, KPI metrics, a time-series line chart, a horizontal bar chart, and a donut chart—using the [`elasticstack_kibana_dashboard`](/docs/resources/kibana_dashboard) resource and Kibana's built-in **sample logs** dataset.
+This guide walks you through building a **web server log monitoring dashboard** with Terraform. You will add panels one at a time—markdown, KPI metrics, a time-series line chart, a horizontal bar chart, and a donut chart—using the [`elasticstack_kibana_dashboard`](../resources/kibana_dashboard) resource and Kibana's built-in **sample logs** dataset.
 
 Every visualization is defined **by value** in Terraform (no pre-existing saved objects required). Lens chart configuration is exported from the Kibana UI and embedded in `vis_config.by_value`; we explain that workflow explicitly so you can adapt the patterns to your own charts.
 
@@ -124,7 +124,7 @@ locals {
 
 Set `data_source_json = local.logs_data_source` on each `metric_chart_config`, `xy_chart_config`, or `pie_chart_config` that reads from the sample logs.
 
-> **By reference vs by value** — This guide uses only **by value** configs (`markdown_config.by_value`, `vis_config.by_value`, and so on) so `terraform apply` is self-contained. You can also reference existing saved visualizations with `by_reference` blocks; see the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard) for that pattern.
+> **By reference vs by value** — This guide uses only **by value** configs (`markdown_config.by_value`, `vis_config.by_value`, and so on) so `terraform apply` is self-contained. You can also reference existing saved visualizations with `by_reference` blocks; see the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard) for that pattern.
 
 ## Markdown panel
 
@@ -390,7 +390,7 @@ Apply the complete configuration:
 
 You now have a runnable logs dashboard defined entirely in Terraform. Continue with the other guides in this series:
 
-- [**Dashboard operations**](/docs/guides/kibana-dashboard-operations) — pinned **options list** controls, KPI rows, stacked area and data table panels, and an embedded **Discover** session on the sample eCommerce dataset.
-- [**Advanced dashboards**](/docs/guides/kibana-dashboard-advanced) — collapsible **sections**, branding **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
+- [**Dashboard operations**](./kibana-dashboard-operations) — pinned **options list** controls, KPI rows, stacked area and data table panels, and an embedded **Discover** session on the sample eCommerce dataset.
+- [**Advanced dashboards**](./kibana-dashboard-advanced) — collapsible **sections**, branding **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
 
-For every field and panel type, use the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide1.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).
+For every field and panel type, use the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide1.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).

--- a/templates/guides/kibana-dashboard-operations.md.tmpl
+++ b/templates/guides/kibana-dashboard-operations.md.tmpl
@@ -9,7 +9,7 @@ description: |-
 
 This guide builds an **interactive eCommerce operations dashboard** with Terraform. You will wire a pinned **options list** control that filters every content panel at once, add a KPI row of Lens metrics, trend and breakdown charts, a Lens **Data Table**, and an embedded **Discover** session—all on the Kibana **sample eCommerce** dataset.
 
-If you have not used `elasticstack_kibana_dashboard` before, start with [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started), which covers the dashboard shell, and the 48-column grid.
+If you have not used `elasticstack_kibana_dashboard` before, start with [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started), which covers the dashboard shell, and the 48-column grid.
 
 The runnable example lives at [`examples/guides/guide2-operations/main.tf`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/examples/guides/guide2-operations/main.tf).
 
@@ -59,7 +59,7 @@ locals {
 }
 ```
 
-That ID is the one Kibana assigns to the sample **eCommerce** data view. For your own dashboards, substitute the real data view ID—for example from an [`elasticstack_kibana_data_view`](/docs/resources/kibana_data_view) resource or from **Stack Management** → **Data views**.
+That ID is the one Kibana assigns to the sample **eCommerce** data view. For your own dashboards, substitute the real data view ID—for example from an [`elasticstack_kibana_data_view`](../resources/kibana_data_view) resource or from **Stack Management** → **Data views**.
 
 Lens panels in this guide use a separate **`data_view_spec`** local (index pattern + time field) embedded in each visualization's `data_source_json`; controls use the UUID form in `data_view_id`.
 
@@ -467,7 +467,7 @@ Apply the full dashboard—including the **Revenue by category** donut panel bet
 
 You now have an interactive eCommerce dashboard with pinned controls and an embedded Discover session. Continue the series:
 
-- [**Getting started with Kibana dashboards**](/docs/guides/kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
-- [**Advanced dashboards**](/docs/guides/kibana-dashboard-advanced) — collapsible **sections**, **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
+- [**Getting started with Kibana dashboards**](./kibana-dashboard-getting-started) — first-time walkthrough on sample web logs (markdown, metrics, line, bar, and donut panels).
+- [**Advanced dashboards**](./kibana-dashboard-advanced) — collapsible **sections**, **image** panels, gauge and heatmap charts, **ES|QL** controls, **access control**, and **tags**.
 
-For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](/docs/resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide2.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).
+For every attribute and panel type, see the [`elasticstack_kibana_dashboard` resource reference](../resources/kibana_dashboard). Regenerate screenshots after UI or config changes with `node scripts/screenshots/guide2.mjs` (see [`scripts/screenshots/README.md`](https://github.com/elastic/terraform-provider-elasticstack/tree/main/scripts/screenshots/README.md)).

--- a/templates/guides/security-roles.md.tmpl
+++ b/templates/guides/security-roles.md.tmpl
@@ -11,11 +11,11 @@ Use this guide when you need to model least-privilege access across Elasticsearc
 
 ## When to use each resource
 
-Use [`elasticstack_elasticsearch_security_role`](/docs/resources/elasticsearch_security_role) when you need to manage Elasticsearch-native privileges such as cluster privileges, index privileges, field-level security, document-level security, or `run_as`. This is the right resource when the access decision is entirely about Elasticsearch APIs and data.
+Use [`elasticstack_elasticsearch_security_role`](../resources/elasticsearch_security_role) when you need to manage Elasticsearch-native privileges such as cluster privileges, index privileges, field-level security, document-level security, or `run_as`. This is the right resource when the access decision is entirely about Elasticsearch APIs and data.
 
-Use [`elasticstack_kibana_security_role`](/docs/resources/kibana_security_role) when you need to manage Kibana application access such as spaces, base privileges, and feature privileges. A Kibana role also carries an `elasticsearch {}` block, so it is the right choice when the same role should describe both the Elasticsearch privileges and the Kibana feature access a user gets in Kibana.
+Use [`elasticstack_kibana_security_role`](../resources/kibana_security_role) when you need to manage Kibana application access such as spaces, base privileges, and feature privileges. A Kibana role also carries an `elasticsearch {}` block, so it is the right choice when the same role should describe both the Elasticsearch privileges and the Kibana feature access a user gets in Kibana.
 
-Use `role_descriptors` on [`elasticstack_elasticsearch_security_api_key`](/docs/resources/elasticsearch_security_api_key) when you need to issue an API key that is narrower than the privileges of the user or role creating it. API key role descriptors use the Elasticsearch role structure and can only further restrict the owner's privileges; they never expand access beyond what the owner already has.
+Use `role_descriptors` on [`elasticstack_elasticsearch_security_api_key`](../resources/elasticsearch_security_api_key) when you need to issue an API key that is narrower than the privileges of the user or role creating it. API key role descriptors use the Elasticsearch role structure and can only further restrict the owner's privileges; they never expand access beyond what the owner already has.
 
 In practice, a common pattern is to define a human-facing Kibana role for interactive access, then mint API keys with narrower `role_descriptors` for automation that should only read from a subset of the same data.
 

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -35,9 +35,9 @@ See also: [Security Roles Guide](../guides/security-roles)
 {{ if eq .Name "elasticstack_kibana_dashboard" }}
 ## See also
 
-- [Getting started with Kibana dashboards](/docs/guides/kibana-dashboard-getting-started) — build your first dashboard step by step
-- [Kibana dashboard operations guide](/docs/guides/kibana-dashboard-operations) — pinned controls, KPIs, and Discover sessions
-- [Advanced Kibana dashboard patterns](/docs/guides/kibana-dashboard-advanced) — sections, ES|QL controls, and access control
+- [Getting started with Kibana dashboards](../guides/kibana-dashboard-getting-started) — build your first dashboard step by step
+- [Kibana dashboard operations guide](../guides/kibana-dashboard-operations) — pinned controls, KPIs, and Discover sessions
+- [Advanced Kibana dashboard patterns](../guides/kibana-dashboard-advanced) — sections, ES|QL controls, and access control
 
 {{ end }}
 


### PR DESCRIPTION
Fixes broken resource and guide links on the Terraform Registry.

The templates used absolute-style Markdown paths such as `/docs/resources/...` and `/docs/guides/...`, which resolve to `https://registry.terraform.io/docs/...` on the Registry (404) instead of the provider-scoped paths.

Changes:
- `templates/guides/*.tmpl`: /docs/resources/X → ../resources/X; /docs/guides/X → ./X
- `templates/resources.md.tmpl`: /docs/guides/X → ../guides/X
- `templates/ephemeral-resources/*.tmpl`: /docs/resources/X → ../resources/X
- Regenerate `docs/` with `make docs-generate`