### PR TITLE
docs(synthetics): document supported check/response sub-keys

### DIFF
--- a/docs/resources/kibana_synthetics_monitor.md
+++ b/docs/resources/kibana_synthetics_monitor.md
@@ -62,6 +62,11 @@ resource "elasticstack_kibana_synthetics_monitor" "my_monitor" {
     mode                    = "all"
     ipv4                    = true
     ipv6                    = true
+    check = jsonencode({
+      response = {
+        status = [200, 201, 301]
+      }
+    })
   }
 }
 ```
@@ -148,7 +153,7 @@ Required:
 
 Optional:
 
-- `check` (String) The check request settings.. Raw JSON object, use `jsonencode` function to represent JSON
+- `check` (String) HTTP request and response check settings. Supported sub-keys include `request.{method,headers,body}` and `response.{status,body,headers,json}`. For example, to assert an expected HTTP status: `check = jsonencode({ response = { status = [200, 201, 301] } })`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list of supported keys (note: the Heartbeat YAML uses dotted keys like `check.response.status`; here they are passed as nested JSON).. Raw JSON object, use `jsonencode` function to represent JSON
 - `ipv4` (Boolean) Whether to ping using the ipv4 protocol.
 - `ipv6` (Boolean) Whether to ping using the ipv6 protocol.
 - `max_redirects` (Number) The maximum number of redirects to follow. Default: `0`
@@ -156,7 +161,7 @@ Optional:
 - `password` (String, Sensitive) The password for authenticating with the server. The credentials are passed with the request.
 - `proxy_header` (String) Additional headers to send to proxies during CONNECT requests. Raw JSON object, use `jsonencode` function to represent JSON
 - `proxy_url` (String) The URL of the proxy to use for this monitor.
-- `response` (String) Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field.. Raw JSON object, use `jsonencode` function to represent JSON
+- `response` (String) Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field. Supported sub-keys include `include_body` (`on_error`/`never`/`always`) and `include_body_max_bytes`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list.. Raw JSON object, use `jsonencode` function to represent JSON
 - `ssl_certificate` (String) Certificate.
 - `ssl_certificate_authorities` (List of String) The list of root certificates for verifications is required.
 - `ssl_key` (String, Sensitive) Certificate key.

--- a/docs/resources/kibana_synthetics_monitor.md
+++ b/docs/resources/kibana_synthetics_monitor.md
@@ -153,7 +153,7 @@ Required:
 
 Optional:
 
-- `check` (String) HTTP request and response check settings. Supported sub-keys include `request.{method,headers,body}` and `response.{status,body,headers,json}`. For example, to assert an expected HTTP status: `check = jsonencode({ response = { status = [200, 201, 301] } })`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list of supported keys (note: the Heartbeat YAML uses dotted keys like `check.response.status`; here they are passed as nested JSON).. Raw JSON object, use `jsonencode` function to represent JSON
+- `check` (String) HTTP request and response check settings. Supported sub-keys include `request.{method,headers,body}` and `response.{status,body,headers,json}`. For example, to assert an expected HTTP status: `check = jsonencode({ response = { status = [200, 201, 301] } })`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list of supported keys (note: the Heartbeat YAML uses dotted keys like `check.response.status`; here they are passed as nested JSON). Raw JSON object, use `jsonencode` function to represent JSON
 - `ipv4` (Boolean) Whether to ping using the ipv4 protocol.
 - `ipv6` (Boolean) Whether to ping using the ipv6 protocol.
 - `max_redirects` (Number) The maximum number of redirects to follow. Default: `0`
@@ -161,7 +161,7 @@ Optional:
 - `password` (String, Sensitive) The password for authenticating with the server. The credentials are passed with the request.
 - `proxy_header` (String) Additional headers to send to proxies during CONNECT requests. Raw JSON object, use `jsonencode` function to represent JSON
 - `proxy_url` (String) The URL of the proxy to use for this monitor.
-- `response` (String) Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field. Supported sub-keys include `include_body` (`on_error`/`never`/`always`) and `include_body_max_bytes`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list.. Raw JSON object, use `jsonencode` function to represent JSON
+- `response` (String) Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field. Supported sub-keys include `include_body` (`on_error`/`never`/`always`) and `include_body_max_bytes`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list. Raw JSON object, use `jsonencode` function to represent JSON
 - `ssl_certificate` (String) Certificate.
 - `ssl_certificate_authorities` (List of String) The list of root certificates for verifications is required.
 - `ssl_key` (String, Sensitive) Certificate key.

--- a/examples/resources/elasticstack_kibana_synthetics_monitor/resource.tf
+++ b/examples/resources/elasticstack_kibana_synthetics_monitor/resource.tf
@@ -32,5 +32,10 @@ resource "elasticstack_kibana_synthetics_monitor" "my_monitor" {
     mode                    = "all"
     ipv4                    = true
     ipv6                    = true
+    check = jsonencode({
+      response = {
+        status = [200, 201, 301]
+      }
+    })
   }
 }

--- a/internal/kibana/synthetics/monitor/schema.go
+++ b/internal/kibana/synthetics/monitor/schema.go
@@ -472,8 +472,8 @@ func httpMonitorFieldsSchema() schema.Attribute {
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"response": jsonObjectSchema("Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field."),
-			"check":    jsonObjectSchema("The check request settings."),
+			"response": jsonObjectSchema("Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field. Supported sub-keys include `include_body` (`on_error`/`never`/`always`) and `include_body_max_bytes`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list."),
+			"check":    jsonObjectSchema("HTTP request and response check settings. Supported sub-keys include `request.{method,headers,body}` and `response.{status,body,headers,json}`. For example, to assert an expected HTTP status: `check = jsonencode({ response = { status = [200, 201, 301] } })`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list of supported keys (note: the Heartbeat YAML uses dotted keys like `check.response.status`; here they are passed as nested JSON)."),
 		},
 	}
 }

--- a/internal/kibana/synthetics/monitor/schema.go
+++ b/internal/kibana/synthetics/monitor/schema.go
@@ -472,8 +472,14 @@ func httpMonitorFieldsSchema() schema.Attribute {
 				Computed:            true,
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
-			"response": jsonObjectSchema("Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field. Supported sub-keys include `include_body` (`on_error`/`never`/`always`) and `include_body_max_bytes`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list."),
-			"check":    jsonObjectSchema("HTTP request and response check settings. Supported sub-keys include `request.{method,headers,body}` and `response.{status,body,headers,json}`. For example, to assert an expected HTTP status: `check = jsonencode({ response = { status = [200, 201, 301] } })`. See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list of supported keys (note: the Heartbeat YAML uses dotted keys like `check.response.status`; here they are passed as nested JSON)."),
+			"response": jsonObjectSchema("Controls the indexing of the HTTP response body contents to the `http.response.body.contents` field. " +
+				"Supported sub-keys include `include_body` (`on_error`/`never`/`always`) and `include_body_max_bytes`. " +
+				"See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list"),
+			"check": jsonObjectSchema("HTTP request and response check settings. " +
+				"Supported sub-keys include `request.{method,headers,body}` and `response.{status,body,headers,json}`. " +
+				"For example, to assert an expected HTTP status: `check = jsonencode({ response = { status = [200, 201, 301] } })`. " +
+				"See [Heartbeat HTTP options](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options) for the full list of supported keys " +
+				"(note: the Heartbeat YAML uses dotted keys like `check.response.status`; here they are passed as nested JSON)"),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Expand the `http.check` and `http.response` attribute descriptions on `elasticstack_kibana_synthetics_monitor` to list the supported Heartbeat sub-keys (`request.{method,headers,body}`, `response.{status,body,headers,json}`, `include_body`, `include_body_max_bytes`) and link to the [Heartbeat HTTP options reference](https://www.elastic.co/docs/reference/beats/heartbeat/monitor-http-options).
- Add a `check.response.status` example to `examples/resources/elasticstack_kibana_synthetics_monitor/resource.tf` so the expected HTTP status code pattern from #1341 is discoverable from the rendered docs.
- Regenerate `docs/resources/kibana_synthetics_monitor.md`.

These keys are already accepted by the underlying Kibana Synthetics API (the provider passes the `check` and `response` JSON through verbatim, and the acceptance tests already exercise `check.response.status` and `response.include_body`). The Kibana OAS describes `check.response` as `additionalProperties: true` without enumerating the sub-fields, so the canonical reference is the Heartbeat docs — this PR points users there.

Fixes #1341

## Changelog
Customer impact: enhancement
Summary: Document supported `check` and `response` sub-keys (including `check.response.status`) on the `elasticstack_kibana_synthetics_monitor` HTTP attribute.

## Test plan
- [ ] `make docs-generate` produces no further diff
- [ ] `make build` succeeds
- [ ] Rendered docs show the example and the expanded `check`/`response` descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)