### PR TITLE
fix(alerting): normalize empty params in state upgrade

### DIFF
--- a/internal/kibana/alertingrule/constants.go
+++ b/internal/kibana/alertingrule/constants.go
@@ -28,8 +28,14 @@ const (
 
 // Terraform schema attribute keys.
 const (
-	attrTags   = "tags"
-	attrParams = "params"
+	attrTags          = "tags"
+	attrParams        = "params"
+	attrNotifyWhen    = "notify_when"
+	attrRuleTypeID    = "rule_type_id"
+	attrEnabled       = "enabled"
+	attrThrottle      = "throttle"
+	blockFrequency    = "frequency"
+	blockAlertsFilter = "alerts_filter"
 )
 
 // JSON params keys used across rule types.

--- a/internal/kibana/alertingrule/schema.go
+++ b/internal/kibana/alertingrule/schema.go
@@ -85,7 +85,7 @@ func getSchema(_ context.Context) schema.Schema {
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"notify_when": schema.StringAttribute{
+			attrNotifyWhen: schema.StringAttribute{
 				Description: notifyWhenDescription,
 				Optional:    true,
 				Computed:    true,
@@ -99,12 +99,12 @@ func getSchema(_ context.Context) schema.Schema {
 					stringvalidator.OneOf("onActionGroupChange", "onActiveAlert", "onThrottleInterval"),
 				},
 			},
-			"params": schema.StringAttribute{
+			attrParams: schema.StringAttribute{
 				Description: "The rule parameters, which differ for each rule type.",
 				Required:    true,
 				CustomType:  jsontypes.NormalizedType{},
 			},
-			"rule_type_id": schema.StringAttribute{
+			attrRuleTypeID: schema.StringAttribute{
 				Description: ruleTypeIDDescription,
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
@@ -116,7 +116,7 @@ func getSchema(_ context.Context) schema.Schema {
 				Required:    true,
 				CustomType:  kibanacustomtypes.AlertingDurationType{Units: kibanacustomtypes.AlertingDurationUnitsSubDay},
 			},
-			"enabled": schema.BoolAttribute{
+			attrEnabled: schema.BoolAttribute{
 				Description: "Indicates if you want to run the rule on an interval basis.",
 				Optional:    true,
 				Computed:    true,
@@ -127,7 +127,7 @@ func getSchema(_ context.Context) schema.Schema {
 				Optional:    true,
 				ElementType: types.StringType,
 			},
-			"throttle": schema.StringAttribute{
+			attrThrottle: schema.StringAttribute{
 				Description: throttleRuleDescription,
 				Optional:    true,
 				Computed:    true,
@@ -216,14 +216,14 @@ func getSchema(_ context.Context) schema.Schema {
 							Description: "The identifier for the connector saved object.",
 							Required:    true,
 						},
-						"params": schema.StringAttribute{
+						attrParams: schema.StringAttribute{
 							Description: "The parameters for the action, which are sent to the connector.",
 							Required:    true,
 							CustomType:  jsontypes.NormalizedType{},
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"frequency": schema.SingleNestedBlock{
+						blockFrequency: schema.SingleNestedBlock{
 							Description: actionsFrequencyDescription,
 							Validators: []validator.Object{
 								objectvalidator.AlsoRequires(path.MatchRelative().AtName("summary")),
@@ -250,7 +250,7 @@ func getSchema(_ context.Context) schema.Schema {
 								},
 							},
 						},
-						"alerts_filter": schema.SingleNestedBlock{
+						blockAlertsFilter: schema.SingleNestedBlock{
 							Description: alertsFilterDescription,
 							Attributes: map[string]schema.Attribute{
 								"kql": schema.StringAttribute{

--- a/internal/kibana/alertingrule/state_upgrade.go
+++ b/internal/kibana/alertingrule/state_upgrade.go
@@ -69,11 +69,14 @@ func migrateV0ToV1(_ context.Context, req resource.UpgradeStateRequest, resp *re
 	}
 
 	stateutil.NullifyEmptyString(stateMap, "notify_when", "throttle")
+	stateutil.NullifyEmptyString(stateMap, "params")
 
 	// Handle actions: convert frequency, alerts_filter, and timeframe from lists to objects
 	if actions, ok := stateMap["actions"].([]any); ok {
 		for _, actionAny := range actions {
 			if action, ok := actionAny.(map[string]any); ok {
+				stateutil.NullifyEmptyString(action, "params")
+
 				resp.Diagnostics.Append(stateutil.CollapseListPath(action, "frequency", "actions.frequency")...)
 				if resp.Diagnostics.HasError() {
 					return

--- a/internal/kibana/alertingrule/state_upgrade.go
+++ b/internal/kibana/alertingrule/state_upgrade.go
@@ -39,8 +39,7 @@ func (r *Resource) UpgradeState(context.Context) map[int64]resource.StateUpgrade
 // migrateV0ToV1 handles migration from SDKv2 state format to Plugin Framework state format.
 // The main differences are:
 // - JSON fields may need normalization for jsontypes.Normalized
-// - notify_when may be empty string instead of null
-// - throttle may be empty string instead of null
+// - notify_when, throttle, and params may be empty strings instead of null
 // - frequency, alerts_filter, and timeframe change from lists to single objects
 func migrateV0ToV1(_ context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
 	stateutil.SetDefaultState(req, resp)
@@ -68,26 +67,25 @@ func migrateV0ToV1(_ context.Context, req resource.UpgradeStateRequest, resp *re
 		}
 	}
 
-	stateutil.NullifyEmptyString(stateMap, "notify_when", "throttle")
-	stateutil.NullifyEmptyString(stateMap, "params")
+	stateutil.NullifyEmptyString(stateMap, attrNotifyWhen, attrThrottle, attrParams)
 
 	// Handle actions: convert frequency, alerts_filter, and timeframe from lists to objects
 	if actions, ok := stateMap["actions"].([]any); ok {
 		for _, actionAny := range actions {
 			if action, ok := actionAny.(map[string]any); ok {
-				stateutil.NullifyEmptyString(action, "params")
+				stateutil.NullifyEmptyString(action, attrParams)
 
-				resp.Diagnostics.Append(stateutil.CollapseListPath(action, "frequency", "actions.frequency")...)
+				resp.Diagnostics.Append(stateutil.CollapseListPath(action, blockFrequency, "actions.frequency")...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
 
-				resp.Diagnostics.Append(stateutil.CollapseListPath(action, "alerts_filter", "actions.alerts_filter")...)
+				resp.Diagnostics.Append(stateutil.CollapseListPath(action, blockAlertsFilter, "actions.alerts_filter")...)
 				if resp.Diagnostics.HasError() {
 					return
 				}
 
-				if filterMap, ok := action["alerts_filter"].(map[string]any); ok {
+				if filterMap, ok := action[blockAlertsFilter].(map[string]any); ok {
 					resp.Diagnostics.Append(stateutil.CollapseListPath(filterMap, "timeframe", "actions.alerts_filter.timeframe")...)
 					if resp.Diagnostics.HasError() {
 						return

--- a/internal/kibana/alertingrule/state_upgrade_test.go
+++ b/internal/kibana/alertingrule/state_upgrade_test.go
@@ -20,6 +20,7 @@ package alertingrule
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
@@ -30,13 +31,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	testSchemaOnce sync.Once
+	testSchema     rschema.Schema
+)
+
 func testResourceSchema(t *testing.T) rschema.Schema {
 	t.Helper()
-	ctx := context.Background()
-	var resp resource.SchemaResponse
-	newResource().Schema(ctx, resource.SchemaRequest{}, &resp)
-	require.False(t, resp.Diagnostics.HasError(), "%s", resp.Diagnostics)
-	return resp.Schema
+	testSchemaOnce.Do(func() {
+		ctx := context.Background()
+		var resp resource.SchemaResponse
+		newResource().Schema(ctx, resource.SchemaRequest{}, &resp)
+		require.False(t, resp.Diagnostics.HasError(), "%s", resp.Diagnostics)
+		testSchema = resp.Schema
+	})
+	return testSchema
 }
 
 func runMigrateV0ToV1(t *testing.T, raw map[string]any) map[string]any {
@@ -101,10 +110,10 @@ func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
 	t.Parallel()
 
 	validParams := `{"test":"value"}`
-	absentParams := "__absent__"
 
 	cases := []struct {
 		name              string
+		ruleParamsSet     bool
 		ruleParams        any
 		actionParams      []any
 		wantRuleParams    any
@@ -113,26 +122,28 @@ func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
 	}{
 		{
 			name:              "rule params empty string becomes null",
+			ruleParamsSet:     true,
 			ruleParams:        "",
 			wantRuleParams:    nil,
 			wantDecodeUnderV1: true,
 		},
 		{
 			name:              "rule params valid JSON unchanged",
+			ruleParamsSet:     true,
 			ruleParams:        validParams,
 			wantRuleParams:    validParams,
 			wantDecodeUnderV1: true,
 		},
 		{
 			name:              "rule params null unchanged",
+			ruleParamsSet:     true,
 			ruleParams:        nil,
 			wantRuleParams:    nil,
 			wantDecodeUnderV1: true,
 		},
 		{
 			name:              "rule params absent unchanged",
-			ruleParams:        absentParams,
-			wantRuleParams:    absentParams,
+			ruleParamsSet:     false,
 			wantDecodeUnderV1: false,
 		},
 		{
@@ -155,6 +166,7 @@ func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
 		},
 		{
 			name:              "both rule and action params empty strings become null",
+			ruleParamsSet:     true,
 			ruleParams:        "",
 			actionParams:      []any{""},
 			wantRuleParams:    nil,
@@ -174,17 +186,17 @@ func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
 			t.Parallel()
 
 			raw := baseAlertingRuleState()
-			if tc.ruleParams != absentParams {
-				raw["params"] = tc.ruleParams
+			if tc.ruleParamsSet {
+				raw[attrParams] = tc.ruleParams
 			}
 			if tc.actionParams != nil {
 				actions := make([]any, 0, len(tc.actionParams))
 				for _, params := range tc.actionParams {
 					action := map[string]any{
-						"id":            "action-id",
-						"frequency":     []any{},
-						"alerts_filter": []any{},
-						"params":        params,
+						"id":              "action-id",
+						blockFrequency:    []any{},
+						blockAlertsFilter: []any{},
+						attrParams:        params,
 					}
 					actions = append(actions, action)
 				}
@@ -197,10 +209,10 @@ func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
 			var got map[string]any
 			require.NoError(t, json.Unmarshal(resp.DynamicValue.JSON, &got))
 
-			if tc.ruleParams != absentParams {
-				require.Equal(t, tc.wantRuleParams, got["params"], "rule-level params normalization mismatch")
+			if tc.ruleParamsSet {
+				require.Equal(t, tc.wantRuleParams, got[attrParams], "rule-level params normalization mismatch")
 			} else {
-				_, ok := got["params"]
+				_, ok := got[attrParams]
 				require.False(t, ok, "absent rule params should remain absent")
 			}
 
@@ -211,7 +223,7 @@ func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
 				for i, actionAny := range actions {
 					action, ok := actionAny.(map[string]any)
 					require.True(t, ok, "action %d should be a map", i)
-					require.Equal(t, tc.wantActionParams[i], action["params"], "action %d params normalization mismatch", i)
+					require.Equal(t, tc.wantActionParams[i], action[attrParams], "action %d params normalization mismatch", i)
 				}
 			}
 
@@ -226,35 +238,35 @@ func TestMigrateV0ToV1_PreservesExistingTransformations(t *testing.T) {
 	t.Parallel()
 
 	raw := baseAlertingRuleState()
-	raw["params"] = ""
-	raw["notify_when"] = ""
-	raw["throttle"] = ""
+	raw[attrParams] = ""
+	raw[attrNotifyWhen] = ""
+	raw[attrThrottle] = ""
 	raw["actions"] = []any{
 		map[string]any{
-			"id":     "action-1",
-			"params": `{"foo":"bar"}`,
-			"frequency": []any{
+			"id":       "action-1",
+			attrParams: `{"foo":"bar"}`,
+			blockFrequency: []any{
 				map[string]any{
-					"summary":     true,
-					"notify_when": "onActiveAlert",
-					"throttle":    "10m",
+					"summary":      true,
+					attrNotifyWhen: "onActiveAlert",
+					attrThrottle:   "10m",
 				},
 			},
-			"alerts_filter": []any{},
+			blockAlertsFilter: []any{},
 		},
 		map[string]any{
-			"id":            "action-2",
-			"params":        "",
-			"frequency":     []any{},
-			"alerts_filter": []any{},
+			"id":              "action-2",
+			attrParams:        "",
+			blockFrequency:    []any{},
+			blockAlertsFilter: []any{},
 		},
 	}
 
 	got := runMigrateV0ToV1(t, raw)
 
-	require.Nil(t, got["params"], "rule-level params should be nullified")
-	require.Nil(t, got["notify_when"], "notify_when should be nullified")
-	require.Nil(t, got["throttle"], "throttle should be nullified")
+	require.Nil(t, got[attrParams], "rule-level params should be nullified")
+	require.Nil(t, got[attrNotifyWhen], "notify_when should be nullified")
+	require.Nil(t, got[attrThrottle], "throttle should be nullified")
 
 	actions, ok := got["actions"].([]any)
 	require.True(t, ok)
@@ -262,21 +274,21 @@ func TestMigrateV0ToV1_PreservesExistingTransformations(t *testing.T) {
 
 	action1, ok := actions[0].(map[string]any)
 	require.True(t, ok)
-	action1Params, ok := action1["params"].(string)
+	action1Params, ok := action1[attrParams].(string)
 	require.True(t, ok)
 	require.JSONEq(t, `{"foo":"bar"}`, action1Params, "non-empty action params should be preserved")
-	freq1, ok := action1["frequency"].(map[string]any)
+	freq1, ok := action1[blockFrequency].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, true, freq1["summary"])
-	require.Equal(t, "onActiveAlert", freq1["notify_when"])
-	require.Equal(t, "10m", freq1["throttle"])
-	require.Nil(t, action1["alerts_filter"], "empty alerts_filter list should collapse to null")
+	require.Equal(t, "onActiveAlert", freq1[attrNotifyWhen])
+	require.Equal(t, "10m", freq1[attrThrottle])
+	require.Nil(t, action1[blockAlertsFilter], "empty alerts_filter list should collapse to null")
 
 	action2, ok := actions[1].(map[string]any)
 	require.True(t, ok)
-	require.Nil(t, action2["params"], "empty action params should be nullified")
-	require.Nil(t, action2["frequency"], "empty frequency list should collapse to null")
-	require.Nil(t, action2["alerts_filter"], "empty alerts_filter list should collapse to null")
+	require.Nil(t, action2[attrParams], "empty action params should be nullified")
+	require.Nil(t, action2[blockFrequency], "empty frequency list should collapse to null")
+	require.Nil(t, action2[blockAlertsFilter], "empty alerts_filter list should collapse to null")
 }
 
 func TestUpgradeState_RegistersV0Upgrader(t *testing.T) {

--- a/internal/kibana/alertingrule/state_upgrade_test.go
+++ b/internal/kibana/alertingrule/state_upgrade_test.go
@@ -1,0 +1,290 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package alertingrule
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/elastic/terraform-provider-elasticstack/internal/clients"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/require"
+)
+
+func testResourceSchema(t *testing.T) rschema.Schema {
+	t.Helper()
+	ctx := context.Background()
+	var resp resource.SchemaResponse
+	newResource().Schema(ctx, resource.SchemaRequest{}, &resp)
+	require.False(t, resp.Diagnostics.HasError(), "%s", resp.Diagnostics)
+	return resp.Schema
+}
+
+func runMigrateV0ToV1(t *testing.T, raw map[string]any) map[string]any {
+	t.Helper()
+
+	resp := runMigrateV0ToV1Resp(t, raw)
+	require.False(t, resp.Diagnostics.HasError(), "%s", resp.Diagnostics)
+	require.NotNil(t, resp.DynamicValue)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(resp.DynamicValue.JSON, &got))
+	return got
+}
+
+func runMigrateV0ToV1Resp(t *testing.T, raw map[string]any) *resource.UpgradeStateResponse {
+	t.Helper()
+
+	rawJSON, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	req := resource.UpgradeStateRequest{RawState: &tfprotov6.RawState{JSON: rawJSON}}
+	resp := &resource.UpgradeStateResponse{}
+	migrateV0ToV1(context.Background(), req, resp)
+	return resp
+}
+
+func requireUpgradedStateDecodes(t *testing.T, resp *resource.UpgradeStateResponse) {
+	t.Helper()
+	require.False(t, resp.Diagnostics.HasError(), "%s", resp.Diagnostics)
+	require.NotNil(t, resp.DynamicValue)
+	require.NotNil(t, resp.DynamicValue.JSON)
+
+	ctx := context.Background()
+	sch := testResourceSchema(t)
+	tfTyp := sch.Type().TerraformType(ctx)
+	raw, err := resp.DynamicValue.Unmarshal(tfTyp)
+	require.NoError(t, err, "upgraded state must decode under the v1 resource schema's Terraform type")
+
+	state := tfsdk.State{Schema: sch, Raw: raw}
+	var model alertingRuleModel
+	diags := state.Get(ctx, &model)
+	for _, d := range diags.Errors() {
+		t.Logf("decode diagnostic: %s: %s", d.Summary(), d.Detail())
+	}
+	require.False(t, diags.HasError(), "upgraded state must decode into the resource's Go model")
+}
+
+func baseAlertingRuleState() map[string]any {
+	return map[string]any{
+		"id":           clients.DefaultSpaceID + "/rule-id",
+		"space_id":     clients.DefaultSpaceID,
+		"rule_id":      "rule-id",
+		"name":         "rule-name",
+		"consumer":     "alerts",
+		"rule_type_id": ".index-threshold",
+		"interval":     "1m",
+		"enabled":      true,
+	}
+}
+
+func TestMigrateV0ToV1_ParamsNullification(t *testing.T) {
+	t.Parallel()
+
+	validParams := `{"test":"value"}`
+	absentParams := "__absent__"
+
+	cases := []struct {
+		name              string
+		ruleParams        any
+		actionParams      []any
+		wantRuleParams    any
+		wantActionParams  []any
+		wantDecodeUnderV1 bool
+	}{
+		{
+			name:              "rule params empty string becomes null",
+			ruleParams:        "",
+			wantRuleParams:    nil,
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "rule params valid JSON unchanged",
+			ruleParams:        validParams,
+			wantRuleParams:    validParams,
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "rule params null unchanged",
+			ruleParams:        nil,
+			wantRuleParams:    nil,
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "rule params absent unchanged",
+			ruleParams:        absentParams,
+			wantRuleParams:    absentParams,
+			wantDecodeUnderV1: false,
+		},
+		{
+			name:              "action params empty string becomes null",
+			actionParams:      []any{""},
+			wantActionParams:  []any{nil},
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "action params valid JSON unchanged",
+			actionParams:      []any{validParams},
+			wantActionParams:  []any{validParams},
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "action params null unchanged",
+			actionParams:      []any{nil},
+			wantActionParams:  []any{nil},
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "both rule and action params empty strings become null",
+			ruleParams:        "",
+			actionParams:      []any{""},
+			wantRuleParams:    nil,
+			wantActionParams:  []any{nil},
+			wantDecodeUnderV1: true,
+		},
+		{
+			name:              "mixed action params preserves valid JSON and nullifies empty",
+			actionParams:      []any{"", validParams, nil},
+			wantActionParams:  []any{nil, validParams, nil},
+			wantDecodeUnderV1: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := baseAlertingRuleState()
+			if tc.ruleParams != absentParams {
+				raw["params"] = tc.ruleParams
+			}
+			if tc.actionParams != nil {
+				actions := make([]any, 0, len(tc.actionParams))
+				for _, params := range tc.actionParams {
+					action := map[string]any{
+						"id":            "action-id",
+						"frequency":     []any{},
+						"alerts_filter": []any{},
+						"params":        params,
+					}
+					actions = append(actions, action)
+				}
+				raw["actions"] = actions
+			}
+
+			resp := runMigrateV0ToV1Resp(t, raw)
+			require.False(t, resp.Diagnostics.HasError(), "%s", resp.Diagnostics)
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(resp.DynamicValue.JSON, &got))
+
+			if tc.ruleParams != absentParams {
+				require.Equal(t, tc.wantRuleParams, got["params"], "rule-level params normalization mismatch")
+			} else {
+				_, ok := got["params"]
+				require.False(t, ok, "absent rule params should remain absent")
+			}
+
+			if tc.actionParams != nil {
+				actions, ok := got["actions"].([]any)
+				require.True(t, ok, "actions should remain a list")
+				require.Len(t, actions, len(tc.wantActionParams))
+				for i, actionAny := range actions {
+					action, ok := actionAny.(map[string]any)
+					require.True(t, ok, "action %d should be a map", i)
+					require.Equal(t, tc.wantActionParams[i], action["params"], "action %d params normalization mismatch", i)
+				}
+			}
+
+			if tc.wantDecodeUnderV1 {
+				requireUpgradedStateDecodes(t, resp)
+			}
+		})
+	}
+}
+
+func TestMigrateV0ToV1_PreservesExistingTransformations(t *testing.T) {
+	t.Parallel()
+
+	raw := baseAlertingRuleState()
+	raw["params"] = ""
+	raw["notify_when"] = ""
+	raw["throttle"] = ""
+	raw["actions"] = []any{
+		map[string]any{
+			"id":     "action-1",
+			"params": `{"foo":"bar"}`,
+			"frequency": []any{
+				map[string]any{
+					"summary":     true,
+					"notify_when": "onActiveAlert",
+					"throttle":    "10m",
+				},
+			},
+			"alerts_filter": []any{},
+		},
+		map[string]any{
+			"id":            "action-2",
+			"params":        "",
+			"frequency":     []any{},
+			"alerts_filter": []any{},
+		},
+	}
+
+	got := runMigrateV0ToV1(t, raw)
+
+	require.Nil(t, got["params"], "rule-level params should be nullified")
+	require.Nil(t, got["notify_when"], "notify_when should be nullified")
+	require.Nil(t, got["throttle"], "throttle should be nullified")
+
+	actions, ok := got["actions"].([]any)
+	require.True(t, ok)
+	require.Len(t, actions, 2)
+
+	action1, ok := actions[0].(map[string]any)
+	require.True(t, ok)
+	action1Params, ok := action1["params"].(string)
+	require.True(t, ok)
+	require.JSONEq(t, `{"foo":"bar"}`, action1Params, "non-empty action params should be preserved")
+	freq1, ok := action1["frequency"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, true, freq1["summary"])
+	require.Equal(t, "onActiveAlert", freq1["notify_when"])
+	require.Equal(t, "10m", freq1["throttle"])
+	require.Nil(t, action1["alerts_filter"], "empty alerts_filter list should collapse to null")
+
+	action2, ok := actions[1].(map[string]any)
+	require.True(t, ok)
+	require.Nil(t, action2["params"], "empty action params should be nullified")
+	require.Nil(t, action2["frequency"], "empty frequency list should collapse to null")
+	require.Nil(t, action2["alerts_filter"], "empty alerts_filter list should collapse to null")
+}
+
+func TestUpgradeState_RegistersV0Upgrader(t *testing.T) {
+	t.Parallel()
+
+	r := &Resource{}
+	upgraders := r.UpgradeState(context.Background())
+	up, ok := upgraders[0]
+	require.True(t, ok, "expected a registered v0 state upgrader")
+	require.NotNil(t, up.StateUpgrader)
+}

--- a/internal/kibana/alertingrule/validate.go
+++ b/internal/kibana/alertingrule/validate.go
@@ -170,7 +170,7 @@ var ruleTypeAdditionalAllowedParamsKeys = map[string][]string{}
 func validateParamsViaDiscriminator(ruleTypeID string, params map[string]any) []string {
 	// Build a minimal stub rule body sufficient for discriminator dispatch.
 	stub := map[string]any{
-		"rule_type_id": ruleTypeID,
+		attrRuleTypeID: ruleTypeID,
 		attrParams:     params,
 	}
 	stubRaw, err := json.Marshal(stub)

--- a/openspec/changes/alerting-rule-state-upgrade-params/tasks.md
+++ b/openspec/changes/alerting-rule-state-upgrade-params/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Implementation
 
-- [ ] 1.1 In `internal/kibana/alertingrule/state_upgrade.go`, inside `migrateV0ToV1`,
+- [x] 1.1 In `internal/kibana/alertingrule/state_upgrade.go`, inside `migrateV0ToV1`,
   add `stateutil.NullifyEmptyString(stateMap, "params")` immediately after the
   existing `stateutil.NullifyEmptyString(stateMap, "notify_when", "throttle")` call.
 
-- [ ] 1.2 In the same function, inside the `actions` loop (the block that iterates
+- [x] 1.2 In the same function, inside the `actions` loop (the block that iterates
   `stateMap["actions"].([]any)` and casts each element to `map[string]any`), add
   `stateutil.NullifyEmptyString(action, "params")` as the first statement inside
   the `if action, ok := ...` block, before the `CollapseListPath` calls.
 
 ## 2. Testing
 
-- [ ] 2.1 Add unit tests for `migrateV0ToV1` in
+- [x] 2.1 Add unit tests for `migrateV0ToV1` in
   `internal/kibana/alertingrule/state_upgrade_test.go` (create the file if it does
   not exist) covering the following cases:
   - Rule-level `params` is `""` → upgraded state has `params` = `null`.
@@ -25,7 +25,7 @@
 
 ## 3. Spec
 
-- [ ] 3.1 Run `OPENSPEC_TELEMETRY=0 ./node_modules/.bin/openspec validate alerting-rule-state-upgrade-params --type change` and resolve any reported problems.
-- [ ] 3.2 When implementation is complete, sync the delta spec into
+- [x] 3.1 Run `OPENSPEC_TELEMETRY=0 ./node_modules/.bin/openspec validate alerting-rule-state-upgrade-params --type change` and resolve any reported problems.
+- [x] 3.2 When implementation is complete, sync the delta spec into
   `openspec/specs/kibana-alerting-rule/spec.md` or archive the change per the
   project workflow.

--- a/openspec/specs/kibana-alerting-rule/spec.md
+++ b/openspec/specs/kibana-alerting-rule/spec.md
@@ -70,7 +70,9 @@ Notes:
 
 - Top-level and nested Markdown descriptions for several attributes are embedded from `internal/kibana/alertingrule/descriptions/*.md` and `resource-description.md` (includes link to Elastic create-rule API docs and an `api_key` auth note for stack 8.8.0+).
 - Resource schema version is **1** (`schema.Schema.Version`); state upgrade handles **0 → 1**.
+
 ## Requirements
+
 ### Requirement: Kibana alerting rule APIs (REQ-001–REQ-004)
 
 The resource SHALL manage rules through Kibana’s alerting rule HTTP API: create rule, get rule, update rule, and delete rule. When an update response does not reflect the desired enabled/disabled state, the provider SHALL perform the follow-up enable or disable operation Kibana expects so the rule ends up in the intended state. Reference: [Create rule API](https://www.elastic.co/guide/en/kibana/master/create-rule-api.html) (as linked from the resource description).
@@ -423,7 +425,8 @@ Saved state at schema version **0** (legacy provider format) SHALL be upgraded a
 - Missing or nil raw state SHALL produce an error diagnostic `Invalid raw state`.
 - If stored JSON cannot be unmarshaled, the provider SHALL error with `Failed to unmarshal raw state`.
 - If `id` is not already composite (`<space_id>/<rule_id>`), the provider SHALL rewrite it to that form using `space_id` from state (default **`"default"`**) and `rule_id` from state when set, otherwise the previous bare `id` value.
-- Empty string values for `notify_when` and `throttle` SHALL become null in upgraded state.
+- Empty string values for `notify_when`, `throttle`, and rule-level `params` SHALL become null in upgraded state. A non-empty or null rule-level `params` value SHALL be preserved.
+- For each action, an empty-string `params` value SHALL become null; non-empty or null action `params` values SHALL be preserved. This prevents invalid empty strings from reaching the `jsontypes.Normalized` action parameter value.
 - For each action, nested `frequency`, `alerts_filter`, and `timeframe` values that were stored as single-element lists in v0 SHALL become the single nested object shape expected by the current schema (or null when the list was empty).
 - If upgrade changes state and re-serialization fails, the provider SHALL error with `Failed to marshal upgraded state`.
 
@@ -432,6 +435,24 @@ Saved state at schema version **0** (legacy provider format) SHALL be upgraded a
 - GIVEN v0 state with `id` equal to a bare rule id and `space_id` set
 - WHEN upgrade runs
 - THEN upgraded state SHALL have composite `id` `<space_id>/<rule_id>`
+
+#### Scenario: Empty rule-level params
+
+- GIVEN v0 state with rule-level `params` equal to an empty string
+- WHEN upgrade runs
+- THEN upgraded state SHALL set rule-level `params` to null
+
+#### Scenario: Empty action params
+
+- GIVEN v0 state with an action whose `params` equals an empty string
+- WHEN upgrade runs
+- THEN upgraded state SHALL set that action's `params` to null
+
+#### Scenario: Valid params preserved
+
+- GIVEN v0 state with a non-empty JSON value in rule-level or action `params`
+- WHEN upgrade runs
+- THEN the upgraded state SHALL preserve that value
 
 ### Requirement: Authenticated access note (REQ-035)
 
@@ -577,6 +598,7 @@ All four fields SHALL be tagged `omitempty` so they do not appear as required ke
 ### Requirement: Discriminator validation coverage guard (REQ-051)
 
 The provider SHALL maintain automated tests ensuring every `rule_type_id` case in `kbapi.AlertingRuleAPIBody.ValueByDiscriminator()` is either validated by the default discriminator params path or explicitly listed in the params validation override table with documented rationale. The coverage-guard test SHALL derive the set of `rule_type_id` values from the generated `ValueByDiscriminator()` implementation (for example by parsing `generated/kbapi/kibana.gen.go`) so kbapi regeneration that adds a new case is detected automatically.
+
 #### Scenario: New kbapi rule type without validation decision
 
 - GIVEN `kbapi` regeneration adds a new case to `ValueByDiscriminator()`


### PR DESCRIPTION
## Changelog
Customer impact: fix
Summary: Normalize empty rule and action `params` values while upgrading alerting-rule state from v0 to v1.

## Summary
- normalize empty rule and action `params` values while upgrading alerting-rule state from v0 to v1
- add migration regression tests and sync the alerting-rule OpenSpec requirement

## Validation
- `go test ./internal/kibana/alertingrule -count=1`
- `make build`
- `OPENSPEC_TELEMETRY=0 ./node_modules/.bin/openspec validate alerting-rule-state-upgrade-params --type change`

Acceptance tests were not run because the configured local Elasticsearch endpoint was unavailable.

Fixes https://github.com/elastic/terraform-provider-elasticstack/issues/4163
