### PR TITLE
chore: add `9.3.6` to matrix testing for regression check

### DIFF
--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -139,6 +139,7 @@ jobs:
           - '9.1.9'
           - '9.2.3'
           - '9.3.0'
+          - '9.3.6'
           - '9.4.0'
         shard: [0, 1]
         include:
@@ -256,7 +257,7 @@ jobs:
 
       - id: setup-fleet
         name: Setup Fleet
-        if: matrix.version == '8.10.3' || matrix.version == '8.11.4' || matrix.version == '8.12.2' || matrix.version == '8.13.4' || matrix.version == '8.14.3' || matrix.version == '8.15.5' || matrix.version == '8.16.6' || matrix.version == '8.17.1' || matrix.version == '9.0.8' || matrix.version == '9.1.9' || matrix.version == '9.2.3' || matrix.version == '9.3.0' || endsWith(matrix.version, '-SNAPSHOT')
+        if: matrix.version == '8.10.3' || matrix.version == '8.11.4' || matrix.version == '8.12.2' || matrix.version == '8.13.4' || matrix.version == '8.14.3' || matrix.version == '8.15.5' || matrix.version == '8.16.6' || matrix.version == '8.17.1' || matrix.version == '9.0.8' || matrix.version == '9.1.9' || matrix.version == '9.2.3' || matrix.version == '9.3.0' || matrix.version == '9.3.6' || endsWith(matrix.version, '-SNAPSHOT')
         run: |-
           make setup-kibana-fleet
         env:


### PR DESCRIPTION
## Detailed changes
add `9.3.6` to matrix testing for regression check

due-to https://github.com/elastic/terraform-provider-elasticstack/issues/3923