### PR TITLE
Propose fleet-managed-integration-ga OpenSpec change

### DIFF
--- a/openspec/changes/fleet-managed-integration-ga/.openspec.yaml
+++ b/openspec/changes/fleet-managed-integration-ga/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/fleet-managed-integration-ga/design.md
+++ b/openspec/changes/fleet-managed-integration-ga/design.md
@@ -1,0 +1,48 @@
+## Context
+
+See `proposal.md` — Why. Requirements are in `specs/fleet-managed-integration/spec.md`.
+
+Three mechanics shape the approach:
+
+- `Provider.Resources()` (`provider/plugin_framework.go`) returns `p.resources(ctx)` and **appends** `p.experimentalResources(ctx)` when `p.version == AccTestVersion` or `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true`. The two lists are concatenated, not merged, so an entry present in both would yield a duplicate `elasticstack_fleet_managed_integration` type name.
+- The `docs-generate` Makefile target runs `tfplugindocs` with `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=false`. That is the reason no `docs/resources/fleet_managed_integration.md` exists today, and the reason one appears as soon as the resource is stable.
+- `provider/plugin_framework_experimental_test.go` exists primarily to pin the current experimental placement of this resource; its five tests also each assert `elasticstack_fleet_agentless_policy` stays absent. `elasticstack_kibana_tag` is the only other entry in `experimentalResources()` and has no gate coverage of its own, so the env-var gate mechanism is currently tested only through the resource this change is promoting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Promote the resource with no behavioural change beyond availability and diagnostic wording.
+- Keep the `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL` gate itself under test after the resource leaves it.
+
+**Non-Goals:**
+
+- Refactoring the experimental-gate mechanism, the `AccTestVersion` sentinel, or `entitycore` version-requirement plumbing.
+- Touching the Kibana 9.5.0 floor, `policyshape.MinVersionCondition`, or the topology preflight.
+- Covering the `DataSources()` experimental gate (which gates `kibanatag.NewDataSource` through a separate code path). It is untested today and stays untested here; extending gate coverage to data sources is a candidate follow-up, not part of this promotion.
+
+## Decisions
+
+**Move, not copy.** The registration entry is deleted from `experimentalResources()` and added to `resources()` in the same commit. The alternative — adding to `resources()` first and cleaning up later — would register the type twice for anyone with the opt-in exported, which the Plugin Framework surfaces as a provider-level duplicate-type error rather than a silent no-op. The spec pins this with an explicit single-registration scenario.
+
+**Express the spec delta as REMOVED + ADDED rather than MODIFIED.** The old requirement's "Resource registered as experimental" scenario has to go, and a MODIFIED block replaces a requirement wholesale — OpenSpec validate and archive both reject a MODIFIED block that drops a scenario the current spec still has. The requirement is also renamed, which only REMOVED + ADDED expresses.
+
+**Drop the `elasticstack_fleet_agentless_policy` clause from the replacement requirement.** The old registration requirement also asserted the agentless-policy resource stays absent, duplicating the dedicated **elasticstack_fleet_agentless_policy resource — REMOVED** requirement the main spec already carries. Since this change rewrites the registration requirement anyway, the replacement leaves that behaviour to its dedicated owner, so a future agentless-policy edit touches one requirement instead of two.
+
+**Retarget the gate tests to `elasticstack_kibana_tag` rather than deleting them.** Once the resource is stable, `TestProvider_managedIntegrationNotRegisteredInDefaultProvider` fails outright, and `TestProvider_managedIntegrationRegisteredWhenExperimentalEnvEnabled` becomes vacuous — its `require.Contains` keeps passing because the stable list now carries the resource, so it no longer exercises the gate. The behaviour they cover — that the env var and the `acctest` sentinel actually gate the experimental slice — is still live for `elasticstack_kibana_tag`. Deleting them would leave the gate untested; retargeting preserves the coverage at no cost. `TestProvider_experimentalResourcesIncludesManagedIntegration` and `TestProvider_stableResourcesExcludeManagedIntegrationTypes` invert into a single stable-registration assertion. One accepted gap: the retargeted tests pin behaviour no spec requirement owns (`openspec/specs/kibana-tag/spec.md` has no registration requirement); adding a kibana-tag delta for it is out of scope for this promotion.
+
+**Rename the test file to `plugin_framework_registration_test.go`.** After retargeting, the file covers both stable and experimental registration, so `_experimental_` is no longer an accurate name. Use `git mv` so the diff reads as a rename. The `registeredResourceTypeNames` / `stableResourceTypeNames` helpers stay as-is; they are already generic and are used only in this file.
+
+**Leave the version-gate requirement alone.** The spec requires only that practitioner-facing errors name the 9.5.0 release. Dropping `(experimental API)` from the message string keeps that true, so this is an implementation-level edit with no delta. Rewriting the requirement would invite a reviewer to think the floor moved — and the floor is exactly what should not move, since 9.5.0 is both the API's minimum version and its GA release.
+
+**Generate the docs page rather than hand-writing it.** No `templates/resources/fleet_managed_integration.md.tmpl` is needed; the resource has no example-heavy behaviour that the default template mishandles, and the schema descriptions already carry the deployment constraints. Add a template only if review of the generated page shows it reads poorly.
+
+## Risks / Trade-offs
+
+- **Users on Kibana < 9.5.0 now see the resource in the schema and hit the version error only at plan/apply time** → Accepted and unchanged in kind: this is how every version-gated resource in the provider behaves. The diagnostic already names the required version. Note this is not a preview-exposure risk: the feature is GA from 9.5 and the gate floor is 9.5.0, so the stable resource never reaches a stack where the API is in preview (see `proposal.md` — Upstream GA status).
+- **The generated docs page lands with wording that was written for an experimental resource** → Review the generated Markdown as part of the change rather than trusting the generator; the schema-description edit is what the page renders from.
+- **Stale references to the change directory in code comments** → comments across the package — the `GetVersionRequirements` and model doc comments in `models.go`, the schema factory comment in `schema.go`, the package comment in `resource.go`, plus `acc_test.go` and `entitycore_contract_test.go` — point at `openspec/changes/fleet-managed-integration/...`, a path that now lives at `openspec/changes/archive/2026-07-22-fleet-managed-integration/`. Fix the comments while editing the package; leaving them deepens the drift.
+
+## Migration Plan
+
+No state migration and no user action. The changelog is regenerated from merged PR titles, so the PR title and description must state the promotion and that `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL` is no longer needed for this resource. Practitioners who set the variable solely for this resource can drop it, and leaving it set stays harmless. Rollback is a revert of the single commit.

