### PR TITLE
fix(fleet/output): default gzip compression_level and preserve unset kafka sasl

### DIFF
--- a/internal/fleet/output/acc_test.go
+++ b/internal/fleet/output/acc_test.go
@@ -710,6 +710,66 @@ func TestAccResourceOutputKafkaUserPass(t *testing.T) {
 	})
 }
 
+func TestAccResourceOutputKafkaGzipDefaultCompressionLevel(t *testing.T) {
+	policyName := sdkacctest.RandString(22)
+	versionutils.SkipIfUnsupported(t, output.MinVersionOutputKafka, versionutils.FlavorAny)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceOutputDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				ConfigVariables: config.Variables{
+					"policy_name": config.StringVariable(policyName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "type", "kafka"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "kafka.compression", "gzip"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "kafka.compression_level", "4"),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("update"),
+				ConfigVariables: config.Variables{
+					"policy_name": config.StringVariable(policyName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "kafka.compression", "gzip"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "kafka.compression_level", "8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceOutputKafkaUserPassNoSasl(t *testing.T) {
+	policyName := sdkacctest.RandString(22)
+	versionutils.SkipIfUnsupported(t, output.MinVersionOutputKafka, versionutils.FlavorAny)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceOutputDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("create"),
+				ConfigVariables: config.Variables{
+					"policy_name": config.StringVariable(policyName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "type", "kafka"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "kafka.auth_type", "user_pass"),
+					resource.TestCheckResourceAttr("elasticstack_fleet_output.test_output", "kafka.username", "testuser"),
+					resource.TestCheckNoResourceAttr("elasticstack_fleet_output.test_output", "kafka.sasl"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceOutputKafkaPartitions(t *testing.T) {
 	policyName := sdkacctest.RandString(22)
 	versionutils.SkipIfUnsupported(t, output.MinVersionOutputKafka, versionutils.FlavorAny)

--- a/internal/fleet/output/constants.go
+++ b/internal/fleet/output/constants.go
@@ -44,3 +44,5 @@ const (
 	attrGroupEvents            = "group_events"
 	attrMechanism              = "mechanism"
 )
+
+const kafkaCompressionGzip = "gzip"

--- a/internal/fleet/output/kafka_plan_modifiers.go
+++ b/internal/fleet/output/kafka_plan_modifiers.go
@@ -103,7 +103,7 @@ func kafkaCompressionLevelDefaultPlanValue(
 		return planValue
 	}
 
-	if compression.ValueString() == "gzip" {
+	if compression.ValueString() == kafkaCompressionGzip {
 		return types.Int64Value(defaultLevel)
 	}
 

--- a/internal/fleet/output/kafka_plan_modifiers.go
+++ b/internal/fleet/output/kafka_plan_modifiers.go
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package output
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const defaultKafkaGzipCompressionLevel int64 = 4
+
+func kafkaCompressionLevelDefaultIfGzip() planmodifier.Int64 {
+	return kafkaCompressionLevelDefaultModifier{defaultLevel: defaultKafkaGzipCompressionLevel}
+}
+
+type kafkaCompressionLevelDefaultModifier struct {
+	defaultLevel int64
+}
+
+func (m kafkaCompressionLevelDefaultModifier) Description(_ context.Context) string {
+	return fmt.Sprintf(
+		"Sets kafka.compression_level to %d when kafka.compression is gzip and no level is configured.",
+		m.defaultLevel,
+	)
+}
+
+func (m kafkaCompressionLevelDefaultModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m kafkaCompressionLevelDefaultModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	resp.PlanValue = kafkaCompressionLevelDefaultPlanValue(
+		kafkaCompressionFromPlanOrConfig(ctx, req.Plan, req.Config, req.Path, resp),
+		req.PlanValue,
+		req.ConfigValue,
+		m.defaultLevel,
+	)
+}
+
+func kafkaCompressionFromPlanOrConfig(
+	ctx context.Context,
+	plan tfsdk.Plan,
+	config tfsdk.Config,
+	currentPath path.Path,
+	resp *planmodifier.Int64Response,
+) types.String {
+	compressionPath := currentPath.ParentPath().AtName("compression")
+
+	var compression types.String
+	diags := plan.GetAttribute(ctx, compressionPath, &compression)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return types.StringUnknown()
+	}
+
+	if !compression.IsUnknown() && !compression.IsNull() {
+		return compression
+	}
+
+	diags = config.GetAttribute(ctx, compressionPath, &compression)
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return types.StringUnknown()
+	}
+
+	return compression
+}
+
+func kafkaCompressionLevelDefaultPlanValue(
+	compression types.String,
+	planValue, configValue types.Int64,
+	defaultLevel int64,
+) types.Int64 {
+	if !planValue.IsUnknown() {
+		return planValue
+	}
+
+	if configValue.IsUnknown() {
+		return planValue
+	}
+
+	if !configValue.IsNull() {
+		return planValue
+	}
+
+	if compression.ValueString() == "gzip" {
+		return types.Int64Value(defaultLevel)
+	}
+
+	return planValue
+}

--- a/internal/fleet/output/kafka_plan_modifiers_test.go
+++ b/internal/fleet/output/kafka_plan_modifiers_test.go
@@ -31,11 +31,11 @@ func Test_kafkaCompressionLevelDefaultPlanValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		compression  types.String
-		planValue    types.Int64
-		configValue  types.Int64
-		want         types.Int64
+		name        string
+		compression types.String
+		planValue   types.Int64
+		configValue types.Int64
+		want        types.Int64
 	}{
 		{
 			name:        "keeps known plan value",

--- a/internal/fleet/output/kafka_plan_modifiers_test.go
+++ b/internal/fleet/output/kafka_plan_modifiers_test.go
@@ -1,0 +1,118 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package output
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_kafkaCompressionLevelDefaultPlanValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		compression  types.String
+		planValue    types.Int64
+		configValue  types.Int64
+		want         types.Int64
+	}{
+		{
+			name:        "keeps known plan value",
+			compression: types.StringValue("gzip"),
+			planValue:   types.Int64Value(6),
+			configValue: types.Int64Null(),
+			want:        types.Int64Value(6),
+		},
+		{
+			name:        "defaults unknown plan value for gzip",
+			compression: types.StringValue("gzip"),
+			planValue:   types.Int64Unknown(),
+			configValue: types.Int64Null(),
+			want:        types.Int64Value(defaultKafkaGzipCompressionLevel),
+		},
+		{
+			name:        "leaves unknown plan value for non-gzip compression",
+			compression: types.StringValue("snappy"),
+			planValue:   types.Int64Unknown(),
+			configValue: types.Int64Null(),
+			want:        types.Int64Unknown(),
+		},
+		{
+			name:        "does not override unknown config interpolation",
+			compression: types.StringValue("gzip"),
+			planValue:   types.Int64Unknown(),
+			configValue: types.Int64Unknown(),
+			want:        types.Int64Unknown(),
+		},
+		{
+			name:        "respects explicit config value",
+			compression: types.StringValue("gzip"),
+			planValue:   types.Int64Unknown(),
+			configValue: types.Int64Value(7),
+			want:        types.Int64Unknown(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := kafkaCompressionLevelDefaultPlanValue(
+				tt.compression,
+				tt.planValue,
+				tt.configValue,
+				defaultKafkaGzipCompressionLevel,
+			)
+			assert.True(t, got.Equal(tt.want))
+		})
+	}
+}
+
+func Test_kafkaCompressionLevelDefaultIfGzip_description(t *testing.T) {
+	t.Parallel()
+
+	modifier := kafkaCompressionLevelDefaultIfGzip()
+	assert.Contains(t, modifier.Description(context.Background()), "4")
+	assert.Equal(t, modifier.Description(context.Background()), modifier.MarkdownDescription(context.Background()))
+}
+
+func Test_schemaKafkaCompressionLevelHasDefaultPlanModifier(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	attr, ok := getSchema(ctx).
+		Attributes["kafka"].(schema.SingleNestedAttribute).
+		Attributes["compression_level"].(schema.Int64Attribute)
+	require.True(t, ok)
+
+	found := false
+	for _, modifier := range attr.PlanModifiers {
+		if modifier.Description(ctx) == kafkaCompressionLevelDefaultIfGzip().Description(ctx) {
+			found = true
+			break
+		}
+	}
+
+	assert.True(t, found, "expected kafkaCompressionLevelDefaultIfGzip plan modifier on compression_level")
+}

--- a/internal/fleet/output/models_kafka.go
+++ b/internal/fleet/output/models_kafka.go
@@ -344,15 +344,15 @@ func (model outputModel) toAPICreateKafkaModel(ctx context.Context) (kbapi.NewOu
 			return &comp
 		}(),
 		CompressionLevel: func() *float32 {
-			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != "gzip" {
+			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != kafkaCompressionGzip {
 				return nil
 			}
 
 			compressionLevel := float32(kafkaModel.CompressionLevel.ValueInt64())
 			return &compressionLevel
 		}(),
-		ConnectionType:   connectionType,
-		Topic:            kafkaModel.Topic.ValueStringPointer(),
+		ConnectionType: connectionType,
+		Topic:          kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsNewOutputKafkaPartition {
 			if !typeutils.IsKnown(kafkaModel.Partition) {
 				return nil
@@ -464,15 +464,15 @@ func (model outputModel) toAPIUpdateKafkaModel(ctx context.Context) (kbapi.Updat
 			return &comp
 		}(),
 		CompressionLevel: func() *float32 {
-			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != "gzip" {
+			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != kafkaCompressionGzip {
 				return nil
 			}
 
 			compressionLevel := float32(kafkaModel.CompressionLevel.ValueInt64())
 			return &compressionLevel
 		}(),
-		ConnectionType:   connectionType,
-		Topic:            kafkaModel.Topic.ValueStringPointer(),
+		ConnectionType: connectionType,
+		Topic:          kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsUpdateOutputKafkaPartition {
 			if !typeutils.IsKnown(kafkaModel.Partition) {
 				return nil

--- a/internal/fleet/output/models_kafka.go
+++ b/internal/fleet/output/models_kafka.go
@@ -360,8 +360,8 @@ func (model outputModel) toAPICreateKafkaModel(ctx context.Context) (kbapi.NewOu
 			return &comp
 		}(),
 		CompressionLevel: kafkaCompressionLevel(kafkaModel.Compression, kafkaModel.CompressionLevel),
-		ConnectionType: connectionType,
-		Topic:          kafkaModel.Topic.ValueStringPointer(),
+		ConnectionType:   connectionType,
+		Topic:            kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsNewOutputKafkaPartition {
 			if !typeutils.IsKnown(kafkaModel.Partition) {
 				return nil
@@ -473,8 +473,8 @@ func (model outputModel) toAPIUpdateKafkaModel(ctx context.Context) (kbapi.Updat
 			return &comp
 		}(),
 		CompressionLevel: kafkaCompressionLevel(kafkaModel.Compression, kafkaModel.CompressionLevel),
-		ConnectionType: connectionType,
-		Topic:          kafkaModel.Topic.ValueStringPointer(),
+		ConnectionType:   connectionType,
+		Topic:            kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsUpdateOutputKafkaPartition {
 			if !typeutils.IsKnown(kafkaModel.Partition) {
 				return nil

--- a/internal/fleet/output/models_kafka.go
+++ b/internal/fleet/output/models_kafka.go
@@ -278,22 +278,6 @@ func readOutputKafkaCompressionLevel(value *float32) *int64 {
 	return &converted
 }
 
-const defaultKafkaGzipCompressionLevel = float32(4)
-
-func kafkaCompressionLevel(compression types.String, compressionLevel types.Int64) *float32 {
-	if !typeutils.IsKnown(compression) || compression.ValueString() != "gzip" {
-		return nil
-	}
-
-	if typeutils.IsKnown(compressionLevel) {
-		val := float32(compressionLevel.ValueInt64())
-		return &val
-	}
-
-	defaultLevel := defaultKafkaGzipCompressionLevel
-	return &defaultLevel
-}
-
 func (model outputModel) toAPICreateKafkaModel(ctx context.Context) (kbapi.NewOutputUnion, diag.Diagnostics) {
 	ssl, diags := objectValueToSSL(ctx, model.Ssl)
 	if diags.HasError() {
@@ -359,7 +343,14 @@ func (model outputModel) toAPICreateKafkaModel(ctx context.Context) (kbapi.NewOu
 			comp := kbapi.KibanaHTTPAPIsNewOutputKafkaCompression(kafkaModel.Compression.ValueString())
 			return &comp
 		}(),
-		CompressionLevel: kafkaCompressionLevel(kafkaModel.Compression, kafkaModel.CompressionLevel),
+		CompressionLevel: func() *float32 {
+			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != "gzip" {
+				return nil
+			}
+
+			compressionLevel := float32(kafkaModel.CompressionLevel.ValueInt64())
+			return &compressionLevel
+		}(),
 		ConnectionType:   connectionType,
 		Topic:            kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsNewOutputKafkaPartition {
@@ -472,7 +463,14 @@ func (model outputModel) toAPIUpdateKafkaModel(ctx context.Context) (kbapi.Updat
 			comp := kbapi.KibanaHTTPAPIsUpdateOutputKafkaCompression(kafkaModel.Compression.ValueString())
 			return &comp
 		}(),
-		CompressionLevel: kafkaCompressionLevel(kafkaModel.Compression, kafkaModel.CompressionLevel),
+		CompressionLevel: func() *float32 {
+			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != "gzip" {
+				return nil
+			}
+
+			compressionLevel := float32(kafkaModel.CompressionLevel.ValueInt64())
+			return &compressionLevel
+		}(),
 		ConnectionType:   connectionType,
 		Topic:            kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsUpdateOutputKafkaPartition {

--- a/internal/fleet/output/models_kafka.go
+++ b/internal/fleet/output/models_kafka.go
@@ -278,6 +278,22 @@ func readOutputKafkaCompressionLevel(value *float32) *int64 {
 	return &converted
 }
 
+const defaultKafkaGzipCompressionLevel = float32(4)
+
+func kafkaCompressionLevel(compression types.String, compressionLevel types.Int64) *float32 {
+	if !typeutils.IsKnown(compression) || compression.ValueString() != "gzip" {
+		return nil
+	}
+
+	if typeutils.IsKnown(compressionLevel) {
+		val := float32(compressionLevel.ValueInt64())
+		return &val
+	}
+
+	defaultLevel := defaultKafkaGzipCompressionLevel
+	return &defaultLevel
+}
+
 func (model outputModel) toAPICreateKafkaModel(ctx context.Context) (kbapi.NewOutputUnion, diag.Diagnostics) {
 	ssl, diags := objectValueToSSL(ctx, model.Ssl)
 	if diags.HasError() {
@@ -343,14 +359,7 @@ func (model outputModel) toAPICreateKafkaModel(ctx context.Context) (kbapi.NewOu
 			comp := kbapi.KibanaHTTPAPIsNewOutputKafkaCompression(kafkaModel.Compression.ValueString())
 			return &comp
 		}(),
-		CompressionLevel: func() *float32 {
-			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != "gzip" {
-				return nil
-			}
-
-			compressionLevel := float32(kafkaModel.CompressionLevel.ValueInt64())
-			return &compressionLevel
-		}(),
+		CompressionLevel: kafkaCompressionLevel(kafkaModel.Compression, kafkaModel.CompressionLevel),
 		ConnectionType: connectionType,
 		Topic:          kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsNewOutputKafkaPartition {
@@ -463,14 +472,7 @@ func (model outputModel) toAPIUpdateKafkaModel(ctx context.Context) (kbapi.Updat
 			comp := kbapi.KibanaHTTPAPIsUpdateOutputKafkaCompression(kafkaModel.Compression.ValueString())
 			return &comp
 		}(),
-		CompressionLevel: func() *float32 {
-			if !typeutils.IsKnown(kafkaModel.CompressionLevel) || kafkaModel.Compression.ValueString() != "gzip" {
-				return nil
-			}
-
-			compressionLevel := float32(kafkaModel.CompressionLevel.ValueInt64())
-			return &compressionLevel
-		}(),
+		CompressionLevel: kafkaCompressionLevel(kafkaModel.Compression, kafkaModel.CompressionLevel),
 		ConnectionType: connectionType,
 		Topic:          kafkaModel.Topic.ValueStringPointer(),
 		Partition: func() *kbapi.KibanaHTTPAPIsUpdateOutputKafkaPartition {
@@ -529,16 +531,20 @@ func (model *outputModel) fromAPIKafkaModel(ctx context.Context, data *kbapi.Kib
 		ssl:                  data.Ssl,
 	})
 
-	// Capture the configured password before re-initializing kafkaModel so that
-	// we can preserve it when Fleet omits/redacts it (it is stored as a secret
-	// reference and not returned in plain form).
+	// Capture the configured password and sasl before re-initializing kafkaModel
+	// so that we can preserve them when Fleet omits/redacts or adds server-side
+	// defaults that the user did not configure.
 	configuredPassword := types.StringNull()
+	saslExplicitlyNull := false
 	if typeutils.IsKnown(model.Kafka) {
 		var existing outputKafkaModel
 		existingDiags := model.Kafka.As(ctx, &existing, basetypes.ObjectAsOptions{})
 		diags.Append(existingDiags...)
 		if !existingDiags.HasError() {
 			configuredPassword = existing.Password
+			if !existing.Sasl.IsUnknown() {
+				saslExplicitlyNull = existing.Sasl.IsNull()
+			}
 		}
 	}
 
@@ -644,7 +650,13 @@ func (model *outputModel) fromAPIKafkaModel(ctx context.Context, data *kbapi.Kib
 	}
 
 	// Handle sasl
-	if data.Sasl != nil {
+	switch {
+	case saslExplicitlyNull:
+		// Fleet may return a default sasl block (e.g. mechanism=PLAIN for
+		// user_pass auth) even when the user did not configure sasl. Preserve
+		// the configured null so Terraform does not see an inconsistent change.
+		kafkaModel.Sasl = types.ObjectNull(getSaslAttrTypes(ctx))
+	case data.Sasl != nil:
 		saslModel := outputSaslModel{
 			Mechanism: func() types.String {
 				if data.Sasl.Mechanism != nil {
@@ -656,7 +668,7 @@ func (model *outputModel) fromAPIKafkaModel(ctx context.Context, data *kbapi.Kib
 		obj, nd := types.ObjectValueFrom(ctx, getSaslAttrTypes(ctx), saslModel)
 		diags.Append(nd...)
 		kafkaModel.Sasl = obj
-	} else {
+	default:
 		kafkaModel.Sasl = types.ObjectNull(getSaslAttrTypes(ctx))
 	}
 

--- a/internal/fleet/output/models_kafka_test.go
+++ b/internal/fleet/output/models_kafka_test.go
@@ -131,40 +131,6 @@ func Test_fromAPIKafkaModel_readsConfiguredSasl(t *testing.T) {
 	assert.Equal(t, "SCRAM-SHA-256", sasl.Mechanism.ValueString())
 }
 
-func Test_kafkaCompressionLevel(t *testing.T) {
-	tests := []struct {
-		name             string
-		compression      types.String
-		compressionLevel types.Int64
-		want             *float32
-	}{
-		{
-			name:        "returns nil when compression is not gzip",
-			compression: types.StringValue("snappy"),
-		},
-		{
-			name:        "returns nil when compression is unknown",
-			compression: types.StringUnknown(),
-		},
-		{
-			name:             "returns explicit level for gzip",
-			compression:      types.StringValue("gzip"),
-			compressionLevel: types.Int64Value(6),
-			want:             new(float32(6)),
-		},
-		{
-			name:        "defaults to 4 for gzip without explicit level",
-			compression: types.StringValue("gzip"),
-			want:        new(float32(4)),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, kafkaCompressionLevel(tt.compression, tt.compressionLevel))
-		})
-	}
-}
-
 func Test_outputKafkaModel_toAPIHash(t *testing.T) {
 	type fields struct {
 		Hash types.Object

--- a/internal/fleet/output/models_kafka_test.go
+++ b/internal/fleet/output/models_kafka_test.go
@@ -24,8 +24,148 @@ import (
 	"github.com/elastic/terraform-provider-elasticstack/generated/kbapi"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_fromAPIKafkaModel_preservesNullSasl(t *testing.T) {
+	ctx := context.Background()
+
+	kafkaObj := types.ObjectValueMust(getKafkaAttrTypes(ctx), map[string]attr.Value{
+		"auth_type":         types.StringValue("user_pass"),
+		"broker_timeout":    types.Float32Null(),
+		"client_id":         types.StringNull(),
+		"compression":       types.StringNull(),
+		"compression_level": types.Int64Null(),
+		"connection_type":   types.StringNull(),
+		"topic":             types.StringValue("elastic-beats"),
+		"partition":         types.StringNull(),
+		"required_acks":     types.Int64Null(),
+		"timeout":           types.Float32Null(),
+		"version":           types.StringNull(),
+		"username":          types.StringValue("kafka_user"),
+		"password":          types.StringValue("kafka_password"),
+		"key":               types.StringNull(),
+		"headers":           types.ListNull(getHeadersAttrTypes(ctx)),
+		"hash":              types.ObjectNull(getHashAttrTypes(ctx)),
+		"random":            types.ObjectNull(getRandomAttrTypes(ctx)),
+		"round_robin":       types.ObjectNull(getRoundRobinAttrTypes(ctx)),
+		"sasl":              types.ObjectNull(getSaslAttrTypes(ctx)),
+	})
+
+	model := outputModel{
+		Type:  types.StringValue("kafka"),
+		Kafka: kafkaObj,
+	}
+
+	mechanism := kbapi.KibanaHTTPAPIsOutputKafkaSaslMechanismPLAIN
+	diags := model.fromAPIKafkaModel(ctx, &kbapi.KibanaHTTPAPIsOutputKafka{
+		Type:     kbapi.KibanaHTTPAPIsOutputKafkaTypeKafka,
+		Name:     "Basic Kafka Output",
+		Hosts:    []string{"kafka:9092"},
+		AuthType: kbapi.KibanaHTTPAPIsOutputKafkaAuthTypeUserPass,
+		Topic:    new("elastic-beats"),
+		Sasl: &kbapi.KibanaHTTPAPIsOutputKafka_Sasl{
+			Mechanism: &mechanism,
+		},
+	})
+	require.False(t, diags.HasError())
+
+	var result outputKafkaModel
+	diags = model.Kafka.As(ctx, &result, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+	assert.True(t, result.Sasl.IsNull())
+}
+
+func Test_fromAPIKafkaModel_readsConfiguredSasl(t *testing.T) {
+	ctx := context.Background()
+
+	kafkaObj := types.ObjectValueMust(getKafkaAttrTypes(ctx), map[string]attr.Value{
+		"auth_type":         types.StringValue("user_pass"),
+		"broker_timeout":    types.Float32Null(),
+		"client_id":         types.StringNull(),
+		"compression":       types.StringNull(),
+		"compression_level": types.Int64Null(),
+		"connection_type":   types.StringNull(),
+		"topic":             types.StringValue("elastic-beats"),
+		"partition":         types.StringNull(),
+		"required_acks":     types.Int64Null(),
+		"timeout":           types.Float32Null(),
+		"version":           types.StringNull(),
+		"username":          types.StringValue("kafka_user"),
+		"password":          types.StringValue("kafka_password"),
+		"key":               types.StringNull(),
+		"headers":           types.ListNull(getHeadersAttrTypes(ctx)),
+		"hash":              types.ObjectNull(getHashAttrTypes(ctx)),
+		"random":            types.ObjectNull(getRandomAttrTypes(ctx)),
+		"round_robin":       types.ObjectNull(getRoundRobinAttrTypes(ctx)),
+		"sasl": types.ObjectValueMust(getSaslAttrTypes(ctx), map[string]attr.Value{
+			"mechanism": types.StringValue("SCRAM-SHA-256"),
+		}),
+	})
+
+	model := outputModel{
+		Type:  types.StringValue("kafka"),
+		Kafka: kafkaObj,
+	}
+
+	mechanism := kbapi.KibanaHTTPAPIsOutputKafkaSaslMechanismSCRAMSHA256
+	diags := model.fromAPIKafkaModel(ctx, &kbapi.KibanaHTTPAPIsOutputKafka{
+		Type:     kbapi.KibanaHTTPAPIsOutputKafkaTypeKafka,
+		Name:     "Kafka Output",
+		Hosts:    []string{"kafka:9092"},
+		AuthType: kbapi.KibanaHTTPAPIsOutputKafkaAuthTypeUserPass,
+		Topic:    new("elastic-beats"),
+		Sasl: &kbapi.KibanaHTTPAPIsOutputKafka_Sasl{
+			Mechanism: &mechanism,
+		},
+	})
+	require.False(t, diags.HasError())
+
+	var result outputKafkaModel
+	diags = model.Kafka.As(ctx, &result, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+
+	var sasl outputSaslModel
+	diags = result.Sasl.As(ctx, &sasl, basetypes.ObjectAsOptions{})
+	require.False(t, diags.HasError())
+	assert.Equal(t, "SCRAM-SHA-256", sasl.Mechanism.ValueString())
+}
+
+func Test_kafkaCompressionLevel(t *testing.T) {
+	tests := []struct {
+		name             string
+		compression      types.String
+		compressionLevel types.Int64
+		want             *float32
+	}{
+		{
+			name:        "returns nil when compression is not gzip",
+			compression: types.StringValue("snappy"),
+		},
+		{
+			name:        "returns nil when compression is unknown",
+			compression: types.StringUnknown(),
+		},
+		{
+			name:             "returns explicit level for gzip",
+			compression:      types.StringValue("gzip"),
+			compressionLevel: types.Int64Value(6),
+			want:             new(float32(6)),
+		},
+		{
+			name:        "defaults to 4 for gzip without explicit level",
+			compression: types.StringValue("gzip"),
+			want:        new(float32(4)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, kafkaCompressionLevel(tt.compression, tt.compressionLevel))
+		})
+	}
+}
 
 func Test_outputKafkaModel_toAPIHash(t *testing.T) {
 	type fields struct {

--- a/internal/fleet/output/models_kafka_test.go
+++ b/internal/fleet/output/models_kafka_test.go
@@ -29,30 +29,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func mustKafkaObject(ctx context.Context, t *testing.T, model outputKafkaModel) types.Object {
+	t.Helper()
+
+	obj, diags := types.ObjectValueFrom(ctx, getKafkaAttrTypes(ctx), model)
+	require.False(t, diags.HasError())
+
+	return obj
+}
+
+func baseTestKafkaModel(ctx context.Context) outputKafkaModel {
+	return outputKafkaModel{
+		AuthType:         types.StringValue("user_pass"),
+		BrokerTimeout:    types.Float32Null(),
+		ClientID:         types.StringNull(),
+		Compression:      types.StringNull(),
+		CompressionLevel: types.Int64Null(),
+		ConnectionType:   types.StringNull(),
+		Topic:            types.StringValue("elastic-beats"),
+		Partition:        types.StringNull(),
+		RequiredAcks:     types.Int64Null(),
+		Timeout:          types.Float32Null(),
+		Version:          types.StringNull(),
+		Username:         types.StringValue("kafka_user"),
+		Password:         types.StringValue("kafka_password"),
+		Key:              types.StringNull(),
+		Headers:          types.ListNull(getHeadersAttrTypes(ctx)),
+		Hash:             types.ObjectNull(getHashAttrTypes(ctx)),
+		Random:           types.ObjectNull(getRandomAttrTypes(ctx)),
+		RoundRobin:       types.ObjectNull(getRoundRobinAttrTypes(ctx)),
+		Sasl:             types.ObjectNull(getSaslAttrTypes(ctx)),
+	}
+}
+
 func Test_fromAPIKafkaModel_preservesNullSasl(t *testing.T) {
 	ctx := context.Background()
 
-	kafkaObj := types.ObjectValueMust(getKafkaAttrTypes(ctx), map[string]attr.Value{
-		"auth_type":         types.StringValue("user_pass"),
-		"broker_timeout":    types.Float32Null(),
-		"client_id":         types.StringNull(),
-		"compression":       types.StringNull(),
-		"compression_level": types.Int64Null(),
-		"connection_type":   types.StringNull(),
-		"topic":             types.StringValue("elastic-beats"),
-		"partition":         types.StringNull(),
-		"required_acks":     types.Int64Null(),
-		"timeout":           types.Float32Null(),
-		"version":           types.StringNull(),
-		"username":          types.StringValue("kafka_user"),
-		"password":          types.StringValue("kafka_password"),
-		"key":               types.StringNull(),
-		"headers":           types.ListNull(getHeadersAttrTypes(ctx)),
-		"hash":              types.ObjectNull(getHashAttrTypes(ctx)),
-		"random":            types.ObjectNull(getRandomAttrTypes(ctx)),
-		"round_robin":       types.ObjectNull(getRoundRobinAttrTypes(ctx)),
-		"sasl":              types.ObjectNull(getSaslAttrTypes(ctx)),
-	})
+	kafkaObj := mustKafkaObject(ctx, t, baseTestKafkaModel(ctx))
 
 	model := outputModel{
 		Type:  types.StringValue("kafka"),
@@ -81,29 +94,14 @@ func Test_fromAPIKafkaModel_preservesNullSasl(t *testing.T) {
 func Test_fromAPIKafkaModel_readsConfiguredSasl(t *testing.T) {
 	ctx := context.Background()
 
-	kafkaObj := types.ObjectValueMust(getKafkaAttrTypes(ctx), map[string]attr.Value{
-		"auth_type":         types.StringValue("user_pass"),
-		"broker_timeout":    types.Float32Null(),
-		"client_id":         types.StringNull(),
-		"compression":       types.StringNull(),
-		"compression_level": types.Int64Null(),
-		"connection_type":   types.StringNull(),
-		"topic":             types.StringValue("elastic-beats"),
-		"partition":         types.StringNull(),
-		"required_acks":     types.Int64Null(),
-		"timeout":           types.Float32Null(),
-		"version":           types.StringNull(),
-		"username":          types.StringValue("kafka_user"),
-		"password":          types.StringValue("kafka_password"),
-		"key":               types.StringNull(),
-		"headers":           types.ListNull(getHeadersAttrTypes(ctx)),
-		"hash":              types.ObjectNull(getHashAttrTypes(ctx)),
-		"random":            types.ObjectNull(getRandomAttrTypes(ctx)),
-		"round_robin":       types.ObjectNull(getRoundRobinAttrTypes(ctx)),
-		"sasl": types.ObjectValueMust(getSaslAttrTypes(ctx), map[string]attr.Value{
-			"mechanism": types.StringValue("SCRAM-SHA-256"),
-		}),
+	kafkaModel := baseTestKafkaModel(ctx)
+	saslObj, diags := types.ObjectValueFrom(ctx, getSaslAttrTypes(ctx), outputSaslModel{
+		Mechanism: types.StringValue("SCRAM-SHA-256"),
 	})
+	require.False(t, diags.HasError())
+	kafkaModel.Sasl = saslObj
+
+	kafkaObj := mustKafkaObject(ctx, t, kafkaModel)
 
 	model := outputModel{
 		Type:  types.StringValue("kafka"),
@@ -111,7 +109,7 @@ func Test_fromAPIKafkaModel_readsConfiguredSasl(t *testing.T) {
 	}
 
 	mechanism := kbapi.KibanaHTTPAPIsOutputKafkaSaslMechanismSCRAMSHA256
-	diags := model.fromAPIKafkaModel(ctx, &kbapi.KibanaHTTPAPIsOutputKafka{
+	diags = model.fromAPIKafkaModel(ctx, &kbapi.KibanaHTTPAPIsOutputKafka{
 		Type:     kbapi.KibanaHTTPAPIsOutputKafkaTypeKafka,
 		Name:     "Kafka Output",
 		Hosts:    []string{"kafka:9092"},

--- a/internal/fleet/output/schema.go
+++ b/internal/fleet/output/schema.go
@@ -225,7 +225,7 @@ func getSchema(_ context.Context) schema.Schema {
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Validators: []validator.String{
-							stringvalidator.OneOf("gzip", "snappy", "lz4", "none"),
+							stringvalidator.OneOf(kafkaCompressionGzip, "snappy", "lz4", "none"),
 						},
 					},
 					"compression_level": schema.Int64Attribute{
@@ -237,7 +237,7 @@ func getSchema(_ context.Context) schema.Schema {
 							kafkaCompressionLevelDefaultIfGzip(),
 						},
 						Validators: []validator.Int64{
-							validators.AllowedIfDependentPathEquals(path.Root("kafka").AtName("compression"), "gzip", validators.AllowedIfOptions{}),
+							validators.AllowedIfDependentPathEquals(path.Root("kafka").AtName("compression"), kafkaCompressionGzip, validators.AllowedIfOptions{}),
 						},
 					},
 					"connection_type": schema.StringAttribute{

--- a/internal/fleet/output/schema.go
+++ b/internal/fleet/output/schema.go
@@ -234,6 +234,7 @@ func getSchema(_ context.Context) schema.Schema {
 						Computed:    true,
 						PlanModifiers: []planmodifier.Int64{
 							int64planmodifier.UseStateForUnknown(),
+							kafkaCompressionLevelDefaultIfGzip(),
 						},
 						Validators: []validator.Int64{
 							validators.AllowedIfDependentPathEquals(path.Root("kafka").AtName("compression"), "gzip", validators.AllowedIfOptions{}),

--- a/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/create/output.tf
+++ b/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/create/output.tf
@@ -1,0 +1,24 @@
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+}
+
+resource "elasticstack_fleet_output" "test_output" {
+  name                 = "Kafka Gzip Default Level ${var.policy_name}"
+  output_id            = "${var.policy_name}-kafka-gzip-default"
+  type                 = "kafka"
+  default_integrations = false
+  default_monitoring   = false
+  hosts = [
+    "kafka:9092"
+  ]
+
+  kafka = {
+    auth_type       = "none"
+    topic           = "beats"
+    partition       = "hash"
+    compression     = "gzip"
+    connection_type = "plaintext"
+    required_acks   = 1
+  }
+}

--- a/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/create/variables.tf
+++ b/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/create/variables.tf
@@ -1,0 +1,3 @@
+variable "policy_name" {
+  type = string
+}

--- a/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/update/output.tf
+++ b/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/update/output.tf
@@ -1,0 +1,25 @@
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+}
+
+resource "elasticstack_fleet_output" "test_output" {
+  name                 = "Kafka Gzip Explicit Level ${var.policy_name}"
+  output_id            = "${var.policy_name}-kafka-gzip-default"
+  type                 = "kafka"
+  default_integrations = false
+  default_monitoring   = false
+  hosts = [
+    "kafka:9092"
+  ]
+
+  kafka = {
+    auth_type         = "none"
+    topic             = "beats"
+    partition         = "hash"
+    compression       = "gzip"
+    compression_level = 8
+    connection_type   = "plaintext"
+    required_acks     = 1
+  }
+}

--- a/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/update/variables.tf
+++ b/internal/fleet/output/testdata/TestAccResourceOutputKafkaGzipDefaultCompressionLevel/update/variables.tf
@@ -1,0 +1,3 @@
+variable "policy_name" {
+  type = string
+}

--- a/internal/fleet/output/testdata/TestAccResourceOutputKafkaUserPassNoSasl/create/output.tf
+++ b/internal/fleet/output/testdata/TestAccResourceOutputKafkaUserPassNoSasl/create/output.tf
@@ -1,0 +1,22 @@
+provider "elasticstack" {
+  elasticsearch {}
+  kibana {}
+}
+
+resource "elasticstack_fleet_output" "test_output" {
+  name                 = "Kafka User Pass No SASL ${var.policy_name}"
+  output_id            = "${var.policy_name}-kafka-user-pass-no-sasl"
+  type                 = "kafka"
+  default_integrations = false
+  default_monitoring   = false
+  hosts = [
+    "kafka:9092"
+  ]
+
+  kafka = {
+    auth_type = "user_pass"
+    topic     = "beats"
+    username  = "testuser"
+    password  = "testpass"
+  }
+}

--- a/internal/fleet/output/testdata/TestAccResourceOutputKafkaUserPassNoSasl/create/variables.tf
+++ b/internal/fleet/output/testdata/TestAccResourceOutputKafkaUserPassNoSasl/create/variables.tf
@@ -1,0 +1,3 @@
+variable "policy_name" {
+  type = string
+}

--- a/openspec/specs/fleet-output/spec.md
+++ b/openspec/specs/fleet-output/spec.md
@@ -39,7 +39,7 @@ resource "elasticstack_fleet_output" "example" {
     broker_timeout    = <optional+computed, float32>
     client_id         = <optional+computed, string>
     compression       = <optional, string>   # one of: "gzip", "snappy", "lz4", "none"
-    compression_level = <optional+computed, int64> # only valid when compression = "gzip"; one of: -1, 0, 1
+    compression_level = <optional+computed, int64> # only valid when compression = "gzip"; defaults to 4 when omitted; one of: -1, 0, 1
     connection_type   = <optional, string>   # one of: "plaintext", "encryption"; only when auth_type = "none"
     topic             = <optional, string>
     partition         = <optional, string>   # one of: "random", "round_robin", "hash"
@@ -90,7 +90,9 @@ data "elasticstack_fleet_output" "example" {
   }))>
 }
 ```
+
 ## Requirements
+
 ### Requirement: Fleet Output CRUD APIs (REQ-001–REQ-004)
 
 The resource SHALL use the Fleet Create output API to create outputs. The resource SHALL use the Fleet Get output API to read outputs. The resource SHALL use the Fleet Update output API to update outputs. The resource SHALL use the Fleet Delete output API to delete outputs. When the Fleet API returns a non-success status for any create, update, or delete operation, the resource SHALL surface the error to Terraform diagnostics.
@@ -242,15 +244,47 @@ When `type = "kafka"` is configured, the resource SHALL verify that the Kibana/F
 - WHEN create or update runs
 - THEN the resource SHALL error with "Unsupported version for Kafka output" and SHALL NOT call the Fleet API
 
-### Requirement: Kafka compression_level constraint (REQ-011)
+### Requirement: Kafka compression_level constraint and default (REQ-011)
 
 The `kafka.compression_level` attribute SHALL only be accepted when `kafka.compression` equals `"gzip"`. The schema validator SHALL enforce this constraint. When building the API request, `compression_level` SHALL only be sent when `compression` is `"gzip"`.
+
+When `kafka.compression` is `"gzip"` and `kafka.compression_level` is omitted, the resource SHALL set `compression_level` to `4` during planning. An explicitly configured level SHALL be preserved. An unknown level value SHALL remain unknown so Terraform can resolve interpolated configuration. The resource SHALL NOT set a default level for non-gzip compression.
 
 #### Scenario: compression_level with non-gzip
 
 - GIVEN `kafka.compression = "snappy"` and `kafka.compression_level` is set
 - WHEN the resource is configured
 - THEN schema validation SHALL return an error
+
+#### Scenario: gzip compression level defaults during planning
+
+- GIVEN `kafka.compression = "gzip"` and `kafka.compression_level` is omitted
+- WHEN Terraform generates a plan
+- THEN `kafka.compression_level` SHALL be planned as `4`
+
+#### Scenario: explicit gzip compression level is preserved
+
+- GIVEN `kafka.compression = "gzip"` and `kafka.compression_level = 8`
+- WHEN Terraform generates a plan
+- THEN `kafka.compression_level` SHALL remain `8`
+
+### Requirement: Kafka SASL server default preservation
+
+When `kafka.sasl` is explicitly null in the configured Kafka model, the resource SHALL preserve null for `kafka.sasl` in state if Fleet returns a server-injected SASL block. This includes Fleet returning `mechanism = "PLAIN"` for `kafka.auth_type = "user_pass"`. This preservation SHALL prevent post-apply inconsistency and perpetual drift. When `kafka.sasl` is configured, the resource SHALL map the SASL block returned by Fleet into state.
+
+#### Scenario: Fleet injects SASL for an omitted block
+
+- GIVEN `kafka.auth_type = "user_pass"` and `kafka.sasl` is omitted
+- AND Fleet returns `kafka.sasl.mechanism = "PLAIN"`
+- WHEN the resource reads the output after create or update
+- THEN `kafka.sasl` SHALL remain null in Terraform state
+
+#### Scenario: configured SASL is read from Fleet
+
+- GIVEN `kafka.sasl.mechanism = "SCRAM-SHA-256"` is configured
+- AND Fleet returns `kafka.sasl.mechanism = "SCRAM-SHA-256"`
+- WHEN the resource reads the output
+- THEN Terraform state SHALL contain `kafka.sasl.mechanism = "SCRAM-SHA-256"`
 
 ### Requirement: Kafka connection_type constraint (REQ-012)
 
@@ -569,4 +603,3 @@ The resource documentation SHALL note that removing `config_yaml` from configura
 - AND someone changes the value to `"a: 2\n"` outside of Terraform
 - WHEN refresh runs
 - THEN `config_yaml` SHALL be updated to `"a: 2\n"` in state and the next plan SHALL show the drift
-


### PR DESCRIPTION
## Summary

- Default `kafka.compression_level` to `4` when `compression = "gzip"` and no level is configured, matching Fleet's default and avoiding 400 validation errors from the Kibana API.
- Preserve null `kafka.sasl` on read when Fleet injects a default `PLAIN` mechanism for `user_pass` auth, preventing "Provider produced inconsistent result after apply" errors.
- Add unit tests for both behaviors.

## Changelog
Customer impact: fix
Summary: Fix Fleet Kafka output apply failures when gzip compression level or sasl block are omitted

## Test plan

- [x] `go test ./internal/fleet/output/ -run 'Test_fromAPIKafkaModel|Test_kafkaCompressionLevel'`
- [ ] `make build`
- [ ] CI Provider checks (build, lint, unit tests)


Made with [Cursor](https://cursor.com)