### PR TITLE
fix(openspec): include SHALL in modified REQ-010 requirement body

### DIFF
--- a/openspec/changes/dashboard-field-stats-table/.openspec.yaml
+++ b/openspec/changes/dashboard-field-stats-table/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/dashboard-field-stats-table/design.md
+++ b/openspec/changes/dashboard-field-stats-table/design.md
@@ -10,9 +10,7 @@ Both branches share:
 - `title` (string, optional)
 - `description` (string, optional)
 - `hide_title` (bool, optional)
-- `hide_border` (bool, optional)
-- `time_range` (object `{ from, to }`, optional)
-
+- `time_range` (object `{ from, to, mode? }`, optional)
 Relevant code locations:
 - `generated/kbapi/kibana.gen.go`: `KibanaHTTPAPIsKbnDashboardPanelTypeFieldStatsTable` (line ~47051), `KibanaHTTPAPIsDataVisualizerFieldStats` (line ~40635).
 - `internal/kibana/dashboard/schema.go` — add `field_stats_table_config`.

--- a/openspec/changes/dashboard-field-stats-table/design.md
+++ b/openspec/changes/dashboard-field-stats-table/design.md
@@ -1,0 +1,60 @@
+## Context
+
+The Kibana Dashboard API defines panel type `field_stats_table` (API type key: `KibanaHTTPAPIsKbnDashboardPanelTypeFieldStatsTable`). Its `config` field is `KibanaHTTPAPIsDataVisualizerFieldStats`, a discriminated union with `view_type` as the discriminator. Two branches exist:
+
+- `KibanaHTTPAPIsDataVisualizerFieldStats0` (`view_type = "dataview"`): requires `data_view_id` (string).
+- `KibanaHTTPAPIsDataVisualizerFieldStats1` (`view_type = "esql"`): requires `query.esql` (string).
+
+Both branches share:
+- `show_distributions` (bool, optional)
+- `title` (string, optional)
+- `description` (string, optional)
+- `hide_title` (bool, optional)
+- `hide_border` (bool, optional)
+- `time_range` (object `{ from, to }`, optional)
+
+Relevant code locations:
+- `generated/kbapi/kibana.gen.go`: `KibanaHTTPAPIsKbnDashboardPanelTypeFieldStatsTable` (line ~47051), `KibanaHTTPAPIsDataVisualizerFieldStats` (line ~40635).
+- `internal/kibana/dashboard/schema.go` — add `field_stats_table_config`.
+- `internal/kibana/dashboard/registry.go` — register the panel handler.
+- Sibling union patterns: `internal/kibana/dashboard/panel/visconfig/`, `internal/kibana/dashboard/panel/discoversession/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose a fully typed `field_stats_table_config` block that maps cleanly to both API branches.
+- Enforce exactly-one-of semantics on `by_dataview` / `by_esql` at plan time.
+- Use panelkit passthroughs for `title`, `description`, `hide_title`, `hide_border`, and `time_range`.
+- Apply REQ-009 null-preservation for `time_range` and other optional fields.
+- Reject `config_json` on `type = "field_stats_table"` panels.
+
+**Non-Goals:**
+- Panel-level drilldowns — the API model does not expose them.
+- Shared branch-scaffolding helpers with the P1 controls-esql restructure (deferred per issue decision).
+- `data_view_id` existence validation at plan time (runtime Kibana errors surface as today).
+
+## Decisions
+
+**Branch naming**: `by_dataview` and `by_esql`, matching the API `view_type` discriminator strings (`"dataview"` / `"esql"`) exactly. Rationale per issue decision: `by_data_view` / `by_esql` was rejected (diverges from API discriminator); `by_field` / `by_esql` was rejected (misleading — the panel enumerates all fields, not a single field).
+
+**Shared attributes inside each branch, not hoisted**: `show_distributions`, `title`, `description`, `hide_title`, `hide_border`, and `time_range` reside inside each branch block. This matches the API layout and the `vis_config` / `discover_session_config` patterns.
+
+**`view_type` not user-facing**: The branch identity (`by_dataview` vs `by_esql`) determines the wire `view_type`. The provider sets it internally; practitioners do not write it in HCL.
+
+**Handler package**: `internal/kibana/dashboard/panel/fieldstatstable/` following the existing naming convention.
+
+**Exactly-one-of validator**: Applied at the `field_stats_table_config` object level, mirroring the discover session validator pattern.
+
+**`config_json` rejected**: `field_stats_table` added to the list of panel types that must use their typed config block. Error diagnostic matches the pattern used for `discover_session`.
+
+**Ships independently of P1 controls-esql (#4001)**: No state migration needed (panel doesn't exist yet), no blocking dependency. Union pattern (`by_X` / `by_esql`) is well-established.
+
+## Risks / Trade-offs
+
+- [Risk] The `query.esql` API nesting (`query.esql` not just `esql`) requires careful model mapping. Mitigation: implement ToAPI and FromAPI with explicit nesting; cover with unit tests.
+- [Risk] `time_range` null-preservation on read requires care (REQ-009 semantics). Mitigation: apply the same null-preservation guard already used by other panels; unit-test the null-preservation path.
+- [Low risk] `show_distributions` default behavior in Kibana is unspecified here. Mitigation: treat as optional bool with null-preservation; do not bake Kibana defaults into the TF schema.
+
+## Open questions
+
+None — all design decisions are resolved per the human direction in the issue comments.

--- a/openspec/changes/dashboard-field-stats-table/proposal.md
+++ b/openspec/changes/dashboard-field-stats-table/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The `elasticstack_kibana_dashboard` resource cannot embed a `field_stats_table` panel — the Data Visualizer's field-statistics table, which enumerates fields on a data view or on the output of an ES|QL query with mini distribution charts and summary stats. Users who want to include field-statistics panels in code-managed dashboards must fall back to raw `config_json` blobs, losing typed validation and drift-safe planning. The Kibana Dashboard API defines a first-class `field_stats_table` panel type with a well-defined config union.
+
+## What Changes
+
+Add a new typed panel block `field_stats_table_config` to the `elasticstack_kibana_dashboard` resource with two mutually exclusive sub-blocks matching the API union:
+
+- `by_dataview` — backed by a Kibana data view (`data_view_id`)
+- `by_esql` — backed by an ES|QL query string (`query`)
+
+Both branches share optional attributes `show_distributions`, `title`, `description`, `hide_title`, `hide_border`, and `time_range`, mirroring the API layout and the union patterns already established by `vis_config.by_value`/`by_reference` and `discover_session_config.by_value`/`by_reference`.
+
+Branch keys match the API's `view_type` discriminator strings (`"dataview"` and `"esql"`) exactly. The `view_type` field is not exposed as a user-facing attribute — the branch identity already carries that information, and the model layer sets it on the wire.
+
+## Capabilities
+
+### New Capabilities
+
+- `kibana-dashboard`: new requirement REQ-047 — `field_stats_table_config` typed panel block supporting `by_dataview` and `by_esql` branches.
+
+### Modified Capabilities
+
+- `kibana-dashboard` REQ-007 — extend the `config_json` rejection guard to include `field_stats_table` in the list of panel types that must be managed via their typed block, not via `config_json`.
+
+## Impact
+
+- `internal/kibana/dashboard/panel/fieldstatstable/` — new package with `schema.go`, `model.go`, `api.go`, `fromapi.go`.
+- `internal/kibana/dashboard/registry.go` — register the new handler in `panelHandlers`.
+- `internal/kibana/dashboard/schema.go` — add `field_stats_table_config` attribute to the panel schema.
+- `openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md` — delta spec adding REQ-047 and updating REQ-007.
+- Acceptance tests in `internal/kibana/dashboard/panel/fieldstatstable/acc_test.go` covering `by_dataview`, `by_esql`, validator rejection, and drift detection.

--- a/openspec/changes/dashboard-field-stats-table/proposal.md
+++ b/openspec/changes/dashboard-field-stats-table/proposal.md
@@ -21,12 +21,12 @@ Branch keys match the API's `view_type` discriminator strings (`"dataview"` and 
 
 ### Modified Capabilities
 
-- `kibana-dashboard` REQ-007 — extend the `config_json` rejection guard to include `field_stats_table` in the list of panel types that must be managed via their typed block, not via `config_json`.
+- `kibana-dashboard` REQ-010 — extend the `config_json` rejection guard to include `field_stats_table` in the list of panel types that must be managed via their typed block, not via `config_json`.
 
 ## Impact
 
 - `internal/kibana/dashboard/panel/fieldstatstable/` — new package with `schema.go`, `model.go`, `api.go`, `fromapi.go`.
 - `internal/kibana/dashboard/registry.go` — register the new handler in `panelHandlers`.
 - `internal/kibana/dashboard/schema.go` — add `field_stats_table_config` attribute to the panel schema.
-- `openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md` — delta spec adding REQ-047 and updating REQ-007.
+- `openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md` — delta spec adding REQ-047 and updating REQ-010.
 - Acceptance tests in `internal/kibana/dashboard/panel/fieldstatstable/acc_test.go` covering `by_dataview`, `by_esql`, validator rejection, and drift detection.

--- a/openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md
+++ b/openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md
@@ -1,17 +1,14 @@
 ## MODIFIED Requirements
 
-### Requirement: config_json unsupported for typed panel types (REQ-007) — partial update
+### Requirement: config_json unsupported for typed panel types (REQ-010) — partial update
 
-Add `field_stats_table` to the list of panel types that must be managed via their typed config block and for which practitioner-authored `config_json` SHALL return an error diagnostic.
+This requirement extends REQ-010 to include the `field_stats_table` panel type.
 
-The existing requirement text SHALL be updated so the example list of unsupported types includes `field_stats_table`:
-
-> using practitioner-authored panel-level `config_json` with any other panel type, including `slo_burn_rate`, `slo_error_budget`, `esql_control`, `image`, `slo_alerts`, `discover_session`, and `field_stats_table`, …
-
+Practitioner-authored panel-level `config_json` SHALL NOT be supported for `field_stats_table` panels; using `config_json` with `type = "field_stats_table"` SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`.
 #### Scenario: config_json rejected for field_stats_table panel type
 
 - GIVEN a panel with `type = "field_stats_table"` configured through `config_json`