--- a/openspec/changes/fleet-managed-integration-ga/proposal.md
+++ b/openspec/changes/fleet-managed-integration-ga/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+`elasticstack_fleet_managed_integration` was shipped behind the provider's experimental gate to match the tech-preview status of the Kibana Fleet `managed_integrations` API. That feature is now generally available (see Upstream GA status below), so the gate costs users more than it protects them. The resource is absent from the provider schema unless `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true` is exported, it has no generated documentation page (`make docs-generate` runs with the flag set to `false`), and its schema and version-gate diagnostics tell practitioners the behaviour may still change.
+
+### Upstream GA status
+
+Elastic Managed integrations are **generally available since Elastic Stack 9.5** — technical preview from 9.0 to 9.4 — and generally available on Elastic Cloud Serverless ([Elastic Managed integrations](https://www.elastic.co/docs/manage-data/ingest/managed-integrations/managed-integrations)).
+
+That boundary lines up exactly with the resource's existing `9.5.0` minimum-version gate, which is what makes this promotion safe rather than merely plausible: the resource already refuses to run against any stack older than 9.5.0, so every Kibana version it can reach is one where the feature is GA. There is no version window in which a stable resource would be talking to a tech-preview API. It also confirms the version gate itself needs no change — see Out of Scope.
+
+## What Changes
+
+- Register `elasticstack_fleet_managed_integration` in the stable `resources()` list in `provider/plugin_framework.go` and remove it from `experimentalResources()`. It must appear in exactly one list — `Resources()` appends the experimental slice to the stable one, so an entry in both would register the same type name twice.
+- Rewrite the `**This resource is experimental**: ...` sentence in the resource schema's `MarkdownDescription` in `internal/fleet/managedintegration/schema.go`. The Kibana 9.5.0 minimum-version statement currently lives inside that sentence, so it cannot be deleted outright; the replacement wording is "The underlying Fleet managed integrations API requires Kibana 9.5.0 or later." The Elastic Cloud Hosted / Serverless-only deployment constraint that follows stays unchanged.
+- Remove the `(experimental API)` suffix from the version-gate diagnostic in `internal/fleet/managedintegration/models.go` (`GetVersionRequirements`).
+- Remove the instruction to export `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true` from `examples/resources/elasticstack_fleet_managed_integration/README.md`; it becomes wrong once the resource is stable.
+- Generate the previously missing `docs/resources/fleet_managed_integration.md` page, which `make docs-generate` now produces because the resource is in the default schema.
+- Update the `fleet-managed-integration` spec requirement **Resource type and registration** so it mandates stable registration instead of `experimentalResources()`.
+
+Not a breaking change: the resource becomes available to configurations that previously needed the opt-in env var, and existing opted-in configurations keep working unchanged. The `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL` mechanism itself stays in place for `elasticstack_kibana_tag`, which remains experimental.
+
+## Out of Scope
+
+- The Kibana 9.5.0 minimum-version gate stays exactly as it is: promotion out of experimental is about provider-level stability guarantees, not about widening version support (see Upstream GA status). Practitioners on older stacks continue to get a version diagnostic, now without the `(experimental API)` wording.
+- No schema attributes, CRUD behaviour, or API endpoints change.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None — this change promotes an existing capability's registration; no new capability is introduced. -->
+
+### Modified Capabilities
+
+- `fleet-managed-integration`: the **Resource type and registration** requirement is removed and replaced by **Resource type and stable registration**. The new requirement mandates registration in the stable `resources()` list and forbids the resource description from calling the resource experimental. It adds scenarios for availability without the opt-in, single registration when the opt-in is set, and documentation generation. The discoverability scenario carries over with a retitle, minus its `elasticstack_fleet_agentless_policy` absence assertion — the dedicated **elasticstack_fleet_agentless_policy resource — REMOVED** requirement already owns that behaviour. The delta is expressed as REMOVED + ADDED rather than MODIFIED, and the **Version gate for managed_integrations endpoint** requirement is deliberately left untouched; see design.md for both rationales.
+
+## Impact
+
+- `provider/plugin_framework.go` — resource moves between the two registration lists.
+- `provider/plugin_framework_experimental_test.go` — five tests pin the current experimental placement; they are retargeted or replaced within the same file, which is renamed to `plugin_framework_registration_test.go` (see design.md).
+- `internal/fleet/managedintegration/schema.go` — `MarkdownDescription` wording.
+- `internal/fleet/managedintegration/models.go` — `GetVersionRequirements` error message and the stale comment above it.
+- `internal/fleet/managedintegration/entitycore_contract_test.go` — two assertions pin the exact error-message string.
+- `internal/fleet/managedintegration/` — stale change-path comments across the package (`schema.go`, `models.go`, `resource.go`, `acc_test.go`, `entitycore_contract_test.go`) point at the pre-archive change directory.
+- `examples/resources/elasticstack_fleet_managed_integration/README.md` — drops the experimental env-var instruction.
+- `docs/resources/fleet_managed_integration.md` — new generated page.
+- `openspec/specs/fleet-managed-integration/spec.md` — updated when this change is archived.
+- No dependency, API-client, or `kbapi` changes. `CHANGELOG.md` needs no manual edit; the `## [Unreleased]` section is regenerated from merged PR history, which is why the Migration Plan in design.md requires the PR title to state the promotion.

--- a/openspec/changes/fleet-managed-integration-ga/specs/fleet-managed-integration/spec.md
+++ b/openspec/changes/fleet-managed-integration-ga/specs/fleet-managed-integration/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Resource type and stable registration
+
+The `elasticstack_fleet_managed_integration` resource SHALL be registered in the provider's stable resource list (`resources()` in `provider/plugin_framework.go`) and SHALL NOT appear in `experimentalResources()`. It SHALL therefore be present in the provider schema with no opt-in, independent of the `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL` environment variable and of the `acctest` provider version sentinel (`AccTestVersion` in `provider/plugin_framework.go`). It SHALL be registered exactly once, so that enabling the experimental opt-in does not register the type twice. The resource description SHALL NOT describe the resource as experimental; it SHALL continue to state the Kibana 9.5.0 minimum version and the Elastic Cloud Hosted / Serverless-only deployment constraint.
+
+#### Scenario: Resource type is discoverable
+- **WHEN** `terraform providers schema -json` is run against the provider
+- **THEN** `elasticstack_fleet_managed_integration` SHALL appear in the resource schema
+
+#### Scenario: Resource available without the experimental opt-in
+- **WHEN** the provider is initialised with `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL` unset and a released provider version
+- **THEN** `elasticstack_fleet_managed_integration` SHALL be registered
+
+#### Scenario: Experimental opt-in does not duplicate registration
+- **WHEN** the provider is initialised with `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL` set to `true`
+- **THEN** `elasticstack_fleet_managed_integration` SHALL be registered exactly once
+
+#### Scenario: Resource description makes no experimental claim
+- **WHEN** the resource schema description is inspected
+- **THEN** it SHALL NOT state that the resource is experimental
+- **AND** it SHALL still state the Kibana 9.5.0 minimum version and the Elastic Cloud Hosted / Serverless-only constraint
+
+#### Scenario: Documentation page is generated
+- **WHEN** provider documentation is generated with the experimental opt-in disabled
+- **THEN** a documentation page for `elasticstack_fleet_managed_integration` SHALL be produced
+
+## REMOVED Requirements
+
+### Requirement: Resource type and registration
+
+**Reason**: The requirement mandated registration in `experimentalResources()` to match the upstream tech-preview status of the Fleet `managed_integrations` API. That API is no longer experimental, so the requirement — and its "Resource registered as experimental" scenario — no longer describes intended behaviour. Replaced by **Resource type and stable registration**, which carries over the discoverability scenario (retitled from "New resource type is discoverable"). The old requirement's `elasticstack_fleet_agentless_policy` absence clause and scenario line are not carried over: the dedicated requirement **elasticstack_fleet_agentless_policy resource — REMOVED** already owns that behaviour.
+
+**Migration**: None for practitioners. Configurations that exported `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true` solely to reach this resource can drop the variable; leaving it set remains harmless and is still required for `elasticstack_kibana_tag`.

--- a/openspec/changes/fleet-managed-integration-ga/tasks.md
+++ b/openspec/changes/fleet-managed-integration-ga/tasks.md
@@ -1,0 +1,33 @@
+## 1. Provider registration
+
+- [ ] 1.1 Add `managedintegration.NewResource` to `resources()` in `provider/plugin_framework.go` and remove it from `experimentalResources()` in the same edit, leaving `kibanatag.NewResource` as the sole experimental entry; verify with `grep -n 'managedintegration.NewResource' provider/plugin_framework.go` showing exactly one hit, located inside `resources()`.
+- [ ] 1.2 Verify `make build` succeeds.
+
+## 2. Drop the experimental wording
+
+- [ ] 2.1 Rewrite the `**This resource is experimental**: ...` sentence in the `MarkdownDescription` in `internal/fleet/managedintegration/schema.go` to `The underlying Fleet managed integrations API requires Kibana 9.5.0 or later.` — the minimum-version statement lives inside the experimental sentence, so the sentence must be rewritten, not deleted — keeping the Elastic Cloud Hosted / Serverless-only constraint that follows it. Verify per the spec scenario "Resource description makes no experimental claim" with a unit assertion that the description does not contain `experimental` and still names `9.5.0`.
+- [ ] 2.2 Remove the ` (experimental API)` suffix from the `ErrorMessage` in `GetVersionRequirements` in `internal/fleet/managedintegration/models.go`, keeping the `v%s or later` phrasing that names 9.5.0; verify the message still names the minimum version.
+- [ ] 2.3 Update the two assertions of the exact error string in `internal/fleet/managedintegration/entitycore_contract_test.go` to the new wording, keeping full-string equality — do not loosen them to a bare `Contains("9.5.0")`; the exact pin is what guards against experimental wording creeping back. Verify `go test ./internal/fleet/managedintegration/...` passes.
+- [ ] 2.4 Fix the stale comments across the package: in `models.go`, change `experimental, added in Kibana 9.5.0` to `GA, added in Kibana 9.5.0` (only the word "experimental" is stale — the API genuinely was added in 9.5.0); and in `schema.go`, `models.go`, `resource.go`, `acc_test.go`, and `entitycore_contract_test.go`, repoint the `openspec/changes/fleet-managed-integration...` references at the archived location `openspec/changes/archive/2026-07-22-fleet-managed-integration/`. Verify with `grep -rn 'openspec/changes/fleet-managed-integration' internal/fleet/managedintegration/` finding no hits (the archive path does not match this pattern) and `grep -rin experimental internal/fleet/managedintegration/` finding no remaining hits.
+
+## 3. Registration tests
+
+- [ ] 3.1 `git mv provider/plugin_framework_experimental_test.go provider/plugin_framework_registration_test.go`; verify `git status` shows a rename.
+- [ ] 3.2 Replace `TestProvider_stableResourcesExcludeManagedIntegrationTypes` and `TestProvider_experimentalResourcesIncludesManagedIntegration` with a stable-registration test asserting `managedIntegrationResourceType` is in `p.resources(ctx)` and absent from `experimentalResources(ctx)`, and that `removedAgentlessPolicyType` is absent from both; verify the new test passes.
+- [ ] 3.3 Retarget `TestProvider_managedIntegrationNotRegisteredInDefaultProvider` and `TestProvider_managedIntegrationRegisteredWhenExperimentalEnvEnabled` to `elasticstack_kibana_tag` (adding a `kibanaTagResourceType` constant) so the env-var gate keeps coverage, rename them accordingly, and add an assertion that a provider with `p.version == AccTestVersion` registers `elasticstack_kibana_tag` — that keeps the `acctest` sentinel branch of the gate under failure-detecting coverage once 3.4 makes the managed-integration assertion pass under any version. Verify the tests pass with the env var respectively unset and set to `true`.
+- [ ] 3.4 Rework `TestProvider_managedIntegrationRegisteredWithExperimentalAccTestVersion` into a stable-availability test renamed to drop `Experimental` (for example `TestProvider_managedIntegrationRegisteredWithoutOptIn`), asserting the resource is registered under a released version string with `t.Setenv(IncludeExperimentalEnvVar, "")` — dropping `t.Parallel()`, which is incompatible with `t.Setenv`, and guarding against dev environments that export the variable — as well as under `AccTestVersion`, covering the spec scenario "Resource available without the experimental opt-in"; verify it passes.
+- [ ] 3.5 Add a test asserting `elasticstack_fleet_managed_integration` is registered exactly once when `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true`, counting occurrences across `p.Resources(ctx)` rather than using the deduplicating name map; verify it passes, then temporarily re-add the resource to `experimentalResources()`, confirm the test fails, and revert.
+- [ ] 3.6 Verify the whole package passes with `go test ./provider/... -count=1`.
+
+## 4. Documentation
+
+- [ ] 4.1 Run `make docs-generate` and verify `docs/resources/fleet_managed_integration.md` is created.
+- [ ] 4.2 Review the generated page for wording that assumed the resource was experimental or hidden, and check no other page changed unexpectedly; verify with `git diff --stat docs/`. Add a `templates/resources/fleet_managed_integration.md.tmpl` only if the generated page reads poorly, then re-run `make docs-generate`.
+- [ ] 4.3 Remove the paragraph in `examples/resources/elasticstack_fleet_managed_integration/README.md` that instructs exporting `TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL=true` before plan, apply, or import; verify with `grep -rn TF_ELASTICSTACK_INCLUDE_EXPERIMENTAL examples/resources/elasticstack_fleet_managed_integration/` finding no hits.
+
+## 5. Validation
+
+- [ ] 5.1 Verify `make lint` and `make build` pass.
+- [ ] 5.2 Verify `make check-openspec` passes (`openspec validate --all`).
+- [ ] 5.3 Run the managed-integration acceptance tests against a live stack with `TF_ACC=1` to confirm CRUD behaviour is unchanged (see `dev-docs/high-level/testing.md`). Note: the acceptance harness instantiates the provider with `AccTestVersion`, which registers experimental resources regardless of the env var, so this run cannot prove opt-in-free availability — that coverage lives in the unit tests from tasks 3.2 and 3.4.
+- [ ] 5.4 For whoever archives this change: because the delta is REMOVED + ADDED, archive appends **Resource type and stable registration** to the end of `openspec/specs/fleet-managed-integration/spec.md` and deletes the old first requirement. The appended position is acceptable — requirement order is not normative, matching the kibana-dashboard graduation precedent; verify the archived spec still passes `make check-openspec`.


### PR DESCRIPTION
## Summary

OpenSpec change proposal (no implementation yet) to promote `elasticstack_fleet_managed_integration` out of the provider's experimental gate.

The Kibana Fleet `managed_integrations` API is generally available since Elastic Stack 9.5 — exactly the resource's existing minimum-version floor — so the experimental gate now only hides the resource (no docs page, opt-in env var, "may change" wording) without protecting anyone: the stable resource can never reach a stack where the API is still in preview.

## What the change covers

- Move the resource from `experimentalResources()` to the stable `resources()` list (move, not copy — `Resources()` appends the experimental slice, so a duplicate entry would register the type twice).
- Rewrite the experimental sentence in the schema `MarkdownDescription` (keeping the Kibana 9.5.0 minimum and the ECH/Serverless-only constraint) and drop the `(experimental API)` suffix from the version-gate diagnostic.
- Retarget the experimental-gate tests to `elasticstack_kibana_tag` so the gate mechanism keeps failure-detecting coverage, and rename the test file to `plugin_framework_registration_test.go`.
- Generate the previously missing `docs/resources/fleet_managed_integration.md` page and remove the obsolete env-var instruction from the examples README.
- Delta spec: requirement **Resource type and registration** is replaced by **Resource type and stable registration** (REMOVED + ADDED, since a scenario is dropped and the requirement is renamed). The Kibana 9.5.0 version-gate requirement is deliberately untouched.

`openspec validate --all` passes.

## Changelog
Customer impact: none

This PR only adds an OpenSpec change proposal under `openspec/changes/`; the implementation (and its enhancement changelog entry) will come in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)