### PR TITLE
fix(elasticsearch-index): compare dynamic templates semantically

### DIFF
--- a/internal/elasticsearch/index/indexmappings/acc_test.go
+++ b/internal/elasticsearch/index/indexmappings/acc_test.go
@@ -193,6 +193,55 @@ func TestAccResourceIndexMappings_allTopLevelKeys(t *testing.T) {
 	})
 }
 
+func TestAccResourceIndexMappings_dynamicTemplatesFromIndexTemplate(t *testing.T) {
+	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(t) },
+		CheckDestroy: checkResourceIndexMappingsDestroy,
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("apply"),
+				ConfigVariables: config.Variables{
+					"index_name": config.StringVariable(indexName),
+				},
+				Check: resource.ComposeTestCheckFunc(
+					checkStateMappingsDynamicTemplates(1),
+				),
+			},
+			{
+				ProtoV6ProviderFactories: acctest.Providers,
+				ConfigDirectory:          acctest.NamedTestCaseDirectory("apply"),
+				ConfigVariables: config.Variables{
+					"index_name": config.StringVariable(indexName),
+				},
+				PreConfig: func() {
+					setDynamicTemplatesOutOfBand(t, indexName, []any{
+						map[string]any{
+							"template_default": map[string]any{
+								"match_mapping_type": "string",
+								"mapping":            map[string]any{"type": "keyword"},
+							},
+						},
+						map[string]any{
+							"text_ja_example": map[string]any{
+								"path_match": "hoge.example_field.freetext",
+								"mapping":    map[string]any{"type": "text"},
+							},
+						},
+					})
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccResourceIndexMappings_import(t *testing.T) {
 	indexName := sdkacctest.RandStringFromCharSet(22, sdkacctest.CharSetAlphaNum)
 
@@ -651,6 +700,25 @@ func addDynamicMappingField(t *testing.T, indexName, fieldName string, fieldMapp
 	diags := esclient.UpdateIndexMappings(context.Background(), client, indexName, string(body))
 	if diags.HasError() {
 		t.Fatalf("failed to add dynamic mapping field: %v", diags)
+	}
+}
+
+func setDynamicTemplatesOutOfBand(t *testing.T, indexName string, templates []any) {
+	t.Helper()
+
+	client, err := clients.NewAcceptanceTestingElasticsearchScopedClient()
+	if err != nil {
+		t.Fatalf("failed to create Elasticsearch client: %s", err)
+	}
+
+	body, err := json.Marshal(map[string]any{"dynamic_templates": templates})
+	if err != nil {
+		t.Fatalf("failed to marshal dynamic templates: %s", err)
+	}
+
+	diags := esclient.UpdateIndexMappings(context.Background(), client, indexName, string(body))
+	if diags.HasError() {
+		t.Fatalf("failed to set dynamic templates out of band: %v", diags)
 	}
 }
 

--- a/internal/elasticsearch/index/indexmappings/testdata/TestAccResourceIndexMappings_dynamicTemplatesFromIndexTemplate/apply/main.tf
+++ b/internal/elasticsearch/index/indexmappings/testdata/TestAccResourceIndexMappings_dynamicTemplatesFromIndexTemplate/apply/main.tf
@@ -1,0 +1,51 @@
+variable "index_name" {
+  type = string
+}
+
+provider "elasticstack" {
+  elasticsearch {}
+}
+
+resource "elasticstack_elasticsearch_index_template" "test" {
+  name           = var.index_name
+  index_patterns = [var.index_name]
+
+  template {
+    mappings = jsonencode({
+      dynamic_templates = [
+        {
+          template_default = {
+            match_mapping_type = "string"
+            mapping = {
+              type = "keyword"
+            }
+          }
+        }
+      ]
+    })
+  }
+}
+
+resource "elasticstack_elasticsearch_index" "test" {
+  name                = var.index_name
+  deletion_protection = false
+
+  depends_on = [elasticstack_elasticsearch_index_template.test]
+}
+
+resource "elasticstack_elasticsearch_index_mappings" "test" {
+  index = elasticstack_elasticsearch_index.test.name
+
+  mappings = jsonencode({
+    dynamic_templates = [
+      {
+        text_ja_example = {
+          path_match = "hoge.example_field.freetext"
+          mapping = {
+            type = "text"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/internal/elasticsearch/index/mappings_value.go
+++ b/internal/elasticsearch/index/mappings_value.go
@@ -381,12 +381,74 @@ func MappingsSemanticallyEqual(userMappings, apiMappings map[string]any) bool {
 			continue
 		}
 
+		if key == "dynamic_templates" {
+			if !dynamicTemplatesSemanticallyEqual(userVal, apiVal) {
+				return false
+			}
+			continue
+		}
+
 		if !scalarSemanticEqual(userVal, apiVal) {
 			return false
 		}
 	}
 
 	return true
+}
+
+// dynamicTemplatesSemanticallyEqual checks that every user-declared named
+// dynamic template exists with an equivalent definition in the API mapping.
+// Elasticsearch may append templates contributed by an index template, so API
+// extras and array ordering are intentionally ignored.
+func dynamicTemplatesSemanticallyEqual(userRaw, apiRaw any) bool {
+	userTemplates, ok := dynamicTemplatesByName(userRaw)
+	if !ok {
+		return false
+	}
+	apiTemplates, ok := dynamicTemplatesByName(apiRaw)
+	if !ok {
+		return false
+	}
+
+	for name, userDefinition := range userTemplates {
+		apiDefinition, ok := apiTemplates[name]
+		if !ok || !fieldSemanticallyEqual(userDefinition, apiDefinition) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// dynamicTemplatesByName converts Elasticsearch's dynamic_templates array to
+// its named definitions. A valid entry is an object containing exactly one
+// template name whose value is an object. Duplicate names are ambiguous and
+// therefore are not considered semantically equal.
+func dynamicTemplatesByName(raw any) (map[string]any, bool) {
+	templates, ok := raw.([]any)
+	if !ok {
+		return nil, false
+	}
+
+	result := make(map[string]any, len(templates))
+	for _, rawTemplate := range templates {
+		template, ok := rawTemplate.(map[string]any)
+		if !ok || len(template) != 1 {
+			return nil, false
+		}
+
+		for name, definition := range template {
+			if _, exists := result[name]; exists {
+				return nil, false
+			}
+			if _, ok := definition.(map[string]any); !ok {
+				return nil, false
+			}
+			result[name] = definition
+		}
+	}
+
+	return result, true
 }
 
 // propertiesSemanticallyEqual recursively checks that all user-owned properties

--- a/internal/elasticsearch/index/mappings_value_test.go
+++ b/internal/elasticsearch/index/mappings_value_test.go
@@ -502,7 +502,12 @@ func TestIndexMappingsValue_RequiresMappingsUpdate(t *testing.T) {
 	field1And2 := index.NewMappingsValue(`{"properties":{"field1":{"type":"text"},"field2":{"type":"keyword"}}}`)
 	field1Plus3 := index.NewMappingsValue(`{"properties":{"field1":{"type":"text"},"extra_field":{"type":"keyword"}}}`)
 	dynamicTemplateOnly := index.NewMappingsValue(`{"dynamic_templates":[{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
-	dynamicTemplateWithExtra := index.NewMappingsValue(`{"dynamic_templates":[{"template_default":{"mapping":{"type":"keyword"},"match_mapping_type":"string"}},{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
+	dynamicTemplateWithExtra := index.NewMappingsValue(`{
+		"dynamic_templates":[
+			{"template_default":{"mapping":{"type":"keyword"},"match_mapping_type":"string"}},
+			{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}
+		]
+	}`)
 	changedDynamicTemplate := index.NewMappingsValue(`{"dynamic_templates":[{"text_ja_example":{"mapping":{"analyzer":"standard","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
 
 	tests := []struct {
@@ -616,7 +621,12 @@ func TestIndexMappingsValue_SemanticEqualsDynamicTemplateSuperset(t *testing.T) 
 	t.Parallel()
 
 	plan := index.NewMappingsValue(`{"dynamic_templates":[{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
-	api := index.NewMappingsValue(`{"dynamic_templates":[{"template_default":{"mapping":{"type":"keyword"},"match_mapping_type":"string"}},{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
+	api := index.NewMappingsValue(`{
+		"dynamic_templates":[
+			{"template_default":{"mapping":{"type":"keyword"},"match_mapping_type":"string"}},
+			{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}
+		]
+	}`)
 
 	eq, diags := plan.StringSemanticEquals(context.Background(), api)
 	require.False(t, diags.HasError())

--- a/internal/elasticsearch/index/mappings_value_test.go
+++ b/internal/elasticsearch/index/mappings_value_test.go
@@ -290,6 +290,82 @@ func TestMappingsSemanticallyEqual_coverageForMappingSupersetAndDrift(t *testing
 			want: true,
 		},
 		{
+			name: "declared dynamic_templates allow reordered template-injected extras",
+			user: map[string]any{
+				"dynamic_templates": []any{
+					map[string]any{
+						"text_ja_example": map[string]any{
+							"path_match": "hoge.example_field.freetext",
+							"mapping": map[string]any{
+								"type":     "text",
+								"analyzer": "kuro",
+							},
+						},
+					},
+				},
+			},
+			api: map[string]any{
+				"dynamic_templates": []any{
+					map[string]any{
+						"template_default": map[string]any{
+							"match_mapping_type": "string",
+							"mapping":            map[string]any{"type": "keyword"},
+						},
+					},
+					map[string]any{
+						"text_ja_example": map[string]any{
+							"mapping": map[string]any{
+								"analyzer": "kuro",
+								"type":     "text",
+							},
+							"path_match": "hoge.example_field.freetext",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "missing declared dynamic template is detected",
+			user: map[string]any{
+				"dynamic_templates": []any{map[string]any{
+					"text_ja_example": map[string]any{"mapping": map[string]any{"type": "text"}},
+				}},
+			},
+			api: map[string]any{
+				"dynamic_templates": []any{map[string]any{
+					"template_default": map[string]any{"mapping": map[string]any{"type": "keyword"}},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "changed declared dynamic template is detected",
+			user: map[string]any{
+				"dynamic_templates": []any{map[string]any{
+					"text_ja_example": map[string]any{"mapping": map[string]any{"analyzer": "kuro", "type": "text"}},
+				}},
+			},
+			api: map[string]any{
+				"dynamic_templates": []any{map[string]any{
+					"text_ja_example": map[string]any{"mapping": map[string]any{"analyzer": "standard", "type": "text"}},
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "malformed dynamic template entry is not equal",
+			user: map[string]any{
+				"dynamic_templates": []any{map[string]any{
+					"text_ja_example": map[string]any{"mapping": map[string]any{"type": "text"}},
+				}},
+			},
+			api: map[string]any{
+				"dynamic_templates": []any{"not-a-template-object"},
+			},
+			want: false,
+		},
+		{
 			name: "retained API-only properties are allowed",
 			user: map[string]any{
 				"properties": map[string]any{
@@ -425,6 +501,9 @@ func TestIndexMappingsValue_RequiresMappingsUpdate(t *testing.T) {
 	field1Only := index.NewMappingsValue(`{"properties":{"field1":{"type":"text"}}}`)
 	field1And2 := index.NewMappingsValue(`{"properties":{"field1":{"type":"text"},"field2":{"type":"keyword"}}}`)
 	field1Plus3 := index.NewMappingsValue(`{"properties":{"field1":{"type":"text"},"extra_field":{"type":"keyword"}}}`)
+	dynamicTemplateOnly := index.NewMappingsValue(`{"dynamic_templates":[{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
+	dynamicTemplateWithExtra := index.NewMappingsValue(`{"dynamic_templates":[{"template_default":{"mapping":{"type":"keyword"},"match_mapping_type":"string"}},{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
+	changedDynamicTemplate := index.NewMappingsValue(`{"dynamic_templates":[{"text_ja_example":{"mapping":{"analyzer":"standard","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
 
 	tests := []struct {
 		name  string
@@ -455,6 +534,18 @@ func TestIndexMappingsValue_RequiresMappingsUpdate(t *testing.T) {
 			plan:  field1Only,
 			state: field1Only,
 			want:  false,
+		},
+		{
+			name:  "state dynamic templates include template-injected extra — no update",
+			plan:  dynamicTemplateOnly,
+			state: dynamicTemplateWithExtra,
+			want:  false,
+		},
+		{
+			name:  "changed dynamic template definition — update required",
+			plan:  changedDynamicTemplate,
+			state: dynamicTemplateWithExtra,
+			want:  true,
 		},
 		{
 			name:  "plan null — no update",
@@ -516,6 +607,17 @@ func TestIndexMappingsValue_SemanticEquals(t *testing.T) {
 	assert.Equal(t, plan.ValueString(), api.ValueString(), "normalized forms should be identical")
 
 	// StringSemanticEquals should also return true.
+	eq, diags := plan.StringSemanticEquals(context.Background(), api)
+	require.False(t, diags.HasError())
+	assert.True(t, eq)
+}
+
+func TestIndexMappingsValue_SemanticEqualsDynamicTemplateSuperset(t *testing.T) {
+	t.Parallel()
+
+	plan := index.NewMappingsValue(`{"dynamic_templates":[{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
+	api := index.NewMappingsValue(`{"dynamic_templates":[{"template_default":{"mapping":{"type":"keyword"},"match_mapping_type":"string"}},{"text_ja_example":{"mapping":{"analyzer":"kuro","type":"text"},"path_match":"hoge.example_field.freetext"}}]}`)
+
 	eq, diags := plan.StringSemanticEquals(context.Background(), api)
 	require.False(t, diags.HasError())
 	assert.True(t, eq)


### PR DESCRIPTION
## Changelog
Customer impact: fix
Summary: Prevent false inconsistent-result errors when index mappings use template-injected dynamic templates.

## Summary

  Fixes false `Provider produced inconsistent result after apply` errors for `elasticstack_elasticsearch_index_mappings` when
  Elasticsearch returns template-injected `dynamic_templates`.

  - Compare `dynamic_templates` by template name instead of JSON array order.
  - Allow additional API-returned templates while requiring every user-declared template to be present with an equivalent definition.
  - Preserve update behavior for missing or changed user-owned templates.
  - Add unit and acceptance regression coverage.

  ## Root cause

  `MappingsSemanticallyEqual` handled `properties` as a user-owned subset of API state, but compared `dynamic_templates` as an exact
  array. Elasticsearch can return additional templates or a different order, making an otherwise compatible mapping fail Terraform's
  post-apply consistency check.

  ## Validation

  - `go test ./internal/elasticsearch/index`
  - `TF_ACC=1 go test -v -run '^TestAccResourceIndexMappings_dynamicTemplatesFromIndexTemplate$' ./internal/elasticsearch/index/
  indexmappings`
  - `make build`

  Fixes #4519