### PR TITLE
fix(ml): reject results_index_name values starting with custom-

### DIFF
--- a/internal/elasticsearch/ml/anomalydetectionjob/schema.go
+++ b/internal/elasticsearch/ml/anomalydetectionjob/schema.go
@@ -433,6 +433,9 @@ func getSchema(_ context.Context) schema.Schema {
 				MarkdownDescription: "A text string that affects the name of the machine learning results index. Do not start the value with `custom-`; Elasticsearch automatically adds this prefix.",
 				Optional:            true,
 				Computed:            true,
+				Validators: []validator.String{
+					resultsIndexNameWithoutCustomPrefix(),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),

--- a/internal/elasticsearch/ml/anomalydetectionjob/validators.go
+++ b/internal/elasticsearch/ml/anomalydetectionjob/validators.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package anomalydetectionjob
+
+import (
+	"context"
+	"strings"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/utils/typeutils"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = resultsIndexNameWithoutCustomPrefixValidator{}
+
+type resultsIndexNameWithoutCustomPrefixValidator struct{}
+
+func resultsIndexNameWithoutCustomPrefix() resultsIndexNameWithoutCustomPrefixValidator {
+	return resultsIndexNameWithoutCustomPrefixValidator{}
+}
+
+func (v resultsIndexNameWithoutCustomPrefixValidator) Description(_ context.Context) string {
+	return "Must not start with \"custom-\"; Elasticsearch automatically adds this prefix to user-defined results index names."
+}
+
+func (v resultsIndexNameWithoutCustomPrefixValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v resultsIndexNameWithoutCustomPrefixValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if !typeutils.IsKnown(req.ConfigValue) {
+		return
+	}
+
+	value := req.ConfigValue.ValueString()
+	if !strings.HasPrefix(value, "custom-") {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid results_index_name",
+		"Do not start the value with \"custom-\"; Elasticsearch automatically adds this prefix. "+
+			"The provider strips the prefix when reading job configuration, so including it causes plan/apply drift.",
+	)
+}

--- a/internal/elasticsearch/ml/anomalydetectionjob/validators_test.go
+++ b/internal/elasticsearch/ml/anomalydetectionjob/validators_test.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package anomalydetectionjob
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResultsIndexNameWithoutCustomPrefixValidator_ValidateString(t *testing.T) {
+	t.Parallel()
+
+	v := resultsIndexNameWithoutCustomPrefix()
+
+	tests := []struct {
+		name      string
+		value     types.String
+		wantError bool
+	}{
+		{
+			name:  "null value skipped",
+			value: types.StringNull(),
+		},
+		{
+			name:  "unknown value skipped",
+			value: types.StringUnknown(),
+		},
+		{
+			name:  "shared allowed",
+			value: types.StringValue("shared"),
+		},
+		{
+			name:  "user suffix allowed",
+			value: types.StringValue("ml-logs-error-count"),
+		},
+		{
+			name:      "custom prefix rejected",
+			value:     types.StringValue("custom-ml-logs-error-count"),
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &validator.StringResponse{}
+			v.ValidateString(context.Background(), validator.StringRequest{
+				Path:        path.Root("results_index_name"),
+				ConfigValue: tc.value,
+			}, resp)
+
+			hasError := resp.Diagnostics.HasError()
+			if hasError != tc.wantError {
+				t.Fatalf("ValidateString() hasError = %v, wantError = %v; diagnostics: %v", hasError, tc.wantError, resp.Diagnostics)
+			}
+		})
+	}
+}

--- a/internal/elasticsearch/ml/anomalydetectionjob/validators_test.go
+++ b/internal/elasticsearch/ml/anomalydetectionjob/validators_test.go
@@ -60,6 +60,7 @@ func TestResultsIndexNameWithoutCustomPrefixValidator_ValidateString(t *testing.
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/elasticsearch/ml/anomalydetectionjob/validators_test.go
+++ b/internal/elasticsearch/ml/anomalydetectionjob/validators_test.go
@@ -60,7 +60,6 @@ func TestResultsIndexNameWithoutCustomPrefixValidator_ValidateString(t *testing.
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/openspec/specs/elasticsearch-ml-anomaly-detection-job/spec.md
+++ b/openspec/specs/elasticsearch-ml-anomaly-detection-job/spec.md
@@ -257,6 +257,16 @@ The `job_id` attribute SHALL be validated to be between 1 and 64 characters, con
 - WHEN the configuration is applied
 - THEN the provider SHALL return a validation error and SHALL not call the API
 
+### Requirement: results_index_name validation (REQ-023a)
+
+The `results_index_name` attribute SHALL reject configuration values that start with the `custom-` prefix. Elasticsearch adds this prefix to user-defined results index names, and the provider strips it when reading job configuration; including the prefix in configuration causes plan/apply drift.
+
+#### Scenario: results_index_name with custom- prefix rejected
+
+- GIVEN `results_index_name = "custom-ml-logs-error-count"`
+- WHEN the configuration is validated at plan time
+- THEN the provider SHALL return a validation error and SHALL not call the API
+
 ### Requirement: analysis_config.detectors validation (REQ-024)
 
 The `analysis_config.detectors` list SHALL contain at least one element. Each detector `function` SHALL be one of the enumerated values. Each detector `exclude_frequent` SHALL be one of: `all`, `none`, `by`, `over`. Each detector `custom_rules[*].actions` value SHALL be one of: `skip_result`, `skip_model_update`. Each detector `custom_rules[*].conditions[*].applies_to` SHALL be one of: `actual`, `typical`, `diff_from_typical`, `time`. Each detector `custom_rules[*].conditions[*].operator` SHALL be one of: `gt`, `gte`, `lt`, `lte`. Each detector `custom_rules[*].scope` entry SHALL have a `filter_id` that is at least 1 character. Each detector `custom_rules[*].scope[*].filter_type` SHALL be one of: `include`, `exclude`. Each detector `custom_rules` entry SHALL have either a non-empty `scope` or at least one `conditions` entry; both may be set simultaneously. When both `scope` and `conditions` are unknown at plan time, the validation SHALL be skipped (to avoid false positives).


### PR DESCRIPTION
## Changelog
Customer impact: fix
Summary: Reject ML anomaly detection job `results_index_name` values starting with `custom-` to prevent plan/apply drift.

## Summary

- Add a plan-time validator on `results_index_name` for the ML anomaly detection job resource that rejects values starting with `custom-`.
- Elasticsearch automatically prepends `custom-` to user-defined results index names; the provider strips that prefix when reading job configuration back into state. Including the prefix in Terraform config therefore causes plan/apply drift (for example `custom-ml-logs-error-count` in config becomes `ml-logs-error-count` in state after apply).
- Document the validation requirement in the OpenSpec spec.

## Test plan

- [x] `go test ./internal/elasticsearch/ml/anomalydetectionjob/ -run TestResultsIndexName -count=1`
- [x] `make build`