-- WHEN Terraform validates the configuration
+- WHEN the provider builds the API request on create or update
 - THEN it SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`
 
 ---
@@ -38,8 +35,7 @@ The `by_dataview` sub-block SHALL accept:
 - `title` (optional, string) — panel display title; null-preserved on read.
 - `description` (optional, string) — panel description; null-preserved on read.
 - `hide_title` (optional, bool) — whether to hide the panel title; null-preserved on read.
-- `hide_border` (optional, bool) — whether to hide the panel border; null-preserved on read.
-- `time_range` (optional, object `{ from = required string, to = required string }`) — panel-level time range override; null-preserved on read: when prior state has `time_range` null, the provider keeps it null even if Kibana returns values.
+- `time_range` (optional, object `{ from = required string, to = required string, mode = optional string }`) — panel-level time range override; null-preserved on read: when prior state has `time_range` null, the provider keeps it null even if Kibana returns values.
 
 On write, the provider SHALL set `view_type = "dataview"` internally and map `data_view_id` and optional fields to the API payload. The `view_type` field is not exposed as a user-facing attribute.
 
@@ -52,8 +48,7 @@ The `by_esql` sub-block SHALL accept:
 - `title` (optional, string) — null-preserved on read.
 - `description` (optional, string) — null-preserved on read.
 - `hide_title` (optional, bool) — null-preserved on read.
-- `hide_border` (optional, bool) — null-preserved on read.
-- `time_range` (optional, object `{ from = required string, to = required string }`) — null-preserved on read.
+- `time_range` (optional, object `{ from = required string, to = required string, mode = optional string }`) — null-preserved on read.
 
 On write, the provider SHALL set `view_type = "esql"` internally and map `query` to `query.esql` and optional fields to the API payload.
 
@@ -143,12 +138,7 @@ panels = [
 - WHEN the post-apply read returns a panel where Kibana populated `show_distributions`
 - THEN state SHALL keep `show_distributions` null and a subsequent plan against configuration that omits it SHALL show no changes
 
-#### Scenario: config_json rejected for field_stats_table panel type
-
-- GIVEN a panel with `type = "field_stats_table"` and `config_json` set to any value
-- WHEN Terraform validates the configuration
-- THEN the resource SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`
-
+This behavior is already covered by the REQ-010 update above.
 #### Scenario: Drift detection — Kibana returns branch data intact
 
 - GIVEN an existing dashboard with a `field_stats_table` panel in state

--- a/openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md
+++ b/openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md
@@ -2,9 +2,8 @@
 
 ### Requirement: config_json unsupported for typed panel types (REQ-010) — partial update
 
-This requirement extends REQ-010 to include the `field_stats_table` panel type.
+This requirement extends REQ-010 to include the `field_stats_table` panel type. Practitioner-authored panel-level `config_json` SHALL NOT be supported for `field_stats_table` panels; using `config_json` with `type = "field_stats_table"` SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`.
 
-Practitioner-authored panel-level `config_json` SHALL NOT be supported for `field_stats_table` panels; using `config_json` with `type = "field_stats_table"` SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`.
 #### Scenario: config_json rejected for field_stats_table panel type
 
 - GIVEN a panel with `type = "field_stats_table"` configured through `config_json`
@@ -139,6 +138,7 @@ panels = [
 - THEN state SHALL keep `show_distributions` null and a subsequent plan against configuration that omits it SHALL show no changes
 
 This behavior is already covered by the REQ-010 update above.
+
 #### Scenario: Drift detection — Kibana returns branch data intact
 
 - GIVEN an existing dashboard with a `field_stats_table` panel in state

--- a/openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md
+++ b/openspec/changes/dashboard-field-stats-table/specs/kibana-dashboard/spec.md
@@ -1,0 +1,156 @@
+## MODIFIED Requirements
+
+### Requirement: config_json unsupported for typed panel types (REQ-007) — partial update
+
+Add `field_stats_table` to the list of panel types that must be managed via their typed config block and for which practitioner-authored `config_json` SHALL return an error diagnostic.
+
+The existing requirement text SHALL be updated so the example list of unsupported types includes `field_stats_table`:
+
+> using practitioner-authored panel-level `config_json` with any other panel type, including `slo_burn_rate`, `slo_error_budget`, `esql_control`, `image`, `slo_alerts`, `discover_session`, and `field_stats_table`, …
+
+#### Scenario: config_json rejected for field_stats_table panel type
+
+- GIVEN a panel with `type = "field_stats_table"` configured through `config_json`
+- WHEN Terraform validates the configuration
+- THEN it SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`
+
+---
+
+## ADDED Requirements
+
+### Requirement: Field statistics table panel behavior (REQ-047)
+
+When a panel entry sets `type = "field_stats_table"`, the resource SHALL accept a `field_stats_table_config` block and SHALL require that block to be present when the panel type is `field_stats_table`. The block SHALL expose two mutually exclusive sub-blocks mirroring the API's `view_type` discriminated union:
+
+- `by_dataview` — backed by a Kibana data view (API `view_type = "dataview"`).
+- `by_esql` — backed by an ES|QL query (API `view_type = "esql"`).
+
+Exactly one of `by_dataview` or `by_esql` SHALL be set; setting both or neither SHALL produce an error diagnostic at plan time.
+
+The `field_stats_table_config` block SHALL conflict with all other typed panel config blocks and with panel-level `config_json`. When `type = "field_stats_table"`, `config_json` SHALL NOT be set on the same panel entry; if it is, the resource SHALL return an error diagnostic indicating `config_json` is not supported for `field_stats_table`.
+
+#### The `by_dataview` sub-block
+
+The `by_dataview` sub-block SHALL accept:
+
+- `data_view_id` (required, string) — the identifier of the source data view.
+- `show_distributions` (optional, bool) — whether to show distribution mini-charts in the table; null-preserved on read per REQ-009: when prior state has it null, the provider keeps it null even if Kibana returns a server-side default.
+- `title` (optional, string) — panel display title; null-preserved on read.
+- `description` (optional, string) — panel description; null-preserved on read.
+- `hide_title` (optional, bool) — whether to hide the panel title; null-preserved on read.
+- `hide_border` (optional, bool) — whether to hide the panel border; null-preserved on read.
+- `time_range` (optional, object `{ from = required string, to = required string }`) — panel-level time range override; null-preserved on read: when prior state has `time_range` null, the provider keeps it null even if Kibana returns values.
+
+On write, the provider SHALL set `view_type = "dataview"` internally and map `data_view_id` and optional fields to the API payload. The `view_type` field is not exposed as a user-facing attribute.
+
+#### The `by_esql` sub-block
+
+The `by_esql` sub-block SHALL accept:
+
+- `query` (required, string) — the ES|QL query string; mapped to `query.esql` in the API payload.
+- `show_distributions` (optional, bool) — null-preserved on read per REQ-009.
+- `title` (optional, string) — null-preserved on read.
+- `description` (optional, string) — null-preserved on read.
+- `hide_title` (optional, bool) — null-preserved on read.
+- `hide_border` (optional, bool) — null-preserved on read.
+- `time_range` (optional, object `{ from = required string, to = required string }`) — null-preserved on read.
+
+On write, the provider SHALL set `view_type = "esql"` internally and map `query` to `query.esql` and optional fields to the API payload.
+
+#### Read behavior
+
+On read, the resource SHALL detect the `view_type` field in the API response and populate the matching sub-block (`by_dataview` or `by_esql`), leaving the other sub-block null. For each optional attribute, the resource SHALL apply REQ-009 null-preservation: if prior state had the attribute null, the provider SHALL keep it null even if the API response contains a value for it.
+
+#### HCL example — by_dataview branch
+
+```hcl
+panels = [
+  {
+    type = "field_stats_table"
+    grid = { x = 0, y = 0, w = 24, h = 15 }
+    field_stats_table_config = {
+      by_dataview = {
+        data_view_id       = "logs-view"
+        show_distributions = true
+        title              = "Field statistics — logs view"
+        hide_title         = false
+        hide_border        = false
+        time_range = {
+          from = "now-24h"
+          to   = "now"
+        }
+      }
+    }
+  }
+]
+```
+
+#### HCL example — by_esql branch
+
+```hcl
+panels = [
+  {
+    type = "field_stats_table"
+    grid = { x = 0, y = 0, w = 24, h = 15 }
+    field_stats_table_config = {
+      by_esql = {
+        query              = "FROM logs | STATS count = COUNT(*) BY service.name"
+        show_distributions = true
+        title              = "Field statistics — logs by service"
+        time_range = {
+          from = "now-24h"
+          to   = "now"
+        }
+      }
+    }
+  }
+]
+```
+
+#### Scenario: by_dataview branch create/read round-trip
+
+- GIVEN a panel with `type = "field_stats_table"` and `field_stats_table_config.by_dataview = { data_view_id = "logs-view", show_distributions = true, time_range = { from = "now-24h", to = "now" } }`
+- WHEN create runs and the post-apply read returns the panel
+- THEN state SHALL contain `by_dataview` populated with the same values, `by_esql` SHALL be null, and a subsequent plan SHALL show no changes
+
+#### Scenario: by_esql branch create/read round-trip
+
+- GIVEN a panel with `type = "field_stats_table"` and `field_stats_table_config.by_esql = { query = "FROM logs | STATS count = COUNT(*) BY service.name", show_distributions = false }`
+- WHEN create runs and the post-apply read returns the panel
+- THEN state SHALL contain `by_esql` populated with the same values, `by_dataview` SHALL be null, and a subsequent plan SHALL show no changes
+
+#### Scenario: Exactly one of by_dataview or by_esql
+
+- GIVEN a panel with both `field_stats_table_config.by_dataview` and `field_stats_table_config.by_esql` set
+- WHEN Terraform validates the configuration
+- THEN the resource SHALL return an error diagnostic indicating exactly one of `by_dataview` or `by_esql` must be set
+
+#### Scenario: Neither branch set
+
+- GIVEN a panel with `field_stats_table_config = {}` (neither `by_dataview` nor `by_esql` set)
+- WHEN Terraform validates the configuration
+- THEN the resource SHALL return an error diagnostic indicating exactly one of `by_dataview` or `by_esql` must be set
+
+#### Scenario: time_range null-preservation
+
+- GIVEN a `field_stats_table_config.by_dataview` panel whose prior state has `time_range = null`
+- WHEN the post-apply read returns a panel where Kibana populated `time_range` with values
+- THEN state SHALL keep `time_range` null and a subsequent plan against configuration that omits `time_range` SHALL show no changes
+
+#### Scenario: show_distributions null-preservation
+
+- GIVEN a `field_stats_table_config.by_esql` panel whose prior state has `show_distributions = null`
+- WHEN the post-apply read returns a panel where Kibana populated `show_distributions`
+- THEN state SHALL keep `show_distributions` null and a subsequent plan against configuration that omits it SHALL show no changes
+
+#### Scenario: config_json rejected for field_stats_table panel type
+
+- GIVEN a panel with `type = "field_stats_table"` and `config_json` set to any value
+- WHEN Terraform validates the configuration
+- THEN the resource SHALL return an error diagnostic stating that `config_json` is not supported for `field_stats_table`
+
+#### Scenario: Drift detection — Kibana returns branch data intact
+
+- GIVEN an existing dashboard with a `field_stats_table` panel in state
+- WHEN Kibana returns the same panel configuration on a subsequent read
+- THEN a plan SHALL show no changes

--- a/openspec/changes/dashboard-field-stats-table/tasks.md
+++ b/openspec/changes/dashboard-field-stats-table/tasks.md
@@ -33,7 +33,7 @@
 ## 6. Registry and config_json guard
 
 - [ ] 6.1 Register the `fieldstatstable` panel handler in `panelHandlers` in `internal/kibana/dashboard/registry.go`
-- [ ] 6.2 Extend the `config_json` rejection guard (REQ-007) to include `field_stats_table` in the error-producing panel type list
+- [ ] 6.2 Extend the `config_json` rejection guard (REQ-010) to include `field_stats_table` in the error-producing panel type list
 
 ## 7. Tests
 

--- a/openspec/changes/dashboard-field-stats-table/tasks.md
+++ b/openspec/changes/dashboard-field-stats-table/tasks.md
@@ -1,0 +1,52 @@
+## 1. Handler package scaffold
+
+- [ ] 1.1 Create `internal/kibana/dashboard/panel/fieldstatstable/` directory with initial files: `schema.go`, `model.go`, `api.go`, `fromapi.go`
+- [ ] 1.2 Add a `descriptions/` sub-directory with embedded description markdown files for `field_stats_table_config`, `by_dataview`, and `by_esql` blocks
+- [ ] 1.3 Implement the `discoverSession`-style exactly-one-of validator for `field_stats_table_config` (ensures exactly one of `by_dataview` / `by_esql` is set)
+
+## 2. Schema
+
+- [ ] 2.1 Define `FieldStatsTableSchema()` in `schema.go` returning the `field_stats_table_config` attribute with nested `by_dataview` and `by_esql` optional object blocks
+- [ ] 2.2 `by_dataview` block: required `data_view_id` (string), optional `show_distributions` (bool), optional `title` (string), optional `description` (string), optional `hide_title` (bool), optional `hide_border` (bool), optional `time_range` object (`from` required, `to` required, `mode` optional per REQ-009 semantics)
+- [ ] 2.3 `by_esql` block: required `query` (string, the ES|QL query text mapped to `query.esql` on the wire), optional `show_distributions` (bool), optional `title` / `description` / `hide_title` / `hide_border` / `time_range` matching `by_dataview`
+- [ ] 2.4 Register the exactly-one-of validator on the `field_stats_table_config` object attribute
+- [ ] 2.5 Add `field_stats_table_config` to the panel schema in `internal/kibana/dashboard/schema.go`
+
+## 3. Model
+
+- [ ] 3.1 Define Go structs `FieldStatsTablePanelConfig`, `FieldStatsTableByDataviewConfig`, and `FieldStatsTableByEsqlConfig` in `model.go` using `types.*` fields for Terraform framework compatibility
+- [ ] 3.2 Define `attrTypes()` helpers for each struct to support `types.ObjectValueFrom` / `types.ObjectAs` usage
+
+## 4. Write path (ToAPI)
+
+- [ ] 4.1 Implement `ToAPI(ctx, config)` in `api.go` that builds the `KibanaHTTPAPIsDataVisualizerFieldStats` union value from the active branch
+- [ ] 4.2 For `by_dataview`: set `view_type = "dataview"`, `data_view_id`, and optional fields
+- [ ] 4.3 For `by_esql`: set `view_type = "esql"`, `query.esql`, and optional fields
+- [ ] 4.4 Apply panelkit helpers for `title`, `description`, `hide_title`, `hide_border`, `time_range` passthrough
+
+## 5. Read path (FromAPI)
+
+- [ ] 5.1 Implement `FromAPI(ctx, raw)` in `fromapi.go` that detects the `view_type` discriminator and populates the matching branch, leaving the other null
+- [ ] 5.2 Apply REQ-009 null-preservation for `time_range` and other optional fields: keep null in state when prior state had them null even if Kibana returns defaults
+- [ ] 5.3 Use `panelkit.SimpleFromAPI` (or equivalent) for common passthrough fields
+
+## 6. Registry and config_json guard
+
+- [ ] 6.1 Register the `fieldstatstable` panel handler in `panelHandlers` in `internal/kibana/dashboard/registry.go`
+- [ ] 6.2 Extend the `config_json` rejection guard (REQ-007) to include `field_stats_table` in the error-producing panel type list
+
+## 7. Tests
+
+- [ ] 7.1 Unit tests in `internal/kibana/dashboard/panel/fieldstatstable/api_test.go`: ToAPI round-trip for `by_dataview`, ToAPI round-trip for `by_esql`, null optional fields omitted from payload
+- [ ] 7.2 Unit tests in `fromapi_test.go` (or combined): FromAPI correctly detects each branch; optional fields null when API omits them; `time_range` null-preservation
+- [ ] 7.3 Validator unit tests: both branches set → error; neither branch set → error; exactly one set → passes
+- [ ] 7.4 Acceptance tests in `acc_test.go`:
+  - Create/read/update round-trip for `by_dataview` branch with `show_distributions = true` and `time_range`
+  - Create/read/update round-trip for `by_esql` branch with `show_distributions = false`
+  - Validator rejection: both `by_dataview` and `by_esql` set simultaneously → plan-time error
+  - Drift detection: Kibana returns branch data intact → no diff on subsequent plan
+- [ ] 7.5 Run `make build`, `go vet ./...`, `go test ./internal/kibana/dashboard/...` (unit); `TF_ACC=1 go test` for acceptance tests
+
+## 8. Spec sync
+
+- [ ] 8.1 Verify `make check-openspec` passes after merging the delta spec into the main spec


### PR DESCRIPTION
Follow-up to #4010. The MODIFIED requirement for `config_json unsupported for typed panel types (REQ-010)` had its first paragraph without a SHALL/MUST verb, causing `openspec validate --all` to fail (1 of 228 items). Merged the contextual sentence into the requirement statement so validation passes (228/228).